### PR TITLE
Allow one more additional scrape config secret

### DIFF
--- a/deploy/osd-customer-monitoring/05-prometheus-k8s-role.yaml
+++ b/deploy/osd-customer-monitoring/05-prometheus-k8s-role.yaml
@@ -12,6 +12,7 @@ rules:
   - alertmanager-main
   - alertmanager-main-proxy
   - prometheus-additional-scrape-config
+  - prometheus-additional-scrape-config-2
   - prometheus-additional-alertmanager-config
   - alertmanager-instance
   - prometheus-auth-proxy

--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -29,6 +29,7 @@ rules:
   - alertmanager-main
   - alertmanager-main-proxy
   - prometheus-additional-scrape-config
+  - prometheus-additional-scrape-config-2
   - prometheus-additional-alertmanager-config
   - alertmanager-instance
   - prometheus-auth-proxy

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2906,6 +2906,7 @@ objects:
         - alertmanager-main
         - alertmanager-main-proxy
         - prometheus-additional-scrape-config
+        - prometheus-additional-scrape-config-2
         - prometheus-additional-alertmanager-config
         - alertmanager-instance
         - prometheus-auth-proxy
@@ -2943,6 +2944,7 @@ objects:
         - alertmanager-main
         - alertmanager-main-proxy
         - prometheus-additional-scrape-config
+        - prometheus-additional-scrape-config-2
         - prometheus-additional-alertmanager-config
         - alertmanager-instance
         - prometheus-auth-proxy

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2906,6 +2906,7 @@ objects:
         - alertmanager-main
         - alertmanager-main-proxy
         - prometheus-additional-scrape-config
+        - prometheus-additional-scrape-config-2
         - prometheus-additional-alertmanager-config
         - alertmanager-instance
         - prometheus-auth-proxy
@@ -2943,6 +2944,7 @@ objects:
         - alertmanager-main
         - alertmanager-main-proxy
         - prometheus-additional-scrape-config
+        - prometheus-additional-scrape-config-2
         - prometheus-additional-alertmanager-config
         - alertmanager-instance
         - prometheus-auth-proxy

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2906,6 +2906,7 @@ objects:
         - alertmanager-main
         - alertmanager-main-proxy
         - prometheus-additional-scrape-config
+        - prometheus-additional-scrape-config-2        
         - prometheus-additional-alertmanager-config
         - alertmanager-instance
         - prometheus-auth-proxy
@@ -2943,6 +2944,7 @@ objects:
         - alertmanager-main
         - alertmanager-main-proxy
         - prometheus-additional-scrape-config
+        - prometheus-additional-scrape-config-2
         - prometheus-additional-alertmanager-config
         - alertmanager-instance
         - prometheus-auth-proxy

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2906,7 +2906,7 @@ objects:
         - alertmanager-main
         - alertmanager-main-proxy
         - prometheus-additional-scrape-config
-        - prometheus-additional-scrape-config-2        
+        - prometheus-additional-scrape-config-2
         - prometheus-additional-alertmanager-config
         - alertmanager-instance
         - prometheus-auth-proxy


### PR DESCRIPTION
Required so that we can have two separate prometheus instances in the openshift-customer-monitoring namespace, and have both of them scrape targets via separate scrape configs.

For more context, please see (internal) https://issues.redhat.com/browse/APPSRE-2343