### PR TITLE
Promote MVO to v0.2.150-3829d1b

### DIFF
--- a/deploy/managed-velero-operator/135-velero.Deployment.yaml
+++ b/deploy/managed-velero-operator/135-velero.Deployment.yaml
@@ -28,7 +28,7 @@ spec:
           operator: Exists
       containers:
         - name: managed-velero-operator
-          image: quay.io/openshift-sre/managed-velero-operator:v0.2.139-456babb
+          image: quay.io/openshift-sre/managed-velero-operator:v0.2.150-3829d1b
           command:
           - managed-velero-operator
           env:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1707,7 +1707,7 @@ objects:
               operator: Exists
             containers:
             - name: managed-velero-operator
-              image: quay.io/openshift-sre/managed-velero-operator:v0.2.139-456babb
+              image: quay.io/openshift-sre/managed-velero-operator:v0.2.150-3829d1b
               command:
               - managed-velero-operator
               env:


### PR DESCRIPTION
https://github.com/openshift/managed-velero-operator/compare/456babb...3829d1b

This is mostly testing changes, but also a key fix for crashlooping when the AWS API gives us inconsistent results for ListBuckets

ref:
https://issues.redhat.com/browse/OSD-3393
https://github.com/openshift/managed-velero-operator/pull/62