### PR TITLE
Added secret names to managed by openshift-acme

### DIFF
--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -531,6 +531,8 @@ rules:
   - secrets
   resourceNames:
   - acme-account
+  - prometheus-instance
+  - alertmanager-instance
   verbs:
   - "*"
 - apiGroups:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2815,6 +2815,8 @@ objects:
         - secrets
         resourceNames:
         - acme-account
+        - prometheus-instance
+        - alertmanager-instance
         verbs:
         - '*'
       - apiGroups:


### PR DESCRIPTION
openshift-acme uses secrets to keep tls info related to routes. We need to define which secrets it's going to manage in this namespace as dedicated admin only has rights to manage certain named resources here

This is a follow-up of #197 

cc @maorfr

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>