### PR TITLE
changed severity level of SLAUptimeSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-sre-api-errors.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-api-errors.PrometheusRule.yaml
@@ -17,5 +17,5 @@ spec:
         (sum(rate(apiserver_request_total{job="apiserver", code=~"(400|5..)"}[5m])) / sum(rate(apiserver_request_total{job="apiserver", code=~"([1-5]..)"}[5m])) >= 1)
       for: 5m
       labels:
-        severity: warning
+        severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10421,7 +10421,7 @@ objects:
               '
             for: 5m
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10421,7 +10421,7 @@ objects:
               '
             for: 5m
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10421,7 +10421,7 @@ objects:
               '
             for: 5m
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
OSD-4517

/hold @jewzaam commented:
 "Holding until we have https://issues.redhat.com/browse/OSD-4414 addressed (SOP on this alert). The big question I have is "what actions does SRE take when this alert fires?" and it's not yet answered so we cannot hit on-call with this as a critical alert yet."