### PR TITLE
Add option to install local pre-push hook to run PR check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,7 @@ clean:
 git-commit:
 	git add ${SELECTOR_SYNC_SET_DESTINATION}
 	git commit -m "Updated selectorsynceset template added"
+
+.PHONY: install-pre-commit-hook
+install-pre-push-hook:
+	cp hack/pre-push .git/hooks/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This repo contains static configuration specific to a "managed" OpenShift Dedica
 
 To add a new SelectorSyncSet, add your yaml manifest to the `deploy` dir, then run the `make` command.
 
+# Local Setup
+
+We have a requirement that the template used for deployment is committed in the repo.  Our PR check validates it.  But you can push (by default) without having run `make` to update that template! That's annoying.  If you want to ensure your `git push` will always pass PR checks you can add a `pre-push` hook that will run the PR check locally before pushing, and fails push if the PR check fails.
+
+```bash
+make install-pre-push-hook
+```
+
 # Building
 
 ## Dependencies

--- a/hack/pre-push
+++ b/hack/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/sh
+
+# make sure 'make' was run before pushing.  requires having no local changes
+
+FILES_CHANGED=$(git status --porcelain | wc -l)
+
+if [ "$FILES_CHANGED" != "0" ];
+then
+    git stash
+    trap "git reset --hard HEAD; git stash pop" EXIT
+else
+    trap "git reset --hard HEAD" EXIT
+fi
+
+./hack/app_sre_pr_check.sh
+


### PR DESCRIPTION
My last 4 PRs I not run `make`.  It annoyed me so I made a simple pre-push hook for myself.
This PR shares it with others with a way to install and docs.