### PR TITLE
Apply extended-dedicated-admins in all staging clusters

### DIFF
--- a/deploy/ccs-dedicated-admins/sss-config.yaml
+++ b/deploy/ccs-dedicated-admins/sss-config.yaml
@@ -1,4 +1,5 @@
 matchLabels:
     api.openshift.com/ccs: "true"
     api.openshift.com/extended-dedicated-admin: "true"
+    api.openshift.com/environment: "staging"
 matchLabelsApplyMode: "OR"    

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -558,6 +558,34 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ccs-dedicated-admins-environment
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/environment: staging
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: project
+        name: dedicated-admins-manage-operators
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - '*'
+        verbs:
+        - '*'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: cluster-monitoring-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Eventually we plan to roll this out to all customer clusters in production but we can't yet.
Until then, roll it out to all of staging.
NOTE this explicitly does not include integration environment because the "or" logic uses the label key for the SSS name and therefore cannot support multiple "or" conditions on the same label.  We have not had asks for integration so the quick update is to just do this for staging.