### PR TITLE
Introduce expectedNodeDrainTime for MUO config

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -25,6 +25,7 @@ data:
       timeOut: 60
     nodeDrain:
       timeOut: 45
+      expectedNodeDrainTime: 8
     healthCheck:
       ignoredCriticals:
       - DNSErrors05MinSRE

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1425,8 +1425,8 @@ objects:
           \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
           \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
           \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
-          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n\
-          \  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
           \  - openshift\n  - kube\n  - default\n"

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1425,8 +1425,8 @@ objects:
           \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
           \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
           \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
-          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n\
-          \  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
           \  - openshift\n  - kube\n  - default\n"

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1425,8 +1425,8 @@ objects:
           \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
           \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
           \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
-          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\nhealthCheck:\n\
-          \  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
           \  - openshift\n  - kube\n  - default\n"


### PR DESCRIPTION
This introduces `expectedNodeDrainTime` into managed-upgrade-operator configuration.

`workerNodeTime` remains included to be backwards compatible with existing MUO deployments until https://github.com/openshift/managed-upgrade-operator/pull/133 is merged and promoted.