### PR TITLE
Remove log that was trying to indicate an upgrade couldn't start

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -302,8 +302,6 @@ do
                     # a match, process it
                     PROCESS=1
                     break
-                else
-                    log $OCM_NAME "prepare" "ERROR: unable to schedule upgrade for cluster name '$OCM_NAME'"
                 fi
             done
 


### PR DESCRIPTION
Just removing it as I don't want to spend a lot of time on getting this into the script.  We are getting to the point we can automate these upgrades.