### PR TITLE
OSD-5138 add configManager block for MUO SSS

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -5,7 +5,10 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
-    ocmBaseUrl: ${OCM_BASE_URL}
+    configManager:
+      source: OCM
+      ocmBaseUrl: ${OCM_BASE_URL}
+      watchInterval: 60
     maintenance:
       controlPlaneTime: 90
       workerNodeTime: 8

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1420,12 +1420,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "ocmBaseUrl: ${OCM_BASE_URL}\nmaintenance:\n  controlPlaneTime:\
-          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
-          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
-          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  workerNodeTime:\
+          \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
+          \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
+          \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
+          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n\
+          \  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1420,12 +1420,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "ocmBaseUrl: ${OCM_BASE_URL}\nmaintenance:\n  controlPlaneTime:\
-          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
-          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
-          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  workerNodeTime:\
+          \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
+          \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
+          \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
+          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n\
+          \  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1420,12 +1420,13 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "ocmBaseUrl: ${OCM_BASE_URL}\nmaintenance:\n  controlPlaneTime:\
-          \ 90\n  workerNodeTime: 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n\
-          \    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n\
-          \    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n\
-          \  timeOut: 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n\
-          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  workerNodeTime:\
+          \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
+          \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
+          \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
+          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n\
+          \  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
This PR adds a `configManager` block to `managed-upgrade-operator`'s configmap in support of OSD-5138, moving the `OCMBaseUrl` field under it.