### PR TITLE
Remove patch for osd-ingress

### DIFF
--- a/deploy/osd-ingress/router-infraNodes.patch.yaml
+++ b/deploy/osd-ingress/router-infraNodes.patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: operator.openshift.io/v1
-applyMode: ApplyOnce
-kind: IngressController
-name: default
-namespace: openshift-ingress-operator
-# patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
-patch: '[{"op":"remove","path":"/spec/nodePlacement"}]'
-patchType: json

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2871,27 +2871,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-ingress
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-    resourceApplyMode: sync
-    patches:
-    - apiVersion: operator.openshift.io/v1
-      applyMode: ApplyOnce
-      kind: IngressController
-      name: default
-      namespace: openshift-ingress-operator
-      patch: '[{"op":"remove","path":"/spec/nodePlacement"}]'
-      patchType: json
-- apiVersion: hive.openshift.io/v1alpha1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-logging
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This patch seems to be running more than once (not what was intended). Removing this patch completely is now safe, and will hopefully fix this issue. We can re-add the osd-ingress patch when the hive bug is fixed.