### PR TITLE
🎨: Refactor vercomp and fix minor :bug:

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -43,15 +43,15 @@ log() {
 }
 
 # Compares two version strings together to determine which is more recent.
-# First parameter is the candidate version
-# Second parameter is the check version.
+# First parameter is the requested version
+# Second parameter is the max allowed version.
 # If the candidate > check, or either version are omitted, return 1. Otherwise return 0
 # Functionally this is used to determine if the requested (candidate) version exceeds the maximum allowed version (check).
 # This relies on Bash (due to input redirection), and sort to do the comparing
 vercomp() {
-    local requested=$1 default=$2 rescheck=
-    rescheck=$(sort --version-sort <(echo $requested) <(echo $default) | tail -n1)
-    if [[ $requested == $rescheck && $requested != $default ]]; then
+    local requested_version=$1 max_allowed_version=$2 sort_result=
+    sort_result=$(sort --version-sort <(echo $requested_version) <(echo $max_allowed_version) | tail -n1)
+    if [[ $requested_version == $sort_result && $requested_version != $max_allowed_version ]]; then
         return 1
     else
         return 0

--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -42,50 +42,20 @@ log() {
     echo "$(date "+%Y-%m-%d_%H.%M.%S") - $CD_NAME - $STAGE - $MESSAGE"
 }
 
+# Compares two version strings together to determine which is more recent.
+# First parameter is the candidate version
+# Second parameter is the check version.
+# If the candidate > check, or either version are omitted, return 1. Otherwise return 0
+# Functionally this is used to determine if the requested (candidate) version exceeds the maximum allowed version (check).
+# This relies on Bash (due to input redirection), and sort to do the comparing
 vercomp() {
-    # Need to be able to compare Semver to decide if requested version > default
-    # Adapted from https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash/4025065#4025065
-    
-    if [[ "$1" == "" ]] || [[ "$2" == "" ]]
-    then
-        # Input missing, fail
+    local requested=$1 default=$2 rescheck=
+    rescheck=$(sort --version-sort <(echo $requested) <(echo $default) | tail -n1)
+    if [[ $requested == $rescheck && $requested != $default ]]; then
         return 1
-    fi
-
-    # If requested version ($1) is greater than the default ($2), return 1
-    if [[ "$1" == "$2" ]]
-    then
-        # Equal, Pass
+    else
         return 0
     fi
-    local IFS=.
-    local i ver1=($1) ver2=($2)
-    # fill empty fields in ver1 with zeros
-    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
-    do
-        ver1[i]=0
-    done
-    # NOTE any non-numeric versions that are not identical will fail in the following loop, it expects numeric components to all versions
-    for ((i=0; i<${#ver1[@]}; i++))
-    do
-        if [[ -z ${ver2[i]} ]]
-        then
-            # fill empty fields in ver2 with zeros
-            ver2[i]=0
-        fi
-        # Greater-than, fail
-        if ((10#${ver1[i]} > 10#${ver2[i]}))
-        then
-            return 1
-        fi
-        if ((10#${ver1[i]} < 10#${ver2[i]}))
-        then
-            # Less-than, Pass
-            return 0
-        fi
-    done
-    # Equal, Pass
-    return 0
 }
 
 setup() {


### PR DESCRIPTION
This commit is largely optional, and the byproduct of a 10 minute rabbit
hole while reviewing the upgrade script in detail as part of SDE-170.

If applied, this will force the bin/bash dependency (already present in
the shebang) due to the `<(...)` input redirection.

Technically, this takes advantage of `sort(1)`'s `-v|--version-sort`
feature since it does all the heavy lifting and handles all kinds of
version strings. The interface has not changed at all, just the inner
workings.

Given two versions, `requested` (`1.2.3`) and `default` (`1.2.2`), we
should expect a return value of 1 and when that happens, we know that
when the two versions are sorted among themselves, `default` will come
first and `requested` will come last:

```
1.2.2 <-- default
1.2.3 <-- requested
```

Thus, if we look at the last line of the sort and find that it is the
same as the requested version, we know it's too far ahead of the default
version and should return a 1 to block the operation. If the two
versions are equal, we have a special case where that is allowed, and
thus return 0.

The :bug: fix is this:

When `requested` = `1.2.3-r2` and `default` = `1.2.3-r1`, we can see
that r2 is more recent than r1 and it should be disallowed based on the
previous logic, however, the previous version will return a 0 to allow
the operation. By utilising `sort(1)`, this behaviour, and other oddball
version strings can be caught.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>