### PR TITLE
CSSRE-954 Adding CS SRE list/get to pdb

### DIFF
--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
@@ -76,4 +76,11 @@ rules:
   - installplans
   verbs:
   - "patch"
-  
+# CS SRE can list/get PDB
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - get

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -869,6 +869,13 @@ objects:
         - installplans
         verbs:
         - patch
+      - apiGroups:
+        - policy
+        resources:
+        - poddisruptionbudgets
+        verbs:
+        - list
+        - get
     - apiVersion: user.openshift.io/v1
       kind: Group
       metadata:
@@ -1055,6 +1062,13 @@ objects:
         - installplans
         verbs:
         - patch
+      - apiGroups:
+        - policy
+        resources:
+        - poddisruptionbudgets
+        verbs:
+        - list
+        - get
     - apiVersion: user.openshift.io/v1
       kind: Group
       metadata:


### PR DESCRIPTION
Update RBAC for CS-SRE to be able to list/view (PDB) Pod Disruption Budgets.