### PR TITLE
lock down cssre to just rhmi and rhoam namespaces

### DIFF
--- a/deploy/backplane/20-cssre.SubjectPermission.yml
+++ b/deploy/backplane/20-cssre.SubjectPermission.yml
@@ -10,7 +10,6 @@ spec:
   permissions:
   - allowFirst: true
     clusterRoleName: backplane-cssre-admins-project
-    namespacesAllowedRegex: .*
-    namespacesDeniedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$)"
+    namespacesAllowedRegex: "(^redhat-rhmi-.*|^redhat-rhoam-.*)"
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-cssre


### PR DESCRIPTION
@karthikperu7 Here are the changes we discussed.  Please review.