### PR TITLE
use a portable shebang

### DIFF
--- a/scripts/generate_upgrade_syncset.py
+++ b/scripts/generate_upgrade_syncset.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import csv
 import uuid


### PR DESCRIPTION
`/bin/env` is not portable, even in the `python:3` image.