### PR TITLE
Fix fix pr check and fix failing pr checks

### DIFF
--- a/deploy/sre-prometheus/100-excessive-memory.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-excessive-memory.PrometheusRule.yaml
@@ -16,6 +16,7 @@ spec:
       for: 30m
       labels:
         severity: warning
+        namespace: "{{ $labels.namespace }}"
       annotations:
         message: System container {{ $labels.namespace }}/{{ $labels.pod_name }}/{{ $labels.container_name }}
           is using in excess of 3G of memory for over 30 minutes.
@@ -25,6 +26,7 @@ spec:
       for: 30m
       labels:
         severity: critical
+        namespace: "{{ $labels.namespace }}"
       annotations:
         message: System container {{ $labels.namespace }}/{{ $labels.pod_name }}/{{ $labels.container_name }}
           is using in excess of 5G of memory for over 30 minutes.

--- a/deploy/sre-prometheus/100-layered-sre-elevation.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-layered-sre-elevation.PrometheusRule.yaml
@@ -15,6 +15,7 @@ spec:
       for: 130m
       labels:
         severity: warning
+        namespace: redhat-layered
       annotations:
         message: Layered SRE "{{ $labels.user }}"
           elevated to layered cluster-admin({{ $labels.group }}) more than 2 hours.

--- a/deploy/sre-prometheus/100-sre-elevation.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-elevation.PrometheusRule.yaml
@@ -15,6 +15,7 @@ spec:
       for: 130m
       labels:
         severity: warning
+        namespace: openshift-monitoring
       annotations:
         message: SRE "{{ $labels.user }}"
           elevated to cluster-admin({{ $labels.group }}) more than 2 hours.

--- a/deploy/sre-prometheus/100-sre-pv.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-pv.PrometheusRule.yaml
@@ -29,6 +29,7 @@ spec:
         < 3
       labels:
         severity: critical
+        namespace: "{{ $labels.namespace }}"
       annotations:
         message: "The customer PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ printf \"%0.2f\" $value }}% free."
 
@@ -42,6 +43,7 @@ spec:
         4 * 24 * 3600) < 0
       labels:
         severity: warning
+        namespace: "{{ $labels.namespace }}"
       annotations:
         message: "Based on recent sampling, the customer PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ printf \"%0.2f\" $value }}% is available."
 
@@ -56,6 +58,7 @@ spec:
         < 3
       labels:
         severity: critical
+        namespace: "{{ $labels.namespace }}"
       annotations:
         message: "The customer PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ printf \"%0.2f\" $value }}% free."
 
@@ -69,5 +72,6 @@ spec:
         4 * 24 * 3600) < 0
       labels:
         severity: warning
+        namespace: "{{ $labels.namespace }}"
       annotations:
         message: "Based on recent sampling, the customer PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ printf \"%0.2f\" $value }}% is available."

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4203,6 +4203,7 @@ objects:
             for: 30m
             labels:
               severity: warning
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: System container {{ $labels.namespace }}/{{ $labels.pod_name
                 }}/{{ $labels.container_name }} is using in excess of 3G of memory
@@ -4212,6 +4213,7 @@ objects:
             for: 30m
             labels:
               severity: critical
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: System container {{ $labels.namespace }}/{{ $labels.pod_name
                 }}/{{ $labels.container_name }} is using in excess of 5G of memory
@@ -4258,6 +4260,7 @@ objects:
             for: 130m
             labels:
               severity: warning
+              namespace: redhat-layered
             annotations:
               message: Layered SRE "{{ $labels.user }}" elevated to layered cluster-admin({{
                 $labels.group }}) more than 2 hours.
@@ -4391,6 +4394,7 @@ objects:
             for: 130m
             labels:
               severity: warning
+              namespace: openshift-monitoring
             annotations:
               message: SRE "{{ $labels.user }}" elevated to cluster-admin({{ $labels.group
                 }}) more than 2 hours.
@@ -4439,6 +4443,7 @@ objects:
               '
             labels:
               severity: critical
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: The customer PersistentVolume claimed by {{ $labels.persistentvolumeclaim
                 }} in Namespace {{ $labels.namespace }} is only {{ printf "%0.2f"
@@ -4457,6 +4462,7 @@ objects:
               '
             labels:
               severity: warning
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: Based on recent sampling, the customer PersistentVolume claimed
                 by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
@@ -4476,6 +4482,7 @@ objects:
               '
             labels:
               severity: critical
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: The customer PersistentVolume claimed by {{ $labels.persistentvolumeclaim
                 }} in Namespace {{ $labels.namespace }} is only {{ printf "%0.2f"
@@ -4494,6 +4501,7 @@ objects:
               '
             labels:
               severity: warning
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: Based on recent sampling, the customer PersistentVolume claimed
                 by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -7,17 +7,18 @@ MISSING_NS="false"
 for F in $(ls deploy/sre-prometheus)
 do
     # requires yq
-    MISSING_NS_COUNT=$(yq '.spec.groups[].rules[] | select(.namespace == null) and select(.labels.namespace == null)' deploy/sre-prometheus/$F | wc -l)
+    MISSING_NS_COUNT=$(cat deploy/sre-prometheus/$F | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))' | jq -r '.spec.groups[].rules[] | select(.namespace == null) and select(.labels.namespace == null)' | wc -l)
 
     if [ "$MISSING_NS_COUNT" != "0" ]
     then
-        echo "Rule missing 'namespace' in file '$F'"
+        echo "ERROR: Rule missing 'namespace' in file '$F'"
         MISSING_NS="true"
     fi
 done
 
 if [ "$MISSING_NS" == "true" ]
 then
+    echo "ERROR: one or more files missing 'namespace' label, see 'ERROR' output in above logs"
     exit 2
 fi
 

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -4,10 +4,10 @@ set -exv
 
 # all custom alerts must have a namespace label
 MISSING_NS="false"
-for F in $(ls deploy/sre-prometheus)
+for F in $(find ./deploy/sre-prometheus -type f -iname '*prometheusrule.yaml')
 do
     # requires yq
-    MISSING_NS_COUNT=$(cat deploy/sre-prometheus/$F | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))' | jq -r '.spec.groups[].rules[] | select(.namespace == null) and select(.labels.namespace == null)' | wc -l)
+    MISSING_NS_COUNT=$(cat $F | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))' | jq -r '.spec.groups[].rules[] | select(.namespace == null) and select(.labels.namespace == null)' | wc -l)
 
     if [ "$MISSING_NS_COUNT" != "0" ]
     then


### PR DESCRIPTION
- removed use of `yq` and opt for straight python
- assign a namespace label in all alerts, even if it's using the namespace label from the alert (this is so we always know where the alert is being routed)