### PR TITLE
Add workload monitoring label to openshift-customer-monitoring namespace

### DIFF
--- a/deploy/osd-customer-monitoring/00-namespace.yaml
+++ b/deploy/osd-customer-monitoring/00-namespace.yaml
@@ -8,3 +8,4 @@ metadata:
     name: "openshift-customer-monitoring"
     openshift.io/cluster-logging: "true"
     openshift.io/cluster-monitoring: "false"
+    openshift.io/workload-monitoring: "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2756,6 +2756,7 @@ objects:
           name: openshift-customer-monitoring
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'false'
+          openshift.io/workload-monitoring: 'true'
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2756,6 +2756,7 @@ objects:
           name: openshift-customer-monitoring
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'false'
+          openshift.io/workload-monitoring: 'true'
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2756,6 +2756,7 @@ objects:
           name: openshift-customer-monitoring
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'false'
+          openshift.io/workload-monitoring: 'true'
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/APPSRE-2537
Also see: https://gitlab.cee.redhat.com/service/app-sre-observability/-/merge_requests/202

When serviceMonitorNamespaceSelector and ruleNamespaceSelector are specified, the selectors are ANDed together.

We need a label that doesn't conflict with the cluster monitoring label. This change is in line with what's in the actual user workload monitoring feature