### PR TITLE
Added logic to limit $CLUSTER_NAME to 15 chars

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -322,7 +322,8 @@ do
             PROCESS=0
             for CLUSTER_NAME in $CLUSTER_NAMES
             do
-                if [ "$CD_NAME" == "$CLUSTER_NAME" ];
+              # $CD_NAME is limited to 15 chars, apply limit to $CLUSTER_NAME
+              if [ "$CD_NAME" == "$(echo $CLUSTER_NAME | cut -c -15)" ];
                 then
                     # a match, process it
                     PROCESS=1


### PR DESCRIPTION
Added logic to limit $CLUSTER_NAME to 15 chars in accordance with the $CD_NAME char limit. This was previously in-accurately making comparisons and failing
when $CLUSTER_NAME matched $CD_NAME, however was not
truncated. See below for example

```
+ for CD_NAME in '`oc -n $CD_NAMESPACE get clusterdeployment -o json | jq -r '\''.items[] | select(.metadata.labels["api.openshift.com/managed"] == "true") | select(.status.installed == true) | select(.status.clusterVersionStatus.history[0].state == "Completed") | .metadata.name'\''`'
+ '[' dom-upgrade-test '!=' all ']'
+ PROCESS=0
+ for CLUSTER_NAME in '$CLUSTER_NAMES'
+ '[' dom-upgrade-tes == dom-upgrade-test ']'
+ '[' 0 == 0 ']'
+ continue
```