### PR TITLE
Split out "view" rbac to new osd-readers ClusterRole for aggregation

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -57,16 +57,6 @@ rules:
   - create
 - apiGroups:
   - ""
-  attributeRestrictions: null
-  resources:
-  - nodes
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
   - security.openshift.io
   attributeRestrictions: null
   resources:
@@ -75,25 +65,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - ""
-  - quota.openshift.io
-  attributeRestrictions: null
-  resources:
-  - clusterresourcequotas
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  - authorization.openshift.io
-  attributeRestrictions: null
-  resources:
-  - clusterpolicybindings
-  verbs:
-  - get
-  - list
 - apiGroups:
   - ""
   - network.openshift.io
@@ -236,16 +207,6 @@ rules:
   verbs:
   - '*'
 ### END
-### START - view ClusterVersion
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusterversions
-  verbs:
-  - list
-  - get
-  - watch
-### END
 ### START - Update groups
 - apiGroups:
   - user.openshift.io
@@ -275,15 +236,6 @@ rules:
   - update
   - watch
 ### END
-### START - run `oc adm top pod` or `oc adm top node`
-- apiGroups:
-  - metrics.k8s.io
-  resources:
-  - nodes
-  - pods
-  verbs:
-  - list
-### END
 ### START - Read permissions of imagestreams
 - apiGroups:
   - ""
@@ -292,17 +244,6 @@ rules:
   resources:
   - images
   - imagestreamtags
-  verbs:
-  - get
-  - list
-  - watch
-### END
-### Start - Allow viewing platform and other infra data in console
-# https://issues.redhat.com/browse/OSD-4298
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - infrastructures
   verbs:
   - get
   - list
@@ -319,13 +260,4 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
-### END
-### Start - fix `oc describe nodes`
-# https://issues.redhat.com/browse/OHSS-1105
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
 ### END

--- a/deploy/rbac-permissions-operator-config/05-dedicated-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-readers.ClusterRole.yaml
@@ -9,6 +9,12 @@ aggregationRule:
       operator: In
       values:
         - "true"
+  # aggregate all "dedicated-readers" scope rbac
+  - matchExpressions:
+    - key: managed.openshift.io/aggregate-to-dedicated-readers
+      operator: In
+      values:
+        - "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -1,0 +1,77 @@
+# a general "reader" / "view" clusterrole that adds a few things we want to grant to any reader on the cluster such as devaccess and dedicated-readers (see labels used for aggregation)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+labels:
+    managed.openshift.io/aggregate-to-dedicated-readers: "true"
+    managed.openshift.io/aggregate-to-devaccess: "true"
+name: osd-readers
+rules:
+- apiGroups:
+  - ""
+  attributeRestrictions: null
+  resources:
+  - nodes
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - quota.openshift.io
+  attributeRestrictions: null
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - authorization.openshift.io
+  attributeRestrictions: null
+  resources:
+  - clusterpolicybindings
+  verbs:
+  - get
+  - list
+### START - view ClusterVersion
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - list
+  - get
+  - watch
+### END
+### START - run `oc adm top pod` or `oc adm top node`
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - list
+### END
+### Start - Allow viewing platform and other infra data in console
+# https://issues.redhat.com/browse/OSD-4298
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+  - watch
+### END
+### Start - fix `oc describe nodes`
+# https://issues.redhat.com/browse/OHSS-1105
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+### END

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
 labels:
     managed.openshift.io/aggregate-to-dedicated-readers: "true"
     managed.openshift.io/aggregate-to-devaccess: "true"
-name: osd-readers
+name: osd-readers-aggregate
 rules:
 - apiGroups:
   - ""

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3945,16 +3945,6 @@ objects:
         - create
       - apiGroups:
         - ''
-        attributeRestrictions: null
-        resources:
-        - nodes
-        - persistentvolumes
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - ''
         - security.openshift.io
         attributeRestrictions: null
         resources:
@@ -3963,25 +3953,6 @@ objects:
         - get
         - list
         - watch
