### PR TITLE
Dockerfile for integretating managed-cluster-config with openshift/release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,9 @@ RUN pip install pyyaml
 
 # Make
 RUN make 
+
+# This image will be replaced by the openshift/release
+FROM openshift/origin-cli
+
+# Ensure make ran as expected
+COPY --from=1 /managed-cluster-config/deploy/ deploy


### PR DESCRIPTION
Adds a new 'FROM' statement to bypass missing package issue caused by openshift/release replacing the last occurrence of 'FROM' when building the image.