### PR TITLE
SREP-2178 Add PodMonitor and turn Prometheus/AlertManager into plural in Role def

### DIFF
--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -33,9 +33,10 @@ rules:
 - apiGroups:
   - "monitoring.coreos.com"
   resources:
-  - prometheus
-  - alertmanager
+  - prometheuses
+  - alertmanagers
   - prometheusrules
   - servicemonitors
+  - podmonitors
   verbs:
   - "*"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1765,10 +1765,11 @@ objects:
       - apiGroups:
         - monitoring.coreos.com
         resources:
-        - prometheus
-        - alertmanager
+        - prometheuses
+        - alertmanagers
         - prometheusrules
         - servicemonitors
+        - podmonitors
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
- Adding manage permission to the new Prometheus CR
- Switching to `prometheuses` and `alertmanagers` in Role definition (instead of singular CRD names)