### PR TITLE
Fix variable for pruning alert

### DIFF
--- a/deploy/sre-prometheus/100-sre-pruning.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-pruning.PrometheusRule.yaml
@@ -17,5 +17,5 @@ spec:
         severity: critical
         namespace: openshift-sre-pruning
       annotations:
-        message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.job_name }}
+        message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.crobjob }}
           is taking more than thirty minutes to complete.

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1479,7 +1479,7 @@ objects:
               severity: critical
               namespace: openshift-sre-pruning
             annotations:
-              message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.job_name
+              message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.crobjob
                 }} is taking more than thirty minutes to complete.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
Used the wrong variable (difference in job vs cronjob) in the message. Verified this one works.

Example:
```
SRE Pruning Job openshift-sre-pruning/builds-pruner is taking more than thirty minutes to complete.
```