### PR TITLE
Remove bad SOP link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ SelectorSyncSet:
 - Sets up a ClusterRoleBinding allowing dedicated-admins to create
   PersistentVolumes.
 
-See [this SOP](https://github.com/openshift/ops-sop/blob/master/v4/howto/enable-efs-csi.asciidoc) for more details.
-
 # Dependencies
 
 pyyaml


### PR DESCRIPTION
This removes a bad link in the README pointing to a private OSD SOP.