### PR TITLE
Do not allow backplane SREP users to access token/secret sensitive data in the cluster-admin namespace

### DIFF
--- a/deploy/backplane/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/20-srep.SubjectPermission.yml
@@ -11,5 +11,6 @@ spec:
   - allowFirst: true
     clusterRoleName: backplane-srep-admins-project
     namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1068,6 +1068,7 @@ objects:
         - allowFirst: true
           clusterRoleName: backplane-srep-admins-project
           namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1068,6 +1068,7 @@ objects:
         - allowFirst: true
           clusterRoleName: backplane-srep-admins-project
           namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1068,6 +1068,7 @@ objects:
         - allowFirst: true
           clusterRoleName: backplane-srep-admins-project
           namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-5896

Srep should not be able to access sa tokens (from `openshift-backplane-cluster-admin`) which could potentially allow them to perform elevated actions without auditing/approval/paper-trail. This PR is to block that.

