### PR TITLE
Use scoped labels for resource quota exemption

### DIFF
--- a/deploy/resource-quotas/10-patch.namespace.openshift-etcd.yaml
+++ b/deploy/resource-quotas/10-patch.namespace.openshift-etcd.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 name: openshift-etcd
 applyMode: AlwaysApply
 patch: |-
-  { "metadata": {"labels": {"storage_pv_quota":"False","service_lb_quota":"False"} } }
+  { "metadata": {"labels": {"managed.openshift.io/storage-pv-quota-exempt":"true","managed.openshift.io/service-lb-quota-exempt":"true"} } }
 patchType: merge

--- a/deploy/resource-quotas/10-patch.namespace.openshift-monitoring.yaml
+++ b/deploy/resource-quotas/10-patch.namespace.openshift-monitoring.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 name: openshift-monitoring
 applyMode: AlwaysApply
 patch: |-
-  { "metadata": {"labels": {"storage_pv_quota":"False","service_lb_quota":"False"} } }
+  { "metadata": {"labels": {"managed.openshift.io/storage-pv-quota-exempt":"true","managed.openshift.io/service-lb-quota-exempt":"true"} } }
 patchType: merge

--- a/deploy/resource-quotas/functions.mk
+++ b/deploy/resource-quotas/functions.mk
@@ -3,11 +3,11 @@
 # $3 - label JSON fragment
 # $4 - exempt namespace
 define process_template
-	sed -e "s/\#EXEMPT_NAMESPACE\#/$(4)/g" \
-		-e "s/\#LABELS\#/$(3)/g" \
-		-e "s/\#PV_EXCLUSION_LABEL_NAME\#/${PV_EXCLUSION_LABEL_NAME}/g" \
-		-e "s/\#LB_EXCLUSION_LABEL_NAME\#/${LB_EXCLUSION_LABEL_NAME}/g" \
-		-e "s/\#DEFAULT_PV_QUOTA\#/${DEFAULT_PV_QUOTA}/g" \
-		-e "s/\#DEFAULT_LB_QUOTA\#/${DEFAULT_LB_QUOTA}/g" \
+	sed -e "s|\#EXEMPT_NAMESPACE\#|$(4)|g" \
+		-e "s|\#LABELS\#|$(3)|g" \
+		-e "s|\#PV_EXCLUSION_LABEL_NAME\#|${PV_EXCLUSION_LABEL_NAME}|g" \
+		-e "s|\#LB_EXCLUSION_LABEL_NAME\#|${LB_EXCLUSION_LABEL_NAME}|g" \
+		-e "s|\#DEFAULT_PV_QUOTA\#|${DEFAULT_PV_QUOTA}|g" \
+		-e "s|\#DEFAULT_LB_QUOTA\#|${DEFAULT_LB_QUOTA}|g" \
 		$(1) > $(2)
 endef

--- a/deploy/resource-quotas/values.mk
+++ b/deploy/resource-quotas/values.mk
@@ -12,5 +12,5 @@ DEFAULT_LB_QUOTA ?= 2
 
 # What label to be set when the LoadBalancer and/or Persistent Volume quotas do
 # not apply
-LB_EXCLUSION_LABEL_NAME ?= service_lb_quota
-PV_EXCLUSION_LABEL_NAME ?= storage_pv_quota
+LB_EXCLUSION_LABEL_NAME ?= managed.openshift.io/service-lb-quota-exempt
+PV_EXCLUSION_LABEL_NAME ?= managed.openshift.io/storage-pv-quota-exempt

--- a/scripts/jsonify.awk
+++ b/scripts/jsonify.awk
@@ -4,7 +4,7 @@
 # pv - list of namespaces which are exempt from PV quotas
 # lb - list of namespaces which are exempt from LB quotas
 # label_pv - what to label those PV-exempt namespaces (value is False)
-# label_pv - what to label those LB-exempt namespaces (value is False) 
+# label_pv - what to label those LB-exempt namespaces (value is False)
 # Output is inentionally escaping double quotes for use in Makefile:
 # VAR := $(shell echo namespace | awk -f jsonify.awk pv=namespace lb=namespace label_pv=label_pv label_lb=label_lb)
 # VAR now is literally: {\"label_pv\":\"False\",\"label_lb\":\"False\"}
@@ -41,13 +41,13 @@ END {
     if (pvexempt[p] == namespace) {
       if (out[namespacex])
         out[namespace] = (out[namespace] ",")
-      out[namespace] = (out[namespace] "\\\"" label_pv "\\\":\\\"False\\\"")
+      out[namespace] = (out[namespace] "\\\"" label_pv "\\\":\\\"true\\\"")
     }
   for (l in lbexempt)
     if (lbexempt[l] == namespace) {
       if (out[namespace])
         out[namespace] = (out[namespace] ",")
-      out[namespace] = (out[namespace] "\\\"" label_lb "\\\":\\\"False\\\"")
+      out[namespace] = (out[namespace] "\\\"" label_lb "\\\":\\\"true\\\"")
     }
   if (length(out[namespace]) > 0)
     print out[namespace]


### PR DESCRIPTION
This changes the labels used for resource quota exemption to use the scoped "managed.openshift.io" namespace. This way, it's easy to tell that these settings are specific to the OSD offering.

I've also swapped the negative label value for a positive one. As we're using `DoesNotExist` as the match operator, this makes the two possible states 'true' if the namespace is exempt, and the label should be omitted completely for normal namespaces.