### PR TITLE
move monitoring solutions to infra

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -6,6 +6,12 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
       retention: 15d
       volumeClaimTemplate:
         metadata:
@@ -15,6 +21,12 @@ data:
             requests:
               storage: 50Gi
     alertmanagerMain:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
       volumeClaimTemplate:
         metadata:
           name: alertmanager-data
@@ -23,4 +35,38 @@ data:
             requests:
               storage: 10Gi
     telemeterClient:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
       telemeterServerURL: ${TELEMETER_SERVER_URL}
+    prometheusOperator:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    grafana:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    k8sPrometheusAdapter:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    kubeStateMetrics:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations: 
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -984,12 +984,26 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  retention: 15d\n  volumeClaimTemplate:\n \
-          \   metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 50Gi\nalertmanagerMain:\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\n"
+        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+          \          storage: 50Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
+          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
+          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
+          prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists"
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
implements: OSD-2392

configmap reference: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-monitoring_creating-infrastructure-machinesets

`test it` in a managed `v4`:

```shell
oc delete -f cluster-monitoring-configmap.yaml && oc create -f cluster-monitoring-configmap.yaml
watch 'oc get pod -n openshift-monitoring -o wide'
```
