### PR TITLE
Update osde2e-noalerts cronjob to ignore moa clusters in non-prod

### DIFF
--- a/snowflake/osde2e-tweaks/non-production/10-noalerts-osde2e.cronjob.yaml
+++ b/snowflake/osde2e-tweaks/non-production/10-noalerts-osde2e.cronjob.yaml
@@ -34,7 +34,8 @@ spec:
               # Label each unlabeled CD in each NS:
               for NS in ${NAMESPACES[@]};
               do
-                  for CD in $(oc -n $NS get cd -o jsonpath="{range .items[*]}{.metadata.name},{.metadata.labels},{'\n'} {end}" | grep -v "ext-managed.openshift.io/noalerts:true" | awk -F, '{print $1}')
+                  # check if it is moa.  if so, skip! we want to hit PD for testing.  also, jsonpath can't do OR so it's in a separate query.
+                  for CD in $(oc -n $NS get cd -o jsonpath="{range .items[*]}{.metadata.name},{.metadata.labels},{'\n'} {end}" | grep -v "api.openshift.com/product:moa" | grep -v "ext-managed.openshift.io/noalerts:true" | awk -F, '{print $1}')
                   do
                       echo "Adding 'ext-managed.openshift.io/noalerts' label to ClusterDeployment '$CD' in Namespace '$NS'"
                       oc -n $NS label clusterdeployment $CD ext-managed.openshift.io/noalerts="true" --overwrite=true


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-5032