### PR TITLE
Permit dedicated-admins to patch/update daemonsets in logging

### DIFF
--- a/deploy/osd-logging/05-role.yaml
+++ b/deploy/osd-logging/05-role.yaml
@@ -43,3 +43,14 @@ rules:
   - persistentvolumeclaims
   verbs:
   - "*"
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3530,6 +3530,17 @@ objects:
         - persistentvolumeclaims
         verbs:
         - '*'
+      - apiGroups:
+        - apps
+        - extensions
+        resources:
+        - daemonsets
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:


### PR DESCRIPTION
CUs can't follow the directions in https://github.com/openshift/cluster-logging-operator/blob/master/docs/unmanaged_configuration.md to enable json log merging, as they can't patch daemonsets.

ref: OSD-4336