### PR TITLE
use of :z for bindmount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ generate-oauth-templates:
 .PHONY: generate-syncset
 generate-syncset: generate-oauth-templates
 	if [ -z ${IN_CONTAINER} ]; then \
-		$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P` python:2.7.15 /bin/sh -c "cd `pwd -P`; pip install oyaml; ${GEN_SYNCSET}"; \
+			$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P`:z python:2.7.15 /bin/sh -c "cd `pwd -P`; pip install oyaml; ${GEN_SYNCSET}"; \
 	else \
 		${GEN_SYNCSET}; \
 	fi


### PR DESCRIPTION
podman makes were failing with `/bin/sh: 1: scripts/generate_syncset.py: Permission denied`. 

Added :z as per:

```
     To  change  a  label  in  the container context, you can add either of two suffixes :z or :Z to the volume mount. These suffixes tell Podman to relabel file objects on the shared volumes. The z option
       tells Podman that two containers share the volume content. As a result, Podman labels the content with a shared content label. Shared volume labels allow all containers to read/write content.   The  Z
       option tells Podman to label the content with a private unshared label.  Only the current container can use a private volume.
```