### PR TITLE
allow dedicated-admins to manage alertmanagers without resourceNames

### DIFF
--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -48,8 +48,6 @@ rules:
   - "monitoring.coreos.com"
   resources:
   - alertmanagers
-  resourceNames:
-  - instance
   verbs:
   - "*"
 - apiGroups:

--- a/deploy/rbac-permissions-operator-config/00-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/00-dedicated-admins-project.ClusterRole.yaml
@@ -105,8 +105,6 @@ rules:
   - "monitoring.coreos.com"
   resources:
   - alertmanagers
-  resourceNames:
-  - instance
   verbs:
   - "*"
 - apiGroups:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2324,8 +2324,6 @@ objects:
         - monitoring.coreos.com
         resources:
         - alertmanagers
-        resourceNames:
-        - instance
         verbs:
         - '*'
       - apiGroups:
@@ -3699,8 +3697,6 @@ objects:
         - monitoring.coreos.com
         resources:
         - alertmanagers
-        resourceNames:
-        - instance
         verbs:
         - '*'
       - apiGroups:


### PR DESCRIPTION
Following the change introduced in #198.
Covers https://redhat.service-now.com/surl.do?n=INC1165575.

This PR allows dedicated-admins to manage alertmanagers in the openshift-customer-monitoring namespace without a resourceNames restriction.

The reason for this removal is that we are currently unable to actually create an Alertmanager called `instance`. This is the error message we are getting:
```
Error from server (Forbidden): error when creating "STDIN": alertmanagers.monitoring.coreos.com is forbidden: User "system:serviceaccount:dedicated-admin:app-sre-bot" cannot create resource "alertmanagers" in API group "monitoring.coreos.com" in the namespace "openshift-customer-monitoring"
```

This is very similar to #195, and I believe it is caused by the same bug.

cc @rogbas 