### PR TITLE
Fix SRE RBAC review permissions

### DIFF
--- a/deploy/sre-authorization/03-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/03-osd-sre-admin.ClusterRole.yaml
@@ -114,6 +114,15 @@ rules:
   - authorization.openshift.io
   resources:
   - localresourceaccessreviews
+  - resourceaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  - authorization.openshift.io
+  resources:
+  - localsubjectaccessreviews
+  - subjectaccessreviews
   verbs:
   - create
 # SRE can get and post to all endpoints

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5121,6 +5121,15 @@ objects:
         - authorization.openshift.io
         resources:
         - localresourceaccessreviews
+        - resourceaccessreviews
+        verbs:
+        - create
+      - apiGroups:
+        - authorization.k8s.io
+        - authorization.openshift.io
+        resources:
+        - localsubjectaccessreviews
+        - subjectaccessreviews
         verbs:
         - create
       - nonResourceURLs:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5121,6 +5121,15 @@ objects:
         - authorization.openshift.io
         resources:
         - localresourceaccessreviews
+        - resourceaccessreviews
+        verbs:
+        - create
+      - apiGroups:
+        - authorization.k8s.io
+        - authorization.openshift.io
+        resources:
+        - localsubjectaccessreviews
+        - subjectaccessreviews
         verbs:
         - create
       - nonResourceURLs:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5121,6 +5121,15 @@ objects:
         - authorization.openshift.io
         resources:
         - localresourceaccessreviews
+        - resourceaccessreviews
+        verbs:
+        - create
+      - apiGroups:
+        - authorization.k8s.io
+        - authorization.openshift.io
+        resources:
+        - localsubjectaccessreviews
+        - subjectaccessreviews
         verbs:
         - create
       - nonResourceURLs:


### PR DESCRIPTION
SREs can't do subject access reviews successfully without elevation. This fixes that oversight.