### PR TITLE
Fixed typo in the aggregating cluster role name

### DIFF
--- a/deploy/layered-sre-authorization/01-layered-cs-sre-admins-cluster.ClusterRole.yaml
+++ b/deploy/layered-sre-authorization/01-layered-cs-sre-admins-cluster.ClusterRole.yaml
@@ -14,5 +14,5 @@ aggregationRule:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: layered-cs-sre-admin-cluster
+  name: layered-cs-sre-admins-cluster
 rules: []

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1495,7 +1495,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
@@ -1559,7 +1559,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
@@ -1623,7 +1623,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1495,7 +1495,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
@@ -1559,7 +1559,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
@@ -1623,7 +1623,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1495,7 +1495,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
@@ -1559,7 +1559,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
@@ -1623,7 +1623,7 @@ objects:
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: layered-cs-sre-admin-cluster
+        name: layered-cs-sre-admins-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding


### PR DESCRIPTION
Updated cluster role name from `layered-cs-sre-admin-cluster` to `layered-cs-sre-admins-cluster` as all cluster role bindings are using the latter. 
