### PR TITLE
Replace cincinatti call with check of clusterversion

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -251,9 +251,9 @@ upgrade() {
 
     # is the desired version supported?
     ALLOWED_UPDATE=$(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc get clusterversion version -o json | jq ".status.availableUpdates[] | select(.force == false and .version == \"$TO\")")
-    VERSION_CANDIDATES=$(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc get clusterversion version -o json | jq ".status.availableUpdates | map(.version) | join(\", \")")
     if [ "$ALLOWED_UPDATE" == "" ];
     then
+        VERSION_CANDIDATES=$(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc get clusterversion version -o json | jq ".status.availableUpdates | map(.version) | join(\", \")")
         log $OCM_NAME $LOG_NAME "Cannot upgrade from $FROM, it is not available in upgrade graph."
         log $OCM_NAME $LOG_NAME "Candidate versions are: $VERSION_CANDIDATES"
         teardown $OCM_NAME $CD_NAMESPACE $CD_NAME


### PR DESCRIPTION
[OSD-2448](https://issues.redhat.com/browse/OSD-2448) proposes updating the cluster-upgrade script to replace the current check of the upgrade graph in Cincinatti with a check of the availableUpgrades managed by the cluster-version-operator. This PR implements that change by checking if the designated "to" version is present in the list of availableUpgrades. If the version is not present, a list of available candidate versions is printed.
