### PR TITLE
Automatically create the operator subscriptions for the logging operator

### DIFF
--- a/deploy/osd-logging/04-subscription.yaml
+++ b/deploy/osd-logging/04-subscription.yaml
@@ -1,0 +1,23 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: elasticsearch-operator
+  namespace: openshift-logging
+spec:
+  channel: "4.3"
+  installPlanApproval: Automatic
+  name: elasticsearch-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: "4.3"
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3485,6 +3485,28 @@ objects:
       spec:
         hard:
           requests.storage: 1200Gi
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: elasticsearch-operator
+        namespace: openshift-logging
+      spec:
+        channel: '4.3'
+        installPlanApproval: Automatic
+        name: elasticsearch-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: cluster-logging
+        namespace: openshift-logging
+      spec:
+        channel: '4.3'
+        installPlanApproval: Automatic
+        name: cluster-logging
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:


### PR DESCRIPTION
This creates the subscriptions for the ClusterLogging operator, so that CUs don't have to manage it themselves.

ref https://issues.redhat.com/browse/OSD-4077