### PR TITLE
Fix SSS generation

### DIFF
--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -586,7 +586,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-adminshive.openshift.io/cluster-platform
+    name: ccs-dedicated-admins-cluster-platform
   spec:
     clusterDeploymentSelector:
       matchLabels:

--- a/scripts/generate_syncset.py
+++ b/scripts/generate_syncset.py
@@ -6,6 +6,7 @@ import os
 import sys
 import argparse
 import copy
+import re
 
 cluster_platform_ann = "hive.openshift.io/cluster-platform"
 sss_config_filename = "sss-config.yaml"
@@ -137,7 +138,7 @@ if __name__ == '__main__':
                 del o["matchLabelsApplyMode"]
 
                 # SSS objects require unique names
-                unique_sss_name = sss_name + key.replace('api.openshift.com/', '-')
+                unique_sss_name = sss_name + '-' + re.sub('^.*?/', '', key)
                 process_yamls(unique_sss_name, dirpath, selectorsyncset_data, o)
         else:
             # Catches anyone with a rouge value


### PR DESCRIPTION
When #347 merged, because it was using a label for selection that we haven't before, it broke SSS generation as it wasn't properly machine `hive.openshift.io` instead of `api.openshift.com`.