### PR TITLE
OSD-4493 Pre-update ClusterVersion.spec.channel with the desired channel if necessary

### DIFF
--- a/scripts/cluster-upgrade.sh
+++ b/scripts/cluster-upgrade.sh
@@ -258,7 +258,7 @@ upgrade() {
     then
         KUBECONFIG=$TMP_DIR/kubeconfig-${CD_NAMESPACE} oc patch clusterversion version --type merge -p "{\"spec\":{\"channel\": \"$DESIRED_CHANNEL\"}}"
 
-        # Wait for CVO to identiofy the update and refresh clusterVersion.status.availableUpdates
+        # Wait for CVO to identify the update and refresh clusterVersion.status.availableUpdates
         sleep 20
     fi
 


### PR DESCRIPTION
Update the ClusterVersion.spec.channel in case of a cluster upgrade to a different minor version (e.g 4.3 to 4.4).

If the channel is already the desired one, don't do anything.