### PR TITLE
Fix admin rolebinding cronjob to set --namespace

### DIFF
--- a/deploy/rbac-permissions-operator-config/99-cleanup-admin-project-rbac.CronJob.yaml
+++ b/deploy/rbac-permissions-operator-config/99-cleanup-admin-project-rbac.CronJob.yaml
@@ -35,7 +35,7 @@ spec:
                         echo "NAMESPACE=$NS"
                         SUBJECT=$(oc -n $NS get rolebinding admin -o jsonpath='{.subjects[*].name}')
                         oc -n $NS delete rolebinding admin
-                        oc adm policy add-role-to-user admin $SUBJECT --rolebinding-name=admin
+                        oc adm policy add-role-to-user admin $SUBJECT --rolebinding-name=admin -n $NS
                     fi
                 done
                 echo "FINISH"

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4437,8 +4437,8 @@ objects:
                     \ \"NAMESPACE=$NS\"\n        SUBJECT=$(oc -n $NS get rolebinding\
                     \ admin -o jsonpath='{.subjects[*].name}')\n        oc -n $NS\
                     \ delete rolebinding admin\n        oc adm policy add-role-to-user\
-                    \ admin $SUBJECT --rolebinding-name=admin\n    fi\ndone\necho\
-                    \ \"FINISH\"\nexit 0\n"
+                    \ admin $SUBJECT --rolebinding-name=admin -n $NS\n    fi\ndone\n\
+                    echo \"FINISH\"\nexit 0\n"
     patches:
     - apiVersion: config.openshift.io/v1
       kind: Project


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-4660

The "admin" rolebindings were recreated in the openshift-rbac-permissions namespace, not what was intended.