### PR TITLE
allow all verbs on project-request template for dedicated-admins

### DIFF
--- a/deploy/osd-project-request-template/02-role.dedicated-admins-project-request.yaml
+++ b/deploy/osd-project-request-template/02-role.dedicated-admins-project-request.yaml
@@ -11,8 +11,4 @@ rules:
   resourceNames:
   - project-request
   verbs:
-  - create
-  - get
-  - patch
-  - update
-  - watch
+  - "*"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3153,7 +3153,7 @@ objects:
         resourceNames:
         - project-request
         verbs:
-        - "*"
+        - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3153,11 +3153,7 @@ objects:
         resourceNames:
         - project-request
         verbs:
-        - create
-        - get
-        - patch
-        - update
-        - watch
+        - "*"
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:


### PR DESCRIPTION
This PR is another attempt to solve https://redhat.service-now.com/surl.do?n=INC1136517.

I think it would make sense for dedicated-admins to be able to also delete their project-request template, so this is probably not a bad change in any case.