### PR TITLE
Attempt to document resources -> SelectorSyncSet -> Template flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@ This repo contains static configuration specific to a "managed" OpenShift Dedica
 
 ## How to use this repo
 
-To add a new SelectorSyncSet, add your yaml manifest to the `deploy` dir, then run the `make` command.
+Yaml files are taken from [./deploy/](./deploy/) dir and deployed through couple layers of indirection:
+
+1.  Each yaml from ./deploy/ gets wrapped it in a [Hive `SelectorSyncSet`] according to [scripts/templates/selectorsyncset.yaml](scripts/templates/selectorsyncset.yaml).
+
+    If the yaml contains `patch` field, it is put under `patches:` in the `SelectorSyncSet`, otherwise it's copied under `resources:`.
+
+    Hive looks for `SelectorSyncSet` resources *in the Hive cluster* matching `ClusterDeployment` labels and creates/syncs the resources / applies the patches described inside into the corresponding clusters.
+
+2.  To allow variations between prod/stage/integration environments, the resulting `SelectorSyncSet`s are wrapped in an openshift `Template` according to [./scripts/templates/template.yaml](./scripts/templates/template.yaml). (This file also contains some fixed resources where wrapping step 1 doesn't fit.)
+
+    The per-environment values for these parameters come from [saas-osd-operators repo](https://gitlab.cee.redhat.com/service/saas-osd-operators/blob/master/managed-cluster-config-services/managed-cluser-config.yaml).
+
+Thus to add a new resource, add your yaml manifest to the ./deploy/ dir.
+Write the yaml as you want it to exist *inside* the OSD cluster, say if you want a ConfigMap, use `kind: ConfigMap`.  Except you can use `${...}` parameters from the template.
+
+To patch existing resource in the cluster, again add a yaml manifest to the ./deploy/ dir, but include `patch`, `patchType`, `applyMode` fields at top level — see [Hive `SelectorSyncSet`] docs.
+
+Then run the `make` command, and commit the generated changes too.
+
+[Hive `SelectorSyncSet`]: https://github.com/openshift/hive/blob/master/docs/syncset.md
 
 # Selector Sync Sets included in this repo
 


### PR DESCRIPTION
Hi, I was curious how the yamls actually make it into the cluster (I think it's useful to understand for other teams involved around OSD).
Here is my attempt at reverse engineering — please review carefully :-)

Questions:

- I wanted to add step "3. then we do `oc process $TEMPLATE | oc apply` into the Hive cluster" or something like that but didn't find any details...   How, and *when* is the resulting template actually deployed?  
  `hack/app_sre_build_deploy.sh` does nothing.
  Is every merged PR automatically deployed?  Is it deployed on MR to `saas-osd-operators` repo bumping the hash?  Is it manual?  This is worth explaining in the README.

- Are all existing clusters affected when you change/add yamls here?  I assume yes (unless one uses patch `applyMode: ApplyOnce`), but it's worth explicitly saying in the README.