### PR TITLE
Use openshift/cli imagestream for pruner

### DIFF
--- a/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: builds-pruner
-            image: quay.io/openshift/origin-cli:4.1
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
             command:
             - oc

--- a/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: deployments-pruner
-            image: quay.io/openshift/origin-cli:4.1
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
             command:
             - oc

--- a/deploy/sre-pruning/110-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-images.CronJob.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: image-pruner
-            image: quay.io/openshift/origin-cli:4.1
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
             args:
             - /bin/bash

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -513,7 +513,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: builds-pruner
-                  image: quay.io/openshift/origin-cli:4.1
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   command:
                   - oc
@@ -542,7 +542,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: deployments-pruner
-                  image: quay.io/openshift/origin-cli:4.1
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   command:
                   - oc
@@ -571,7 +571,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: image-pruner
-                  image: quay.io/openshift/origin-cli:4.1
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash


### PR DESCRIPTION
Had one more look at this, and turns out there is an internal imagestream for the cli:
```
$ oc get imagestream -n openshift cli --output=custom-columns="NAME:.metadata.name,IMAGE REPOSITORY:.status.dockerImageRepository,TAGS:.status.tags[].tag"
NAME   IMAGE REPOSITORY                                                 TAGS
cli    image-registry.openshift-image-registry.svc:5000/openshift/cli   latest
```

Using this is best case, as this ensures the oc version always matches that of the cluster.

/assign @jewzaam @lisa
/hold