### PR TITLE
Refactor sre-build-test bash script

### DIFF
--- a/deploy/sre-build-test/50-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-build-test.CronJob.yaml
@@ -33,30 +33,56 @@ spec:
           - name: sre-build-test
             image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
+            env:
+              - name: JOB_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
             command:
-            - /bin/sh
+            - /bin/bash
             - -c
-            - >-
-              export NS=openshift-build-test-$(date +%s); 
-              oc create ns $NS; 
-              oc -n $NS new-build nodejs~https://github.com/openshift/nodejs-ex --name=sre-build-test; 
-              echo $(date): Waiting for build to complete.; 
-              while :; 
-              do  
-                export ST=$(oc -n $NS get build -o custom-columns=STATUS:.status.phase --no-headers);
-                echo Checking the state of the build: $ST;
-                if [[ $ST = "Failed" ]]
-                then 
-                echo "Build Failed" && exit 1
-                elif [[ $ST = "Cancelled" ]]
-                then
-                echo "Build was Cancelled" && exit 1
-                elif [[ $ST = "Complete" ]]
-                then
-                echo "Build Complete" && break
-                fi 
-                echo $(date): Checking build again in 15 seconds, NS=$NS; 
-                sleep 15; 
-              done; 
-              echo $(date): Done, deleting build NS=$NS; 
-              oc delete ns $NS
+            - |
+              # ensure we fail if something exits non-zero
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+
+              # cleanup traps on exiting, so these always run
+              cleanup () {
+                echo "$(date): Done, deleting build NS=$NS"
+                oc delete ns "${NS}"
+              }
+              trap "cleanup" EXIT SIGINT
+
+              # set NS to include job name, to ease linking namespace to a specific job
+              export NS="openshift-build-test-${JOB_NAME##sre-build-test-}"
+              oc create ns "${NS}"
+
+              # run build
+              oc -n "${NS}" new-build nodejs~https://github.com/openshift/nodejs-ex --name=sre-build-test
+              echo "$(date): Waiting for build to complete."
+              while :
+              do
+                export ST=$(oc -n "${NS}" get build -o custom-columns=STATUS:.status.phase --no-headers)
+                case ${ST} in
+                  "")
+                    # if build status is blank, assume we are still starting the build
+                    ST="Starting"
+                    ;;
+                  Failed)
+                    echo "$(date): Build Failed" >&2
+                    exit 1
+                    ;;
+                  Cancelled)
+                    echo "$(date): Build was Cancelled" >&2
+                    exit 1
+                    ;;
+                  Complete)
+                    echo "$(date): Build Complete"
+                    break
+                    ;;
+                esac
+                echo "$(date): Build is ${ST}; checking build again in 15 seconds, NS=${NS}"
+                sleep 15
+              done
+              exit 0

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4874,21 +4874,33 @@ objects:
                 - name: sre-build-test
                   image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
+                  env:
+                  - name: JOB_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
                   command:
-                  - /bin/sh
+                  - /bin/bash
                   - -c
-                  - "export NS=openshift-build-test-$(date +%s);  oc create ns $NS;\
-                    \  oc -n $NS new-build nodejs~https://github.com/openshift/nodejs-ex\
-                    \ --name=sre-build-test;  echo $(date): Waiting for build to complete.;\
-                    \  while :;  do  \n  export ST=$(oc -n $NS get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers);\n  echo Checking the state of the build: $ST;\n\
-                    \  if [[ $ST = \"Failed\" ]]\n  then \n  echo \"Build Failed\"\
-                    \ && exit 1\n  elif [[ $ST = \"Cancelled\" ]]\n  then\n  echo\
-                    \ \"Build was Cancelled\" && exit 1\n  elif [[ $ST = \"Complete\"\
-                    \ ]]\n  then\n  echo \"Build Complete\" && break\n  fi \n  echo\
-                    \ $(date): Checking build again in 15 seconds, NS=$NS; \n  sleep\
-                    \ 15; \ndone;  echo $(date): Done, deleting build NS=$NS;  oc\
-                    \ delete ns $NS"
+                  - "# ensure we fail if something exits non-zero\nset -o errexit\n\
+                    set -o nounset\nset -o pipefail\n\n# cleanup traps on exiting,\
+                    \ so these always run\ncleanup () {\n  echo \"$(date): Done, deleting\
+                    \ build NS=$NS\"\n  oc delete ns \"${NS}\"\n}\ntrap \"cleanup\"\
+                    \ EXIT SIGINT\n\n# set NS to include job name, to ease linking\
+                    \ namespace to a specific job\nexport NS=\"openshift-build-test-${JOB_NAME##sre-build-test-}\"\
+                    \noc create ns \"${NS}\"\n\n# run build\noc -n \"${NS}\" new-build\
+                    \ nodejs~https://github.com/openshift/nodejs-ex --name=sre-build-test\n\
+                    echo \"$(date): Waiting for build to complete.\"\nwhile :\ndo\n\
+                    \  export ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
+                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
+                    \ status is blank, assume we are still starting the build\n  \
+                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ Build Failed\" >&2\n      exit 1\n      ;;\n    Cancelled)\n\
+                    \      echo \"$(date): Build was Cancelled\" >&2\n      exit 1\n\
+                    \      ;;\n    Complete)\n      echo \"$(date): Build Complete\"\
+                    \n      break\n      ;;\n  esac\n  echo \"$(date): Build is ${ST};\
+                    \ checking build again in 15 seconds, NS=${NS}\"\n  sleep 15\n\
+                    done\nexit 0\n"
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Building off of #339, this refactors the bash script a little bit, to make it slightly more resilient.

Example logs:

```
namespace/openshift-build-test-1590010500-ltfjx created
warning: Cannot find git. Ensure that it is installed and in your path. Git is required to work with git repositories.
--> Found image 843b4d7 (8 days old) in image stream "openshift/nodejs" under tag "10-SCL" for "nodejs"

    Node.js 10 
    ---------- 
    Node.js 10 available as container is a base platform for building and running various Node.js 10 applications and frameworks. Node.js is a platform built on Chrome's JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.

    Tags: builder, nodejs, nodejs10

    * A source build using source code from https://github.com/openshift/nodejs-ex will be created
      * The resulting image will be pushed to image stream tag "sre-build-test:latest"
      * Use 'oc start-build' to trigger a new build

--> Creating resources with label build=sre-build-test ...
    imagestream.image.openshift.io "sre-build-test" created
    buildconfig.build.openshift.io "sre-build-test" created
--> Success
Wed May 20 21:35:31 UTC 2020: Waiting for build to complete.
Wed May 20 21:35:31 UTC 2020: Build is Starting; checking build again in 15 seconds, NS=openshift-build-test-1590010500-ltfjx
Wed May 20 21:35:47 UTC 2020: Build is Running; checking build again in 15 seconds, NS=openshift-build-test-1590010500-ltfjx
Wed May 20 21:36:02 UTC 2020: Build is Running; checking build again in 15 seconds, NS=openshift-build-test-1590010500-ltfjx
Wed May 20 21:36:17 UTC 2020: Build Complete
Wed May 20 21:36:17 UTC 2020: Done, deleting build NS=openshift-build-test-1590010500-ltfjx
namespace "openshift-build-test-1590010500-ltfjx" deleted
```