### PR TITLE
SDE-931 + OSD-5587: Enable HSTS on default OSD routes in stage

### DIFF
--- a/deploy/osd-hsts-routes/config.yaml
+++ b/deploy/osd-hsts-routes/config.yaml
@@ -3,4 +3,4 @@ selectorSyncSet:
   matchExpressions:
   - key: api.openshift.com/environment
     operator: NotIn
-    values: ["production", "stage"]
+    values: ["production"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3576,7 +3576,6 @@ objects:
         operator: NotIn
         values:
         - production
-        - stage
     resourceApplyMode: Sync
     patches:
     - apiVersion: route.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3576,7 +3576,6 @@ objects:
         operator: NotIn
         values:
         - production
-        - stage
     resourceApplyMode: Sync
     patches:
     - apiVersion: route.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3576,7 +3576,6 @@ objects:
         operator: NotIn
         values:
         - production
-        - stage
     resourceApplyMode: Sync
     patches:
     - apiVersion: route.openshift.io/v1


### PR DESCRIPTION
No new failures were introduced in the osde2e tests in int and there were no issues with manual tests in Chrome or Firefox, so I think this change is ready to be tested more widely in stage