### PR TITLE
Added custom alert for tracking monthly SLA

### DIFF
--- a/deploy/sre-prometheus/100-sre-api-errors.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-api-errors.PrometheusRule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: sre-uptime-sla
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-uptime-sla
+    rules:
+    - alert: SLAUptimeSRE
+      annotations:
+        message: The API server has had 100 percent request failures for 300 seconds.
+      expr: |
+        (sum(rate(apiserver_request_count{job="apiserver", code=~"(400|5..)"}[5m])) / sum(rate(apiserver_request_count{job="apiserver"}[5m])) >= 1)
+      for: 5m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4377,6 +4377,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: k8s
+          role: alert-rules
+        name: sre-uptime-sla
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-uptime-sla
+          rules:
+          - alert: SLAUptimeSRE
+            annotations:
+              message: The API server has had 100 percent request failures for 300
+                seconds.
+            expr: '(sum(rate(apiserver_request_count{job="apiserver", code=~"(400|5..)"}[5m]))
+              / sum(rate(apiserver_request_count{job="apiserver"}[5m])) >= 1)
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: osd-sre-cluster-admins
           role: alert-rules
         name: osd-sre-cluster-admins


### PR DESCRIPTION
Added a custom alert to track monthly SLA breaches. This alert is then used in thanos/grafana to calculate monthly SLA values.