### PR TITLE
Update pruning configuration

### DIFF
--- a/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: builds-pruner
-            image: quay.io/openshift/origin-cli:4.2
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
             command:
             - oc

--- a/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: deployments-pruner
-            image: quay.io/openshift/origin-cli:4.2
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
             command:
             - oc

--- a/deploy/sre-pruning/110-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-images.CronJob.yaml
@@ -22,4 +22,11 @@ spec:
             args:
             - /bin/bash
             - -c
-            - "oc adm prune images --token=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) --server=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT) --keep-younger-than=24h --keep-tag-revisions=5 --ignore-invalid-refs=true --insecure-skip-tls-verify=true --confirm"
+            - >-
+              oc adm prune images
+              --token=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+              --keep-younger-than=24h
+              --keep-tag-revisions=5
+              --ignore-invalid-refs=true
+              --confirm

--- a/deploy/sre-pruning/110-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-images.CronJob.yaml
@@ -17,7 +17,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: image-pruner
-            image: quay.io/openshift/origin-cli:4.2
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
             args:
             - /bin/bash

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4713,7 +4713,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: builds-pruner
-                  image: quay.io/openshift/origin-cli:4.2
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   command:
                   - oc
@@ -4742,7 +4742,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: deployments-pruner
-                  image: quay.io/openshift/origin-cli:4.2
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   command:
                   - oc
@@ -4771,15 +4771,15 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: image-pruner
-                  image: quay.io/openshift/origin-cli:4.2
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash
                   - -c
                   - oc adm prune images --token=$$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-                    --server=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
+                    --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
                     --keep-younger-than=24h --keep-tag-revisions=5 --ignore-invalid-refs=true
-                    --insecure-skip-tls-verify=true --confirm
+                    --confirm
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
- Updates the pruning update to use the imagestream again, so this is an 4.3 version of `oc`. BZ 1755155 (https://bugzilla.redhat.com/show_bug.cgi?id=1755115) was fixed as of 4.3, so the `cli:latest` imagestream on cluster should work, and should always track the cluster version now.
- Use the `service-ca.crt` certificate for the image registry, so that we don't need to allow insecure connections