### PR TITLE
Fix SREP access for cluster scoped resources in backplane

### DIFF
--- a/deploy/backplane/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/10-srep-admins-cluster.ClusterRole.yml
@@ -82,4 +82,14 @@ rules:
   - users
   verbs:
   - delete
+# SREP can view machineconfigs, machineconfigpools, kubeletconfigs,
+#    controllerconfigs
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
 ### End

--- a/deploy/backplane/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/10-srep-admins-cluster.ClusterRole.yml
@@ -59,3 +59,27 @@ rules:
   - '*'
   verbs:
   - '*'
+#### Start - more perms for srep
+# https://issues.redhat.com/browse/OSD-5537
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  - selfsubjectaccessreviews
+  - selfsubjectrulesreviews
+  verbs:
+  - '*'
+- apiGroups:
+  - authorization.openshift.io
+  resources:
+  - resourceaccessreviews
+  - subjectaccessreviews
+  verbs:
+  - '*'
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - users
+  verbs:
+  - delete
+### End

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -167,16 +167,6 @@ rules:
   - get
   - list
   - watch
-# osd-readers can view machineconfigs, machineconfigpools, kubeletconfigs,
-#    controllerconfigs
-- apiGroups:
-  - machineconfiguration.openshift.io
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - metal3.io
   resources:

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -39,16 +39,6 @@ rules:
   verbs:
   - get
   - list
-### START - view ClusterVersion
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusterversions
-  verbs:
-  - list
-  - get
-  - watch
-### END
 ### START - run `oc adm top pod` or `oc adm top node`
 - apiGroups:
   - metrics.k8s.io
@@ -57,17 +47,6 @@ rules:
   - pods
   verbs:
   - list
-### END
-### Start - Allow viewing platform and other infra data in console
-# https://issues.redhat.com/browse/OSD-4298
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - infrastructures
-  verbs:
-  - get
-  - list
-  - watch
 ### END
 ### Start - fix `oc describe nodes`
 # https://issues.redhat.com/browse/OHSS-1105
@@ -87,3 +66,281 @@ rules:
   verbs:
   - get
   - list
+### END
+### Start - Allow read permissions to more resources
+# https://issues.redhat.com/browse/OSD-5537
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - selfsubjectaccessreviews
+  - subjectaccessreviews
+  - selfsubjectrulesreviews
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.openshift.io
+  resources:
+  - clusterrolebindings
+  - subjectaccessreviews
+  - resourceaccessreviews
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - clusterautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view oauths, clusterversions, infrastructures, apiservers, consoles,
+#    authentications, builds, clusteroperators, dnses, schedulers, projects,
+#    featuregates, images, ingresses, networks, operatorhubs, proxies
+#    https://issues.redhat.com/browse/OSD-4298
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view consolelinks, consolenotifications, consoleexternalloglinks,
+#    consoleyamlsamples
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view flowschemas and prioritylevelconfigurations
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - images
+  - imagesignatures
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view configs and imagepruners
+- apiGroups:
+  - imageregistry.operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view machineconfigs, machineconfigpools, kubeletconfigs,
+#    controllerconfigs
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - provisionings
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view storagestates and storageversionmigrations
+- apiGroups:
+  - migration.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - network.openshift.io
+  resources:
+  - clusternetworks
+  - hostsubnets
+  - netnamespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view oauthaccesstokens, oauthauthorizetokens, oauthclients,
+#    oauthclientauthorizations
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# osd-readers can view authentications, cloudcredentials, clustercsidrivers,
+#    configs, consoles, csisnapshotcontrollers, dnses, etcds,
+#    imagecontentsourcepolicies, ingresscontrollers, kubeapiservers,
+#    kubecontrollermanagers, kubeschedulers, kubestorageversionmigrators,
+#    networks, openshiftapiservers, openshiftcontrollermanagers,
+#    servicecas, storages
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projectrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - samples.operator.openshift.io
+  resources:
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  - rangeallocations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  - csinodes
+  - csidrivers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - brokertemplateinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  - identities
+  - users
+  verbs:
+  - get
+  - list
+  - watch
+### End

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -102,21 +102,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - authorization.k8s.io
-  resources:
-  - selfsubjectaccessreviews
-  - subjectaccessreviews
-  - selfsubjectrulesreviews
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - authorization.openshift.io
   resources:
   - clusterrolebindings
-  - subjectaccessreviews
-  - resourceaccessreviews
   - clusterroles
   verbs:
   - get
@@ -228,16 +216,6 @@ rules:
   - node.k8s.io
   resources:
   - runtimeclasses
