### PR TITLE
Fix typo in readme and update namespace regex for layered-cssre subjectPermission

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To add a new SelectorSyncSet, add your yaml manifest to the `deploy` dir, then r
 
 - oyaml: `pip install oyaml`
 
-# Configuation
+# Configuration
 
 All resources in `deploy/` are bundled into a template that is used by config management to apply to target "hive" clusters.  The configuration for this supports two options for deployment.  They can be deployed in the template so they are:
 

--- a/deploy/layered-sre-authorization/02-layered-cs-sre-admin.SubjectPermission.yaml
+++ b/deploy/layered-sre-authorization/02-layered-cs-sre-admin.SubjectPermission.yaml
@@ -11,6 +11,6 @@ spec:
   - allowFirst: true
     clusterRoleName: layered-cs-sre-admin-project
     namespacesAllowedRegex: .*
-    namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+    namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)
   subjectKind: Group
   subjectName: layered-cs-sre-admins  

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1619,7 +1619,7 @@ objects:
         - allowFirst: true
           clusterRoleName: layered-cs-sre-admin-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)
         subjectKind: Group
         subjectName: layered-cs-sre-admins
 - apiVersion: hive.openshift.io/v1
@@ -1849,7 +1849,7 @@ objects:
         - allowFirst: true
           clusterRoleName: layered-cs-sre-admin-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)
         subjectKind: Group
         subjectName: layered-cs-sre-admins
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1619,7 +1619,7 @@ objects:
         - allowFirst: true
           clusterRoleName: layered-cs-sre-admin-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)
         subjectKind: Group
         subjectName: layered-cs-sre-admins
 - apiVersion: hive.openshift.io/v1
@@ -1849,7 +1849,7 @@ objects:
         - allowFirst: true
           clusterRoleName: layered-cs-sre-admin-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)
         subjectKind: Group
         subjectName: layered-cs-sre-admins
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1619,7 +1619,7 @@ objects:
         - allowFirst: true
           clusterRoleName: layered-cs-sre-admin-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)
         subjectKind: Group
         subjectName: layered-cs-sre-admins
 - apiVersion: hive.openshift.io/v1
@@ -1849,7 +1849,7 @@ objects:
         - allowFirst: true
           clusterRoleName: layered-cs-sre-admin-project
           namespacesAllowedRegex: .*
-          namespacesDeniedRegex: (^openshift-.*|^kube-.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)
         subjectKind: Group
         subjectName: layered-cs-sre-admins
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
while working on backplane RBAC roles, I found out that cssre subjectPermission has namespace references from V3.
eg: 

- ops-health-monitoring
- logging
- management-infra
- sre-app-check

 Removing the above for consistency.

Also a small typo fix on the main readme.