### PR TITLE
Added new permissions to CS SRE group that are needed for SOPS

### DIFF
--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-cluster.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-cluster.ClusterRole.yaml
@@ -10,6 +10,14 @@ rules:
   - projects
   verbs:
   - '*'
+# CS SRE can get infrastructure details (cluster)
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  - oauths
+  verbs:
+  - 'get'
 - apiGroups:
   - project.openshift.io
   resources:
@@ -32,6 +40,7 @@ rules:
   verbs:
   - patch
   - update
+  - get
 # CS SRE can interact with RHMI ClusterResourceQuotas (Only for LA)
 - apiGroups:
   - quota.openshift.io

--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
@@ -47,3 +47,20 @@ rules:
   - '*'
   verbs:
   - '*'
+# CS SRE can interact with secrets, configmaps and PVC's
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  - persistentvolumeclaims
+  verbs:
+  - "*"
+# CS SRE can interact with installplans
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - installplans
+  verbs:
+  - "patch"
+  

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -594,6 +594,13 @@ objects:
         verbs:
         - '*'
       - apiGroups:
+        - config.openshift.io
+        resources:
+        - infrastructures
+        - oauths
+        verbs:
+        - get
+      - apiGroups:
         - project.openshift.io
         resources:
         - projects
@@ -613,6 +620,7 @@ objects:
         verbs:
         - patch
         - update
+        - get
       - apiGroups:
         - quota.openshift.io
         resources:
@@ -667,6 +675,20 @@ objects:
         - '*'
         verbs:
         - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        - configmaps
+        - persistentvolumeclaims
+        verbs:
+        - '*'
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - patch
     - apiVersion: user.openshift.io/v1
       kind: Group
       metadata:


### PR DESCRIPTION
This PR adds the following RBAC to CS SRE

ClusterScope:
GET - infrastructures and oauths (config.openshift.io) - Needed for installation SOP
GET - groups (user.openshift.io) - Resolves issues using breakglass

ProjectScope:
Allow CS SRE to fully interact with secrets, configmaps and PVC's
Allow CS SRE to patch operator installplans (needed for RHMI) 