### PR TITLE
Add AlertManagerSilenceSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-alertmanager-silences-active
+    role: alert-rules
+  name: sre-alertmanager-silences-active
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-alertmanager-silences-active
+    rules:
+    - alert: AlertmanagerSilencesActiveSRE
+      # Ignore alerting on silences if the cluster is upgrading, as the 
+      # upgrade process will generate a silence itself. (OSD-3426)
+      expr: count(alertmanager_silences{state="active"} == 1) > 0 unless (count(cluster_version{type="updating"}) > 0)
+      for: 15m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+      annotations:
+        message: Active AlertManager silences have been detected on the cluster for the last 15 minutes. As a result, active alerts may potentially not be being reported back.

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4943,6 +4943,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-alertmanager-silences-active
+          role: alert-rules
+        name: sre-alertmanager-silences-active
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-alertmanager-silences-active
+          rules:
+          - alert: AlertmanagerSilencesActiveSRE
+            expr: count(alertmanager_silences{state="active"} == 1) > 0 unless (count(cluster_version{type="updating"})
+              > 0)
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Active AlertManager silences have been detected on the cluster
+                for the last 15 minutes. As a result, active alerts may potentially
+                not be being reported back.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-cluster-upgrade-alerts
           role: alert-rules
         name: sre-cluster-upgrade-alerts


### PR DESCRIPTION
This PR implements [OSD-3494](https://issues.redhat.com/browse/OSD-3494) to add a new alert "AlertManagerSilenceSRE" which raises if active AlertManager silences are detected on the cluster.

The following exclusions apply to when this alert will fire:
- The alert will not fire if the cluster is in the process of upgrading. Alert manager silences are expected during the upgrade process via the Upgrade Operator (see [OSD-3426](https://issues.redhat.com/browse/OSD-3426))
- The alert will not fire if alertmanager is set up to silence the AlertManagerSilenceSRE alert itself. I can't think how to get around this one.

SOPs for the alert have been undertaken [as part of this ops-sop PR](https://github.com/openshift/ops-sop/pull/787) and should be reviewed alongside this PR.