### PR TITLE
Do not allow customers to adminster RHMI CRs

### DIFF
--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
@@ -20,12 +20,32 @@ aggregationRule:
       operator: In
       values:
       - OperatorGroup
+    # exclude specific operator groups by name (aka owner)
+    - key: olm.owner
+      operator: NotIn
+      values:
+      # platform operator groups
+      - openshift-cluster-monitoring
+      - olm-operators
+      # OSD operator groups
+      - cloud-ingress-operator
+      - rbac-permissions-operator
+      - splunk-forwarder-operator-og
+      # Layred Product operator groups
+      - redhat-layered-product-og
+      # RHMI operator groups (legacy)
+      - addon-rhmi-og
+      - addon-rhmi-internal-og
+      - rhmi-registry-og
+    # exclude specific namespaces too, just in case
     - key: olm.owner.namespace
       operator: NotIn
       values:
-      - openshift-cloud-ingress-operator
+      # platform namespaces
       - openshift-monitoring
       - openshift-operator-lifecycle-manager
+      # OSD namespaces
+      - openshift-cloud-ingress-operator
       - openshift-rbac-permissions
       - openshift-splunk-forwarder-operator
       - openshift-velero

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3799,12 +3799,24 @@ objects:
             operator: In
             values:
             - OperatorGroup
+          - key: olm.owner
+            operator: NotIn
+            values:
+            - openshift-cluster-monitoring
+            - olm-operators
+            - cloud-ingress-operator
+            - rbac-permissions-operator
+            - splunk-forwarder-operator-og
+            - redhat-layered-product-og
+            - addon-rhmi-og
+            - addon-rhmi-internal-og
+            - rhmi-registry-og
           - key: olm.owner.namespace
             operator: NotIn
             values:
-            - openshift-cloud-ingress-operator
             - openshift-monitoring
             - openshift-operator-lifecycle-manager
+            - openshift-cloud-ingress-operator
             - openshift-rbac-permissions
             - openshift-splunk-forwarder-operator
             - openshift-velero


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3636

Switched from using namespace to using operator group name (label olm.owner).
Include the list of current RHMI operator group names.

Tested in Stage, works as expected.  Dedicated-admins can "get" but CANNOT "edit" `Rhmis` CRs.