### PR TITLE
Update managed-velero-operator to v0.1.64-c5ab0f3

### DIFF
--- a/deploy/managed-velero-operator/130-velero.CredentialRequest.yaml
+++ b/deploy/managed-velero-operator/130-velero.CredentialRequest.yaml
@@ -14,12 +14,13 @@ spec:
     - effect: Allow
       action:
       - s3:CreateBucket
+      - s3:DeleteObjectTagging
+      - s3:GetBucketTagging
+      - s3:ListAllMyBuckets
       - s3:ListBucket
       - s3:PutBucketAcl
       - s3:PutBucketPublicAccessBlock
+      - s3:PutBucketTagging
       - s3:PutEncryptionConfiguration
       - s3:PutLifecycleConfiguration
-      - s3:PutBucketTagging
-      - s3:DeleteObjectTagging
-      - s3:GetBucketTagging
       resource: "*"

--- a/deploy/managed-velero-operator/135-velero.Deployment.yaml
+++ b/deploy/managed-velero-operator/135-velero.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           operator: Exists
       containers:
         - name: managed-velero-operator
-          image: quay.io/openshift-sre/managed-velero-operator:v0.1.62-e4ab9b9
+          image: quay.io/openshift-sre/managed-velero-operator:v0.1.64-c5ab0f3
           command:
           - managed-velero-operator
           env:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1362,14 +1362,15 @@ objects:
           - effect: Allow
             action:
             - s3:CreateBucket
+            - s3:DeleteObjectTagging
+            - s3:GetBucketTagging
+            - s3:ListAllMyBuckets
             - s3:ListBucket
             - s3:PutBucketAcl
             - s3:PutBucketPublicAccessBlock
+            - s3:PutBucketTagging
             - s3:PutEncryptionConfiguration
             - s3:PutLifecycleConfiguration
-            - s3:PutBucketTagging
-            - s3:DeleteObjectTagging
-            - s3:GetBucketTagging
             resource: '*'
     - apiVersion: apps/v1
       kind: Deployment
@@ -1401,7 +1402,7 @@ objects:
               operator: Exists
             containers:
             - name: managed-velero-operator
-              image: quay.io/openshift-sre/managed-velero-operator:v0.1.62-e4ab9b9
+              image: quay.io/openshift-sre/managed-velero-operator:v0.1.64-c5ab0f3
               command:
               - managed-velero-operator
               env:


### PR DESCRIPTION
This allows the managed-velero-operator to recover an existing S3 bucket.
https://github.com/openshift/managed-velero-operator/pull/28
