### PR TITLE
[openshift-customer-monitoring] enable openshift-acme

### DIFF
--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -520,3 +520,37 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - acme-account
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  attributeRestrictions: null
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2782,6 +2782,40 @@ objects:
         - patch
         - update
         - watch
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - acme-account
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        attributeRestrictions: null
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:


### PR DESCRIPTION
This PR adds more permissions for dedicated-admins.
Specifically, it allows them to manage Role, RoleBinding, ServiceAccount and a Secret called `acme-account`.

This should enable us to install openshift-acme on the openshift-customer-monitoring namespace and having our own domain used for the Routes there.

related to https://redhat.service-now.com/surl.do?n=INC1142220