### PR TITLE
Update image pull policy for pruning jobs

### DIFF
--- a/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
@@ -18,6 +18,7 @@ spec:
           containers:
           - name: builds-pruner
             image: quay.io/openshift/origin-cli:4.1
+            imagePullPolicy: Always
             command:
             - oc
             - adm

--- a/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
@@ -18,6 +18,7 @@ spec:
           containers:
           - name: deployments-pruner
             image: quay.io/openshift/origin-cli:4.1
+            imagePullPolicy: Always
             command:
             - oc
             - adm

--- a/deploy/sre-pruning/110-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-images.CronJob.yaml
@@ -18,6 +18,7 @@ spec:
           containers:
           - name: image-pruner
             image: quay.io/openshift/origin-cli:4.1
+            imagePullPolicy: Always
             args:
             - /bin/bash
             - -c

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -514,6 +514,7 @@ objects:
                 containers:
                 - name: builds-pruner
                   image: quay.io/openshift/origin-cli:4.1
+                  imagePullPolicy: Always
                   command:
                   - oc
                   - adm
@@ -542,6 +543,7 @@ objects:
                 containers:
                 - name: deployments-pruner
                   image: quay.io/openshift/origin-cli:4.1
+                  imagePullPolicy: Always
                   command:
                   - oc
                   - adm
@@ -570,6 +572,7 @@ objects:
                 containers:
                 - name: image-pruner
                   image: quay.io/openshift/origin-cli:4.1
+                  imagePullPolicy: Always
                   args:
                   - /bin/bash
                   - -c


### PR DESCRIPTION
One more follow up to #96. As the :4.1 tag is a floating tag, update the `imagePullPolicy` to Always.