### PR TITLE
Fix dedicated-admins RBAC aggregation

### DIFF
--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
@@ -1,10 +1,13 @@
 aggregationRule:
   clusterRoleSelectors:
-  - matchLabels:
-    # aggregate all "cluster" scope rbac from SRE to dedicated-admins-cluster
-    rbac.authorization.k8s.io/aggregate-to-dedicated-admins: "cluster"
+  # aggregate all "cluster" scope rbac from SRE to dedicated-admins-cluster
   - matchExpressions:
-    # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster
+    - key: managed.openshift.io/aggregate-to-dedicated-admins
+      operator: In
+      values:
+        - "cluster"
+  # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster
+  - matchExpressions:
     - key: olm.opgroup.permissions/aggregate-to-admin
       operator: In
       values:

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
@@ -1,13 +1,19 @@
 aggregationRule:
   clusterRoleSelectors:
-  - matchLabels:
-    # aggregate all "project" scope rbac from SRE to dedicated-admins-project
-    rbac.authorization.k8s.io/aggregate-to-dedicated-admins: "project"
-  - matchLabels:
-    # aggregate all "admin" scope rbac from OCP to dedicated-admins-project
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  # aggregate all "project" scope rbac from SRE to dedicated-admins-project
   - matchExpressions:
-    # aggregate all customer installed operator rbac from OLM to dedicated-admins-project
+    - key: managed.openshift.io/aggregate-to-dedicated-admins
+      operator: In
+      values:
+        - "project"
+  # aggregate all "admin" scope rbac from OCP to dedicated-admins-project
+  - matchExpressions:
+    - key: rbac.authorization.k8s.io/aggregate-to-admin
+      operator: In
+      values:
+        - "true"
+  # aggregate all customer installed operator rbac from OLM to dedicated-admins-project
+  - matchExpressions:
     - key: olm.opgroup.permissions/aggregate-to-admin
       operator: In
       values:

--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  label:
-    rbac.authorization.k8s.io/aggregate-to-dedicated-admins: "cluster"
+  labels:
+    managed.openshift.io/aggregate-to-dedicated-admins: "cluster"
   name: dedicated-admins-aggregate-cluster
 rules:
 - apiGroups:

--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.k8s.io/aggregate-to-dedicated-admins: "project"
+    managed.openshift.io/aggregate-to-dedicated-admins: "project"
   name: dedicated-admins-aggregate-project
 rules:
 - apiGroups:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3124,8 +3124,11 @@ objects:
           openshift.io/node-selector: ''
     - aggregationRule:
         clusterRoleSelectors:
-        - matchLabels: null
-          rbac.authorization.k8s.io/aggregate-to-dedicated-admins: cluster
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-dedicated-admins
+            operator: In
+            values:
+            - cluster
         - matchExpressions:
           - key: olm.opgroup.permissions/aggregate-to-admin
             operator: In
@@ -3140,10 +3143,16 @@ objects:
       rules: []
     - aggregationRule:
         clusterRoleSelectors:
-        - matchLabels: null
-          rbac.authorization.k8s.io/aggregate-to-dedicated-admins: project
-        - matchLabels: null
-          rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-dedicated-admins
+            operator: In
+            values:
+            - project
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-admin
+            operator: In
+            values:
+            - 'true'
         - matchExpressions:
           - key: olm.opgroup.permissions/aggregate-to-admin
             operator: In
@@ -3159,8 +3168,8 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        label:
-          rbac.authorization.k8s.io/aggregate-to-dedicated-admins: cluster
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: cluster
         name: dedicated-admins-aggregate-cluster
       rules:
       - apiGroups:
@@ -3406,7 +3415,7 @@ objects:
       kind: ClusterRole
       metadata:
         labels:
-          rbac.authorization.k8s.io/aggregate-to-dedicated-admins: project
+          managed.openshift.io/aggregate-to-dedicated-admins: project
         name: dedicated-admins-aggregate-project
       rules:
       - apiGroups:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3153

There's some weird whitespace requirements using aggregationRule w/ matchLabel which can result in ALL ClusterRoles being aggregated.  So I moved to matchExpression which works just as well and doesn't have that odd behavior.  Basically you have to indent an extra time for the contents of matchLabel and if you don't it matches everything..