### PR TITLE
Adding SelectorSyncIdentityProvider for Google Auth

### DIFF
--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -493,7 +493,7 @@ objects:
         name: osd-google-secret
       hostedDomain: redhat.com
     mappingMethod: claim
-    name: Openshift_SRE
+    name: OpenShift_SRE
     type: Google
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -491,7 +491,7 @@ objects:
         name: osd-google-secret
       hostedDomain: redhat.com
     mappingMethod: claim
-    name: Openshift-SRE
+    name: OpenShift_SRE
     type: Google
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -19,7 +19,7 @@ parameters:
 - name: IDENTITY_URL
   required: true
 - name: IDENTITY_SRE_GOOGLE_CLIENTID
-  required: false
+  required: true
 - name: IDENTITY_NAME
   required: true
 - name: IDENTITY_MAPPING_METHOD

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -451,7 +451,7 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpresions:
       - key: api.openshift.com/environment
-        operator: notIn
+        operator: NotIn
         values:
         - production
     identityProviders:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -447,6 +447,11 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpresions:
+      - key: api.openshift.com/environment
+        operator: notIn
+        values:
+        - production
     identityProviders:
     - challenge: true
       ldap:
@@ -470,6 +475,24 @@ objects:
       mappingMethod: ${IDENTITY_MAPPING_METHOD}
       name: ${IDENTITY_NAME}
       type: LDAP
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: SelectorSyncIdentityProvider
+  metadata:
+    name: osd-sre-google-identityprovider
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/environment: production
+    identityProviders:
+    - google: null
+      clientID: 211953714079-afmg28lojv8m2vv97b56s64ivm5ercn4.apps.googleusercontent.com
+      clientSecret:
+        name: osd-google-secret
+      hostedDomain: redhat.com
+    mappingMethod: claim
+    name: Openshift-SRE
+    type: Google
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -18,6 +18,8 @@ parameters:
   required: true
 - name: IDENTITY_URL
   required: true
+- name: IDENTITY_SRE_GOOGLE_CLIENTID
+  required: false
 - name: IDENTITY_NAME
   required: true
 - name: IDENTITY_MAPPING_METHOD
@@ -486,12 +488,12 @@ objects:
         api.openshift.com/environment: production
     identityProviders:
     - google: null
-      clientID: 211953714079-afmg28lojv8m2vv97b56s64ivm5ercn4.apps.googleusercontent.com
+      clientID: ${IDENTITY_SRE_GOOGLE_CLIENTID}
       clientSecret:
         name: osd-google-secret
       hostedDomain: redhat.com
     mappingMethod: claim
-    name: OpenShift_SRE
+    name: Openshift_SRE
     type: Google
 - apiVersion: hive.openshift.io/v1alpha1
   kind: SelectorSyncSet

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -449,6 +449,11 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: "true"
+      matchExpresions:
+        - key: api.openshift.com/environment
+          operator: notIn
+          values:
+          - "production"
     identityProviders:
     - challenge: true
       ldap:
@@ -472,3 +477,22 @@ objects:
       mappingMethod: ${IDENTITY_MAPPING_METHOD}
       name: ${IDENTITY_NAME}
       type: LDAP
+# SelectorSyncIdentityProvider for prod clusters
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: SelectorSyncIdentityProvider
+  metadata:
+    name: osd-sre-google-identityprovider
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: "true"
+        api.openshift.com/environment: "production"
+    identityProviders:
+    - google:
+      clientID: 211953714079-afmg28lojv8m2vv97b56s64ivm5ercn4.apps.googleusercontent.com
+      clientSecret:
+        name: osd-google-secret
+      hostedDomain: redhat.com
+    mappingMethod: claim
+    name: Openshift-SRE
+    type: Google

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -18,6 +18,8 @@ parameters:
   required: true
 - name: IDENTITY_URL
   required: true
+- name: IDENTITY_SRE_GOOGLE_CLIENTID
+  required: false
 - name: IDENTITY_NAME
   required: true
 - name: IDENTITY_MAPPING_METHOD
@@ -489,10 +491,10 @@ objects:
         api.openshift.com/environment: "production"
     identityProviders:
     - google:
-      clientID: 211953714079-afmg28lojv8m2vv97b56s64ivm5ercn4.apps.googleusercontent.com
+      clientID: ${IDENTITY_SRE_GOOGLE_CLIENTID}
       clientSecret:
         name: osd-google-secret
       hostedDomain: redhat.com
     mappingMethod: claim
-    name: Openshift-SRE
+    name: Openshift_SRE
     type: Google

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -19,7 +19,7 @@ parameters:
 - name: IDENTITY_URL
   required: true
 - name: IDENTITY_SRE_GOOGLE_CLIENTID
-  required: false
+  required: true
 - name: IDENTITY_NAME
   required: true
 - name: IDENTITY_MAPPING_METHOD
@@ -453,7 +453,7 @@ objects:
         api.openshift.com/managed: "true"
       matchExpresions:
         - key: api.openshift.com/environment
-          operator: notIn
+          operator: NotIn
           values:
           - "production"
     identityProviders:
@@ -496,5 +496,5 @@ objects:
         name: osd-google-secret
       hostedDomain: redhat.com
     mappingMethod: claim
-    name: Openshift_SRE
+    name: OpenShift_SRE
     type: Google


### PR DESCRIPTION
- Adding SelectorIdentityProvider for Google IDP - applying to production only
- Updating the existing LDAP SelectorIdentityProvider to match non-production

