### PR TITLE
Remove outdated MUO config and increase upgrade window

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
+    configManager:
+      source: OCM
+      ocmBaseUrl: ${OCM_BASE_URL}
+      watchInterval: 60
     maintenance:
       controlPlaneTime: 90
       ignoredAlerts:

--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -5,13 +5,8 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
-    configManager:
-      source: OCM
-      ocmBaseUrl: ${OCM_BASE_URL}
-      watchInterval: 60
     maintenance:
       controlPlaneTime: 90
-      workerNodeTime: 8
       ignoredAlerts:
         controlPlaneCriticals:
         - etcdMembersDown
@@ -22,7 +17,7 @@ data:
     scale:
       timeOut: 30
     upgradeWindow:
-      timeOut: 60
+      timeOut: 120
     nodeDrain:
       timeOut: 45
       expectedNodeDrainTime: 8

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1926,16 +1926,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  workerNodeTime:\
-          \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
-          \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
-          \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
-          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n   \
+          \ controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
+          \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
+          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
+          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1926,8 +1926,9 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n   \
-          \ controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
+        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
           \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
           scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
           \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1926,16 +1926,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  workerNodeTime:\
-          \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
-          \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
-          \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
-          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n   \
+          \ controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
+          \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
+          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
+          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1926,8 +1926,9 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n   \
-          \ controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
+        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
           \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
           scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
           \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1926,16 +1926,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  workerNodeTime:\
-          \ 8\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - etcdMembersDown\n\
-          \    - KubeDeploymentReplicasMismatch\n    - ClusterOperatorDown\n    -\
-          \ MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\nscale:\n  timeOut:\
-          \ 30\nupgradeWindow:\n  timeOut: 60\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n   \
+          \ controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
+          \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
+          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
+          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1926,8 +1926,9 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "maintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n   \
-          \ controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
+        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
           \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
           scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
           \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\


### PR DESCRIPTION
This PR performs some maintenance on the `managed-upgrade-operator-config` configmap to:

- Remove the deprecated `workerNodeTime` configuration (this was removed in https://github.com/openshift/managed-upgrade-operator/pull/133 and replaced by `expectedNodeDrainTime`)
- Doubling the `upgradeWindow.timeout` from an hour to two hours.
