### PR TITLE
Define MVO's cluster-config role/binding here to workaround CSV permissions issue

### DIFF
--- a/deploy/managed-velero-operator-rolebinding/111-velero.Role.yaml
+++ b/deploy/managed-velero-operator-rolebinding/111-velero.Role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: cluster-config-v1-reader
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - cluster-config-v1
+  resources:
+  - configmaps
+  verbs:
+  - get

--- a/deploy/managed-velero-operator-rolebinding/116-velero.RoleBinding.yaml
+++ b/deploy/managed-velero-operator-rolebinding/116-velero.RoleBinding.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: managed-velero-operator-cluster-config-v1-reader
+  namespace: kube-system
+  labels:
+    owner: managed-velero-operator
+    owner.namespace: managed-velero-operator
+subjects:
+- kind: ServiceAccount
+  name: managed-velero-operator
+  namespace: openshift-velero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-config-v1-reader

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1648,6 +1648,51 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: managed-velero-operator-rolebinding
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        creationTimestamp: null
+        name: cluster-config-v1-reader
+        namespace: kube-system
+      rules:
+      - apiGroups:
+        - ''
+        resourceNames:
+        - cluster-config-v1
+        resources:
+        - configmaps
+        verbs:
+        - get
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: managed-velero-operator-cluster-config-v1-reader
+        namespace: kube-system
+        labels:
+          owner: managed-velero-operator
+          owner.namespace: managed-velero-operator
+      subjects:
+      - kind: ServiceAccount
+        name: managed-velero-operator
+        namespace: openshift-velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: cluster-config-v1-reader
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
The managed-velero-operator is being deployed via OLM now, but the role and rolebinding used to read the cluster-config-v1 configmap from the kube-system namespace can't be created in the CSV for the operator. As a workaround, this selectorsyncset will create that role and rolebinding. 