### PR TITLE
Add BZ1883589 workaround

### DIFF
--- a/deploy/bz1883589-kubeapiserver-fix/00-cluster.kubeapiserver.patch.yaml
+++ b/deploy/bz1883589-kubeapiserver-fix/00-cluster.kubeapiserver.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operator.openshift.io/v1
+kind: KubeAPIServer
+name: cluster
+applyMode: AlwaysApply
+# https://bugzilla.redhat.com/show_bug.cgi?id=1883589#c8
+patch: '{"spec":{"unsupportedConfigOverrides":{"apiServerArguments":{"feature-gates":["APIPriorityAndFairness=false"]}}}}'
+patchType: merge

--- a/deploy/bz1883589-kubeapiserver-fix/OWNERS
+++ b/deploy/bz1883589-kubeapiserver-fix/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+- cblecker
+- jewzaam

--- a/deploy/bz1883589-kubeapiserver-fix/config.yaml
+++ b/deploy/bz1883589-kubeapiserver-fix/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.5"]
+  - key: hive.openshift.io/version-major-minor-patch
+    operator: NotIn
+    values: ["4.5.99"] # this should be replaced with the fixed version

--- a/deploy/bz1883589-kubeapiserver-revert/00-cluster.kubeapiserver.patch.yaml
+++ b/deploy/bz1883589-kubeapiserver-revert/00-cluster.kubeapiserver.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operator.openshift.io/v1
+kind: KubeAPIServer
+name: cluster
+applyMode: AlwaysApply
+# https://bugzilla.redhat.com/show_bug.cgi?id=1883589#c8
+patch: '[{ "op": "remove", "path": "/spec/unsupportedConfigOverrides" }]'
+patchType: json

--- a/deploy/bz1883589-kubeapiserver-revert/OWNERS
+++ b/deploy/bz1883589-kubeapiserver-revert/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+- cblecker
+- jewzaam

--- a/deploy/bz1883589-kubeapiserver-revert/config.yaml
+++ b/deploy/bz1883589-kubeapiserver-revert/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor-patch
+    operator: In
+    values: ["4.5.99"] # this should be replaced with the fixed version

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1066,6 +1066,60 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1883589-kubeapiserver-fix
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: NotIn
+        values:
+        - 4.5.99
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: KubeAPIServer
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"spec":{"unsupportedConfigOverrides":{"apiServerArguments":{"feature-gates":["APIPriorityAndFairness=false"]}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: bz1883589-kubeapiserver-revert
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.5.99
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: KubeAPIServer
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '[{ "op": "remove", "path": "/spec/unsupportedConfigOverrides" }]'
+      patchType: json
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins-ccs
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1066,6 +1066,60 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1883589-kubeapiserver-fix
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: NotIn
+        values:
+        - 4.5.99
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: KubeAPIServer
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"spec":{"unsupportedConfigOverrides":{"apiServerArguments":{"feature-gates":["APIPriorityAndFairness=false"]}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: bz1883589-kubeapiserver-revert
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.5.99
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: KubeAPIServer
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '[{ "op": "remove", "path": "/spec/unsupportedConfigOverrides" }]'
+      patchType: json
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins-ccs
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1066,6 +1066,60 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1883589-kubeapiserver-fix
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: NotIn
+        values:
+        - 4.5.99
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: KubeAPIServer
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"spec":{"unsupportedConfigOverrides":{"apiServerArguments":{"feature-gates":["APIPriorityAndFairness=false"]}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: bz1883589-kubeapiserver-revert
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.5.99
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: KubeAPIServer
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '[{ "op": "remove", "path": "/spec/unsupportedConfigOverrides" }]'
+      patchType: json
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins-ccs
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Adds the workaround from https://bugzilla.redhat.com/show_bug.cgi?id=1883589#c8 to all 4.5 clusters that aren't 4.5.99 (a fixed version that we'll have to replace later)