### PR TITLE
Manage telemeter server URL

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -24,3 +24,5 @@ data:
           resources:
             requests:
               storage: 10Gi
+    telemeterClient:
+      telemeterServerURL: ${TELEMETER_SERVER_URL}

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -654,7 +654,8 @@ objects:
           \     name: prometheus-data\n    spec:\n      storageClassName: gp2\n      resources:\n
           \       requests:\n          storage: 50Gi\nalertmanagerMain:\n  volumeClaimTemplate:\n
           \   metadata:\n      name: alertmanager-data\n    spec:\n      storageClassName:
-          gp2\n      resources:\n        requests:\n          storage: 10Gi\n"
+          gp2\n      resources:\n        requests:\n          storage: 10Gi\ntelemeterClient:\n
+          \ telemeterServerURL: ${TELEMETER_SERVER_URL}\n"
       kind: ConfigMap
       metadata:
         name: cluster-monitoring-config
@@ -1092,4 +1093,6 @@ parameters:
 - name: IDENTITY_NAME
   required: true
 - name: IDENTITY_MAPPING_METHOD
+  required: true
+- name: TELEMETER_SERVER_URL
   required: true

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: IDENTITY_MAPPING_METHOD
   required: true
+- name: TELEMETER_SERVER_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1594

So we can pass in a different telemeter instance for non-production OSD clusters.