-      - apiGroups:
-        - ''
-        - quota.openshift.io
-        attributeRestrictions: null
-        resources:
-        - clusterresourcequotas
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - ''
-        - authorization.openshift.io
-        attributeRestrictions: null
-        resources:
-        - clusterpolicybindings
-        verbs:
-        - get
-        - list
       - apiGroups:
         - ''
         - network.openshift.io
@@ -4103,14 +4074,6 @@ objects:
         verbs:
         - '*'
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - clusterversions
-        verbs:
-        - list
-        - get
-        - watch
-      - apiGroups:
         - user.openshift.io
         resources:
         - groups
@@ -4136,27 +4099,12 @@ objects:
         - update
         - watch
       - apiGroups:
-        - metrics.k8s.io
-        resources:
-        - nodes
-        - pods
-        verbs:
-        - list
-      - apiGroups:
         - ''
         - image.openshift.io
         attributeRestrictions: null
         resources:
         - images
         - imagestreamtags
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - infrastructures
         verbs:
         - get
         - list
@@ -4170,12 +4118,6 @@ objects:
         - securitycontextconstraints
         verbs:
         - use
-      - apiGroups:
-        - coordination.k8s.io
-        resources:
-        - leases
-        verbs:
-        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4341,6 +4283,11 @@ objects:
             operator: In
             values:
             - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-dedicated-readers
+            operator: In
+            values:
+            - 'true'
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4348,6 +4295,72 @@ objects:
           managed.openshift.io/aggregate-to-dedicated-admins: cluster
         name: dedicated-readers
       rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: null
+      labels:
+        managed.openshift.io/aggregate-to-dedicated-readers: 'true'
+        managed.openshift.io/aggregate-to-devaccess: 'true'
+      name: osd-readers
+      rules:
+      - apiGroups:
+        - ''
+        attributeRestrictions: null
+        resources:
+        - nodes
+        - persistentvolumes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        attributeRestrictions: null
+        resources:
+        - clusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - authorization.openshift.io
+        attributeRestrictions: null
+        resources:
+        - clusterpolicybindings
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - nodes
+        - pods
+        verbs:
+        - list
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - infrastructures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4301,7 +4301,7 @@ objects:
       labels:
         managed.openshift.io/aggregate-to-dedicated-readers: 'true'
         managed.openshift.io/aggregate-to-devaccess: 'true'
-      name: osd-readers
+      name: osd-readers-aggregate
       rules:
       - apiGroups:
         - ''

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3945,16 +3945,6 @@ objects:
         - create
       - apiGroups:
         - ''
-        attributeRestrictions: null
-        resources:
-        - nodes
-        - persistentvolumes
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - ''
         - security.openshift.io
         attributeRestrictions: null
         resources:
@@ -3963,25 +3953,6 @@ objects:
         - get
         - list
         - watch
-      - apiGroups:
-        - ''
-        - quota.openshift.io
-        attributeRestrictions: null
-        resources:
-        - clusterresourcequotas
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - ''
-        - authorization.openshift.io
-        attributeRestrictions: null
-        resources:
-        - clusterpolicybindings
-        verbs:
-        - get
-        - list
       - apiGroups:
         - ''
         - network.openshift.io
@@ -4103,14 +4074,6 @@ objects:
         verbs:
         - '*'
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - clusterversions
-        verbs:
-        - list
-        - get
-        - watch
-      - apiGroups:
         - user.openshift.io
         resources:
         - groups
@@ -4136,27 +4099,12 @@ objects:
         - update
         - watch
       - apiGroups:
-        - metrics.k8s.io
-        resources:
-        - nodes
-        - pods
-        verbs:
-        - list
-      - apiGroups:
         - ''
         - image.openshift.io
         attributeRestrictions: null
         resources:
         - images
         - imagestreamtags
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - infrastructures
         verbs:
         - get
         - list
@@ -4170,12 +4118,6 @@ objects:
         - securitycontextconstraints
         verbs:
         - use
-      - apiGroups:
-        - coordination.k8s.io
-        resources:
-        - leases
-        verbs:
-        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4341,6 +4283,11 @@ objects:
             operator: In
             values:
             - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-dedicated-readers
+            operator: In
+            values:
+            - 'true'
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4348,6 +4295,72 @@ objects:
           managed.openshift.io/aggregate-to-dedicated-admins: cluster
         name: dedicated-readers
       rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: null
