### PR TITLE
to support the removal of dedicated-admin and use of rbac-operator

### DIFF
--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1886,24 +1886,6 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
-          prometheus: sre-dedicated-admin-operator-offline-alerts
-          role: alert-rules
-        name: sre-dedicated-admin-operator-offline-alerts
-        namespace: openshift-monitoring
-      spec:
-        groups:
-        - name: sre-dedicated-admin-operator-offline-alerts
-          rules:
-          - alert: DedicatedAdminOperatorOfflineSRE
-            expr: absent(up{service="dedicated-admin-operator"})
-            for: 15m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-    - apiVersion: monitoring.coreos.com/v1
-      kind: PrometheusRule
-      metadata:
-        labels:
           prometheus: sre-dns-alerts
           role: alert-rules
         name: sre-dns-alerts


### PR DESCRIPTION
Alertmanager throws an alert on the no longer present DedicatedAdminOperatorOfflineSRE. This removes the alert. We should also look at plugging in relative alerts for the rbac-operator. 