### PR TITLE
OSD-3304 - Remove Operator Curation - Step 3 - update operatorhub CR via patch

### DIFF
--- a/deploy/osd-curated-operatorsources-revert/00-operatorhub.cr.yaml
+++ b/deploy/osd-curated-operatorsources-revert/00-operatorhub.cr.yaml
@@ -1,8 +1,6 @@
 apiVersion: config.openshift.io/v1
+applyMode: AlwaysApply
 kind: OperatorHub
-metadata:
-  name: cluster
-  annotations:
-    release.openshift.io/create-only: "true"
-spec:
-  disableAllDefaultSources: false
+name: cluster
+patch: '{"spec":{"disableAllDefaultSources":false}}'
+patchType: merge

--- a/deploy/osd-curated-operatorsources/00-operatorhub.cr.yaml
+++ b/deploy/osd-curated-operatorsources/00-operatorhub.cr.yaml
@@ -1,8 +1,6 @@
 apiVersion: config.openshift.io/v1
+applyMode: AlwaysApply
 kind: OperatorHub
-metadata:
-  name: cluster
-  annotations:
-    release.openshift.io/create-only: "true"
-spec:
-  disableAllDefaultSources: true
+name: cluster
+patch: '{"spec":{"disableAllDefaultSources":true}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2227,15 +2227,14 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: true
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":true}}'
+      patchType: merge
+    resources:
     - apiVersion: operators.coreos.com/v1
       kind: OperatorSource
       metadata:
@@ -2292,15 +2291,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/ccs: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2396,15 +2394,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/extended-dedicated-admin: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2500,15 +2497,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/environment: staging
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2604,15 +2600,14 @@ objects:
         api.openshift.com/managed: 'true'
         hive.openshift.io/cluster-platform: gcp
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2708,15 +2703,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/cluster-admin: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2227,15 +2227,14 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: true
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":true}}'
+      patchType: merge
+    resources:
     - apiVersion: operators.coreos.com/v1
       kind: OperatorSource
       metadata:
@@ -2292,15 +2291,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/ccs: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2396,15 +2394,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/extended-dedicated-admin: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2500,15 +2497,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/environment: staging
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2604,15 +2600,14 @@ objects:
         api.openshift.com/managed: 'true'
         hive.openshift.io/cluster-platform: gcp
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2708,15 +2703,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/cluster-admin: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2227,15 +2227,14 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: true
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":true}}'
+      patchType: merge
+    resources:
     - apiVersion: operators.coreos.com/v1
       kind: OperatorSource
       metadata:
@@ -2292,15 +2291,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/ccs: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2396,15 +2394,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/extended-dedicated-admin: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2500,15 +2497,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/environment: staging
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2604,15 +2600,14 @@ objects:
         api.openshift.com/managed: 'true'
         hive.openshift.io/cluster-platform: gcp
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -2708,15 +2703,14 @@ objects:
         api.openshift.com/managed: 'true'
         api.openshift.com/cluster-admin: 'true'
     resourceApplyMode: Upsert
-    resources:
+    patches:
     - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
       kind: OperatorHub
-      metadata:
-        name: cluster
-        annotations:
-          release.openshift.io/create-only: 'true'
-      spec:
-        disableAllDefaultSources: false
+      name: cluster
+      patch: '{"spec":{"disableAllDefaultSources":false}}'
+      patchType: merge
+    resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:


### PR DESCRIPTION
Instead of applying OperatorHub CR changes via resource, do it via patch.

This change is needed because in a next step, some SSSs will be removed/renamed, and when it happens, hive tries deleting the CR. Since OperatorHub CRs can't be deleted, it would cause errors when doing the SSS sync