### PR TITLE
allow dedicated-admin to create project-request template in openshift-config

### DIFF
--- a/deploy/osd-project-request-template/02-role.dedicated-admins-project-request.yaml
+++ b/deploy/osd-project-request-template/02-role.dedicated-admins-project-request.yaml
@@ -11,6 +11,7 @@ rules:
   resourceNames:
   - project-request
   verbs:
+  - create
   - get
   - patch
   - update

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3163,6 +3163,7 @@ objects:
         resourceNames:
         - project-request
         verbs:
+        - create
         - get
         - patch
         - update


### PR DESCRIPTION
according to the attached docs, we need to create a project-request template in openshift-config.
since the template does not exist, `create` needs to be added.

https://docs.openshift.com/container-platform/4.2/applications/projects/configuring-project-creation.html