### PR TITLE
Change image pruner to ignore invalid refs

### DIFF
--- a/deploy/sre-pruning/110-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-images.CronJob.yaml
@@ -22,4 +22,4 @@ spec:
             args:
             - /bin/bash
             - -c
-            - "oc adm prune images --token=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) --server=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT) --keep-younger-than=24h --keep-tag-revisions=5 --insecure-skip-tls-verify=true --confirm"
+            - "oc adm prune images --token=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) --server=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT) --keep-younger-than=24h --keep-tag-revisions=5 --ignore-invalid-refs=true --insecure-skip-tls-verify=true --confirm"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4778,8 +4778,8 @@ objects:
                   - -c
                   - oc adm prune images --token=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
                     --server=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
-                    --keep-younger-than=24h --keep-tag-revisions=5 --insecure-skip-tls-verify=true
-                    --confirm
+                    --keep-younger-than=24h --keep-tag-revisions=5 --ignore-invalid-refs=true
+                    --insecure-skip-tls-verify=true --confirm
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-2344

Will possibly prune images a customer intended to use.  Keeps anything newer than 24h and 5 revisions still.