### PR TITLE
Removing resourceNames from CS SRE clusterresourcequotas  RBAC

### DIFF
--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-cluster.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-cluster.ClusterRole.yaml
@@ -59,6 +59,3 @@ rules:
   - clusterresourcequotas
   verbs:
   - '*'
-  resourceNames:
-  - rhmi-loadbalancer-quota
-  - rhmi-persistent-volume-quota

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -638,9 +638,6 @@ objects:
         - clusterresourcequotas
         verbs:
         - '*'
-        resourceNames:
-        - rhmi-loadbalancer-quota
-        - rhmi-persistent-volume-quota
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
TIL: Create requests cannot be restricted by resourceName, as the object name is not known at authorization time.

CS SRE creates two clusterresourcequotas at provisioning time. 