### PR TITLE
Bump m-v-o to 6bca798

### DIFF
--- a/deploy/managed-velero-operator/135-velero.Deployment.yaml
+++ b/deploy/managed-velero-operator/135-velero.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           operator: Exists
       containers:
         - name: managed-velero-operator
-          image: quay.io/openshift-sre/managed-velero-operator:v0.1.64-c5ab0f3
+          image: quay.io/openshift-sre/managed-velero-operator:v0.1.72-6bca798
           command:
           - managed-velero-operator
           env:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1390,7 +1390,7 @@ objects:
               operator: Exists
             containers:
             - name: managed-velero-operator
-              image: quay.io/openshift-sre/managed-velero-operator:v0.1.64-c5ab0f3
+              image: quay.io/openshift-sre/managed-velero-operator:v0.1.72-6bca798
               command:
               - managed-velero-operator
               env:


### PR DESCRIPTION
Brings in the following changes to stage: https://github.com/openshift/managed-velero-operator/compare/c5ab0f3...6bca798

In particular:
- https://github.com/openshift/managed-velero-operator/commit/f04974b60f93eeb3442c353f3d3b231b4eb8b497
- fixes https://issues.redhat.com/browse/OSD-2718

/assign @dak1n1 
FYI @jeefy 