### PR TITLE
Osd 4234

### DIFF
--- a/deploy/osd-cluster-admin/06-osd-impersonators.Group.yaml
+++ b/deploy/osd-cluster-admin/06-osd-impersonators.Group.yaml
@@ -1,0 +1,4 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: osd-impersonators

--- a/deploy/osd-cluster-admin/08-osd-impersonators.ClusterRoleBinding.yaml
+++ b/deploy/osd-cluster-admin/08-osd-impersonators.ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sudoer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sudoer
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: osd-impersonators

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2257,6 +2257,22 @@ objects:
       - apiGroup: rbac.authorization.k8s.io
         kind: Group
         name: cluster-admins
+    - apiVersion: user.openshift.io/v1
+      kind: Group
+      metadata:
+        name: osd-impersonators
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sudoer
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: sudoer
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: osd-impersonators
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-4234

Introduced a new impersonators group, and enabling the 'sudoers' ClusterRole with a ClusterRoleBinding. This is designed to only allow existing ClusterAdmin clusters, the ability to leverage impersonation of the system:admin role without required changes to existing workflows.