### PR TITLE
Add alert-pruner job

### DIFF
--- a/deploy/sre-pruning/105-pruning.rbac.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.yaml
@@ -59,12 +59,19 @@ rules:
   - builds
   verbs:
   - delete
+# alerts pruning
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheusrules
+  verbs:
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: sre-pruner-buildsdeploys-pruning
-roleRef: 
+roleRef:
   kind: ClusterRole
   name: sre-pruner-buildsdeploys-cr
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/sre-pruning/110-pruning-alerts.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-alerts.CronJob.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: alert-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "0 */1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+          - name: alert-pruner
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - >-
+              oc delete
+              prometheusrules.monitoring.coreos.com/kube-apiserver
+              --namespace=openshift-kube-apiserver
+              --ignore-not-found

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -5437,6 +5437,12 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - prometheusrules
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -5449,6 +5455,31 @@ objects:
       - kind: ServiceAccount
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: alert-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 */1 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: alert-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete prometheusrules.monitoring.coreos.com/kube-apiserver
+                    --namespace=openshift-kube-apiserver --ignore-not-found
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:


### PR DESCRIPTION
This job is to manually delete the `prometheusrules.monitoring.coreos.com/kube-apiserver` object if it exists. The product team currently believes this should be on users to delete.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=1816773

Once all clusters have been upgraded > 4.3.8, *and* this has run on clusters at least once, we can remove this job.