### PR TITLE
Deploy managed-velero-operator:v0.2.133-c6455c5 to stage

### DIFF
--- a/deploy/managed-velero-operator/130-velero.CredentialRequest.yaml
+++ b/deploy/managed-velero-operator/130-velero.CredentialRequest.yaml
@@ -1,7 +1,7 @@
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: managed-velero-operator-iam-credentials
+  name: managed-velero-operator-iam-credentials-aws
   namespace: openshift-velero
 spec:
   secretRef:

--- a/deploy/managed-velero-operator/131-velero.CredentialRequest.yaml
+++ b/deploy/managed-velero-operator/131-velero.CredentialRequest.yaml
@@ -1,0 +1,16 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: managed-velero-operator-iam-credentials-gcp
+  namespace: openshift-velero
+spec:
+  secretRef:
+    name: managed-velero-operator-iam-credentials
+    namespace: openshift-velero
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/storage.admin
+    - roles/iam.serviceAccountUser
+    skipServiceCheck: true

--- a/deploy/managed-velero-operator/135-velero.Deployment.yaml
+++ b/deploy/managed-velero-operator/135-velero.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           operator: Exists
       containers:
         - name: managed-velero-operator
-          image: quay.io/openshift-sre/managed-velero-operator:v0.2.117-ededc3e
+          image: quay.io/openshift-sre/managed-velero-operator:v0.2.133-c6455c5
           command:
           - managed-velero-operator
           env:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1397,7 +1397,7 @@ objects:
     - apiVersion: cloudcredential.openshift.io/v1
       kind: CredentialsRequest
       metadata:
-        name: managed-velero-operator-iam-credentials
+        name: managed-velero-operator-iam-credentials-aws
         namespace: openshift-velero
       spec:
         secretRef:
@@ -1421,6 +1421,22 @@ objects:
             - s3:PutEncryptionConfiguration
             - s3:PutLifecycleConfiguration
             resource: '*'
+    - apiVersion: cloudcredential.openshift.io/v1
+      kind: CredentialsRequest
+      metadata:
+        name: managed-velero-operator-iam-credentials-gcp
+        namespace: openshift-velero
+      spec:
+        secretRef:
+          name: managed-velero-operator-iam-credentials
+          namespace: openshift-velero
+        providerSpec:
+          apiVersion: cloudcredential.openshift.io/v1
+          kind: GCPProviderSpec
+          predefinedRoles:
+          - roles/storage.admin
+          - roles/iam.serviceAccountUser
+          skipServiceCheck: true
     - apiVersion: apps/v1
       kind: Deployment
       metadata:
@@ -1451,7 +1467,7 @@ objects:
               operator: Exists
             containers:
             - name: managed-velero-operator
-              image: quay.io/openshift-sre/managed-velero-operator:v0.2.117-ededc3e
+              image: quay.io/openshift-sre/managed-velero-operator:v0.2.133-c6455c5
               command:
               - managed-velero-operator
               env:


### PR DESCRIPTION
This upgrades the managed-velero-operator to `v0.2.133-c6455c5`.

The key feature being deployed is GCP support.

Detailed changes:
https://github.com/openshift/managed-velero-operator/compare/ededc3e...c6455c5