### PR TITLE
OHSS-1670 Fix Extended Dedicated-admin matching selector

### DIFF
--- a/deploy/ccs-dedicated-admins/config.yaml
+++ b/deploy/ccs-dedicated-admins/config.yaml
@@ -1,8 +1,6 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
-  matchLabels:
-      api.openshift.com/ccs: "true"
-      api.openshift.com/extended-dedicated-admin: "true"
-      api.openshift.com/environment: "staging"
-      hive.openshift.io/cluster-platform: "gcp"
-  matchLabelsApplyMode: "OR"
+  matchExpressions:
+  - key: api.openshift.com/extended-dedicated-admin
+    operator: NotIn
+    values: ["false"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1125,141 +1125,16 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-ccs
+    name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/ccs: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-extended-dedicated-admin
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/extended-dedicated-admin: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-environment
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/environment: staging
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-cluster-platform
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        hive.openshift.io/cluster-platform: gcp
+      matchExpressions:
+      - key: api.openshift.com/extended-dedicated-admin
+        operator: NotIn
+        values:
+        - 'false'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1125,141 +1125,16 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-ccs
+    name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/ccs: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-extended-dedicated-admin
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/extended-dedicated-admin: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-environment
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/environment: staging
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-cluster-platform
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        hive.openshift.io/cluster-platform: gcp
+      matchExpressions:
+      - key: api.openshift.com/extended-dedicated-admin
+        operator: NotIn
+        values:
+        - 'false'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1125,141 +1125,16 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-ccs
+    name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/ccs: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-extended-dedicated-admin
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/extended-dedicated-admin: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-environment
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/environment: staging
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRole
-      metadata:
-        labels:
-          managed.openshift.io/aggregate-to-dedicated-admins: project
-        name: dedicated-admins-manage-operators
-      rules:
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - '*'
-        verbs:
-        - '*'
-    - apiVersion: managed.openshift.io/v1alpha1
-      kind: SubjectPermission
-      metadata:
-        name: dedicated-admins-customer-monitoring
-        namespace: openshift-rbac-permissions
-      spec:
-        subjectKind: Group
-        subjectName: dedicated-admins
-        permissions:
-        - clusterRoleName: dedicated-admins-project
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-        - clusterRoleName: admin
-          namespacesAllowedRegex: ^openshift-customer-monitoring$
-          allowFirst: true
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: ccs-dedicated-admins-cluster-platform
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        hive.openshift.io/cluster-platform: gcp
+      matchExpressions:
+      - key: api.openshift.com/extended-dedicated-admin
+        operator: NotIn
+        values:
+        - 'false'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fix matching selector for the extended-dedicated-admin capabilities, always granting it, unless the  `api.openshift.com/extended-dedicated-admin` label is explicitly set to `false`.


With that change, the logic will be considerably simplified, and we'll be able to use a single SelectorSyncSet instead of multiple ones.