### PR TITLE
Removing CS SRE ability to delete namespaces and RHMI installation CR

### DIFF
--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-cluster.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-cluster.ClusterRole.yaml
@@ -9,7 +9,12 @@ rules:
   resources:
   - projects
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 # CS SRE can get infrastructure details (cluster)
 - apiGroups:
   - config.openshift.io
@@ -31,7 +36,12 @@ rules:
   - namespaces
   - namespaces/finalize
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 # CS SRE can update existing groups (enables break glass)
 - apiGroups:
   - user.openshift.io

--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
@@ -46,7 +46,12 @@ rules:
   resources:
   - '*'
   verbs:
-  - '*'
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 # CS SRE can interact with secrets, configmaps and PVC's
 - apiGroups:
   - ""

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -592,7 +592,12 @@ objects:
         resources:
         - projects
         verbs:
-        - '*'
+        - create
+        - get
+        - list
+        - patch
+        - update
+        - watch
       - apiGroups:
         - config.openshift.io
         resources:
@@ -612,7 +617,12 @@ objects:
         - namespaces
         - namespaces/finalize
         verbs:
-        - '*'
+        - create
+        - get
+        - list
+        - patch
+        - update
+        - watch
       - apiGroups:
         - user.openshift.io
         resources:
@@ -674,7 +684,12 @@ objects:
         resources:
         - '*'
         verbs:
-        - '*'
+        - create
+        - get
+        - list
+        - patch
+        - update
+        - watch
       - apiGroups:
         - ''
         resources:


### PR DESCRIPTION
Removing CS SRE ability to delete namespaces and RHMI installation CR

Motivation - Deletion of any of these resources should be a break-glass option. 