### PR TITLE
adding label to openshift-customer-monitoring

### DIFF
--- a/deploy/osd-customer-monitoring/00-namespace.yaml
+++ b/deploy/osd-customer-monitoring/00-namespace.yaml
@@ -5,5 +5,6 @@ metadata:
   annotations:
     openshift.io/node-selector: ""
   labels:
+    name: "openshift-customer-monitoring"
     openshift.io/cluster-logging: "true"
     openshift.io/cluster-monitoring: "false"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2237,6 +2237,7 @@ objects:
         annotations:
           openshift.io/node-selector: ''
         labels:
+          name: openshift-customer-monitoring
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'false'
     - apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
To allow for network polices to be used from and to openshift-customer-monitoring, we have to have a label identifying that namespace.
I propose to be straight forward and use `name`