### PR TITLE
Update managed-velero-operator prometheus role

### DIFF
--- a/deploy/managed-velero-operator/112-velero.Role.yaml
+++ b/deploy/managed-velero-operator/112-velero.Role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: prometheus-k8s
+  namespace: openshift-velero
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/managed-velero-operator/117-velero.RoleBinding.yaml
+++ b/deploy/managed-velero-operator/117-velero.RoleBinding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-velero
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -997,6 +997,23 @@ objects:
         - configmaps
         verbs:
         - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        creationTimestamp: null
+        name: prometheus-k8s
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -1039,6 +1056,19 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: cluster-config-v1-reader
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-k8s
     - apiVersion: v1
       kind: ServiceAccount
       metadata:


### PR DESCRIPTION
Adds a R/RB for prometheus monitoring of the managed-velero-operator

This was added to the operator in https://github.com/openshift/managed-velero-operator/pull/18