### PR TITLE
Add "openshift-sre-sshd" namespace

### DIFF
--- a/deploy/osd-ingress/00-openshift-sre-sshd.Namespace.yaml
+++ b/deploy/osd-ingress/00-openshift-sre-sshd.Namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sre-sshd

--- a/deploy/resource-quotas/10-patch.namespace.openshift-sre-sshd.yaml
+++ b/deploy/resource-quotas/10-patch.namespace.openshift-sre-sshd.yaml
@@ -1,0 +1,7 @@
+kind: Namespace
+apiVersion: v1
+name: openshift-sre-sshd
+applyMode: AlwaysApply
+patch: |-
+  { "metadata": {"labels": {"managed.openshift.io/storage-lb-quota-exempt":"true"} } }
+patchType: merge

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -2975,6 +2975,11 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-sre-sshd
     patches:
     - apiVersion: operator.openshift.io/v1
       applyMode: AlwaysApply
@@ -4330,6 +4335,13 @@ objects:
       name: openshift-monitoring
       applyMode: AlwaysApply
       patch: '{ "metadata": {"labels": {"managed.openshift.io/storage-pv-quota-exempt":"true"}
+        } }'
+      patchType: merge
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-sre-sshd
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"managed.openshift.io/storage-lb-quota-exempt":"true"}
         } }'
       patchType: merge
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
The SSHD pod controller ([OSD-3599](https://issues.redhat.com/browse/OSD-3599)) and SSH key ConfigMaps ([OSD-3601](https://issues.redhat.com/browse/OSD-3601)) will exist here. 
Requires a service load balancer quota exemption.