### PR TITLE
Allow generating sss per matchlabel

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ There is a limited configuration available at this time.  The file `sss-config.y
 
 * matchLabels (default: `{}`) - adds additional `matchLabels` conditions to the `clusterDeploymentSelector`
 * resourceApplyMode (default: `"Sync"`) - sets the `resourceApplyMode`
+* matchLabelsApplyMode (optional, default: not set) - When set as `"OR"` generates additional SSS per `matchLabels` conditions. This is to tackle a situation where we want to apply configuration to multiple labels.
 
 # Selector Sync Sets included in this repo
 

--- a/deploy/layered-sre-authorization/sss-config.yaml
+++ b/deploy/layered-sre-authorization/sss-config.yaml
@@ -1,2 +1,4 @@
 matchLabels:
     api.openshift.com/addon-rhmi-operator: "true"
+    api.openshift.com/addon-rhmi-operator-internal: "true"
+matchLabelsApplyMode: "OR"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -877,6 +877,192 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: layered-sre-authorization
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-rhmi-operator-internal: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: layered-sre-cluster-admins
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+      - kind: Group
+        name: layered-sre-cluster-admins
+    - apiVersion: user.openshift.io/v1
+      kind: Group
+      metadata:
+        name: layered-sre-cluster-admins
+      users: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: layered-cs-sre-admin-cluster
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - projects
+        verbs:
+        - create
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - infrastructures
+        - oauths
+        verbs:
+        - get
+      - apiGroups:
+        - project.openshift.io
+        resources:
+        - projects
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        - namespaces/finalize
+        verbs:
+        - create
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - groups
+        verbs:
+        - patch
+        - update
+        - get
+      - apiGroups:
+        - quota.openshift.io
+        resources:
+        - clusterresourcequotas/status
+        - clusterresourcequotas
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: layered-cs-sre-admin-project
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - jobs
+        verbs:
+        - delete
+        - deletecollection
+      - apiGroups:
+        - build.openshift.io
+        resources:
+        - builds
+        verbs:
+        - delete
+        - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - pods/attach
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - pods/log
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+      - apiGroups:
+        - integreatly.org
+        resources:
+        - '*'
+        verbs:
+        - create
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        - configmaps
+        - persistentvolumeclaims
+        verbs:
+        - '*'
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - patch
+    - apiVersion: user.openshift.io/v1
+      kind: Group
+      metadata:
+        name: layered-cs-sre-admins
+      users:
+      - ${RHMI_SRE_USER1}
+      - ${RHMI_SRE_USER2}
+      - ${RHMI_SRE_USER3}
+      - ${RHMI_SRE_USER4}
+      - ${RHMI_SRE_USER5}
+      - ${RHMI_SRE_USER6}
+      - ${RHMI_SRE_USER7}
+      - ${RHMI_SRE_USER8}
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: layered-cs-sre-admin
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - dedicated-admins-cluster
+        - layered-cs-sre-admin-cluster
+        permissions:
+        - allowFirst: true
+          clusterRoleName: layered-cs-sre-admin-project
+          namespacesAllowedRegex: .*
+          namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+        subjectKind: Group
+        subjectName: layered-cs-sre-admins
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: managed-velero-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -691,7 +691,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: layered-sre-authorization
+    name: layered-sre-authorization-addon-rhmi-operator
   spec:
     clusterDeploymentSelector:
       matchLabels:
@@ -877,7 +877,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: layered-sre-authorization
+    name: layered-sre-authorization-addon-rhmi-operator-internal
   spec:
     clusterDeploymentSelector:
       matchLabels:

--- a/scripts/generate_syncset.py
+++ b/scripts/generate_syncset.py
@@ -130,11 +130,15 @@ if __name__ == '__main__':
         if "matchLabelsApplyMode" in sss_config and sss_config["matchLabelsApplyMode"] == "OR":
             # generate new SSS per matchLabels line
             for key, value in sss_config['matchLabels'].items():
+
                 o = copy.deepcopy(sss_config)
                 o['matchLabels'].clear()
                 o['matchLabels'].update({key:value})
                 del o["matchLabelsApplyMode"]
-                process_yamls(sss_name, dirpath, selectorsyncset_data, o)
+
+                # SSS objects require unique names
+                unique_sss_name = sss_name + key.replace('api.openshift.com/', '-')
+                process_yamls(unique_sss_name, dirpath, selectorsyncset_data, o)
         else:
             # Catches anyone with a rouge value
             process_yamls(sss_name, dirpath, selectorsyncset_data, sss_config)

--- a/scripts/generate_syncset.py
+++ b/scripts/generate_syncset.py
@@ -126,7 +126,18 @@ if __name__ == '__main__':
             if sss_name.startswith("UPSERT-"):
                 sss_name = sss_name[7:]
 
-        process_yamls(sss_name, dirpath, selectorsyncset_data, sss_config)
+        # If no matchLabelsApplyMode, process as nornmal
+        if "matchLabelsApplyMode" in sss_config and sss_config["matchLabelsApplyMode"] == "OR":
+            # generate new SSS per matchLabels line
+            for key, value in sss_config['matchLabels'].items():
+                o = copy.deepcopy(sss_config)
+                o['matchLabels'].clear()
+                o['matchLabels'].update({key:value})
+                del o["matchLabelsApplyMode"]
+                process_yamls(sss_name, dirpath, selectorsyncset_data, o)
+        else:
+            # Catches anyone with a rouge value
+            process_yamls(sss_name, dirpath, selectorsyncset_data, sss_config)
 
 
     # write template file ordering by keys


### PR DESCRIPTION
Allows the use of a matchLabelsApplyMode flag (OR). When set all matchLabels are applied as separate SSS.

This is to tackle a situation where we want to apply configuration across multiple labels. (RHMI as an example)
