### PR TITLE
OSD-3985 Set suspend=false for 4.6 cluster image pruner

### DIFF
--- a/deploy/sre-pruning/images/00-cluster.ImagePruner.patch.yaml
+++ b/deploy/sre-pruning/images/00-cluster.ImagePruner.patch.yaml
@@ -3,5 +3,5 @@ applyMode: AlwaysApply
 kind: ImagePruner
 name: cluster
 namespace: openshift-image-registry
-patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences": true, "schedule": "0 */1 * * *"}}'
+patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences": true, "schedule": "0 */1 * * *", "suspend": false}}'
 patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6743,7 +6743,7 @@ objects:
       name: cluster
       namespace: openshift-image-registry
       patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences":
-        true, "schedule": "0 */1 * * *"}}'
+        true, "schedule": "0 */1 * * *", "suspend": false}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6743,7 +6743,7 @@ objects:
       name: cluster
       namespace: openshift-image-registry
       patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences":
-        true, "schedule": "0 */1 * * *"}}'
+        true, "schedule": "0 */1 * * *", "suspend": false}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6743,7 +6743,7 @@ objects:
       name: cluster
       namespace: openshift-image-registry
       patch: '{"spec":{"keepYoungerThan":86400000000000, "ignoreInvalidImageReferences":
-        true, "schedule": "0 */1 * * *"}}'
+        true, "schedule": "0 */1 * * *", "suspend": false}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
This PR follows up on [OSD-3985](https://issues.redhat.com/browse/OSD-3985) which enabled the cluster image pruner for OSD 4.6 clusters.

Some clusters have set the `imagepruner` CR's `suspend` field to false in favour of the SRE image pruner. As the SRE image pruner no longer runs on 4.6 clusters, these clusters will be left in a state of no pruning unless the cluster pruner is re-enabled.

This PR ensures that, if the `imagepruner` is suspended, it is re-enabled.
