### PR TITLE
Revert changes to swap out 'admin' clusterole for project 'admin' rolebinding

### DIFF
--- a/deploy/rbac-permissions-operator-config/01-osd-project-request.Template.yaml
+++ b/deploy/rbac-permissions-operator-config/01-osd-project-request.Template.yaml
@@ -28,7 +28,7 @@ objects:
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
-    name: dedicated-admins-project
+    name: admin
   subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
@@ -6,46 +6,12 @@ aggregationRule:
       operator: In
       values:
         - "project"
-  # aggregate all "edit" scope rbac from base OCP to dedicated-admins-project
-  # note we used to use "admin" but that will aggregate the "edit" clusterrole which includes SRE CRs
-  - matchExpressions:
-    - key: rbac.authorization.k8s.io/aggregate-to-edit
-      operator: In
-      values:
-        - "true"
-    - key:  kubernetes.io/bootstrapping
-      operator: In
-      values:
-        - "rbac-defaults"
-  # aggregate all OLM generated CR to dedicated-admins-project except "admin" and "edit" for SRE CRs
+  # aggregate all "admin" scope rbac from OCP to dedicated-admins-project (webhooks deny management of specific SRE apiGroups)
   - matchExpressions:
     - key: rbac.authorization.k8s.io/aggregate-to-admin
       operator: In
       values:
         - "true"
-    # https://issues.redhat.com/browse/OSD-4660
-    - key: olm.opgroup.permissions/aggregate-to-81852df0cc9f2a7a-admin
-      operator: DoesNotExist
-    - key: olm.opgroup.permissions/aggregate-to-81852df0cc9f2a7a-edit
-      operator: DoesNotExist
-    # https://issues.redhat.com/browse/OSD-4660
-    - key: olm.opgroup.permissions/aggregate-to-9e5a7a2e55ef37d2-admin
-      operator: DoesNotExist
-    - key: olm.opgroup.permissions/aggregate-to-9e5a7a2e55ef37d2-edit
-      operator: DoesNotExist
-    # https://issues.redhat.com/browse/OSD-4660
-    - key: olm.opgroup.permissions/aggregate-to-b86eb585a91e38c9-admin
-      operator: DoesNotExist
-    - key: olm.opgroup.permissions/aggregate-to-b86eb585a91e38c9-edit
-      operator: DoesNotExist
-    # https://issues.redhat.com/browse/OSD-4660
-    - key: olm.opgroup.permissions/aggregate-to-d86540dbb89f693d-admin
-      operator: DoesNotExist
-    - key: olm.opgroup.permissions/aggregate-to-d86540dbb89f693d-edit
-      operator: DoesNotExist
-    # exclude "edit" which only has this label on it (for now.. sigh)
-    - key: kubernetes.io/bootstrapping
-      operator: DoesNotExist
   # aggregate all customer installed operator rbac from OLM to dedicated-admins-cluster (pre 4.3.12)
   - matchExpressions:
     - key: olm.opgroup.permissions/aggregate-to-admin

--- a/deploy/rbac-permissions-operator-config/50-dedicated-admins-serviceaccounts.SubjectPermission.yaml
+++ b/deploy/rbac-permissions-operator-config/50-dedicated-admins-serviceaccounts.SubjectPermission.yaml
@@ -12,5 +12,10 @@ spec:
     - 
       clusterRoleName: dedicated-admins-project
       namespacesAllowedRegex: ".*"
-      namespacesDeniedRegex: "(^kube.*|^openshift.*|^default$|^redhat-.*)"
+      namespacesDeniedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+      allowFirst: true
+    - 
+      clusterRoleName: admin 
+      namespacesAllowedRegex: ".*" 
+      namespacesDeniedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
       allowFirst: true

--- a/deploy/rbac-permissions-operator-config/50-dedicated-admins.SubjectPermission.yaml
+++ b/deploy/rbac-permissions-operator-config/50-dedicated-admins.SubjectPermission.yaml
@@ -12,5 +12,10 @@ spec:
     - 
       clusterRoleName: dedicated-admins-project
       namespacesAllowedRegex: ".*"
-      namespacesDeniedRegex: "(^kube.*|^openshift.*|^default$|^redhat-.*)"
+      namespacesDeniedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+      allowFirst: true
+    - 
+      clusterRoleName: admin 
+      namespacesAllowedRegex: ".*" 
+      namespacesDeniedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
       allowFirst: true

--- a/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config.selectorsyncset.yaml.tmpl
@@ -3707,7 +3707,7 @@ objects:
         roleRef:
           apiGroup: rbac.authorization.k8s.io
           kind: ClusterRole
-          name: dedicated-admins-project
+          name: admin
         subjects:
         - apiGroup: rbac.authorization.k8s.io
           kind: User
@@ -3772,37 +3772,10 @@ objects:
             values:
             - project
         - matchExpressions:
-          - key: rbac.authorization.k8s.io/aggregate-to-edit
-            operator: In
-            values:
-            - 'true'
-          - key: kubernetes.io/bootstrapping
-            operator: In
-            values:
-            - rbac-defaults
-        - matchExpressions:
           - key: rbac.authorization.k8s.io/aggregate-to-admin
             operator: In
             values:
             - 'true'
-          - key: olm.opgroup.permissions/aggregate-to-81852df0cc9f2a7a-admin
-            operator: DoesNotExist
-          - key: olm.opgroup.permissions/aggregate-to-81852df0cc9f2a7a-edit
-            operator: DoesNotExist
-          - key: olm.opgroup.permissions/aggregate-to-9e5a7a2e55ef37d2-admin
-            operator: DoesNotExist
-          - key: olm.opgroup.permissions/aggregate-to-9e5a7a2e55ef37d2-edit
-            operator: DoesNotExist
-          - key: olm.opgroup.permissions/aggregate-to-b86eb585a91e38c9-admin
-            operator: DoesNotExist
-          - key: olm.opgroup.permissions/aggregate-to-b86eb585a91e38c9-edit
-            operator: DoesNotExist
-          - key: olm.opgroup.permissions/aggregate-to-d86540dbb89f693d-admin
-            operator: DoesNotExist
-          - key: olm.opgroup.permissions/aggregate-to-d86540dbb89f693d-edit
-            operator: DoesNotExist
-          - key: kubernetes.io/bootstrapping
-            operator: DoesNotExist
         - matchExpressions:
           - key: olm.opgroup.permissions/aggregate-to-admin
             operator: In
@@ -4432,7 +4405,11 @@ objects:
         permissions:
         - clusterRoleName: dedicated-admins-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^kube.*|^openshift.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: .*
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
           allowFirst: true
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
@@ -4447,7 +4424,11 @@ objects:
         permissions:
         - clusterRoleName: dedicated-admins-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^kube.*|^openshift.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: .*
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
           allowFirst: true
     patches:
     - apiVersion: config.openshift.io/v1


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-4749

NOTES for this PR:
* keeps the project request template (assumes OSD-2765 will "fix" this)
* does not patch existing rolebindings
* adds SubjectPermissions back for dedicated-admins in project to the 'admin' clusterrole
* fixes regex for SubjectPermissions

Of note on regex, a project can be created named `openshift[^-]*` or `kube[^-]*`.  But not `kube`, `openshift`, `kube-.*`, or `openshift-.*`.  The regex now reflects this.