### PR TITLE
OSD-2809 - Enable missing Secrets permissions in openshift-strimzi NS

### DIFF
--- a/deploy/osd-strimzi-operator/05-role.yaml
+++ b/deploy/osd-strimzi-operator/05-role.yaml
@@ -37,6 +37,10 @@ rules:
   verbs:
   - create
   - update
+  - get
+  - list
+  - watch
+  - delete
 - apiGroups:
   - ""
   resources:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3306,6 +3306,10 @@ objects:
         verbs:
         - create
         - update
+        - get
+        - list
+        - watch
+        - delete
       - apiGroups:
         - ''
         resources:


### PR DESCRIPTION
Per discussion with PM/BU, enabling Secrets permissions for dedicated-admins in openshift-strimzi NS