### PR TITLE
Remove alert DNSLatencyOver200ms5MinSRE

### DIFF
--- a/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
@@ -10,11 +10,6 @@ spec:
   groups:
   - name: sre-dns-alerts
     rules:
-    - alert: DNSLatencyOver200ms5MinSRE
-      expr: max_over_time(dns_latency_milliseconds_sum[5m]) > 0.2
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
     - alert: DNSErrors05MinSRE
       expr: rate(dns_failure_failure_total[5m]) > 0
       for: 5m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7383,11 +7383,6 @@ objects:
         groups:
         - name: sre-dns-alerts
           rules:
-          - alert: DNSLatencyOver200ms5MinSRE
-            expr: max_over_time(dns_latency_milliseconds_sum[5m]) > 0.2
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
           - alert: DNSErrors05MinSRE
             expr: rate(dns_failure_failure_total[5m]) > 0
             for: 5m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7383,11 +7383,6 @@ objects:
         groups:
         - name: sre-dns-alerts
           rules:
-          - alert: DNSLatencyOver200ms5MinSRE
-            expr: max_over_time(dns_latency_milliseconds_sum[5m]) > 0.2
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
           - alert: DNSErrors05MinSRE
             expr: rate(dns_failure_failure_total[5m]) > 0
             for: 5m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7383,11 +7383,6 @@ objects:
         groups:
         - name: sre-dns-alerts
           rules:
-          - alert: DNSLatencyOver200ms5MinSRE
-            expr: max_over_time(dns_latency_milliseconds_sum[5m]) > 0.2
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
           - alert: DNSErrors05MinSRE
             expr: rate(dns_failure_failure_total[5m]) > 0
             for: 5m


### PR DESCRIPTION
Signed-off-by: Ben Ye <yb532204897@gmail.com>

https://issues.redhat.com/browse/OSD-4438

This alert never worked since it uses the wrong metric name https://github.com/openshift/managed-prometheus-exporter-dns/blob/master/monitor/main.py#L12. 

Also, we are planning to add a new DNS latency alert based on CoreDNS metrics. So it is okay to remove this old alert.