### PR TITLE
Allow dedicated-admins to manage additional ca.crt in cluster

### DIFF
--- a/deploy/customer-registry-cas/10-dedicated-admins-registry-cas.ClusterRole.yaml
+++ b/deploy/customer-registry-cas/10-dedicated-admins-registry-cas.ClusterRole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dedicated-admins-registry-cas-cluster
+rules:
+# For: https://issues.redhat.com/browse/OSD-3144
+# https://docs.openshift.com/container-platform/4.3/builds/setting-up-trusted-ca.html#configmap-adding-ca_setting-up-trusted-ca
+# allow view and edit, not create or delete, on 'cluster' images.config.openshift.io
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - images
+  resourceNames:
+  - cluster
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update

--- a/deploy/customer-registry-cas/15-dedicated-admins-registry-cas.Role.yaml
+++ b/deploy/customer-registry-cas/15-dedicated-admins-registry-cas.Role.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-registry-cas-project
+  namespace: openshift-config
+rules:
+# For: https://issues.redhat.com/browse/OSD-3144
+# https://docs.openshift.com/container-platform/4.3/builds/setting-up-trusted-ca.html#configmap-adding-ca_setting-up-trusted-ca
+
+# create doesn't work with resourceNames, so grant create for any resources
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+
+  # limit CM to just specific resourceNames
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - "*"
+  resourceNames:
+  # OSD docs will be updated to reflect this name
+  - registry-cas

--- a/deploy/customer-registry-cas/20-dedicated-admins-registry-cas.ClusterRoleBinding.yaml
+++ b/deploy/customer-registry-cas/20-dedicated-admins-registry-cas.ClusterRoleBinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dedicated-admins-registry-cas-cluster
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dedicated-admins-registry-cas-cluster

--- a/deploy/customer-registry-cas/25-dedicated-admins-registry-cas.RoleBinding.yaml
+++ b/deploy/customer-registry-cas/25-dedicated-admins-registry-cas.RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-registry-cas-project
+  namespace: openshift-config
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-registry-cas-project

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -517,6 +517,86 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: customer-registry-cas
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: dedicated-admins-registry-cas-cluster
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - images
+        resourceNames:
+        - cluster
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-registry-cas-project
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - '*'
+        resourceNames:
+        - registry-cas
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: dedicated-admins-registry-cas-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: dedicated-admins-registry-cas-cluster
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-registry-cas-project
+        namespace: openshift-config
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-registry-cas-project
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3144

https://docs.openshift.com/container-platform/4.3/builds/setting-up-trusted-ca.html#configmap-adding-ca_setting-up-trusted-ca