### PR TITLE
Add support for podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ FROM python:2.7.15 AS runner
 COPY --from=builder /oc /bin/
 
 # Environment
-ARG IN_DOCKER_CONTAINER="true"
+ARG IN_CONTAINER="true"
 ENV REPO_PATH=/managed-cluster-config
 
-# Copy repo into docker image:
+# Copy repo into container image:
 COPY . ${REPO_PATH}
 WORKDIR ${REPO_PATH}
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ generate-oauth-templates:
 
 .PHONY: generate-syncset
 generate-syncset: generate-oauth-templates
-	if [ -z ${IN_DOCKER_CONTAINER} ]; then \
-		docker run --rm -v `pwd -P`:`pwd -P` python:2.7.15 /bin/sh -c "cd `pwd`; pip install oyaml; ${GEN_SYNCSET}"; \
+	if [ -z ${IN_CONTAINER} ]; then \
+		`which podman 2>/dev/null || which docker 2>/dev/null` run --rm -v `pwd -P`:`pwd -P` python:2.7.15 /bin/sh -c "cd `pwd`; pip install oyaml; ${GEN_SYNCSET}"; \
 	else \
 		${GEN_SYNCSET}; \
 	fi


### PR DESCRIPTION
On fedora 31 I have not gotten docker builds to work but podman does.  This will change to using podman if it's available on the system, falling back to docker if not.