### PR TITLE
OSD-5414 add MUO alert for failure to sync upgradeconfig

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -90,3 +90,12 @@ spec:
       annotations:
         summary: "Node drain failed in the given time period which is not caused by the PDB"
         description: "node drain takes too long and cannot be finished in the given time period during cluster upgrade"
+    - alert: UpgradeConfigSyncTimeOutSRE
+      expr: upgradeoperator_upgradeconfig_synced > 0
+      for: 30m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+        annotations:
+          summary: "UpgradeConfig has not been synced in time"
+          description: "This clusters UpgradeConfig has not been synced in time and may be out of date"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6109,6 +6109,16 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
+          - alert: UpgradeConfigSyncTimeOutSRE
+            expr: upgradeoperator_upgradeconfig_synced > 0
+            for: 30m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              annotations:
+                summary: UpgradeConfig has not been synced in time
+                description: This clusters UpgradeConfig has not been synced in time
+                  and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6109,6 +6109,16 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
+          - alert: UpgradeConfigSyncTimeOutSRE
+            expr: upgradeoperator_upgradeconfig_synced > 0
+            for: 30m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              annotations:
+                summary: UpgradeConfig has not been synced in time
+                description: This clusters UpgradeConfig has not been synced in time
+                  and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6109,6 +6109,16 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
+          - alert: UpgradeConfigSyncTimeOutSRE
+            expr: upgradeoperator_upgradeconfig_synced > 0
+            for: 30m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              annotations:
+                summary: UpgradeConfig has not been synced in time
+                description: This clusters UpgradeConfig has not been synced in time
+                  and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
This PR adds a new `warning` level alert `UpgradeConfigSyncTimeOutSRE` which indicates when a cluster has been unable to sync with OCM for the purposes of pulling an `UpgradeConfig` for a sustained period of time.

Corresponding SOP: https://github.com/openshift/ops-sop/pull/1068

Refs: [OSD-5414](https://issues.redhat.com/browse/OSD-5414)