### PR TITLE
Modify curation and logging storage quota

### DIFF
--- a/deploy/osd-logging/02-curator.configmap.yaml
+++ b/deploy/osd-logging/02-curator.configmap.yaml
@@ -48,12 +48,12 @@ data:
     #    days: 30
     .defaults:
       delete:
-        days: 2
+        days: 7
 
     # to keep ops logs for a different duration:
     .operations:
       delete:
-        days: 1
+        days: 0
 
     # example for a normal project
     #myapp:

--- a/deploy/osd-logging/03-storage-quota.yaml
+++ b/deploy/osd-logging/03-storage-quota.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: openshift-logging
 spec:
   hard:
-    requests.storage: "600Gi"
+    requests.storage: "1200Gi"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3056,8 +3056,8 @@ objects:
           '
         config.yaml: "# Logging example curator config file\n\n# uncomment and use\
           \ this to override the defaults from env vars\n#.defaults:\n#  delete:\n\
-          #    days: 30\n.defaults:\n  delete:\n    days: 2\n\n# to keep ops logs\
-          \ for a different duration:\n.operations:\n  delete:\n    days: 1\n\n# example\
+          #    days: 30\n.defaults:\n  delete:\n    days: 7\n\n# to keep ops logs\
+          \ for a different duration:\n.operations:\n  delete:\n    days: 0\n\n# example\
           \ for a normal project\n#myapp:\n#  delete:\n#    weeks: 1\n"
         curator5.yaml: "---\nclient:\n  hosts:\n  - ${ES_HOST}\n  port: ${ES_PORT}\n\
           \  use_ssl: True\n  certificate: ${ES_CA}\n  client_cert: ${ES_CLIENT_CERT}\n\
@@ -3075,7 +3075,7 @@ objects:
         namespace: openshift-logging
       spec:
         hard:
-          requests.storage: 600Gi
+          requests.storage: 1200Gi
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3323

.defaults updated to 7 days (from 2 days)
.operations updated to 0 days (from 1 days)
openshift-logging storage quota updated to 1200Gi (from 600Gi)