### PR TITLE
adjust MetricsClientSendFailingSRE to fire if error budget is burned fast

### DIFF
--- a/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
@@ -11,8 +11,10 @@ spec:
   - name: sre-telemeter-client
     rules:
     - alert: MetricsClientSendFailingSRE
-      expr: absent(rate(metricsclient_request_send{status_code="200"}[5m]) > 0) or rate(metricsclient_request_send{status_code!="200"}[5m]) > 0
-      for: 15m
+      expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+      for: 5m
       labels:
         severity: critical
         namespace: openshift-monitoring
+      annotations:
+        description: "Telemeter client is experiencing a high error rate over the past hour"

--- a/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
@@ -11,6 +11,10 @@ spec:
   - name: sre-telemeter-client
     rules:
     - alert: MetricsClientSendFailingSRE
+    # metricsclient sends 1 request/5m, 12/60m, 288/day, 8064/28days.
+    # SLO=90%, Error Budget=10% or 806 failed requests.
+    # Send an alert when 2% of Error budget (16.12 requests) is burned within a 2 hour window. Why 2 hours? Because the combination of request frequency and SLO @90% requires atleast 2 hours to breach a 2% burn. 
+    # The short window of 10 minutes allows for quick recovery once the issue is resolved. 
       expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[10m])) / sum by (job) (rate(metricsclient_request_send[10m])) > (16.12 - (1-0.90000)) and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[2h])) / sum by (job) (rate(metricsclient_request_send[2h])) > (16.12 - (1-0.90000))
       for: 10m
       labels:

--- a/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-telemeter-client
     rules:
     - alert: MetricsClientSendFailingSRE
-      expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
+      expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000) and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
       for: 5m
       labels:
         severity: critical

--- a/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-telemeter-client
     rules:
     - alert: MetricsClientSendFailingSRE
-      expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+      expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
       for: 5m
       labels:
         severity: critical

--- a/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-telemeter-client
     rules:
     - alert: MetricsClientSendFailingSRE
-      expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
+      expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
       for: 5m
       labels:
         severity: critical

--- a/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-telemeter-client
     rules:
     - alert: MetricsClientSendFailingSRE
-      expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
+      expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
       for: 5m
       labels:
         severity: critical

--- a/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-telemeter-client.PrometheusRule.yaml
@@ -11,8 +11,8 @@ spec:
   - name: sre-telemeter-client
     rules:
     - alert: MetricsClientSendFailingSRE
-      expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m])) / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000) and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h])) / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
-      for: 5m
+      expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[10m])) / sum by (job) (rate(metricsclient_request_send[10m])) > (16.12 - (1-0.90000)) and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[2h])) / sum by (job) (rate(metricsclient_request_send[2h])) > (16.12 - (1-0.90000))
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -83,7 +83,7 @@ x = burn rate
 Now we have the burn rate we can start creating our alert.
 We care about the error rate. `requests with errors / all requests` gives us that.
 For example 20 errors of 100 requests total:
-`20 / 100 = 0,2` so a 20% error rate.
+`20 / 100 = 0.2` so a 20% error rate.
 Adding the 5m time window in a real world metric:
 `rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m])`
 

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -42,7 +42,7 @@ Practice:
 30d / 1		= 30d
 30d / 2		= 15d
 30d / 10	= 3d
-30d / 14,4	= 2,083~d
+30d / 14,4	= 2.083~d
 ```
 
 Multiplying the result, by 24 gets us the hours until budget burned

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -85,7 +85,7 @@ We care about the error rate. `requests with errors / all requests` gives us tha
 For example 20 errors of 100 requests total:
 `20 / 100 = 0.2` so a 20% error rate.
 Adding the 5m time window in a real world metric:
-`rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m])`
+`rate(metricsclient_request_send{status_code!="200"}[5m]) / rate(metricsclient_request_send[5m])`
 
 This rate needs to be bigger than the burn rate we allow ourselves in order to fire:
 `> 14.4`

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -101,9 +101,9 @@ Bringing it home:
 Now add the conditions together to cover both the short and long windows that allow for fast recovery and fast alerting
 
 ```
-rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1
+rate(metricsclient_request_send{status_code!="200"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1
 and
-rate(metricsclient_request_send{status_code="5xx"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+rate(metricsclient_request_send{status_code!="200"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
 ```
 
 You may notice how the results differ in the equasion, we need to compare the same on both sides;

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -38,17 +38,21 @@ Rolling window / burn rate = days until budget burned
 
 Practice:
 
+```
 30d / 1		= 30d
 30d / 2		= 15d
 30d / 10	= 3d
 30d / 14,4	= 2,083~d
+```
 
 Multiplying the result, by 24 gets us the hours until budget burned
 
+```
 30d	* 24 = 720h
 15d	* 24 = 360h
 3d	* 24 = 72h
 2,083d	* 24 = 50h
+```
 
 We know:
 * Rolling window
@@ -56,18 +60,25 @@ We know:
 * desired time frame
 
 Assuming 2% in 1h
+
 2% in 1h adding up to 100%
+
+```
 100 / 2 = 50
 1h * 50 = 50h
 50 / 24 = 2,083~d
+```
 
 Calculating the burn rate
+
+```
 x = burn rate
 
 30d / x	= 2,083
 30 	= 2,083 * X
 30 / 2,0833333333 = x
 **14,4 = x**
+```
 
 Now we have the burn rate we can start creating our alert.
 We care about the error rate. `requests with errors / all requests` gives us that.

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -1,0 +1,104 @@
+# Explanations
+
+## Burn Rates
+### Explanation
+Burn rates define the rate at which the SLO error budget is used.
+A burn rate of 1 means the complete error budget is used after the complete rolling window.
+### Details
+In the basic implementation a couple of questions need to be asked:
+* How fast to we need to be alerted?
+* How much budget can we burn worst case until we're alerted?
+* How fast do we want to recover?
+
+The combinaiton of the first and the last question hints that we always want to be implementing at least a short
+and a long window.
+
+We want to avoid flapping alerts therefore a good time period to chose for a condition to exist
+is 1h. We now combine that with the time to recover, which should in this case not exceed 5m
+This means that a condition has to exist for the last 1h **and** 5m.
+
+To answer how much budget we can burn before we're alerted we have to take the time frame into consideration.
+The longer the evaluation period, the more budget we can allow to burn.
+Burning 5% in 6 hours is probably not worse than burning 2% in 1h.
+Therefore for hour guidelines we assume the following to be acceptable:
+
+| Time Spent | Budget Burned |
+|------------|---------------|
+| 1h         | 2%            |
+| 6h         | 5%            |
+| 3d         | 10%           |
+
+As you can see the longer the time frame, the slower the burn in our assumptions.
+
+### The math to create alerts
+
+Theory:
+
+Rolling window / burn rate = days until budget burned
+
+Practice:
+
+30d / 1		= 30d
+30d / 2		= 15d
+30d / 10	= 3d
+30d / 14,4	= 2,083~d
+
+Multiplying the result, by 24 gets us the hours until budget burned
+
+30d	* 24 = 720h
+15d	* 24 = 360h
+3d	* 24 = 72h
+2,083d	* 24 = 50h
+
+We know:
+* Rolling window
+* Desired budget burned
+* desired time frame
+
+Assuming 2% in 1h
+2% in 1h adding up to 100%
+100 / 2 = 50
+1h * 50 = 50h
+50 / 24 = 2,083~d
+
+Calculating the burn rate
+x = burn rate
+
+30d / x	= 2,083
+30 	= 2,083 * X
+30 / 2,0833333333 = x
+**14,4 = x**
+
+Now we have the burn rate we can start creating our alert.
+We care about the error rate. `requests with errors / all requests` gives us that.
+For example 20 errors of 100 requests total:
+`20 / 100 = 0,2` so a 20% error rate.
+Adding the 5m time window in a real world metric:
+`rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m])`
+
+This rate needs to be bigger than the burn rate we allow ourselves in order to fire:
+`> 14.4`
+
+However we don't have 100% of all requests we can burn but only a subset based on our SLO.
+Assuming an SLO of 90% success that leaves for an error budget of 10%
+`14.4 * 0,1`
+
+Bringing it home:
+
+`rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0,1` 
+
+Now add the condition tht we have to have this condition for 5m AND 1h
+
+```
+rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1
+and
+rate(metricsclient_request_send{status_code="5xx"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+```
+
+You may notice how the results differ in the equasion, we need to compare the same on both sides;
+
+```
+100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1
+and
+100 * rate(metricsclient_request_send{status_code="5xx"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+```

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -51,7 +51,7 @@ Multiplying the result, by 24 gets us the hours until budget burned
 30d	* 24 = 720h
 15d	* 24 = 360h
 3d	* 24 = 72h
-2,083d	* 24 = 50h
+2.083d	* 24 = 50h
 ```
 
 We know:

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -66,7 +66,7 @@ Assuming 2% in 1h
 ```
 100 / 2 = 50
 1h * 50 = 50h
-50 / 24 = 2,083~d
+50 / 24 = 2.083~d
 ```
 
 Calculating the burn rate

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -109,7 +109,7 @@ rate(metricsclient_request_send{status_code!="200"}[1h]) / rate(metricsclient_re
 You may notice how the results differ in the equasion, we need to compare the same on both sides;
 
 ```
-100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1
+100 * rate(metricsclient_request_send{status_code!="200"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1
 and
-100 * rate(metricsclient_request_send{status_code="5xx"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+100 * rate(metricsclient_request_send{status_code!="200"}[1h]) / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
 ```

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -74,10 +74,10 @@ Calculating the burn rate
 ```
 x = burn rate
 
-30d / x	= 2,083
-30 	= 2,083 * X
-30 / 2,0833333333 = x
-**14,4 = x**
+30d / x	= 2.083
+30 	= 2.083 * X
+30 / 2.0833333333 = x
+**14.4 = x**
 ```
 
 Now we have the burn rate we can start creating our alert.

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -92,7 +92,7 @@ This rate needs to be bigger than the burn rate we allow ourselves in order to f
 
 However we don't have 100% of all requests we can burn but only a subset based on our SLO.
 Assuming an SLO of 90% success that leaves for an error budget of 10%
-`14.4 * 0,1`
+`14.4 * 0.1`
 
 Bringing it home:
 

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -98,7 +98,7 @@ Bringing it home:
 
 `rate(metricsclient_request_send{status_code!="200"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0,1` 
 
-Now add the condition tht we have to have this condition for 5m AND 1h
+Now add the conditions together to cover both the short and long windows that allow for fast recovery and fast alerting
 
 ```
 rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0.1

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -96,7 +96,7 @@ Assuming an SLO of 90% success that leaves for an error budget of 10%
 
 Bringing it home:
 
-`rate(metricsclient_request_send{status_code="5xx"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0,1` 
+`rate(metricsclient_request_send{status_code!="200"}[5m]) / rate(metricsclient_request_send[5m]) > 14.4 * 0,1` 
 
 Now add the condition tht we have to have this condition for 5m AND 1h
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5589,9 +5589,10 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) /
-              rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h])
-              / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
+              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and
+              100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
+              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5589,12 +5589,16 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: absent(rate(metricsclient_request_send{status_code="200"}[5m]) >
-              0) or rate(metricsclient_request_send{status_code!="200"}[5m]) > 0
-            for: 15m
+            expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) /
+              rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h])
+              / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+            for: 5m
             labels:
               severity: critical
               namespace: openshift-monitoring
+            annotations:
+              description: Telemeter client is experiencing a high error rate over
+                the past hour
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5590,9 +5590,9 @@ objects:
           rules:
           - alert: MetricsClientSendFailingSRE
             expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and
+              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
               100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
+              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5589,11 +5589,11 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000)
-              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
-            for: 5m
+            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[10m]))
+              / sum by (job) (rate(metricsclient_request_send[10m])) > (16.12 - (1-0.90000))
+              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[2h]))
+              / sum by (job) (rate(metricsclient_request_send[2h])) > (16.12 - (1-0.90000))
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5589,9 +5589,9 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
+            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
               / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
-              100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
+              100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
               / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
             for: 5m
             labels:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5589,10 +5589,10 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
-              100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
+            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
+              / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000)
+              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
+              / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5589,9 +5589,10 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) /
-              rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h])
-              / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
+              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and
+              100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
+              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5589,12 +5589,16 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: absent(rate(metricsclient_request_send{status_code="200"}[5m]) >
-              0) or rate(metricsclient_request_send{status_code!="200"}[5m]) > 0
-            for: 15m
+            expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) /
+              rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h])
+              / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+            for: 5m
             labels:
               severity: critical
               namespace: openshift-monitoring
+            annotations:
+              description: Telemeter client is experiencing a high error rate over
+                the past hour
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5590,9 +5590,9 @@ objects:
           rules:
           - alert: MetricsClientSendFailingSRE
             expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and
+              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
               100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
+              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5589,11 +5589,11 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000)
-              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
-            for: 5m
+            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[10m]))
+              / sum by (job) (rate(metricsclient_request_send[10m])) > (16.12 - (1-0.90000))
+              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[2h]))
+              / sum by (job) (rate(metricsclient_request_send[2h])) > (16.12 - (1-0.90000))
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5589,9 +5589,9 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
+            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
               / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
-              100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
+              100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
               / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
             for: 5m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5589,10 +5589,10 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
-              100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
+            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
+              / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000)
+              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
+              / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5589,9 +5589,10 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) /
-              rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h])
-              / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
+              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and
+              100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
+              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5589,12 +5589,16 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: absent(rate(metricsclient_request_send{status_code="200"}[5m]) >
-              0) or rate(metricsclient_request_send{status_code!="200"}[5m]) > 0
-            for: 15m
+            expr: 100 * rate(metricsclient_request_send{status_code="5xx"}[5m]) /
+              rate(metricsclient_request_send[5m]) > 14.4 * 0.1 and 100 * rate(metricsclient_request_send{status_code="5xx"}[1h])
+              / rate(metricsclient_request_send[1h]) > 14.4 * 0.1
+            for: 5m
             labels:
               severity: critical
               namespace: openshift-monitoring
+            annotations:
+              description: Telemeter client is experiencing a high error rate over
+                the past hour
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5590,9 +5590,9 @@ objects:
           rules:
           - alert: MetricsClientSendFailingSRE
             expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 0.1 and
+              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
               100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 0.1
+              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
             for: 5m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5589,11 +5589,11 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000)
-              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
-            for: 5m
+            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[10m]))
+              / sum by (job) (rate(metricsclient_request_send[10m])) > (16.12 - (1-0.90000))
+              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[2h]))
+              / sum by (job) (rate(metricsclient_request_send[2h])) > (16.12 - (1-0.90000))
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5589,9 +5589,9 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[5m]))
+            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
               / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
-              100 * sum by (job) (rate(metricsclient_request_send{status_code="5xx"}[1h]))
+              100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
               / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
             for: 5m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5589,10 +5589,10 @@ objects:
         - name: sre-telemeter-client
           rules:
           - alert: MetricsClientSendFailingSRE
-            expr: 100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
-              / sum by (job) (rate(metricsclient_request_send[5m])) > 14.4 * 10 and
-              100 * sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
-              / sum by (job) (rate(metricsclient_request_send[1h])) > 14.4 * 10
+            expr: sum by (job) (rate(metricsclient_request_send{status_code!="200"}[5m]))
+              / sum by (job) (rate(metricsclient_request_send[5m])) > (6 - (1-0.90000)
+              and sum by (job) (rate(metricsclient_request_send{status_code!="200"}[1h]))
+              / sum by (job) (rate(metricsclient_request_send[1h])) > (6 - (1-0.90000)
             for: 5m
             labels:
               severity: critical


### PR DESCRIPTION
making MetricsClientSendFailingSRE more fault tolerant
This assumes an SLO of telemeter itself of 90% and will only fire if the client is burning the corresponding error budget fast.
After an hour 2% of a months error budget would have been consumed.
Since there is not a whole lot to do on the SRE end, I am tempted to additionally reduce it to warning.
This only fires if the error rate has been high for the past 1h AND 5m allowing us to recover quickly.

