### PR TITLE
Fix provider for OperatorHub

### DIFF
--- a/deploy/osd-curated-operatorsources/10-curated-certified-operators.OperatorSource.yaml
+++ b/deploy/osd-curated-operatorsources/10-curated-certified-operators.OperatorSource.yaml
@@ -3,6 +3,8 @@ kind: OperatorSource
 metadata:
   name: osd-curated-certified-operators
   namespace: openshift-marketplace
+  labels:
+    opsrc-provider: certified
 spec:
   authorizationToken: {}
   displayName: Certified Operators

--- a/deploy/osd-curated-operatorsources/10-curated-community-operators.OperatorSource.yaml
+++ b/deploy/osd-curated-operatorsources/10-curated-community-operators.OperatorSource.yaml
@@ -3,6 +3,8 @@ kind: OperatorSource
 metadata:
   name: osd-curated-community-operators
   namespace: openshift-marketplace
+  labels:
+    opsrc-provider: community
 spec:
   authorizationToken: {}
   displayName: Community Operators

--- a/deploy/osd-curated-operatorsources/10-curated-redhat-operators.OperatorSource.yaml
+++ b/deploy/osd-curated-operatorsources/10-curated-redhat-operators.OperatorSource.yaml
@@ -3,6 +3,8 @@ kind: OperatorSource
 metadata:
   name: osd-curated-redhat-operators
   namespace: openshift-marketplace
+  labels:
+    opsrc-provider: redhat
 spec:
   authorizationToken: {}
   displayName: Red Hat Operators

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2190,6 +2190,8 @@ objects:
       metadata:
         name: osd-curated-certified-operators
         namespace: openshift-marketplace
+        labels:
+          opsrc-provider: certified
       spec:
         authorizationToken: {}
         displayName: Certified Operators
@@ -2202,6 +2204,8 @@ objects:
       metadata:
         name: osd-curated-community-operators
         namespace: openshift-marketplace
+        labels:
+          opsrc-provider: community
       spec:
         authorizationToken: {}
         displayName: Community Operators
@@ -2214,6 +2218,8 @@ objects:
       metadata:
         name: osd-curated-redhat-operators
         namespace: openshift-marketplace
+        labels:
+          opsrc-provider: redhat
       spec:
         authorizationToken: {}
         displayName: Red Hat Operators


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-2404

Note this only fixes things if the catalog source is re-deployed.
Labeling the catalog source does not update the console UI.