-  verbs:
-  - get
-  - list
-  - watch
-# osd-readers can view oauthaccesstokens, oauthauthorizetokens, oauthclients,
-#    oauthclientauthorizations
-- apiGroups:
-  - oauth.openshift.io
-  resources:
-  - '*'
   verbs:
   - get
   - list

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -908,6 +908,27 @@ objects:
         - '*'
         verbs:
         - '*'
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        - selfsubjectaccessreviews
+        - selfsubjectrulesreviews
+        verbs:
+        - '*'
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - resourceaccessreviews
+        - subjectaccessreviews
+        verbs:
+        - '*'
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - users
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4689,28 +4710,12 @@ objects:
         - get
         - list
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - clusterversions
-        verbs:
-        - list
-        - get
-        - watch
-      - apiGroups:
         - metrics.k8s.io
         resources:
         - nodes
         - pods
         verbs:
         - list
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - infrastructures
-        verbs:
-        - get
-        - list
-        - watch
       - apiGroups:
         - coordination.k8s.io
         resources:
@@ -4724,6 +4729,261 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - admissionregistration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiregistration.k8s.io
+        resources:
+        - apiservices
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.k8s.io
+        resources:
+        - selfsubjectaccessreviews
+        - subjectaccessreviews
+        - selfsubjectrulesreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - clusterrolebindings
+        - subjectaccessreviews
+        - resourceaccessreviews
+        - clusterroles
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - clusterautoscalers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - flowcontrol.apiserver.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        - imagesignatures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - imageregistry.operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - metal3.io
+        resources:
+        - provisionings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - migration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - clusternetworks
+        - hostsubnets
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - ingressclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - node.k8s.io
+        resources:
+        - runtimeclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - oauth.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - project.openshift.io
+        resources:
+        - projectrequests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - samples.operator.openshift.io
+        resources:
+        - configs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - scheduling.k8s.io
+        resources:
+        - priorityclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        - rangeallocations
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshotcontents
+        - volumesnapshotclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - storage.k8s.io
+        resources:
+        - volumeattachments
+        - csinodes
+        - csidrivers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - template.openshift.io
+        resources:
+        - brokertemplateinstances
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - groups
+        - identities
+        - users
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -929,6 +929,14 @@ objects:
         - users
         verbs:
         - delete
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4762,21 +4770,9 @@ objects:
         - list
         - watch
       - apiGroups:
-        - authorization.k8s.io
-        resources:
-        - selfsubjectaccessreviews
-        - subjectaccessreviews
-        - selfsubjectrulesreviews
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
         - authorization.openshift.io
         resources:
         - clusterrolebindings
-        - subjectaccessreviews
-        - resourceaccessreviews
         - clusterroles
         verbs:
         - get
@@ -4832,14 +4828,6 @@ objects:
         - list
         - watch
       - apiGroups:
-        - machineconfiguration.openshift.io
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
         - metal3.io
         resources:
         - provisionings
@@ -4877,14 +4865,6 @@ objects:
         - node.k8s.io
         resources:
         - runtimeclasses
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - oauth.openshift.io
-        resources:
-        - '*'
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -908,6 +908,27 @@ objects:
         - '*'
         verbs:
         - '*'
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        - selfsubjectaccessreviews
+        - selfsubjectrulesreviews
+        verbs:
+        - '*'
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - resourceaccessreviews
+        - subjectaccessreviews
+        verbs:
+        - '*'
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - users
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4689,28 +4710,12 @@ objects:
         - get
         - list
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - clusterversions
-        verbs:
-        - list
-        - get
-        - watch
-      - apiGroups:
         - metrics.k8s.io
         resources:
         - nodes
         - pods
         verbs:
         - list
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - infrastructures
-        verbs:
-        - get
-        - list
-        - watch
       - apiGroups:
         - coordination.k8s.io
         resources:
@@ -4724,6 +4729,261 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - admissionregistration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiregistration.k8s.io
+        resources:
+        - apiservices
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.k8s.io
+        resources:
+        - selfsubjectaccessreviews
+        - subjectaccessreviews
+        - selfsubjectrulesreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - clusterrolebindings
+        - subjectaccessreviews
+        - resourceaccessreviews
+        - clusterroles
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - clusterautoscalers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - flowcontrol.apiserver.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        - imagesignatures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - imageregistry.operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - metal3.io
+        resources:
+        - provisionings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - migration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - clusternetworks
+        - hostsubnets
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - ingressclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - node.k8s.io
+        resources:
+        - runtimeclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - oauth.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - project.openshift.io
+        resources:
+        - projectrequests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - samples.operator.openshift.io
+        resources:
+        - configs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - scheduling.k8s.io
+        resources:
+        - priorityclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        - rangeallocations
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshotcontents
+        - volumesnapshotclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - storage.k8s.io
+        resources:
+        - volumeattachments
+        - csinodes
+        - csidrivers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - template.openshift.io
+        resources:
+        - brokertemplateinstances
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - groups
+        - identities
+        - users
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -929,6 +929,14 @@ objects:
         - users
         verbs:
         - delete
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4762,21 +4770,9 @@ objects:
         - list
         - watch
       - apiGroups:
