### PR TITLE
Add reports/export Rule To Dedicated-Admin

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
@@ -150,10 +150,10 @@ rules:
   - events
   verbs:
   - create
-# Grant 'get' on 'reports/export' until this is resolved: https://issues.redhat.com/browse/MC-832
+# Grant '*' on 'reports/export' until this is resolved: https://issues.redhat.com/browse/MC-832
 - apiGroups:
   - metering.openshift.io
   resources:
   - reports/export
   verbs:
-  - get
+  - "*"

--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
@@ -150,3 +150,9 @@ rules:
   - events
   verbs:
   - create
+- apiGroups:
+  - metering.openshift.io
+  resources:
+  - reports/export
+  verbs:
+  - get

--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
@@ -150,6 +150,7 @@ rules:
   - events
   verbs:
   - create
+# Grant 'get' on 'reports/export' until this is resolved: https://issues.redhat.com/browse/MC-832
 - apiGroups:
   - metering.openshift.io
   resources:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4314,7 +4314,7 @@ objects:
         resources:
         - reports/export
         verbs:
-        - get
+        - '*'
     - aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4309,6 +4309,12 @@ objects:
         - events
         verbs:
         - create
+      - apiGroups:
+        - metering.openshift.io
+        resources:
+        - reports/export
+        verbs:
+        - get
     - aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:


### PR DESCRIPTION
This RBAC rule is required for the customer (dedicated-admin) to use the Metering Operator's report-exporter role.

```
oc adm policy add-role-to-user report-exporter <username> --role-namespace=<namespace> -n <namespace>
```