### PR TITLE
Enable dedicated-admins to use anyuid and nonroot SCCs

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -308,3 +308,14 @@ rules:
   - list
   - watch
 ### END
+### Start - anyuid and nonroot SSCs
+# https://issues.redhat.com/browse/OSD-3655
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - "anyuid"
+  - "nonroot"
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use


### PR DESCRIPTION
Implement OSD-3655

Enables dedicated-admins to use the anyuid and nonroot SCCs if containers requires specific users to run. 