### PR TITLE
fix(sre-build-test): now deletes consistently

### DIFF
--- a/deploy/sre-build-test/50-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-build-test.CronJob.yaml
@@ -63,6 +63,24 @@ spec:
               NS="${POD_NS}-${POD_NAME##${JOB_PREFIX}-}"
               JOB_NAME=$(echo "${POD_NAME}" | rev | cut -d- -f2- | rev)
 
+              GET_FAILED_JOBS=$(cat <<END
+              import json,sys
+              r = json.load(sys.stdin)
+              # create a list of jobs
+              jobs = [ job['metadata']['name'] for job in r['items'] if
+                # no jobs are currently running 
+                ( not 'active' in job['status']) and
+                # if '.status.failed' exists on job
+                'failed' in job['status'] and
+                # if job failed count is bigger than backoffLimit
+                #
+                # this check is because the failed tries can be one less than limit
+                # see code in https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/job/job_controller.go#L509
+                # if this changes we should consider using an easier implementation
+                job['spec']['backoffLimit'] - 1 <= job['status']['failed']]
+              print(" ".join(jobs))
+              END
+              )
               oc create ns "${NS}"
 
               # run build
@@ -87,8 +105,9 @@ spec:
                   Complete)
                     echo "$(date): Build Complete"
                     # Get all job names that have exceeded failed retries
-                    JOBS_TO_DELETE=$(oc -n "${POD_NS}" get job -o \
-                                       jsonpath='{.items[?(@.status.failed==@.spec.backoffLimit)].metadata.name}' || true)
+                    JOBS=$(oc -n "${POD_NS}" get job -o json)
+                    JOBS_TO_DELETE=$(echo "${JOBS}" | python -c "$GET_FAILED_JOBS")
+
                     if [[ -n "${JOBS_TO_DELETE}" ]] ; then
                       echo "$(date): Selected jobs for deletion: ${JOBS_TO_DELETE}"
                       echo "${JOBS_TO_DELETE}" | xargs oc -n "${POD_NS}" delete job

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -4915,7 +4915,17 @@ objects:
                     \ EXIT SIGINT\n\n# set NS to include job name, to ease linking\
                     \ namespace to a specific job\nJOB_PREFIX=sre-build-test\nNS=\"\
                     ${POD_NS}-${POD_NAME##${JOB_PREFIX}-}\"\nJOB_NAME=$(echo \"${POD_NAME}\"\
-                    \ | rev | cut -d- -f2- | rev)\n\noc create ns \"${NS}\"\n\n# run\
+                    \ | rev | cut -d- -f2- | rev)\n\nGET_FAILED_JOBS=$(cat <<END\n\
+                    import json,sys\nr = json.load(sys.stdin)\n# create a list of\
+                    \ jobs\njobs = [ job['metadata']['name'] for job in r['items']\
+                    \ if\n  # no jobs are currently running \n  ( not 'active' in\
+                    \ job['status']) and\n  # if '.status.failed' exists on job\n\
+                    \  'failed' in job['status'] and\n  # if job failed count is bigger\
+                    \ than backoffLimit\n  #\n  # this check is because the failed\
+                    \ tries can be one less than limit\n  # see code in https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/job/job_controller.go#L509\n\
+                    \  # if this changes we should consider using an easier implementation\n\
+                    \  job['spec']['backoffLimit'] - 1 <= job['status']['failed']]\n\
+                    print(\" \".join(jobs))\nEND\n)\noc create ns \"${NS}\"\n\n# run\
                     \ build\noc -n \"${NS}\" new-build nodejs~https://github.com/openshift/nodejs-ex\
                     \ --name=\"${JOB_PREFIX}\"\necho \"$(date): Waiting for build\
                     \ to complete.\"\nwhile :\ndo\n  ST=$(oc -n \"${NS}\" get build\
@@ -4926,14 +4936,14 @@ objects:
                     \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      exit 1\n      ;;\n    Complete)\n\
                     \      echo \"$(date): Build Complete\"\n      # Get all job names\
-                    \ that have exceeded failed retries\n      JOBS_TO_DELETE=$(oc\
-                    \ -n \"${POD_NS}\" get job -o \\\n                         jsonpath='{.items[?(@.status.failed==@.spec.backoffLimit)].metadata.name}'\
-                    \ || true)\n      if [[ -n \"${JOBS_TO_DELETE}\" ]] ; then\n \
-                    \       echo \"$(date): Selected jobs for deletion: ${JOBS_TO_DELETE}\"\
-                    \n        echo \"${JOBS_TO_DELETE}\" | xargs oc -n \"${POD_NS}\"\
-                    \ delete job\n      fi\n      break\n      ;;\n  esac\n  echo\
-                    \ \"$(date): Build is ${ST}; checking build again in 15 seconds,\
-                    \ NS=${NS}\"\n  sleep 15\ndone\nexit 0\n"
+                    \ that have exceeded failed retries\n      JOBS=$(oc -n \"${POD_NS}\"\
+                    \ get job -o json)\n      JOBS_TO_DELETE=$(echo \"${JOBS}\" |\
+                    \ python -c \"$GET_FAILED_JOBS\")\n\n      if [[ -n \"${JOBS_TO_DELETE}\"\
+                    \ ]] ; then\n        echo \"$(date): Selected jobs for deletion:\
+                    \ ${JOBS_TO_DELETE}\"\n        echo \"${JOBS_TO_DELETE}\" | xargs\
+                    \ oc -n \"${POD_NS}\" delete job\n      fi\n      break\n    \
+                    \  ;;\n  esac\n  echo \"$(date): Build is ${ST}; checking build\
+                    \ again in 15 seconds, NS=${NS}\"\n  sleep 15\ndone\nexit 0\n"
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
now when the job runs it will delete all jobs that have
failed.

WORTH NOTING: this doesn't check if:
* there state of the job is `backoff`
which would make this job much more stable