### PR TITLE
efs-csi: Pin driver image to `release-0.4`

### DIFF
--- a/deploy/efs-csi/04-daemonset.yaml
+++ b/deploy/efs-csi/04-daemonset.yaml
@@ -30,11 +30,8 @@ spec:
         - name: efs-plugin
           securityContext:
             privileged: true
-          # DELTA: fq image
-          # TODO(efried): Pin this to a release once >0.3 is available
-          # (0.3 doesn't support TLS, which is required for access points)
-          # Follow https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/152
-          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:latest
+          # DELTA: fq image pinned to a release
+          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:release-0.4
           args:
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -758,7 +758,7 @@ objects:
             - name: efs-plugin
               securityContext:
                 privileged: true
-              image: registry.hub.docker.com/amazon/aws-efs-csi-driver:latest
+              image: registry.hub.docker.com/amazon/aws-efs-csi-driver:release-0.4
               args:
               - --endpoint=$(CSI_ENDPOINT)
               - --logtostderr


### PR DESCRIPTION
Revert(ish) of
https://github.com/openshift/managed-cluster-config/pull/311/commits/bc2abcf36cad8525028671bf9412299df538c79c
to use a pinned version of the driver image that supports TLS.