### PR TITLE
SREP-1119: Add CronJobs & RBAC to prune Builds and Deployments

### DIFF
--- a/deploy/sre-pruning/100-pruning.Namespace.yaml
+++ b/deploy/sre-pruning/100-pruning.Namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sre-pruning

--- a/deploy/sre-pruning/105-pruning.rbac.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.yaml
@@ -1,8 +1,3 @@
-# Service Account needs permission to:
-#  * Delete deployments
-#  * Delete Builds
-#  * Delete Images
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/sre-pruning/105-pruning.rbac.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.yaml
@@ -1,0 +1,66 @@
+# Service Account needs permission to:
+#  * Delete deployments
+#  * Delete Builds
+#  * Delete Images
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-pruner-sa
+  namespace: openshift-sre-pruning
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sre-pruner-buildsdeploys-cr
+rules:
+# deployment pruning
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - replicationcontrollers
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - delete
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+# builds pruning
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - builds
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - builds
+  verbs:
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sre-pruner-buildsdeploys-pruning
+roleRef: 
+  kind: ClusterRole
+  name: sre-pruner-buildsdeploys-cr
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: sre-pruner-sa
+  namespace: openshift-sre-pruning

--- a/deploy/sre-pruning/105-pruning.rbac.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.yaml
@@ -5,6 +5,19 @@ metadata:
   namespace: openshift-sre-pruning
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sre-pruner-images
+roleRef:
+  kind: ClusterRole
+  name: system:image-pruner
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: sre-pruner-sa
+  namespace: openshift-sre-pruning
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: sre-pruner-buildsdeploys-cr

--- a/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: builds-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  schedule: "* */1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never          
+          containers:
+          - name: builds-pruner
+            image: quay.io/openshift/origin-cli:v4.0.0
+            command: 
+            - oc
+            - adm
+            - prune
+            - builds
+            - --keep-younger-than=24h
+            - --keep-complete=1
+            - --keep-failed=1
+            - --confirm

--- a/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: deployments-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  schedule: "* */1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never          
+          containers:
+          - name: deployments-pruner
+            image: quay.io/openshift/origin-cli:v4.0.0
+            command: 
+            - oc
+            - adm
+            - prune
+            - deployments
+            - --keep-complete=1
+            - --keep-younger-than=24h
+            - --keep-failed=1
+            - --confirm

--- a/deploy/sre-pruning/110-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-images.CronJob.yaml
@@ -1,0 +1,33 @@
+# Refer to SREP-1104 (and PROD-984)
+# This is on hold until image pruning can be done with a service account
+# (or implemented a different way)
+#---
+#apiVersion: batch/v1beta1
+#kind: CronJob
+#metadata:
+#  name: image-pruner
+#  namespace: openshift-sre-pruning
+#spec:
+#  failedJobsHistoryLimit: 5
+#  successfulJobsHistoryLimit: 3
+#  concurrencyPolicy: Forbid
+#  schedule: "* */1 * * *"
+#  jobTemplate:
+#    spec:
+#      template:
+#        spec:
+#          serviceAccountName: sre-pruner-sa
+#          restartPolicy: Never          
+#          containers:
+#          - name: image-pruner
+#            image: quay.io/openshift/origin-cli:v4.0.0
+#            command: 
+#            - oc
+#            - adm
+#            - prune
+#            - images
+#            - --token=/var/run/secrets/kubernetes.io/serviceaccount/token
+#            - --keep-younger-than=24h
+#            - --keep-tag-revisions=5
+#            - --confirm
+#

--- a/deploy/sre-pruning/110-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-images.CronJob.yaml
@@ -1,33 +1,24 @@
-# Refer to SREP-1104 (and PROD-984)
-# This is on hold until image pruning can be done with a service account
-# (or implemented a different way)
-#---
-#apiVersion: batch/v1beta1
-#kind: CronJob
-#metadata:
-#  name: image-pruner
-#  namespace: openshift-sre-pruning
-#spec:
-#  failedJobsHistoryLimit: 5
-#  successfulJobsHistoryLimit: 3
-#  concurrencyPolicy: Forbid
-#  schedule: "* */1 * * *"
-#  jobTemplate:
-#    spec:
-#      template:
-#        spec:
-#          serviceAccountName: sre-pruner-sa
-#          restartPolicy: Never          
-#          containers:
-#          - name: image-pruner
-#            image: quay.io/openshift/origin-cli:v4.0.0
-#            command: 
-#            - oc
-#            - adm
-#            - prune
-#            - images
-#            - --token=/var/run/secrets/kubernetes.io/serviceaccount/token
-#            - --keep-younger-than=24h
-#            - --keep-tag-revisions=5
-#            - --confirm
-#
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: image-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
+  schedule: "* */1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never          
+          containers:
+          - name: image-pruner
+            image: quay.io/openshift/origin-cli:v4.0.0
+            args:
+            - /bin/bash
+            - -c
+            - "oc adm prune images --token=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) --server=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT) --keep-younger-than=24h --keep-tag-revisions=5 --insecure-skip-tls-verify=true --confirm"


### PR DESCRIPTION
Meant to also include images (see SREP-813, and the stub `deploy/sre-pruning/110-pruning-images.CronJob.yaml`) but images is blocked.
    
Signed-off-by: Lisa Seelye <lseelye@redhat.com>
