### PR TITLE
OSD-4930 Add additional alert ignores for managed-upgrade-operator

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -13,6 +13,8 @@ data:
         - etcdMembersDown
         - KubeDeploymentReplicasMismatch
         - ClusterOperatorDown
+        - MachineWithNoRunningPhase
+        - ClusterOperatorDegraded
     scale:
       timeOut: 30
     upgradeWindow:
@@ -24,3 +26,4 @@ data:
       - DNSErrors05MinSRE
       - MetricsClientSendFailingSRE
       - UpgradeNodeScalingFailedSRE
+      - UpgradeClusterCheckFailedSRE

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1300,10 +1300,11 @@ objects:
       data:
         config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
           \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
-          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n"
+          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
+          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4081,6 +4082,15 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - security.openshift.io
+        resourceNames:
+        - anyuid
+        - nonroot
+        resources:
+        - securitycontextconstraints
+        verbs:
+        - use
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1300,10 +1300,11 @@ objects:
       data:
         config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
           \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
-          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n"
+          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
+          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4081,6 +4082,15 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - security.openshift.io
+        resourceNames:
+        - anyuid
+        - nonroot
+        resources:
+        - securitycontextconstraints
+        verbs:
+        - use
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1300,10 +1300,11 @@ objects:
       data:
         config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
           \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
-          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n"
+          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
+          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4081,6 +4082,15 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - security.openshift.io
+        resourceNames:
+        - anyuid
+        - nonroot
+        resources:
+        - securitycontextconstraints
+        verbs:
+        - use
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
This PR updates the managed-upgrade-operator's configuration to declare two additional alerts to silence during managed upgrades, as they are expected:

- MachineWithNoRunningPhase
- ClusterOperatorDegraded

*DO NOTE*: This PR also includes the changes of #440, as it would seem that a `make` was not run as part of its PR and so they are being picked up during the `make` process of this one.