### PR TITLE
Revert "Change velero alerts to info"

### DIFF
--- a/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
@@ -21,7 +21,7 @@ spec:
         time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
         scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 3600 + 600
       labels:
-        severity: info
+        severity: warning
         namespace: openshift-monitoring
       annotations:
         message: The hourly Velero backup has not successfully completed
@@ -32,7 +32,7 @@ spec:
         time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="daily-full-backup"},
         scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 86400 + 600
       labels:
-        severity: info
+        severity: warning
         namespace: openshift-monitoring
       annotations:
         message: The daily Velero backup has not successfully completed
@@ -43,7 +43,7 @@ spec:
         time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="weekly-full-backup"},
         scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 604800 + 600
       labels:
-        severity: info
+        severity: warning
         namespace: openshift-monitoring
       annotations:
         message: The weekly Velero backup has not successfully completed

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4926,7 +4926,7 @@ objects:
 
               '
             labels:
-              severity: info
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: The hourly Velero backup has not successfully completed
@@ -4938,7 +4938,7 @@ objects:
 
               '
             labels:
-              severity: info
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: The daily Velero backup has not successfully completed
@@ -4950,7 +4950,7 @@ objects:
 
               '
             labels:
-              severity: info
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: The weekly Velero backup has not successfully completed


### PR DESCRIPTION
This reverts commit ca0704878f817081de6cc4666c006b3467eafbb2.

As https://github.com/openshift/managed-velero-operator/pull/87 pulls in the long term fix for https://issues.redhat.com/browse/OSD-3656, reverting these alerts back to warning, so that we can identify when we have issues with our backups