### PR TITLE
Fixes to cluster_upgrade for 4.3 clusters

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -426,7 +426,7 @@ prepare_kubeconfig() {
 
     if [ ! -f "${TMP_DIR}/kubeconfig-${CD_NAMESPACE}" ];
     then
-        oc -n $CD_NAMESPACE extract secret/"$(oc -n $CD_NAMESPACE get clusterdeployment $CD_NAME -o json | jq -r '.spec.clusterMetadata.adminKubeconfigSecretRef.name')" --keys=kubeconfig --to=- > ${TMP_DIR}/kubeconfig-${CD_NAMESPACE}
+        oc -n $CD_NAMESPACE extract "secret/$(oc -n $CD_NAMESPACE get clusterdeployment $CD_NAME -o json | jq -r '.spec.clusterMetadata.adminKubeconfigSecretRef.name')" --keys=kubeconfig --to=- > ${TMP_DIR}/kubeconfig-${CD_NAMESPACE}
     fi
 }
 

--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -426,7 +426,7 @@ prepare_kubeconfig() {
 
     if [ ! -f "${TMP_DIR}/kubeconfig-${CD_NAMESPACE}" ];
     then
-        oc -n $CD_NAMESPACE extract "$(oc -n $CD_NAMESPACE get clusterdeployment $CD_NAME -o json | jq -r '.spec.clusterMetdata.adminKubeconfigSecretRef.name')" --keys=kubeconfig --to=- > ${TMP_DIR}/kubeconfig-${CD_NAMESPACE}
+        oc -n $CD_NAMESPACE extract secret/"$(oc -n $CD_NAMESPACE get clusterdeployment $CD_NAME -o json | jq -r '.spec.clusterMetadata.adminKubeconfigSecretRef.name')" --keys=kubeconfig --to=- > ${TMP_DIR}/kubeconfig-${CD_NAMESPACE}
     fi
 }
 
@@ -634,7 +634,7 @@ fi
 
 for CD_NAMESPACE in $(oc get clusterdeployment --all-namespaces | awk '{print $1}' | sort | uniq);
 do  
-    for CD_NAME in $(oc -n $CD_NAMESPACE get clusterdeployment -o json | jq -r '.items[] | select(.metadata.labels["api.openshift.com/managed"] == "true") | select(.metadata.deletionTimestamp == null or .metadata.deletionTimestamp == "") | select(.status.installed == true) | select(.status.clusterVersionStatus.history[0].state == "Completed") | .metadata.name');
+    for CD_NAME in $(oc -n $CD_NAMESPACE get clusterdeployment -o json | jq -r '.items[] | select(.metadata.labels["api.openshift.com/managed"] == "true") | select(.metadata.deletionTimestamp == null or .metadata.deletionTimestamp == "") | select(.spec.installed == true) | select(.status.clusterVersionStatus.history[0].state == "Completed") | .metadata.name');
     do  
         if [ "$CLUSTER_NAMES" != "all" ];
         then


### PR DESCRIPTION
This PR addresses some issues found when testing cluster_upgrade.sh on 4.3 OSD staging clusters.

- Use .spec.installed instead of .status.installed to verify the to-be-upgraded cluster's presence. This was needed due to [this hive commit](https://github.com/openshift/hive/commit/a40cd1fbe929fd915e0ea1e31253174f32b38d8f). All clusterdeployments appear to now be using .spec.installed rather than .status.installed

- Fixed a bug to gather the kubeconfigs needed to operate the upgrade, that was introduced in [this commit](https://github.com/openshift/managed-cluster-config/commit/4446226b6c8f284df61625aafdf1d2df7f71bd36).