-        - authorization.k8s.io
-        resources:
-        - selfsubjectaccessreviews
-        - subjectaccessreviews
-        - selfsubjectrulesreviews
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
         - authorization.openshift.io
         resources:
         - clusterrolebindings
-        - subjectaccessreviews
-        - resourceaccessreviews
         - clusterroles
         verbs:
         - get
@@ -4832,14 +4828,6 @@ objects:
         - list
         - watch
       - apiGroups:
-        - machineconfiguration.openshift.io
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
         - metal3.io
         resources:
         - provisionings
@@ -4877,14 +4865,6 @@ objects:
         - node.k8s.io
         resources:
         - runtimeclasses
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - oauth.openshift.io
-        resources:
-        - '*'
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -908,6 +908,27 @@ objects:
         - '*'
         verbs:
         - '*'
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        - selfsubjectaccessreviews
+        - selfsubjectrulesreviews
+        verbs:
+        - '*'
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - resourceaccessreviews
+        - subjectaccessreviews
+        verbs:
+        - '*'
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - users
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4689,28 +4710,12 @@ objects:
         - get
         - list
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - clusterversions
-        verbs:
-        - list
-        - get
-        - watch
-      - apiGroups:
         - metrics.k8s.io
         resources:
         - nodes
         - pods
         verbs:
         - list
-      - apiGroups:
-        - config.openshift.io
-        resources:
-        - infrastructures
-        verbs:
-        - get
-        - list
-        - watch
       - apiGroups:
         - coordination.k8s.io
         resources:
@@ -4724,6 +4729,261 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - admissionregistration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiregistration.k8s.io
+        resources:
+        - apiservices
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.k8s.io
+        resources:
+        - selfsubjectaccessreviews
+        - subjectaccessreviews
+        - selfsubjectrulesreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - clusterrolebindings
+        - subjectaccessreviews
+        - resourceaccessreviews
+        - clusterroles
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - clusterautoscalers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - flowcontrol.apiserver.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        - imagesignatures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - imageregistry.operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - metal3.io
+        resources:
+        - provisionings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - migration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - clusternetworks
+        - hostsubnets
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - ingressclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - node.k8s.io
+        resources:
+        - runtimeclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - oauth.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - project.openshift.io
+        resources:
+        - projectrequests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - samples.operator.openshift.io
+        resources:
+        - configs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - scheduling.k8s.io
+        resources:
+        - priorityclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        - rangeallocations
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshotcontents
+        - volumesnapshotclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - storage.k8s.io
+        resources:
+        - volumeattachments
+        - csinodes
+        - csidrivers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - template.openshift.io
+        resources:
+        - brokertemplateinstances
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - groups
+        - identities
+        - users
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -929,6 +929,14 @@ objects:
         - users
         verbs:
         - delete
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -4762,21 +4770,9 @@ objects:
         - list
         - watch
       - apiGroups:
-        - authorization.k8s.io
-        resources:
-        - selfsubjectaccessreviews
-        - subjectaccessreviews
-        - selfsubjectrulesreviews
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
         - authorization.openshift.io
         resources:
         - clusterrolebindings
-        - subjectaccessreviews
-        - resourceaccessreviews
         - clusterroles
         verbs:
         - get
@@ -4832,14 +4828,6 @@ objects:
         - list
         - watch
       - apiGroups:
-        - machineconfiguration.openshift.io
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
         - metal3.io
         resources:
         - provisionings
@@ -4877,14 +4865,6 @@ objects:
         - node.k8s.io
         resources:
         - runtimeclasses
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - oauth.openshift.io
-        resources:
-        - '*'
         verbs:
         - get
         - list


### PR DESCRIPTION
Cleaner version of https://github.com/openshift/managed-cluster-config/pull/531
 > The srep role in backplane doesnt have read access to many in-cluster resources. This PR aims at adding read permission to the osd-reader-cluster role which get aggregated to backplane-srep-readers-cluster. Also adding a few update/delete perms to backplane-srep-admins-cluster directly.

> This is in-line with enforcing least-privilege access to SREP in backplane.

> Jira: https://issues.redhat.com/browse/OSD-5537

> There is a google sheet linked in the jira that was used to first come up with these set of resources and permissions.