### PR TITLE
Allow sre-admins to upgrade and use who-can

### DIFF
--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -138,6 +138,19 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversion
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - authorization.openshift.io
+  resources:
+  - localresourceaccessreviews
+  verbs:
+  - create
 - nonResourceURLs:
   - '*'
   verbs:


### PR DESCRIPTION
Went to upgrade a cluster today as myself and I couldn't.  I also couldn't see who can do what.  This change addresses those two issues, so that as sre-admins I can:

- `oc adm upgrade --to=<target version>`
- `oc adm policy who-can edit clusterversion`