### PR TITLE
Update OWNERS with leads list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,9 @@
 approvers:
-- NautiluX
-- RiRa12621
-- drewandersonnz
-- c-e-brumm
-- jharrington22
-- rogbas
+- sre-platform-leads
+- cblecker
 - jewzaam
 - mwoodson
-- cblecker
+- NautiluX
 reviewers:
 - cblecker
 - jewzaam

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
+
+aliases:
+  sre-platform-leads:
+    - c-e-brumm
+    - cblecker
+    - jaybeeunix
+    - jewzaam
+    - jharrington22
+    - lisa
+    - mwoodson
+    - RiRa12621
+    - rogbas


### PR DESCRIPTION
Now that the slack bits support OWNERS_ALIASES files, trying to implement https://github.com/openshift/managed-velero-operator/pull/34 in here