### PR TITLE
OSD-3985 configure cluster image-pruner to SRE preferences

### DIFF
--- a/deploy/sre-pruning/105-pruning.rbac.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.yaml
@@ -5,19 +5,6 @@ metadata:
   namespace: openshift-sre-pruning
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: sre-pruner-images
-roleRef:
-  kind: ClusterRole
-  name: system:image-pruner
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: sre-pruner-sa
-  namespace: openshift-sre-pruning
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: sre-pruner-buildsdeploys-cr

--- a/deploy/sre-pruning/images-pre-4.6/00-pruning.rbac.yaml
+++ b/deploy/sre-pruning/images-pre-4.6/00-pruning.rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sre-pruner-images
+roleRef:
+  kind: ClusterRole
+  name: system:image-pruner
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: sre-pruner-sa
+  namespace: openshift-sre-pruning

--- a/deploy/sre-pruning/images-pre-4.6/01-pruning-images.CronJob.yaml
+++ b/deploy/sre-pruning/images-pre-4.6/01-pruning-images.CronJob.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -8,7 +7,7 @@ spec:
   failedJobsHistoryLimit: 5
   successfulJobsHistoryLimit: 3
   concurrencyPolicy: Replace
-  schedule: "0 */1 * * *"
+  schedule: "30 */1 * * *"
   jobTemplate:
     spec:
       template:

--- a/deploy/sre-pruning/images-pre-4.6/config.yaml
+++ b/deploy/sre-pruning/images-pre-4.6/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.0","4.1","4.2","4.3","4.4","4.5"]

--- a/deploy/sre-pruning/images/00-cluster.ImagePruner.patch.yaml
+++ b/deploy/sre-pruning/images/00-cluster.ImagePruner.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+applyMode: AlwaysApply
+kind: ImagePruner
+name: cluster
+namespace: openshift-image-registry
+patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences": true, "schedule": "0 */1 * * *"}}'
+patchType: merge

--- a/deploy/sre-pruning/images/config.yaml
+++ b/deploy/sre-pruning/images/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: NotIn
+    values: ["4.0","4.1","4.2","4.3","4.4","4.5"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6564,18 +6564,6 @@ objects:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
     - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: sre-pruner-images
-      roleRef:
-        kind: ClusterRole
-        name: system:image-pruner
-        apiGroup: rbac.authorization.k8s.io
-      subjects:
-      - kind: ServiceAccount
-        name: sre-pruner-sa
-        namespace: openshift-sre-pruning
-    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: sre-pruner-buildsdeploys-cr
@@ -6748,6 +6736,74 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-images
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: imageregistry.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: ImagePruner
+      name: cluster
+      namespace: openshift-image-registry
+      patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences":
+        true, "schedule": "0 */1 * * *"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-images-pre-4.6
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-pruner-images
+      roleRef:
+        kind: ClusterRole
+        name: system:image-pruner
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pruner-sa
+        namespace: openshift-sre-pruning
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:
@@ -6757,7 +6813,7 @@ objects:
         failedJobsHistoryLimit: 5
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
-        schedule: 0 */1 * * *
+        schedule: 30 */1 * * *
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6564,18 +6564,6 @@ objects:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
     - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: sre-pruner-images
-      roleRef:
-        kind: ClusterRole
-        name: system:image-pruner
-        apiGroup: rbac.authorization.k8s.io
-      subjects:
-      - kind: ServiceAccount
-        name: sre-pruner-sa
-        namespace: openshift-sre-pruning
-    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: sre-pruner-buildsdeploys-cr
@@ -6748,6 +6736,74 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-images
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: imageregistry.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: ImagePruner
+      name: cluster
+      namespace: openshift-image-registry
+      patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences":
+        true, "schedule": "0 */1 * * *"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-images-pre-4.6
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-pruner-images
+      roleRef:
+        kind: ClusterRole
+        name: system:image-pruner
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pruner-sa
+        namespace: openshift-sre-pruning
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:
@@ -6757,7 +6813,7 @@ objects:
         failedJobsHistoryLimit: 5
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
-        schedule: 0 */1 * * *
+        schedule: 30 */1 * * *
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6564,18 +6564,6 @@ objects:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
     - apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: sre-pruner-images
-      roleRef:
-        kind: ClusterRole
-        name: system:image-pruner
-        apiGroup: rbac.authorization.k8s.io
-      subjects:
-      - kind: ServiceAccount
-        name: sre-pruner-sa
-        namespace: openshift-sre-pruning
-    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: sre-pruner-buildsdeploys-cr
@@ -6748,6 +6736,74 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-images
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: imageregistry.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: ImagePruner
+      name: cluster
+      namespace: openshift-image-registry
+      patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences":
+        true, "schedule": "0 */1 * * *"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-images-pre-4.6
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-pruner-images
+      roleRef:
+        kind: ClusterRole
+        name: system:image-pruner
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pruner-sa
+        namespace: openshift-sre-pruning
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:
@@ -6757,7 +6813,7 @@ objects:
         failedJobsHistoryLimit: 5
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
-        schedule: 0 */1 * * *
+        schedule: 30 */1 * * *
         jobTemplate:
           spec:
             template:


### PR DESCRIPTION
This PR patches the `cluster` ImagePruner in OSD clusters >= `4.6` to have execution preferences matching SRE's existing custom image pruner cronjob. Changes from the `cluster` defaults are:
 
- cronjob will run hourly rather than daily
- cronjob will ignore invalid image refs (default is to not ignore)
- cronjob will keep images younger than a day (default is 1 hour)

This job is being performed by a new SelectorSyncSet that will only apply to clusters that are 4.6+.

The existing `sre-image-pruner` cronjob has also been modified.

- Moved into its own SelectorSyncSet that will only apply to 4.3/4.4/4.5 clusters.
- Changed to run on the `30` minute mark, to avoid colliding with the `cluster` image pruner, something which is presently a source of many PagerDuty alerts during APAC region on 4.6 clusters when the two jobs run simultaneously ([BZ1890828](https://bugzilla.redhat.com/show_bug.cgi?id=1890828)).

Refs: [OSD-3985](https://issues.redhat.com/browse/OSD-3985)
