### PR TITLE
This exclude the service loadbalancer quota from  openshift-kube-apiserver

### DIFF
--- a/deploy/resource-quotas/10-patch.namespace.openshift-kube-apiserver.yaml
+++ b/deploy/resource-quotas/10-patch.namespace.openshift-kube-apiserver.yaml
@@ -1,0 +1,7 @@
+kind: Namespace
+apiVersion: v1
+name: openshift-kube-apiserver
+applyMode: AlwaysApply
+patch: |-
+  { "metadata": {"labels": {"managed.openshift.io/service-lb-quota-exempt":"true"} } }
+patchType: merge

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4615,6 +4615,13 @@ objects:
       patchType: merge
     - kind: Namespace
       apiVersion: v1
+      name: openshift-kube-apiserver
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"managed.openshift.io/service-lb-quota-exempt":"true"}
+        } }'
+      patchType: merge
+    - kind: Namespace
+      apiVersion: v1
       name: openshift-monitoring
       applyMode: AlwaysApply
       patch: '{ "metadata": {"labels": {"managed.openshift.io/storage-pv-quota-exempt":"true"}


### PR DESCRIPTION
It looks like we have a apischeme CR by default, and this will create a service using loadbalancer, we should exclude this.