### PR TITLE
OSD-5414 Add UpgradeConfigSyncFailureOver1HrSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -90,3 +90,12 @@ spec:
       annotations:
         summary: "Node drain failed in the given time period which is not caused by the PDB"
         description: "node drain takes too long and cannot be finished in the given time period during cluster upgrade"
+    - alert: UpgradeConfigSyncFailureOver1HrSRE
+      expr: upgradeoperator_upgradeconfig_synced > 0
+      for: 1h
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+        annotations:
+          summary: "UpgradeConfig has not successfully synced in 1 hour."
+          description: "This clusters UpgradeConfig has not been synced in 1 hour and may be out of date"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6300,6 +6300,16 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
+          - alert: UpgradeConfigSyncFailureOver1HrSRE
+            expr: upgradeoperator_upgradeconfig_synced > 0
+            for: 1h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              annotations:
+                summary: UpgradeConfig has not successfully synced in 1 hour.
+                description: This clusters UpgradeConfig has not been synced in 1
+                  hour and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6300,6 +6300,16 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
+          - alert: UpgradeConfigSyncFailureOver1HrSRE
+            expr: upgradeoperator_upgradeconfig_synced > 0
+            for: 1h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              annotations:
+                summary: UpgradeConfig has not successfully synced in 1 hour.
+                description: This clusters UpgradeConfig has not been synced in 1
+                  hour and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6300,6 +6300,16 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
+          - alert: UpgradeConfigSyncFailureOver1HrSRE
+            expr: upgradeoperator_upgradeconfig_synced > 0
+            for: 1h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              annotations:
+                summary: UpgradeConfig has not successfully synced in 1 hour.
+                description: This clusters UpgradeConfig has not been synced in 1
+                  hour and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
This PR is a re-do of #541 , which was promoted too early. It introduces a new warning-level `UpgradeConfigSyncFailureOver1HrSRE` alert for the `managed-upgrade-operator` which indicates when a cluster has been unable to sync its upgrade configuration with OCM for over an hour.

Corresponding SOP PR: https://github.com/openshift/ops-sop/pull/1089