### PR TITLE
Dockerfile update, No more need for epel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,21 @@
 FROM openshift/origin-cli:v3.11
 
+# Multistage with python
+FROM python:2.7
+
+# Bring oc binary to python image
+COPY --from=0 /bin/oc /bin/
+
 # Environment
 ARG IN_DOCKER_CONTAINER="true"
-ENV VENV=/venv
 ENV REPO_PATH=/managed-cluster-config
 
 # Copy repo into docker image:
 COPY . ${REPO_PATH}
 WORKDIR ${REPO_PATH}
 
-# Docker dependencies:
-RUN yum update -y && yum install -y \
-    git \
-    make \
-    epel-release
-RUN yum -y install python-pip && yum clean all
-
 # Upgrade pip and install necessasry packages
-RUN pip install \
-    --upgrade pip \
-    virtualenv \
-    pyyaml
-
-# Set up venv
-RUN virtualenv -p /usr/bin/python2.7 ${VENV} && \
-    . ${VENV}/bin/activate
+RUN pip install pyyaml
 
 # Make
 RUN make 


### PR DESCRIPTION
previous commit depended on epel  which was not available when testing at `openshift/release`, this multistage Dockerfile update hopefully remedies the issue.