### PR TITLE
Refactoring upgrade script to use CLI for upgrade validation and initiation

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -250,9 +250,10 @@ upgrade() {
         UPGRADE_COMMAND_OUTPUT=$(KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc adm upgrade --to=$TO 2>&1)
         UPGRADE_COMMAND_STATUS=$?
 
+        log $OCM_NAME "upgrade" "${UPGRADE_COMMAND_OUTPUT}"
+
         if echo "$UPGRADE_COMMAND_OUTPUT" | grep -q "Cluster is already at version" || [ $UPGRADE_COMMAND_STATUS -eq 1 ]
         then
-            log $OCM_NAME "upgrade" "${UPGRADE_COMMAND_OUTPUT}"
             teardown $OCM_NAME $CD_NAMESPACE $CD_NAME
             return
         fi


### PR DESCRIPTION
This PR is intended to utilize the `oc adm upgrade` CLI to check for upgrades and available versions and replace existing script logic. 

Examples:
```
# If cluster already on 4.3.12
$ oc adm upgrade --to=4.3.12
info: Cluster is already at version 4.3.12
$

# Upgrading to a version not available from upstream server
$ oc adm upgrade --to=4.3.15
error: The update 4.3.15 is not one of the available updates: 4.3.13
$ 

# Mentioning wrong syntax for a version
$ oc adm upgrade --to=4.3.15.16
error: --to must be a semantic version (e.g. 4.0.1 or 4.1.0-nightly-20181104): Invalid character(s) found in patch number "15.16"
$
```

Tried covering the teardown logic and message logging as well but can let me know if I missed anything.