### PR TITLE
Allow dedicated-admins to see "Dashboards" link in console under "Monitoring"

### DIFF
--- a/deploy/rbac-permissions-operator-config/40-dedicated-admins-monitoring.Role.yaml
+++ b/deploy/rbac-permissions-operator-config/40-dedicated-admins-monitoring.Role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-openshift-monitoring
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/deploy/rbac-permissions-operator-config/40-dedicated-admins-monitoring.RoleBinding.yaml
+++ b/deploy/rbac-permissions-operator-config/40-dedicated-admins-monitoring.RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-openshift-monitoring
+  namespace: openshift-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-openshift-monitoring

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3779,6 +3779,35 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-openshift-dns
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-openshift-monitoring
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-monitoring
+        namespace: openshift-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshift-monitoring
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3295