### PR TITLE
enable dedadmin update logging InstallPlans

### DIFF
--- a/deploy/osd-logging/05-role.yaml
+++ b/deploy/osd-logging/05-role.yaml
@@ -38,6 +38,12 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+  - operators.coreos.com
+  resources:
+  - installplans
+  verbs:
+  - update
+- apiGroups:
   - ""
   resources:
   - persistentvolumeclaims

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3734,6 +3734,12 @@ objects:
         verbs:
         - '*'
       - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - update
+      - apiGroups:
         - ''
         resources:
         - persistentvolumeclaims

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3734,6 +3734,12 @@ objects:
         verbs:
         - '*'
       - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - update
+      - apiGroups:
         - ''
         resources:
         - persistentvolumeclaims

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3734,6 +3734,12 @@ objects:
         verbs:
         - '*'
       - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - update
+      - apiGroups:
         - ''
         resources:
         - persistentvolumeclaims


### PR DESCRIPTION
Currently when a dedicated admin selects to manually manage the strategy
for operaters in operatorhub, they are unable to approve their own
installations due to RBAC. This change enables them the `update`
verb on the `installplan` resource within the `openshift-logging` namespace.