### PR TITLE
OSD-5341 add CloudCredentialOperatorDown to MUO silence

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -18,6 +18,7 @@ data:
         - ClusterOperatorDown
         - MachineWithNoRunningPhase
         - ClusterOperatorDegraded
+        - CloudCredentialOperatorDown
     scale:
       timeOut: 30
     upgradeWindow:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1838,12 +1838,12 @@ objects:
           \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
           \    controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
           \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
-          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
-          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\nverification:\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
-          \ kube\n  - default\n"
+          \    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\n\
+          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1838,12 +1838,12 @@ objects:
           \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
           \    controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
           \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
-          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
-          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\nverification:\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
-          \ kube\n  - default\n"
+          \    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\n\
+          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1838,12 +1838,12 @@ objects:
           \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
           \    controlPlaneCriticals:\n    - etcdMembersDown\n    - KubeDeploymentReplicasMismatch\n\
           \    - ClusterOperatorDown\n    - MachineWithNoRunningPhase\n    - ClusterOperatorDegraded\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  timeOut: 120\nnodeDrain:\n  timeOut:\
-          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
-          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\nverification:\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
-          \ kube\n  - default\n"
+          \    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\n\
+          healthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
This adds `CloudCredentialOperatorDown` as an ignored critical alert during managed upgrades.

This alert will fire in the 4.5 to 4.6 upgrade hop as identified by [this BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1889540). It is a no-op and self-resolves, but is quite noisy during the control plane upgrade.

Refs [OSD-5341](https://issues.redhat.com/browse/OSD-5341)
