### PR TITLE
OSD-5137 Add OCM_BASE_URL into MUO configmap

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
+    ocmBaseUrl: ${OCM_BASE_URL}
     maintenance:
       controlPlaneTime: 90
       workerNodeTime: 8

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32,6 +32,8 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
+- name: OCM_BASE_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -1418,13 +1420,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
-          \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
-          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
-          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
-          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n"
+        config.yaml: "ocmBaseUrl: ${OCM_BASE_URL}\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
+          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
+          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
+          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
+          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32,6 +32,8 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
+- name: OCM_BASE_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -1418,13 +1420,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
-          \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
-          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
-          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
-          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n"
+        config.yaml: "ocmBaseUrl: ${OCM_BASE_URL}\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
+          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
+          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
+          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
+          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32,6 +32,8 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
+- name: OCM_BASE_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -1418,13 +1420,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  workerNodeTime: 8\n\
-          \  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n \
-          \   - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n\
-          \    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
-          \  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n"
+        config.yaml: "ocmBaseUrl: ${OCM_BASE_URL}\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
+          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
+          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
+          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
+          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -32,6 +32,8 @@ parameters:
   required: true
 - name: SREP_USERS
   required: true
+- name: OCM_BASE_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:


### PR DESCRIPTION
This PR adds a new configmap entry to managed-upgrade-operator's configmap, with a value read from OCM_BASE_URL.

OCM_BASE_URL is set per OSD environment in app-interface via MR 8232. [0]

A previous attempt at this (#480) failed because double-curly-braces were used; after consulting with AppSRE it should be single-curly-braces instead.

This is needed in order to supply the managed-upgrade-operator with the correct OCM API to query for upgrade policies.

Refs: OSD-5137

[0] https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8232/