### PR TITLE
Updated rbac for some roles that didn't include dedicated-admin SA

### DIFF
--- a/deploy/rbac-permissions-operator-config/01-dedicated-admins-operators.RoleBinding.yaml
+++ b/deploy/rbac-permissions-operator-config/01-dedicated-admins-operators.RoleBinding.yaml
@@ -4,8 +4,11 @@ metadata:
   name: dedicated-admins-openshift-operators
   namespace: openshift-operators
 subjects:
-- kind: Group
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
   name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/rbac-permissions-operator-config/02-dedicated-admins-marketplace.RoleBinding.yaml
+++ b/deploy/rbac-permissions-operator-config/02-dedicated-admins-marketplace.RoleBinding.yaml
@@ -1,12 +1,14 @@
-
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: dedicated-admins-openshift-marketplace
   namespace: openshift-marketplace
 subjects:
-- kind: Group
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
   name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-dns.RoleBinding.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-dns.RoleBinding.yaml
@@ -4,8 +4,11 @@ metadata:
   name: dedicated-admins-openshift-dns
   namespace: openshift-dns
 subjects:
-- kind: Group
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
   name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3516,8 +3516,11 @@ objects:
         name: dedicated-admins-openshift-operators
         namespace: openshift-operators
       subjects:
-      - kind: Group
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
         name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
@@ -3548,8 +3551,11 @@ objects:
         name: dedicated-admins-openshift-marketplace
         namespace: openshift-marketplace
       subjects:
-      - kind: Group
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
         name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
@@ -3574,8 +3580,11 @@ objects:
         name: dedicated-admins-openshift-dns
         namespace: openshift-dns
       subjects:
-      - kind: Group
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
         name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role


### PR DESCRIPTION
Noticed when doing https://github.com/openshift/managed-cluster-config/pull/253 that some of the roles we have were missing the dedicated-admin SAs in subjects