### PR TITLE
Always cleanup syncset, don't log error for oc delete

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -143,13 +143,9 @@ EOF
                 # report can't upgrade if version is not upgradable and upgrade is not in progress
                 UPGRADE_NOT_POSSIBLE="${UPGRADE_NOT_POSSIBLE}  $CD_NAME ($OCP_CURRENT_VERSION)\n"
             else
-                # cluster is already upgraded?
-                if [ -z $SS_VERSION_FROM ];
-                then
-                    # delete the syncset, it's not needed anymore
-                    oc -n $CD_NAMESPACE delete SyncSet $SS_NAME
-                    UPGRADE_DONE="${UPGRADE_DONE}  $CD_NAME ($OCP_CURRENT_VERSION)\n"
-                fi
+                # delete the syncset, it's not needed anymore
+                oc -n $CD_NAMESPACE delete SyncSet $SS_NAME 2>/dev/null
+                UPGRADE_DONE="${UPGRADE_DONE}  $CD_NAME ($OCP_CURRENT_VERSION)\n"
             fi
         fi
     done

--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -144,7 +144,7 @@ EOF
                 UPGRADE_NOT_POSSIBLE="${UPGRADE_NOT_POSSIBLE}  $CD_NAME ($OCP_CURRENT_VERSION)\n"
             else
                 # delete the syncset, it's not needed anymore
-                oc -n $CD_NAMESPACE delete SyncSet $SS_NAME 2>/dev/null
+                oc -n "$CD_NAMESPACE" delete SyncSet "$SS_NAME" 2>/dev/null
                 UPGRADE_DONE="${UPGRADE_DONE}  $CD_NAME ($OCP_CURRENT_VERSION)\n"
             fi
         fi


### PR DESCRIPTION
Just annoying output at this time when running the script, this cleans up state in hive better and doesn't report useless errors in script output.