### PR TITLE
Adding RBAC for CS SRE to view pod logs

### DIFF
--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
@@ -33,6 +33,14 @@ rules:
   - pods/attach
   verbs:
   - create
+# CS SRE can get pod logs
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
 # CS SRE can delete pods
 - apiGroups:
   - ""

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -754,6 +754,13 @@ objects:
         - ''
         resources:
         - pods
+        - pods/log
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        resources:
+        - pods
         verbs:
         - delete
       - apiGroups:


### PR DESCRIPTION
Adding RBAC to allow CS SRE (Layered SRE) to view pod log files.