### PR TITLE
Set MVO's SSS resourceApplyMode to Upsert prior to rolling out OLM deployed MVO

### DIFF
--- a/deploy/managed-velero-operator/sss-config.yaml
+++ b/deploy/managed-velero-operator/sss-config.yaml
@@ -1,0 +1,1 @@
+resourceApplyMode: Upsert

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1228,7 +1228,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition


### PR DESCRIPTION
The managed-velero-operator is going to be removed from this repo once it has been fully migrated over to being deployed by OLM. For a brief period, both MCC and OLM will be applying selectorsyncsets on hive. This PR changes the the resourceApplyMode of MCC's SSS to "Upsert" which will ensure that any resources applied by the SSS won't be deleted over the course of the migration. 