### PR TITLE
OSD-2807 Add permission for dedicated-admins to create events in their NSs

### DIFF
--- a/deploy/rbac-permissions-operator-config/00-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/00-dedicated-admins-project.ClusterRole.yaml
@@ -144,3 +144,9 @@ rules:
   - prowjobs
   verbs:
   - "*"
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3744,6 +3744,12 @@ objects:
         - prowjobs
         verbs:
         - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - events
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:


### PR DESCRIPTION
   * Req to support Prow migration to v4

Prow serviceAccount needs to create events in it's own NS.