### PR TITLE
Delete replacing CSVs from openshift-monitoring

### DIFF
--- a/deploy/sre-pruning/105-pruning.rbac.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.yaml
@@ -73,6 +73,13 @@ rules:
   - customresourcedefinitions
   verbs:
   - delete
+# csv pruning
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/sre-pruning/110-pruning-csvs.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-csvs.CronJob.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: csv-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+          - name: crd-pruner
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - >-
+              oc -n openshift-monitoring get csv | grep Replacing | awk '{print $1}' | xargs oc -n openshift-monitoring delete csv --wait=0 --ignore-not-found

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5775,6 +5775,12 @@ objects:
         - customresourcedefinitions
         verbs:
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -5867,6 +5873,31 @@ objects:
                   - oc delete customresourcedefinition.apiextensions.k8s.io/machinedisruptionbudgets.healthchecking.openshift.io
                     customresourcedefinition.apiextensions.k8s.io/machinehealthchecks.healthchecking.openshift.io
                     --ignore-not-found
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: csv-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: crd-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc -n openshift-monitoring get csv | grep Replacing | awk '{print
+                    $1}' | xargs oc -n openshift-monitoring delete csv --wait=0 --ignore-not-found
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5775,6 +5775,12 @@ objects:
         - customresourcedefinitions
         verbs:
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -5867,6 +5873,31 @@ objects:
                   - oc delete customresourcedefinition.apiextensions.k8s.io/machinedisruptionbudgets.healthchecking.openshift.io
                     customresourcedefinition.apiextensions.k8s.io/machinehealthchecks.healthchecking.openshift.io
                     --ignore-not-found
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: csv-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: crd-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc -n openshift-monitoring get csv | grep Replacing | awk '{print
+                    $1}' | xargs oc -n openshift-monitoring delete csv --wait=0 --ignore-not-found
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5775,6 +5775,12 @@ objects:
         - customresourcedefinitions
         verbs:
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -5867,6 +5873,31 @@ objects:
                   - oc delete customresourcedefinition.apiextensions.k8s.io/machinedisruptionbudgets.healthchecking.openshift.io
                     customresourcedefinition.apiextensions.k8s.io/machinehealthchecks.healthchecking.openshift.io
                     --ignore-not-found
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: csv-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: crd-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc -n openshift-monitoring get csv | grep Replacing | awk '{print
+                    $1}' | xargs oc -n openshift-monitoring delete csv --wait=0 --ignore-not-found
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:


### PR DESCRIPTION
This should delete any replacing CSVs in openshift-monitoring. Once complete, we can delete this cronjob.