### PR TITLE
Support ClusterRole label changes in OCP 4.3.12+

### DIFF
--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
@@ -6,7 +6,7 @@ aggregationRule:
       operator: In
       values:
         - "cluster"
-  # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster
+  # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster (pre 4.3.12)
   - matchExpressions:
     - key: olm.opgroup.permissions/aggregate-to-admin
       operator: In
@@ -14,6 +14,21 @@ aggregationRule:
         - openshift-logging
         - openshift-operators
         - openshift-operators-redhat
+  # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster (4.3.12+)
+  - matchExpressions:
+    - key: olm.owner.kind
+      operator: In
+      values:
+      - OperatorGroup
+    - key: olm.owner.namespace
+      operator: NotIn
+      values:
+      - openshift-cloud-ingress-operator
+      - openshift-monitoring
+      - openshift-operator-lifecycle-manager
+      - openshift-rbac-permissions
+      - openshift-splunk-forwarder-operator
+      - openshift-velero
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
@@ -12,7 +12,7 @@ aggregationRule:
       operator: In
       values:
         - "true"
-  # aggregate all customer installed operator rbac from OLM to dedicated-admins-project
+  # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster (pre 4.3.12)
   - matchExpressions:
     - key: olm.opgroup.permissions/aggregate-to-admin
       operator: In
@@ -20,6 +20,21 @@ aggregationRule:
         - openshift-logging
         - openshift-operators
         - openshift-operators-redhat
+  # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster (4.3.12+)
+  - matchExpressions:
+    - key: olm.owner.kind
+      operator: In
+      values:
+      - OperatorGroup
+    - key: olm.owner.namespace
+      operator: NotIn
+      values:
+      - openshift-cloud-ingress-operator
+      - openshift-monitoring
+      - openshift-operator-lifecycle-manager
+      - openshift-rbac-permissions
+      - openshift-splunk-forwarder-operator
+      - openshift-velero
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3489,6 +3489,20 @@ objects:
             - openshift-logging
             - openshift-operators
             - openshift-operators-redhat
+        - matchExpressions:
+          - key: olm.owner.kind
+            operator: In
+            values:
+            - OperatorGroup
+          - key: olm.owner.namespace
+            operator: NotIn
+            values:
+            - openshift-cloud-ingress-operator
+            - openshift-monitoring
+            - openshift-operator-lifecycle-manager
+            - openshift-rbac-permissions
+            - openshift-splunk-forwarder-operator
+            - openshift-velero
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -3513,6 +3527,20 @@ objects:
             - openshift-logging
             - openshift-operators
             - openshift-operators-redhat
+        - matchExpressions:
+          - key: olm.owner.kind
+            operator: In
+            values:
+            - OperatorGroup
+          - key: olm.owner.namespace
+            operator: NotIn
+            values:
+            - openshift-cloud-ingress-operator
+            - openshift-monitoring
+            - openshift-operator-lifecycle-manager
+            - openshift-rbac-permissions
+            - openshift-splunk-forwarder-operator
+            - openshift-velero
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3431

Labels applied by OLM to ClusterRoles for CR RBAC changed.
This uses a different approach and fixes a gap for extended dedicated-admin when operators are installed in a customer namespace.