### PR TITLE
Update severity 'warn' to 'warning'

### DIFF
--- a/deploy/prometheus/100-ebs-iops-burstbalance.PrometheusRule.yaml
+++ b/deploy/prometheus/100-ebs-iops-burstbalance.PrometheusRule.yaml
@@ -14,7 +14,7 @@ spec:
       expr: avg(ebs_iops_credits) < 40
       for: 60m
       labels:
-        severity: warn
+        severity: warning
     - alert: EbsVolumeBurstBalanceLT20PctSRE
       expr: avg(ebs_iops_credits) < 20
       for: 60m

--- a/deploy/prometheus/100-router-health.PrometheusRule.yaml
+++ b/deploy/prometheus/100-router-health.PrometheusRule.yaml
@@ -17,7 +17,7 @@ spec:
         on(replicationcontroller,namespace)
         max(kube_replicationcontroller_status_replicas{namespace="default",replicationcontroller=~"router.?-.*"} >0) by (replicationcontroller,namespace)) < 0.5
       labels:
-        severity: warn
+        severity: warning
     - alert: RouterAvailabilityLT30PctSRE
       expr: |
         (sum(avg_over_time(kube_replicationcontroller_status_ready_replicas[1h])) by (replicationcontroller,namespace) 

--- a/deploy/prometheus/100-stuck-builds.PrometheusRule.yaml
+++ b/deploy/prometheus/100-stuck-builds.PrometheusRule.yaml
@@ -13,4 +13,4 @@ spec:
     - alert: StuckNewBuilds3MinSRE
       expr: count(openshift_build_active_time_seconds{phase="New"} < time() - 180) > 0
       labels:
-        severity: warn
+        severity: warning

--- a/deploy/prometheus/100-stuck-volumes.PrometheusRule.yaml
+++ b/deploy/prometheus/100-stuck-volumes.PrometheusRule.yaml
@@ -13,7 +13,7 @@ spec:
     - alert: EbsVolumeStuckAttaching5MinSRE
       expr: min_over_time(ebs_volume_state{ebs_volume_state="attaching"}[5m]) == 1
       labels:
-        severity: warn
+        severity: warning
     - alert: EbsVolumeStuckAttaching10MinSRE
       expr: min_over_time(ebs_volume_state{ebs_volume_state="attaching"}[10m]) == 1
       labels:
@@ -21,7 +21,7 @@ spec:
     - alert: EbsVolumeStuckDetaching5MinSRE
       expr: min_over_time(ebs_volume_state{ebs_volume_state="detaching"}[5m]) == 1
       labels:
-        severity: warn
+        severity: warning
     - alert: EbsVolumeStuckDetaching10MinSRE
       expr: min_over_time(ebs_volume_state{ebs_volume_state="detaching"}[10m]) == 1
       labels:


### PR DESCRIPTION
OCP v4 ships with 3 severity values:
- critical
- warning
- none (Watchdog alert)

This PR updates our alerts to be consistent.