### PR TITLE
Add patch to wipe users from hive

### DIFF
--- a/deploy/sre-authorization/20-osd-sre-cluster-admins.patch.yaml
+++ b/deploy/sre-authorization/20-osd-sre-cluster-admins.patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+name: osd-sre-cluster-admins
+metadata:
+  name: osd-sre-cluster-admins
+applyMode: AlwaysApply
+patch: '{"users": null}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -954,6 +954,15 @@ objects:
       metadata:
         name: osd-ldap-ca-configmap
         namespace: openshift-config
+    patches:
+    - apiVersion: user.openshift.io/v1
+      kind: Group
+      name: osd-sre-cluster-admins
+      metadata:
+        name: osd-sre-cluster-admins
+      applyMode: AlwaysApply
+      patch: '{"users": null}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
The group itself isn't reapplyed yet (https://jira.coreos.com/browse/CO-528) so this is a stopgap with the intent to always apply the patch which is expected.