### PR TITLE
Fix osd-sre-cluster-admins group to use empty array

### DIFF
--- a/deploy/sre-authorization/00-osd-sre-cluster-admins.Group.yaml
+++ b/deploy/sre-authorization/00-osd-sre-cluster-admins.Group.yaml
@@ -2,5 +2,5 @@ apiVersion: user.openshift.io/v1
 kind: Group
 metadata:
   name: osd-sre-cluster-admins
-users: null
-# NOTE when created as a SelectorSyncSet, Hive will wipe out the list of users when cache expires because `users: null` and this is desired!
+users: []
+# NOTE when created as a SelectorSyncSet, Hive will wipe out the list of users when cache expires because `users: []` and this is desired!

--- a/deploy/sre-authorization/20-osd-sre-cluster-admins.patch.yaml
+++ b/deploy/sre-authorization/20-osd-sre-cluster-admins.patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: user.openshift.io/v1
-kind: Group
-name: osd-sre-cluster-admins
-metadata:
-  name: osd-sre-cluster-admins
-applyMode: AlwaysApply
-patch: '{"users": null}'
-patchType: merge

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -846,7 +846,7 @@ objects:
       kind: Group
       metadata:
         name: osd-sre-cluster-admins
-      users: null
+      users: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -1036,15 +1036,6 @@ objects:
       metadata:
         name: osd-ldap-ca-configmap
         namespace: openshift-config
-    patches:
-    - apiVersion: user.openshift.io/v1
-      kind: Group
-      name: osd-sre-cluster-admins
-      metadata:
-        name: osd-sre-cluster-admins
-      applyMode: AlwaysApply
-      patch: '{"users": null}'
-      patchType: merge
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
It came up in original review but didn't seem important to switch.  Turns out it is.

https://jira.coreos.com/browse/SREP-1908

The patch used to wipe the user list is removed with this change.