### PR TITLE
SREP-1932: Quote the quota limits

### DIFF
--- a/deploy/resource-quotas/15-resource.clusterresourcequota.yaml
+++ b/deploy/resource-quotas/15-resource.clusterresourcequota.yaml
@@ -12,7 +12,7 @@ spec:
         operator: DoesNotExist
   quota:
     hard:
-      requests.storage: 100Gi
+      requests.storage: "100Gi"
 ---
 kind: ClusterResourceQuota
 apiVersion: quota.openshift.io/v1
@@ -27,4 +27,4 @@ spec:
         operator: DoesNotExist
   quota:
     hard:
-      services.loadbalancers: 2
+      services.loadbalancers: "2"

--- a/deploy/resource-quotas/templates/15-resource.clusterresourcequota.yaml.tmpl
+++ b/deploy/resource-quotas/templates/15-resource.clusterresourcequota.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
         operator: DoesNotExist
   quota:
     hard:
-      requests.storage: #DEFAULT_PV_QUOTA#
+      requests.storage: "#DEFAULT_PV_QUOTA#"
 ---
 kind: ClusterResourceQuota
 apiVersion: quota.openshift.io/v1
@@ -27,4 +27,4 @@ spec:
         operator: DoesNotExist
   quota:
     hard:
-      services.loadbalancers: #DEFAULT_LB_QUOTA#
+      services.loadbalancers: "#DEFAULT_LB_QUOTA#"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1192,7 +1192,7 @@ objects:
               operator: DoesNotExist
         quota:
           hard:
-            services.loadbalancers: 2
+            services.loadbalancers: '2'
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
With 4.2, it is required to have integers quoted. I have quoted the
storage quota (which is implicitly a string) to be explicit about its
typing.

Signed-off-by: Lisa Seelye <lseelye@redhat.com>