### PR TITLE
Remove prometheus alert links to access.redhat.com

### DIFF
--- a/deploy/sre-prometheus/100-machine-api.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-machine-api.PrometheusRule.yaml
@@ -16,11 +16,9 @@ spec:
       severity: warning
       annotations:
         message: "The Machine object {{ $labels.machine_name }} hasn't had an associated Node for the past 30 minutes."
-        link: &kcslink "https://access.redhat.com"
     - alert: NoNodeObjectForMachineCriticalSRE
       expr: *promql
       for: 30m
       severity: critical
       annotations:
         message: "The Machine object {{ $labels.machine_name }} hasn't had an associated Node for the past 60 minutes."
-        link: *kcslink

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -398,7 +398,6 @@ objects:
             annotations:
               message: The Machine object {{ $labels.machine_name }} hasn't had an
                 associated Node for the past 30 minutes.
-              link: https://access.redhat.com
           - alert: NoNodeObjectForMachineCriticalSRE
             expr: machine_api_status == 0
             for: 30m
@@ -406,7 +405,6 @@ objects:
             annotations:
               message: The Machine object {{ $labels.machine_name }} hasn't had an
                 associated Node for the past 60 minutes.
-              link: https://access.redhat.com
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1664

The links were straight to access.redhat.com, updates in AM config will resolve to SOPs on github.com based on alert name.