### PR TITLE
Additional Resources Required for Metering Operator

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
@@ -154,6 +154,11 @@ rules:
 - apiGroups:
   - metering.openshift.io
   resources:
+  - reports
   - reports/export
+  - reportqueries
+  - reportdatasources
+  - prestotables
+  - storagelocations
   verbs:
   - "*"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4312,7 +4312,12 @@ objects:
       - apiGroups:
         - metering.openshift.io
         resources:
+        - reports
         - reports/export
+        - reportqueries
+        - reportdatasources
+        - prestotables
+        - storagelocations
         verbs:
         - '*'
     - aggregationRule:


### PR DESCRIPTION
Adds additional resources required for full 'reporting-admin' permissions. This is required for exposing and configuring reports as documented here: https://github.com/kube-reporting/metering-operator/blob/master/Documentation/configuring-reporting-operator.md