### PR TITLE
Remove redundant oauth resource permission from osd-readers

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -57,16 +57,6 @@ rules:
   verbs:
   - get
 ### END
-### Start - Allow viewing of oauths
-# https://issues.redhat.com/browse/OSD-5261
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - oauths
-  verbs:
-  - get
-  - list
-### END
 ### Start - Allow read permissions to more resources
 # https://issues.redhat.com/browse/OSD-5537
 - apiGroups:
@@ -122,6 +112,7 @@ rules:
 #    authentications, builds, clusteroperators, dnses, schedulers, projects,
 #    featuregates, images, ingresses, networks, operatorhubs, proxies
 #    https://issues.redhat.com/browse/OSD-4298
+#    https://issues.redhat.com/browse/OSD-5261
 - apiGroups:
   - config.openshift.io
   resources:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4792,13 +4792,6 @@ objects:
         verbs:
         - get
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - oauths
-        verbs:
-        - get
-        - list
-      - apiGroups:
         - admissionregistration.k8s.io
         resources:
         - '*'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4792,13 +4792,6 @@ objects:
         verbs:
         - get
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - oauths
-        verbs:
-        - get
-        - list
-      - apiGroups:
         - admissionregistration.k8s.io
         resources:
         - '*'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4792,13 +4792,6 @@ objects:
         verbs:
         - get
       - apiGroups:
-        - config.openshift.io
-        resources:
-        - oauths
-        verbs:
-        - get
-        - list
-      - apiGroups:
         - admissionregistration.k8s.io
         resources:
         - '*'


### PR DESCRIPTION
Removing oauth resource from osd-readers as it will be covered by:
```
- apiGroups:
  - config.openshift.io
  resources:
  - '*'
  verbs:
  - get
  - list
  - watch
```
Added the original jira associated with adding oauth to osd-readers as a comment to maintain consistency/history from the code block being removed.

Associated/Related jira: [OSD-5537](https://issues.redhat.com/browse/OSD-5537)