+      labels:
+        managed.openshift.io/aggregate-to-dedicated-readers: 'true'
+        managed.openshift.io/aggregate-to-devaccess: 'true'
+      name: osd-readers
+      rules:
+      - apiGroups:
+        - ''
+        attributeRestrictions: null
+        resources:
+        - nodes
+        - persistentvolumes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        attributeRestrictions: null
+        resources:
+        - clusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - authorization.openshift.io
+        attributeRestrictions: null
+        resources:
+        - clusterpolicybindings
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - nodes
+        - pods
+        verbs:
+        - list
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - infrastructures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4301,7 +4301,7 @@ objects:
       labels:
         managed.openshift.io/aggregate-to-dedicated-readers: 'true'
         managed.openshift.io/aggregate-to-devaccess: 'true'
-      name: osd-readers
+      name: osd-readers-aggregate
       rules:
       - apiGroups:
         - ''

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3945,16 +3945,6 @@ objects:
         - create
       - apiGroups:
         - ''
-        attributeRestrictions: null
-        resources:
-        - nodes
-        - persistentvolumes
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - ''
         - security.openshift.io
         attributeRestrictions: null
         resources:
@@ -3963,25 +3953,6 @@ objects:
         - get
         - list
         - watch
-      - apiGroups:
-        - ''
-        - quota.openshift.io
-        attributeRestrictions: null
-        resources:
-        - clusterresourcequotas
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - ''
-        - authorization.openshift.io
-        attributeRestrictions: null
-        resources:
-        - clusterpolicybindings
-        verbs:
-        - get
-        - list
       - apiGroups:
         - ''
         - network.openshift.io
@@ -4103,14 +4074,6 @@ objects:
         verbs:
         - '*'
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - clusterversions
-        verbs:
-        - list
-        - get
-        - watch
-      - apiGroups:
         - user.openshift.io
         resources:
         - groups
@@ -4136,27 +4099,12 @@ objects:
         - update
         - watch
       - apiGroups:
-        - metrics.k8s.io
-        resources:
-        - nodes
-        - pods
-        verbs:
-        - list
-      - apiGroups:
         - ''
         - image.openshift.io
         attributeRestrictions: null
         resources:
         - images
         - imagestreamtags
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - infrastructures
         verbs:
         - get
         - list
@@ -4170,12 +4118,6 @@ objects:
         - securitycontextconstraints
         verbs:
         - use
-      - apiGroups:
-        - coordination.k8s.io
-        resources:
-        - leases
-        verbs:
-        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4341,6 +4283,11 @@ objects:
             operator: In
             values:
             - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-dedicated-readers
+            operator: In
+            values:
+            - 'true'
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4348,6 +4295,72 @@ objects:
           managed.openshift.io/aggregate-to-dedicated-admins: cluster
         name: dedicated-readers
       rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata: null
+      labels:
+        managed.openshift.io/aggregate-to-dedicated-readers: 'true'
+        managed.openshift.io/aggregate-to-devaccess: 'true'
+      name: osd-readers
+      rules:
+      - apiGroups:
+        - ''
+        attributeRestrictions: null
+        resources:
+        - nodes
+        - persistentvolumes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        attributeRestrictions: null
+        resources:
+        - clusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - authorization.openshift.io
+        attributeRestrictions: null
+        resources:
+        - clusterpolicybindings
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        verbs:
+        - list
+        - get
+        - watch
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - nodes
+        - pods
+        verbs:
+        - list
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - infrastructures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4301,7 +4301,7 @@ objects:
       labels:
         managed.openshift.io/aggregate-to-dedicated-readers: 'true'
         managed.openshift.io/aggregate-to-devaccess: 'true'
-      name: osd-readers
+      name: osd-readers-aggregate
       rules:
       - apiGroups:
         - ''


### PR DESCRIPTION
Aggregate osd-readers to dedicated-readers
Aggregate osd-readers to osd-devaccess

Note, dedicated-readers aggregates to dedicated-admins-cluster.  Anything moved out from dedicated-admins-cluster is still going to be rolled up and available to dedicated-admins.