### PR TITLE
Remove namespace from ClusterRoleBinding

### DIFF
--- a/deploy/osd-project-request-template/01-clusterrolebinding.project-config.yaml
+++ b/deploy/osd-project-request-template/01-clusterrolebinding.project-config.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dedicated-admins-project-config
-  namespace: openshift-config
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4001,7 +4001,6 @@ objects:
       kind: ClusterRoleBinding
       metadata:
         name: dedicated-admins-project-config
-        namespace: openshift-config
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4001,7 +4001,6 @@ objects:
       kind: ClusterRoleBinding
       metadata:
         name: dedicated-admins-project-config
-        namespace: openshift-config
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4001,7 +4001,6 @@ objects:
       kind: ClusterRoleBinding
       metadata:
         name: dedicated-admins-project-config
-        namespace: openshift-config
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole


### PR DESCRIPTION
Found [CO-1238](https://issues.redhat.com/browse/CO-1238) as a part of [OSD-5566](https://issues.redhat.com/browse/OSD-5566), existance of `namespace` on CRB causes hive to not delete the resource.