### PR TITLE
Remove 'list' on 'secrets' in 'openshift-codeready-workspaces'

### DIFF
--- a/deploy/osd-codeready-workspaces/05-role.yaml
+++ b/deploy/osd-codeready-workspaces/05-role.yaml
@@ -40,10 +40,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
+  # DO NOT grant "list" on "secerts", it will allow users to also get the yaml and then decode data
   - configmaps
   verbs:
-  # DO NOT grant "get" on "secrets"!
   - list
 - apiGroups:
   - org.eclipse.che

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1316,7 +1316,6 @@ objects:
       - apiGroups:
         - ''
         resources:
-        - secrets
         - configmaps
         verbs:
         - list


### PR DESCRIPTION
This will negatively impact console experience. But granting 'list' also allows getting the data for the resource.
It appears there are no secrets with CRW that require the user to have access for it to function.