### PR TITLE
OSD-5290 add lowercase PDB config for MUO

### DIFF
--- a/scripts/generate_upgrade_syncset.py
+++ b/scripts/generate_upgrade_syncset.py
@@ -107,6 +107,7 @@ def generate_upgradeconfig(start_time, version, channel):
             'type': 'OSD',
             'upgradeAt': start_time,
             'PDBForceDrainTimeout': UPGRADECONFIG_PODDISRUPTIONBUDGET_TIMEOUT_DEFAULT,
+            'pdbForceDrainTimeout': UPGRADECONFIG_PODDISRUPTIONBUDGET_TIMEOUT_DEFAULT,
             'desired': {
                 'version': version,
                 'channel': channel,


### PR DESCRIPTION
This PR updates the `managed-upgrade-operator` SyncSet generator to include a lowercase version of the `pdbForceDrainTimeout` field in support of https://github.com/openshift/managed-upgrade-operator/pull/125

The existing upper-case `PDBForceDrainTimeout` field is deliberately left in until the aforementioned PR is merged and promoted, allowing the operator to read the lowercase version. Without doing this, the installation of the updated operator fails due to an invalid UpgradeConfig CR.

Once the `managed-upgrade-operator` PR is promoted and installed across the fleet, the uppercase `PDB` field will be removed.

Refs OSD-5290

