### PR TITLE
Add alerts for SRE operators being offline for 15 minutes

### DIFF
--- a/deploy/sre-prometheus/100-configure-alertmanager-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-configure-alertmanager-operator.PrometheusRule.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-configure-alertmanager-operator-offline-alerts
+    role: alert-rules
+  name: sre-configure-alertmanager-operator-offline-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-configure-alertmanager-operator-offline-alerts
+    rules:
+    - alert: ConfigureAlertmanagerOperatorOfflineSRE
+      expr: absent(up{service="configure-alertmanager-operator"})
+      for: 15m
+      labels:
+        severity: critical

--- a/deploy/sre-prometheus/100-dedicated-admin-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-dedicated-admin-operator.PrometheusRule.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-dedicated-admin-operator-offline-alerts
+    role: alert-rules
+  name: sre-dedicated-admin-operator-offline-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-dedicated-admin-operator-offline-alerts
+    rules:
+    - alert: DedicatedAdminOperatorOfflineSRE
+      expr: absent(up{service="dedicated-admin-operator"})
+      for: 15m
+      labels:
+        severity: critical

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -274,6 +274,40 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-configure-alertmanager-operator-offline-alerts
+          role: alert-rules
+        name: sre-configure-alertmanager-operator-offline-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-configure-alertmanager-operator-offline-alerts
+          rules:
+          - alert: ConfigureAlertmanagerOperatorOfflineSRE
+            expr: absent(up{service="configure-alertmanager-operator"})
+            for: 15m
+            labels:
+              severity: critical
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-dedicated-admin-operator-offline-alerts
+          role: alert-rules
+        name: sre-dedicated-admin-operator-offline-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-dedicated-admin-operator-offline-alerts
+          rules:
+          - alert: DedicatedAdminOperatorOfflineSRE
+            expr: absent(up{service="dedicated-admin-operator"})
+            for: 15m
+            labels:
+              severity: critical
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-dns-alerts
           role: alert-rules
         name: sre-dns-alerts


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1724742

OLM on OCP 4.1.3 caused outage of dedicated-admin operator in stage.  This will at least alert us when this happens for our operators.