### PR TITLE
efs-csi: use `latest` CSI driver image

### DIFF
--- a/deploy/efs-csi/04-daemonset.yaml
+++ b/deploy/efs-csi/04-daemonset.yaml
@@ -30,8 +30,11 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          # DELTA: fq image pinned to a release
-          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:release-0.3
+          # DELTA: fq image
+          # TODO(efried): Pin this to a release once >0.3 is available
+          # (0.3 doesn't support TLS, which is required for access points)
+          # Follow https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/152
+          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:latest
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -758,7 +758,7 @@ objects:
             - name: efs-plugin
               securityContext:
                 privileged: true
-              image: registry.hub.docker.com/amazon/aws-efs-csi-driver:release-0.3
+              image: registry.hub.docker.com/amazon/aws-efs-csi-driver:latest
               args:
               - --endpoint=$(CSI_ENDPOINT)
               - --logtostderr


### PR DESCRIPTION
In testing it was discovered that aws-efs-csi-driver:release-0.3 was
built using amazon-efs-utils 1.21, which doesn't include a dependency on
openssl, and therefore doesn't support TLS, which is required in order
to mount with access points.

Requesting a new tagged build via [this
issue](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/152),
whereupon we'll revert this commit.