### PR TITLE
remove resourceNames from dedicated-admins-project-request

### DIFF
--- a/deploy/osd-project-request-template/02-role.dedicated-admins-project-request.yaml
+++ b/deploy/osd-project-request-template/02-role.dedicated-admins-project-request.yaml
@@ -8,7 +8,5 @@ rules:
   - template.openshift.io
   resources:
   - templates
-  resourceNames:
-  - project-request
   verbs:
   - "*"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3150,8 +3150,6 @@ objects:
         - template.openshift.io
         resources:
         - templates
-        resourceNames:
-        - project-request
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
removing the resourceNames section as it seems there is a related bug.

i left the RoleBinding name as is, as this will probably be restored in the future

cc @rogbas 