### PR TITLE
Fix AlertmanagerSilencesActiveSRE to see when there are 2+ silences

### DIFF
--- a/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
@@ -11,9 +11,11 @@ spec:
   - name: sre-alertmanager-silences-active
     rules:
     - alert: AlertmanagerSilencesActiveSRE
-      # Ignore alerting on silences if the cluster is upgrading, as the 
+      # Ignore alerting on silences if the cluster is upgrading, as the
       # upgrade process will generate a silence itself. (OSD-3426)
-      expr: count(alertmanager_silences{state="active"} == 1) > 0 unless (count(cluster_version{type="updating"}) > 0)
+      # Use an average as without instance,pod, so that all AM pods are taken
+      # into consideration
+      expr: avg without (instance,pod)(alertmanager_silences{state="active"}) > 0 unless (count(cluster_version{type="updating"}) > 0)
       for: 15m
       labels:
         severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5393,8 +5393,8 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: count(alertmanager_silences{state="active"} == 1) > 0 unless (count(cluster_version{type="updating"})
-              > 0)
+            expr: avg without (instance,pod)(alertmanager_silences{state="active"})
+              > 0 unless (count(cluster_version{type="updating"}) > 0)
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5393,8 +5393,8 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: count(alertmanager_silences{state="active"} == 1) > 0 unless (count(cluster_version{type="updating"})
-              > 0)
+            expr: avg without (instance,pod)(alertmanager_silences{state="active"})
+              > 0 unless (count(cluster_version{type="updating"}) > 0)
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5393,8 +5393,8 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: count(alertmanager_silences{state="active"} == 1) > 0 unless (count(cluster_version{type="updating"})
-              > 0)
+            expr: avg without (instance,pod)(alertmanager_silences{state="active"})
+              > 0 unless (count(cluster_version{type="updating"}) > 0)
             for: 15m
             labels:
               severity: warning


### PR DESCRIPTION
If there are 2+ silences, the current metric doesn't match.