### PR TITLE
Fix PV quota to 100Gi

### DIFF
--- a/deploy/resource-quotas/15-resource.clusterresourcequota.yaml
+++ b/deploy/resource-quotas/15-resource.clusterresourcequota.yaml
@@ -12,7 +12,7 @@ spec:
         operator: DoesNotExist
   quota:
     hard:
-      requests.storage: 100
+      requests.storage: 100Gi
 ---
 kind: ClusterResourceQuota
 apiVersion: quota.openshift.io/v1

--- a/deploy/resource-quotas/values.mk
+++ b/deploy/resource-quotas/values.mk
@@ -5,7 +5,7 @@ PERSISTENT_VOLUME_EXCEPTIONS ?= openshift-etcd openshift-monitoring
 LOAD_BALANCER_EXCEPTIONS ?= $(PERSISTENT_VOLUME_EXCEPTIONS)
 
 # Default PV quota per namespace in Gi
-DEFAULT_PV_QUOTA ?= 100
+DEFAULT_PV_QUOTA ?= 100Gi
 
 # Default Load balancer per namespace quota
 DEFAULT_LB_QUOTA ?= 2


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage

> Limits and requests for `ephemeral-storage` are measured in bytes.

Changes 100B to 100GiB