### PR TITLE
Removing UpgradeConfigSyncTimeOutSRE

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -90,12 +90,3 @@ spec:
       annotations:
         summary: "Node drain failed in the given time period which is not caused by the PDB"
         description: "node drain takes too long and cannot be finished in the given time period during cluster upgrade"
-    - alert: UpgradeConfigSyncTimeOutSRE
-      expr: upgradeoperator_upgradeconfig_synced > 0
-      for: 30m
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
-      annotations:
-        summary: "UpgradeConfig has not been synced in Time"
-        description: "This clusters UpgradeConfig has not been synced in time and may be out of date"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5715,16 +5715,6 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
-          - alert: UpgradeConfigSyncTimeOutSRE
-            expr: upgradeoperator_upgradeconfig_synced > 0
-            for: 30m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: UpgradeConfig has not been synced in Time
-              description: This clusters UpgradeConfig has not been synced in time
-                and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5715,16 +5715,6 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
-          - alert: UpgradeConfigSyncTimeOutSRE
-            expr: upgradeoperator_upgradeconfig_synced > 0
-            for: 30m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: UpgradeConfig has not been synced in Time
-              description: This clusters UpgradeConfig has not been synced in time
-                and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5715,16 +5715,6 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
-          - alert: UpgradeConfigSyncTimeOutSRE
-            expr: upgradeoperator_upgradeconfig_synced > 0
-            for: 30m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: UpgradeConfig has not been synced in Time
-              description: This clusters UpgradeConfig has not been synced in time
-                and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Was added a little early. Needs to wait for rollout of upgrade policy api