### PR TITLE
Allow dedicated-admins to list 'thanosrulers'

### DIFF
--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -42,6 +42,7 @@ rules:
   - prometheusrules
   - servicemonitors
   - podmonitors
+  - thanosrulers
   verbs:
   - "*"
 - apiGroups:

--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-project.ClusterRole.yaml
@@ -116,6 +116,7 @@ rules:
   - prometheusrules
   - servicemonitors
   - podmonitors
+  - thanosrulers
   verbs:
   - "*"
 - apiGroups:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2440,6 +2440,7 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        - thanosrulers
         verbs:
         - '*'
       - apiGroups:
@@ -4236,6 +4237,7 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        - thanosrulers
         verbs:
         - '*'
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2440,6 +2440,7 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        - thanosrulers
         verbs:
         - '*'
       - apiGroups:
@@ -4236,6 +4237,7 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        - thanosrulers
         verbs:
         - '*'
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2440,6 +2440,7 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        - thanosrulers
         verbs:
         - '*'
       - apiGroups:
@@ -4236,6 +4237,7 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        - thanosrulers
         verbs:
         - '*'
       - apiGroups:


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/APPSRE-2461

thanosrulers is a new CRD added by the prometheus operator. Without this RBAC patch, the prometheus operator fails to watch CR's of this type and logs an error message along the lines of:

>E0909 14:13:01.999482 1 reflector.go:123] github.com/coreos/prometheus-operator/pkg/thanos/operator.go:316: Failed to list *v1.ThanosRuler: thanosrulers.monitoring.coreos.com is forbidden: User "system:serviceaccount:openshift-customer-monitoring:prometheus-operator" cannot list resource "thanosrulers" in API group "monitoring.coreos.com" in the namespace "openshift-customer-monitoring"