### PR TITLE
SREP-2351 Pre-patch channel in ClusterVersion before starting upgrade to v4.2

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -139,7 +139,10 @@ upgrade() {
         log $OCM_NAME "upgrade" "upgrading from $FROM to $TO"
 
         oc -n $CD_NAMESPACE extract "$(oc -n $CD_NAMESPACE get secrets -o name | grep $CD_NAME | grep kubeconfig)" --keys=kubeconfig --to=- > ${TMP_DIR}/kubeconfig-${CD_NAMESPACE}
+        CHANNEL_NAME=$(get_channel $TO)
 
+        KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc patch clusterversion version --type merge -p "{\"spec\":{\"channel\": \"$CHANNEL_NAME\"}}"
+        sleep 15
         KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc patch clusterversion version --type merge -p "{\"spec\":{\"desiredUpdate\": {\"version\": \"$TO\"}}}"
     fi
 


### PR DESCRIPTION
This is the script tested in stage to upgrade to v4.2. Clusters sre-up{1,2,3,4}-4-2-2.

It was added a pre-patch updating the ClusterVersion `spec.channel` before actually triggering the cluster upgrade. It's necessary because upgrades to 4.2 need to happen using the fast-4.2 channel. 

