### PR TITLE
Add additional cluster_upgrade alert filters.

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -468,8 +468,8 @@ check_cluster_status() {
     fi
 
     # get a list of firing critical alerts in core namespaces (these would alert SREP in PD)
-    # NOTE exclude ClusterUpgradingSRE and DNSErrors05MinSRE
-    CA=$(curl -G -s -k -H "Authorization: Bearer $(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc -n openshift-monitoring sa get-token prometheus-k8s)" --data-urlencode "query=ALERTS{alertstate=\"firing\",severity=\"critical\",namespace=~\"^openshift.*|^kube.*|^default$\",alertname!=\"ClusterUpgradingSRE\",alertname!=\"DNSErrors05MinSRE\"}" "https://$(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc -n openshift-monitoring get routes prometheus-k8s -o json | jq -r .spec.host)/api/v1/query" | jq -r '.data.result[].metric.alertname' | tr '\n' ',' )
+    # NOTE exclude ClusterUpgradingSRE, DNSErrors05MinSRE and MetricsClientSendFailingSRE
+    CA=$(curl -G -s -k -H "Authorization: Bearer $(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc -n openshift-monitoring sa get-token prometheus-k8s)" --data-urlencode "query=ALERTS{alertstate=\"firing\",severity=\"critical\",namespace=~\"^openshift.*|^kube.*|^default$\",namespace!=\"openshift-customer-monitoring\",alertname!=\"ClusterUpgradingSRE\",alertname!=\"DNSErrors05MinSRE\",alertname!=\"MetricsClientSendFailingSRE\"}" "https://$(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc -n openshift-monitoring get routes prometheus-k8s -o json | jq -r .spec.host)/api/v1/query" | jq -r '.data.result[].metric.alertname' | tr '\n' ',' )    
 
     if [ "$CA" != "" ];
     then


### PR DESCRIPTION
Additional alert filters have been added to the cluster_upgrade script so that, if they are firing, they do not block upgrades from commencing:

 - filtering out all alerts from openshift-customer-monitoring namespace
 - filtering out MetricsClientSendFailingSRE alert