### PR TITLE
OSD-4024 add managed-upgrade-operator configmap

### DIFF
--- a/deploy/managed-upgrade-operator/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator/10-managed-upgrade-operator-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: managed-upgrade-operator-config
+  namespace: openshift-managed-upgrade-operator
+data:
+  config.yaml: |
+    maintenance:
+      controlPlaneTime: 90
+      workerNodeTime: 8
+    scale:
+      timeOut: 30
+    upgradeWindow:
+      timeOut: 60
+    nodeDrain:
+      timeOut: 45

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -1225,6 +1225,29 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: managed-upgrade-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut:\
+          \ 45\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: managed-velero-operator-rolebinding
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This PR adds a SelectorSyncSet-distributed ConfigMap for the managed-upgrade-operator to define SRE time preferences for maintenance window sizings.

Refs OSD-4024