### PR TITLE
Change velero alerts to info

### DIFF
--- a/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
@@ -21,7 +21,7 @@ spec:
         time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
         scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 3600 + 600
       labels:
-        severity: warning
+        severity: info
         namespace: openshift-monitoring
       annotations:
         message: The hourly Velero backup has not successfully completed
@@ -32,7 +32,7 @@ spec:
         time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="daily-full-backup"},
         scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 86400 + 600
       labels:
-        severity: warning
+        severity: info
         namespace: openshift-monitoring
       annotations:
         message: The daily Velero backup has not successfully completed
@@ -43,7 +43,7 @@ spec:
         time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="weekly-full-backup"},
         scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 604800 + 600
       labels:
-        severity: warning
+        severity: info
         namespace: openshift-monitoring
       annotations:
         message: The weekly Velero backup has not successfully completed

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -5432,7 +5432,7 @@ objects:
 
               '
             labels:
-              severity: warning
+              severity: info
               namespace: openshift-monitoring
             annotations:
               message: The hourly Velero backup has not successfully completed
@@ -5444,7 +5444,7 @@ objects:
 
               '
             labels:
-              severity: warning
+              severity: info
               namespace: openshift-monitoring
             annotations:
               message: The daily Velero backup has not successfully completed
@@ -5456,7 +5456,7 @@ objects:
 
               '
             labels:
-              severity: warning
+              severity: info
               namespace: openshift-monitoring
             annotations:
               message: The weekly Velero backup has not successfully completed


### PR DESCRIPTION
fixes OSD-3656

These alerts can sometimes be unactionable. We have issues opened with upstream to get some things fixed, but until they are, we should lower this to `info` so they don't page SRE.