### PR TITLE
Fixing alerts for master resizing

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -16,29 +16,29 @@ spec:
         record: sre:node_roles:memory_total_bytes
       - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
         record: sre:node_workers:count
-      # master has less than 8GB RAM, worker count > 25, and worker count <= 100
-      # master has less than 16GB RAM, worker count > 100, and worker count <= 250
-      # master has less than 32GB RAM, worker count > 250
+      # master has less than 16GB RAM, worker count > 25, and worker count <= 100
+      # master has less than 32GB RAM, worker count > 100, and worker count <= 250
+      # master has less than 64GB RAM, worker count > 250
       - expr: (
-                sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"} < 8*1024*1024*1024
+                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 16*1024*1024*1024
                 AND sre:node_workers:count > 25 
                 AND sre:node_workers:count <= 100 
               )
               OR 
               (
-                sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"} < 16*1024*1024*1024
+                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 32*1024*1024*1024
                 AND sre:node_workers:count > 100
                 AND sre:node_workers:count <= 250 
               )
               OR 
               (
-                sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"} < 32*1024*1024*1024
+                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 64*1024*1024*1024
                 AND sre:node_workers:count > 250
               )
         record: sre:node_masters:need_resize
   - name: sre-control-plane-resizing-alerts
     rules:
-      - alert: ControlPlaneNodesNeedResizingSRE
+      - alert: MasetrNodesNeedResizingSRE
         expr: sre:node_masters:need_resize > 0
         for: 15m
         labels:

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -5035,16 +5035,16 @@ objects:
             record: sre:node_roles:memory_total_bytes
           - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
             record: sre:node_workers:count
-          - expr: ( sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}
-              < 8*1024*1024*1024 AND sre:node_workers:count > 25 AND sre:node_workers:count
-              <= 100 ) OR ( sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}
-              < 16*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
-              <= 250 ) OR ( sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}
-              < 32*1024*1024*1024 AND sre:node_workers:count > 250 )
+          - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
+              < 16*1024*1024*1024 AND sre:node_workers:count > 25 AND sre:node_workers:count
+              <= 100 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
+              < 32*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
+              <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
+              < 64*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
-          - alert: ControlPlaneNodesNeedResizingSRE
+          - alert: MasetrNodesNeedResizingSRE
             expr: sre:node_masters:need_resize > 0
             for: 15m
             labels:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-3215

Renamed alerts.
Using `avg` to remove labels for the `and` logic in recording rule.
Updated memory requirements to align w/ OCP docs.