### PR TITLE
Allow dedicated-admins to 'list' resource 'namespaces'

### DIFF
--- a/deploy/rbac-permissions-operator-config/00-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/00-dedicated-admins-cluster.ClusterRole.yaml
@@ -119,6 +119,7 @@ rules:
   - namespaces
   verbs:
   - get
+  - list
   - update
   - patch
 ### END - customer can use monitoring web applications

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3163,6 +3163,7 @@ objects:
         - namespaces
         verbs:
         - get
+        - list
         - update
         - patch
       - apiGroups:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-2956

Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1811757

Grants the RBAC expected by current dashbaords.  Generally OK to grant anyway, so once the BZ is resolved this RBAC can stay.

This enables use of the additional dashboards in the web console.
