### PR TITLE
CSSRE-955: Add list/get verbs for statefulsets for CSSRE users.

### DIFF
--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admin-project.ClusterRole.yaml
@@ -84,3 +84,11 @@ rules:
   verbs:
   - list
   - get
+# CS SRE can list/get statefulsets
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - get

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -876,6 +876,13 @@ objects:
         verbs:
         - list
         - get
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        verbs:
+        - list
+        - get
     - apiVersion: user.openshift.io/v1
       kind: Group
       metadata:
@@ -1066,6 +1073,13 @@ objects:
         - policy
         resources:
         - poddisruptionbudgets
+        verbs:
+        - list
+        - get
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
         verbs:
         - list
         - get


### PR DESCRIPTION
**Jira**: https://issues.redhat.com/browse/CSSRE-955

**Issue**: CSSRE users do not have permissions to list or get statefulsets.

**Solution**: Add list and get verbs in layered-cs-sre-admin-project cluster role.

**Tests**: Successfully tested in a test cluster.