### PR TITLE
Remove DNSErrors05MinSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
@@ -15,11 +15,3 @@ spec:
       labels:
         severity: critical
         namespace: openshift-monitoring
-    - alert: DNSErrors05MinSRE
-      expr: rate(dns_failure_failure_total[5m]) > 0
-      for: 5m
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
-      annotations:
-        message: DNS checks have been failing for the past 5 minutes on pod- {{ $labels.pod }}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7388,15 +7388,6 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
-          - alert: DNSErrors05MinSRE
-            expr: rate(dns_failure_failure_total[5m]) > 0
-            for: 5m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: DNS checks have been failing for the past 5 minutes on pod-
-                {{ $labels.pod }}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7388,15 +7388,6 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
-          - alert: DNSErrors05MinSRE
-            expr: rate(dns_failure_failure_total[5m]) > 0
-            for: 5m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: DNS checks have been failing for the past 5 minutes on pod-
-                {{ $labels.pod }}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7388,15 +7388,6 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
-          - alert: DNSErrors05MinSRE
-            expr: rate(dns_failure_failure_total[5m]) > 0
-            for: 5m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: DNS checks have been failing for the past 5 minutes on pod-
-                {{ $labels.pod }}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

https://issues.redhat.com/browse/OSD-4437

We are porting this alert to upstream cluster-dns-operator, so we can remove this alert here.

Please hold this pr until https://github.com/openshift/cluster-dns-operator/pull/184 gets merged.