### PR TITLE
Revert "OSD-5137 Add OCM_BASE_URL into MUO configmap"

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
-    ocmBaseUrl: "${{OCM_BASE_URL}}"
     maintenance:
       controlPlaneTime: 90
       workerNodeTime: 8

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32,8 +32,6 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
-- name: OCM_BASE_URL
-  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -1420,13 +1418,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "ocmBaseUrl: \"${{OCM_BASE_URL}}\"\nmaintenance:\n  controlPlaneTime:\
-          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
-          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
-          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
+        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
+          \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
+          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
+          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32,8 +32,6 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
-- name: OCM_BASE_URL
-  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -1420,13 +1418,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "ocmBaseUrl: \"${{OCM_BASE_URL}}\"\nmaintenance:\n  controlPlaneTime:\
-          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
-          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
-          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
+        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
+          \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
+          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
+          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32,8 +32,6 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
-- name: OCM_BASE_URL
-  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -1420,13 +1418,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "ocmBaseUrl: \"${{OCM_BASE_URL}}\"\nmaintenance:\n  controlPlaneTime:\
-          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
-          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
-          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
+        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
+          \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
+          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
+          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -32,8 +32,6 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
-- name: OCM_BASE_URL
-  required: true
 metadata:
   name: selectorsyncset-template
 objects:


### PR DESCRIPTION
This reverts commit 7456effbe4cc84617db40b2bc5e878ab6c52f65b.
as it hasn't had the desired effect of replacing OCM_BASE_URL via the CI pipeline. Refs OSD-5137