### PR TITLE
Prune what sre-admins can do in OSD clusters.

### DIFF
--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -62,6 +62,13 @@ rules:
   - projects
   verbs:
   - '*'
+# SRE can manage namespaces
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - '*'
 # SRE can review pod security policies
 - apiGroups:
   - security.openshift.io

--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -47,7 +47,8 @@ rules:
   verbs:
   - '*'
 # SRE can review pod security policies
-- apiGroup: security.openshift.io
+- apiGroups:
+  - security.openshift.io
   resources:
   - podsecuritypolicyreviews
   - podsecuritypolicyselfsubjectreviews

--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -67,8 +67,16 @@ rules:
   - ""
   resources:
   - namespaces
+  - namespaces/finalize
   verbs:
   - '*'
+# SRE can delete pods
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
 # SRE can review pod security policies
 - apiGroups:
   - security.openshift.io

--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -9,7 +9,9 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - get
+  - list
+  - watch
 - apiGroups:
   - '*'
   resources:

--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -20,6 +20,20 @@ rules:
   - get
   - list
   - watch
+# SRE can manage nodes
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - patch
+# SRE can evict pods
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
 # SRE can delete jobs and builds
 - apiGroups:
   - batch

--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -5,14 +5,6 @@ metadata:
 rules:
 # SRE can get, list, and watch all resources
 - apiGroups:
-  - ""
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - '*'
   resources:
   - '*'

--- a/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/01-osd-sre-admin.ClusterRole.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   name: osd-sre-admin
 rules:
+# SRE can get, list, and watch all resources
 - apiGroups:
   - ""
   resources:
@@ -17,55 +18,22 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - customresourcedefinitions
-  - customresourcedefinitions/status
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - '*'
-  verbs:
-  - delete
-  - deletecollection
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - delete
-  - deletecollection
+# SRE can delete jobs and builds
 - apiGroups:
   - batch
   resources:
-  - job
-  - cronjob
+  - jobs
   verbs:
   - delete
   - deletecollection
 - apiGroups:
   - build.openshift.io
   resources:
-  - buildconfigs
   - builds
   verbs:
   - delete
   - deletecollection
-- apiGroups:
-  - cloudcredential.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
+# SRE can manage projects
 - apiGroups:
   - config.openshift.io
   resources:
@@ -73,64 +41,20 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - hive.openshift.io
-  resources:
-  - clusterdeployments
-  - selectorsyncidentityproviders
-  - selectorsyncsets
-  - syncidentityproviders
-  - syncsets
-  verbs:
-  - '*'
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - subscriptions
-  verbs:
-  - '*'
-- apiGroups:
-  - policy
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
   - project.openshift.io
   resources:
-  - '*'
+  - projects
   verbs:
   - '*'
-- apiGroups:
-  - quota.openshift.io
+# SRE can review pod security policies
+- apiGroup: security.openshift.io
   resources:
-  - '*'
+  - podsecuritypolicyreviews
+  - podsecuritypolicyselfsubjectreviews
+  - podsecuritypolicysubjectreviews
   verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - '*'
-- apiGroups:
-  - security.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - tuned.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  - create
+# SRE can update existing groups
 - apiGroups:
   - user.openshift.io
   resources:
@@ -138,19 +62,22 @@ rules:
   verbs:
   - patch
   - update
+# SRE can upgrade the cluster
 - apiGroups:
   - config.openshift.io
   resources:
-  - clusterversion
+  - clusterversions
   verbs:
   - patch
   - update
+# SRE can review RBAC policies (i.e. oc adm policy who-can ...)
 - apiGroups:
   - authorization.openshift.io
   resources:
   - localresourceaccessreviews
   verbs:
   - create
+# SRE can get and post to all endpoints
 - nonResourceURLs:
   - '*'
   verbs:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -633,12 +633,6 @@ objects:
         name: osd-sre-admin
       rules:
       - apiGroups:
-        - ''
-        resources:
-        - '*'
-        verbs:
-        - '*'
-      - apiGroups:
         - '*'
         resources:
         - '*'
@@ -647,54 +641,31 @@ objects:
         - list
         - watch
       - apiGroups:
-        - apiextensions.k8s.io
+        - ''
         resources:
-        - '*'
+        - nodes
         verbs:
-        - '*'
+        - patch
       - apiGroups:
-        - admissionregistration.k8s.io
+        - ''
         resources:
-        - customresourcedefinitions
-        - customresourcedefinitions/status
+        - pods/eviction
         verbs:
-        - '*'
-      - apiGroups:
-        - apps
-        resources:
-        - '*'
-        verbs:
-        - delete
-        - deletecollection
-      - apiGroups:
-        - apps.openshift.io
-        resources:
-        - '*'
-        verbs:
-        - delete
-        - deletecollection
+        - create
       - apiGroups:
         - batch
         resources:
-        - job
-        - cronjob
+        - jobs
         verbs:
         - delete
         - deletecollection
       - apiGroups:
         - build.openshift.io
         resources:
-        - buildconfigs
         - builds
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - cloudcredential.openshift.io
-        resources:
-        - '*'
-        verbs:
-        - '*'
       - apiGroups:
         - config.openshift.io
         resources:
@@ -702,64 +673,32 @@ objects:
         verbs:
         - '*'
       - apiGroups:
-        - hive.openshift.io
-        resources:
-        - clusterdeployments
-        - selectorsyncidentityproviders
-        - selectorsyncsets
-        - syncidentityproviders
-        - syncsets
-        verbs:
-        - '*'
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - subscriptions
-        verbs:
-        - '*'
-      - apiGroups:
-        - policy
-        resources:
-        - '*'
-        verbs:
-        - '*'
-      - apiGroups:
         - project.openshift.io
         resources:
-        - '*'
+        - projects
         verbs:
         - '*'
       - apiGroups:
-        - quota.openshift.io
+        - ''
         resources:
-        - '*'
+        - namespaces
+        - namespaces/finalize
         verbs:
         - '*'
       - apiGroups:
-        - rbac.authorization.k8s.io
+        - ''
         resources:
-        - rolebindings
-        - roles
+        - pods
         verbs:
-        - '*'
+        - delete
       - apiGroups:
         - security.openshift.io
         resources:
-        - '*'
+        - podsecuritypolicyreviews
+        - podsecuritypolicyselfsubjectreviews
+        - podsecuritypolicysubjectreviews
         verbs:
-        - '*'
-      - apiGroups:
-        - storage.k8s.io
-        resources:
-        - '*'
-        verbs:
-        - '*'
-      - apiGroups:
-        - tuned.openshift.io
-        resources:
-        - '*'
-        verbs:
-        - '*'
+        - create
       - apiGroups:
         - user.openshift.io
         resources:
@@ -770,7 +709,7 @@ objects:
       - apiGroups:
         - config.openshift.io
         resources:
-        - clusterversion
+        - clusterversions
         verbs:
         - patch
         - update


### PR DESCRIPTION
The goal of this is to drive all changes to config management.  It is expected that some updates may be required over time.