### PR TITLE
OSD-2681 Update the curation-revert SSS to apply to clusters with ext…

### DIFF
--- a/deploy/osd-curated-operatorsources-revert/sss-config.yaml
+++ b/deploy/osd-curated-operatorsources-revert/sss-config.yaml
@@ -1,4 +1,4 @@
-matchExpressions:
-- key: api.openshift.com/ccs
-  operator: In
-  values: ["true"]
+matchLabels:
+  api.openshift.com/ccs: "true"
+  api.openshift.com/extended-dedicated-admin: "true"
+matchLabelsApplyMode: "OR"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2312,16 +2312,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-curated-operatorsources-revert
+    name: osd-curated-operatorsources-revert-ccs
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/ccs
-        operator: In
-        values:
-        - 'true'
+        api.openshift.com/ccs: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: config.openshift.io/v1
+      kind: OperatorHub
+      metadata:
+        name: cluster
+        annotations:
+          release.openshift.io/create-only: 'true'
+      spec:
+        disableAllDefaultSources: false
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-curated-operatorsources-revert-extended-dedicated-admin
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/extended-dedicated-admin: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: config.openshift.io/v1


### PR DESCRIPTION
…ended-dedicated-admin label

As part of removing curation for extended-dedicate-admin clusters, extending the revert of OperatorHub CR back original state.