### PR TITLE
Remove all node placement constraints on router

### DIFF
--- a/deploy/osd-ingress/router-infraNodes.patch.yaml
+++ b/deploy/osd-ingress/router-infraNodes.patch.yaml
@@ -1,9 +1,8 @@
-
 apiVersion: operator.openshift.io/v1
-applyMode: AlwaysApply
+applyMode: ApplyOnce
 kind: IngressController
 name: default
 namespace: openshift-ingress-operator
 # patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
-patch: '{"spec":{"nodePlacement":{"nodeSelector":{"matchLabels":{"node-role.kubernetes.io/infra":""}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}}'
-patchType: merge 
+patch: '[{"op":"remove","path":"/spec/nodePlacement"}]'
+patchType: json

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2879,12 +2879,12 @@ objects:
     resourceApplyMode: sync
     patches:
     - apiVersion: operator.openshift.io/v1
-      applyMode: AlwaysApply
+      applyMode: ApplyOnce
       kind: IngressController
       name: default
       namespace: openshift-ingress-operator
-      patch: '{"spec":{"nodePlacement":{"nodeSelector":{"matchLabels":{"node-role.kubernetes.io/infra":""}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}}'
-      patchType: merge
+      patch: '[{"op":"remove","path":"/spec/nodePlacement"}]'
+      patchType: json
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
This removes the nodePlacement constraints on the router, so that they aren't being forced to infra nodes. This is only an `ApplyOnce` so that after it runs and removes all the existing nodeSelectors and tolerations, it doesn't try to compete with Hive to modify the existing nodePlacement settings.

I've tested this manually on a stage cluster, and works successfully.

/assign @jewzaam 