### PR TITLE
OHSS-1014 Increase logging resource quota to 1500GiB

### DIFF
--- a/deploy/osd-logging/03-storage-quota.yaml
+++ b/deploy/osd-logging/03-storage-quota.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: openshift-logging
 spec:
   hard:
-    requests.storage: "1200Gi"
+    requests.storage: "1500Gi"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3304,7 +3304,7 @@ objects:
         namespace: openshift-logging
       spec:
         hard:
-          requests.storage: 1200Gi
+          requests.storage: 1500Gi
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3304,7 +3304,7 @@ objects:
         namespace: openshift-logging
       spec:
         hard:
-          requests.storage: 1200Gi
+          requests.storage: 1500Gi
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3304,7 +3304,7 @@ objects:
         namespace: openshift-logging
       spec:
         hard:
-          requests.storage: 1200Gi
+          requests.storage: 1500Gi
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:


### PR DESCRIPTION
This PR bumps the hard ResourceQuota limit for logging from 1200GiB to 1500GiB.

This shall prevent clusters which have been granted >1200GiB logging (and shouldn't have) from repeatedly raising `KubeQuotaExceeded` alerts.

SRE are still instructed to only actually grow logging quota to a maximum of 1200GiB in [the SOPs](https://github.com/openshift/ops-sop/blob/master/v4/howto/logging.md). Provided the SOPs are followed, there is no expectation that clusters can or should grow to the 1500GiB level.

Refs: [OHSS-1014](https://issues.redhat.com/browse/OHSS-1014) where this has been discussed.