### PR TITLE
Velero alert on 3 failed backups

### DIFF
--- a/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
@@ -15,11 +15,12 @@ spec:
     # the deployment's creation time if there's been no backup yet), plus a
     # small static buffer to account for some variation.
     - alert: VeleroHourlyObjectBackupMissed
-      # Hourly backup should complete about 3600 seconds (1 hour) after the
+      # Hourly backup can fail twice before alerting. 
+      # should complete about 10800 seconds (3 hours) after the
       # last successful backup, with a 600 second (10 minute) buffer.
       expr: |
         time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
-        scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 3600 + 600
+        scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"}))) > 10800 + 600
       labels:
         severity: warning
         namespace: openshift-monitoring

--- a/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-velero-operator.PrometheusRule.yaml
@@ -14,7 +14,7 @@ spec:
     # alerts measure the time since the last successful backup finished (or
     # the deployment's creation time if there's been no backup yet), plus a
     # small static buffer to account for some variation.
-    - alert: VeleroHourlyObjectBackupMissed
+    - alert: VeleroHourlyObjectBackupsMissedConsecutively
       # Hourly backup can fail twice before alerting. 
       # should complete about 10800 seconds (3 hours) after the
       # last successful backup, with a 600 second (10 minute) buffer.
@@ -25,7 +25,7 @@ spec:
         severity: warning
         namespace: openshift-monitoring
       annotations:
-        message: The hourly Velero backup has not successfully completed
+        message: Consecutive hourly Velero backups have not successfully completed
     - alert: VeleroDailyFullBackupMissed
       # Daily backup should complete about 86,400 seconds (1 day) after the
       # last successful backup, with a 600 second (10 minute) buffer.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5361,7 +5361,7 @@ objects:
         groups:
         - name: sre-managed-velero-operator-alerts
           rules:
-          - alert: VeleroHourlyObjectBackupMissed
+          - alert: VeleroHourlyObjectBackupsMissedConsecutively
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
 
               scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"})))
@@ -5372,7 +5372,7 @@ objects:
               severity: warning
               namespace: openshift-monitoring
             annotations:
-              message: The hourly Velero backup has not successfully completed
+              message: Consecutive hourly Velero backups have not successfully completed
           - alert: VeleroDailyFullBackupMissed
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="daily-full-backup"},
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5365,7 +5365,7 @@ objects:
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
 
               scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"})))
-              > 3600 + 600
+              > 10800 + 600
 
               '
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5361,7 +5361,7 @@ objects:
         groups:
         - name: sre-managed-velero-operator-alerts
           rules:
-          - alert: VeleroHourlyObjectBackupMissed
+          - alert: VeleroHourlyObjectBackupsMissedConsecutively
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
 
               scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"})))
@@ -5372,7 +5372,7 @@ objects:
               severity: warning
               namespace: openshift-monitoring
             annotations:
-              message: The hourly Velero backup has not successfully completed
+              message: Consecutive hourly Velero backups have not successfully completed
           - alert: VeleroDailyFullBackupMissed
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="daily-full-backup"},
 

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5365,7 +5365,7 @@ objects:
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
 
               scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"})))
-              > 3600 + 600
+              > 10800 + 600
 
               '
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5361,7 +5361,7 @@ objects:
         groups:
         - name: sre-managed-velero-operator-alerts
           rules:
-          - alert: VeleroHourlyObjectBackupMissed
+          - alert: VeleroHourlyObjectBackupsMissedConsecutively
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
 
               scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"})))
@@ -5372,7 +5372,7 @@ objects:
               severity: warning
               namespace: openshift-monitoring
             annotations:
-              message: The hourly Velero backup has not successfully completed
+              message: Consecutive hourly Velero backups have not successfully completed
           - alert: VeleroDailyFullBackupMissed
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="daily-full-backup"},
 

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5365,7 +5365,7 @@ objects:
             expr: 'time() - clamp_min(velero_backup_last_successful_timestamp{namespace="openshift-velero",schedule="hourly-object-backup"},
 
               scalar(max(kube_deployment_created{namespace="openshift-velero",deployment="velero"})))
-              > 3600 + 600
+              > 10800 + 600
 
               '
             labels:


### PR DESCRIPTION
We currently have no SLO for storing 100% of hourly backups. This alert
appears too frequently to be paged on. Dropping this to 3 sequential
failed backups before alerting.

Evidence is available in pager duty.