### PR TITLE
Added a Prometheus rule to fire an info level alert when console routes are unavailable

### DIFF
--- a/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
@@ -18,7 +18,7 @@ spec:
         severity: info
         namespace: openshift-monitoring
 
-    - alert: API-Route-SLO-Breach
+    - alert: OpenShift-API-Server-Route-SLO-Breach
       expr: haproxy_server_response_errors_total{exported_service=~"(console)"} > 0
       for: 5m
       labels:

--- a/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
@@ -12,15 +12,11 @@ spec:
   - name: sre-important-routes-slo-alerts
     rules:
     - alert: ConsoleRoute-SLO-Breach
-      expr: haproxy_server_response_errors_total{exported_service=~"(oauth-openshift)"} > 0
-      for: 5m
-      labels:
-        severity: info
-        namespace: openshift-monitoring
-
-    - alert: OpenShift-API-Server-Route-SLO-Breach
-      expr: haproxy_server_response_errors_total{exported_service=~"(console)"} > 0
-      for: 5m
+      annotations:
+        message: The console route has had 100 percent request failures for 60 seconds.
+      expr: |
+        (sum(rate(haproxy_backend_http_responses_total{route=~"console",code=~"(5..)"}[1m])) / sum(rate(haproxy_backend_http_responses_total{route=~"console",code=~"([1-5]..)"}[1m])) >= 1)
+      for: 1m
       labels:
         severity: info
         namespace: openshift-monitoring

--- a/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   groups:
   - name: sre-important-routes-slo-alerts
     rules:
-    - alert: ConsoleRoute-SLO-Breach
+    - alert: ConsoleRequestErrorsSRE
       annotations:
         message: The console route has had 100 percent request failures for 60 seconds.
       expr: |

--- a/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
@@ -1,0 +1,26 @@
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-important-routes-slo
+    role: alert-rules
+  name: sre-important-routes-slo
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-important-routes-slo-alerts
+    rules:
+    - alert: ConsoleRoute-SLO-Breach
+      expr: haproxy_server_response_errors_total{exported_service=~"(oauth-openshift)"} > 0
+      for: 5m
+      labels:
+        severity: info
+        namespace: openshift-monitoring
+
+    - alert: API-Route-SLO-Breach
+      expr: haproxy_server_response_errors_total{exported_service=~"(console)"} > 0
+      for: 5m
+      labels:
+        severity: info
+        namespace: openshift-monitoring

--- a/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         message: The console route has had 100 percent request failures for 60 seconds.
       expr: |
-        (sum(rate(haproxy_backend_http_responses_total{route=~"console",code=~"(5..)"}[1m])) / sum(rate(haproxy_backend_http_responses_total{route=~"console",code=~"([1-5]..)"}[1m])) >= 1)
+        sum(rate(haproxy_backend_http_responses_total{route=~"console",code=~"(5..)"}[1m])) / sum(rate(haproxy_backend_http_responses_total{route=~"console",code=~"([1-5]..)"}[1m])) >= 1
       for: 1m
       labels:
         severity: info

--- a/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-important-routes-slo-PrometheusRule.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:


### PR DESCRIPTION
@RiRa12621 Is that the correct implementation? 
In this rule, all "response error total" metrics bigger than 0 will be firing an alert.
Can we later use this to calculate SLO in the telemeter dashboard?