### PR TITLE
OSD-3193 Fix ClusterRoleBinding name colision

### DIFF
--- a/deploy/osd-cluster-admin/03-cluster-admin.ClusterRoleBinding.yaml
+++ b/deploy/osd-cluster-admin/03-cluster-admin.ClusterRoleBinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cluster-admin
+  name: osd-cluster-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2094,7 +2094,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: cluster-admin
+        name: osd-cluster-admin
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole


### PR DESCRIPTION
Fixed a ClusterRoleBinding name collision, updating `metadata.name` from `cluster-admin` to `osd-cluster-admin`