### PR TITLE
Update IOPs burst balance alert rules

### DIFF
--- a/deploy/sre-prometheus/aws/100-ebs-iops-burstbalance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/aws/100-ebs-iops-burstbalance.PrometheusRule.yaml
@@ -10,15 +10,17 @@ spec:
   groups:
   - name: sre-ebs-iops-burstbalance
     rules:
-    - alert: EbsVolumeBurstBalanceLT40PctSRE
-      expr: avg(ebs_iops_credits) < 40
+    - alert: EbsVolumeBurstBalanceLowSRE
+      expr: 100 - min_over_time(ebs_iops_credits[30m:5m]) > 80
       for: 60m
       labels:
         severity: warning
         namespace: openshift-monitoring
-    - alert: EbsVolumeBurstBalanceLT20PctSRE
-      expr: avg(ebs_iops_credits) < 20
-      for: 60m
+    - alert: EbsVolumeBurstBalanceEmptySRE
+      expr: 100 - min_over_time(ebs_iops_credits[3h:15m]) == 100
+      annotations:
+        message: "The EBS volume {{ $labels.vol_id }} has exhausted its IOPs burst credit for over 2 hours"
+      for: 120m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5658,15 +5658,18 @@ objects:
         groups:
         - name: sre-ebs-iops-burstbalance
           rules:
-          - alert: EbsVolumeBurstBalanceLT40PctSRE
-            expr: avg(ebs_iops_credits) < 40
+          - alert: EbsVolumeBurstBalanceLowSRE
+            expr: 100 - min_over_time(ebs_iops_credits[30m:5m]) > 80
             for: 60m
             labels:
               severity: warning
               namespace: openshift-monitoring
-          - alert: EbsVolumeBurstBalanceLT20PctSRE
-            expr: avg(ebs_iops_credits) < 20
-            for: 60m
+          - alert: EbsVolumeBurstBalanceEmptySRE
+            expr: 100 - min_over_time(ebs_iops_credits[3h:15m]) == 100
+            annotations:
+              message: The EBS volume {{ $labels.vol_id }} has exhausted its IOPs
+                burst credit for over 2 hours
+            for: 120m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5658,15 +5658,18 @@ objects:
         groups:
         - name: sre-ebs-iops-burstbalance
           rules:
-          - alert: EbsVolumeBurstBalanceLT40PctSRE
-            expr: avg(ebs_iops_credits) < 40
+          - alert: EbsVolumeBurstBalanceLowSRE
+            expr: 100 - min_over_time(ebs_iops_credits[30m:5m]) > 80
             for: 60m
             labels:
               severity: warning
               namespace: openshift-monitoring
-          - alert: EbsVolumeBurstBalanceLT20PctSRE
-            expr: avg(ebs_iops_credits) < 20
-            for: 60m
+          - alert: EbsVolumeBurstBalanceEmptySRE
+            expr: 100 - min_over_time(ebs_iops_credits[3h:15m]) == 100
+            annotations:
+              message: The EBS volume {{ $labels.vol_id }} has exhausted its IOPs
+                burst credit for over 2 hours
+            for: 120m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5658,15 +5658,18 @@ objects:
         groups:
         - name: sre-ebs-iops-burstbalance
           rules:
-          - alert: EbsVolumeBurstBalanceLT40PctSRE
-            expr: avg(ebs_iops_credits) < 40
+          - alert: EbsVolumeBurstBalanceLowSRE
+            expr: 100 - min_over_time(ebs_iops_credits[30m:5m]) > 80
             for: 60m
             labels:
               severity: warning
               namespace: openshift-monitoring
-          - alert: EbsVolumeBurstBalanceLT20PctSRE
-            expr: avg(ebs_iops_credits) < 20
-            for: 60m
+          - alert: EbsVolumeBurstBalanceEmptySRE
+            expr: 100 - min_over_time(ebs_iops_credits[3h:15m]) == 100
+            annotations:
+              message: The EBS volume {{ $labels.vol_id }} has exhausted its IOPs
+                burst credit for over 2 hours
+            for: 120m
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
* These alerts should be using min_over_time rather than avg
* Inverted balance for clarity when viewing Prometheus graphs