### PR TITLE
move cluster ingress to infra nodes

### DIFF
--- a/deploy/osd-ingress/router-infraNodes.patch.yaml
+++ b/deploy/osd-ingress/router-infraNodes.patch.yaml
@@ -1,0 +1,9 @@
+
+apiVersion: operator.openshift.io/v1
+applyMode: AlwaysApply
+kind: IngressController
+name: default
+namespace: openshift-ingress-operator
+# patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
+patch: '{"spec":{"nodePlacement":{"nodeSelector":{"matchLabels":{"node-role.kubernetes.io/infra":""}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}}'
+patchType: merge 

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2816,6 +2816,27 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-ingress
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+      patch: '{"spec":{"nodePlacement":{"nodeSelector":{"matchLabels":{"node-role.kubernetes.io/infra":""}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-logging
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
implements: OSD-2392

Patch reference: https://github.com/openshift/api/blob/master/operator/v1/0000_50_ingress-operator_00-custom-resource-definition.yaml
and
https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-router_creating-infrastructure-machinesets

Reproduce: 


Patch: 
```JSON
{
	"spec": {
		"nodePlacement": {
			"nodeSelector": {
				"matchLabels": {
					"node-role.kubernetes.io/infra": ""
				}
			},
			"tolerations": [{
				"effect": "NoSchedule",
				"key": "node-role.kubernetes.io/infra",
				"operator": "Exists"
			}]
		}
	}
}
```

```shell
oc edit ingresscontroller default -n openshift-ingress-operator -o yaml
```

