### PR TITLE
Add permissions to dedicated for the openshift pipelines operator

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -202,6 +202,8 @@ rules:
   - spinnakeroperators.charts.helm.k8s.io
 # Twistlock Console Operator
   - twistlockconsoles.charts.helm.k8s.io
+# Openshift Pipelines Operator
+  - tekton.dev
   resources:
   - '*'
   verbs:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5011,6 +5011,7 @@ objects:
         - seldondeployments.machinelearning.seldon.io
         - spinnakeroperators.charts.helm.k8s.io
         - twistlockconsoles.charts.helm.k8s.io
+        - tekton.dev
         resources:
         - '*'
         verbs:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5011,6 +5011,7 @@ objects:
         - seldondeployments.machinelearning.seldon.io
         - spinnakeroperators.charts.helm.k8s.io
         - twistlockconsoles.charts.helm.k8s.io
+        - tekton.dev
         resources:
         - '*'
         verbs:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5011,6 +5011,7 @@ objects:
         - seldondeployments.machinelearning.seldon.io
         - spinnakeroperators.charts.helm.k8s.io
         - twistlockconsoles.charts.helm.k8s.io
+        - tekton.dev
         resources:
         - '*'
         verbs:


### PR DESCRIPTION
[Tekton pipelines](https://tekton.dev/) have been available in OCP since v4.4. All tekton resources are under the namespace `tekton.dev` and this PR adds permissions for `dedicated-admin` to create, modify and delete resources in this namespace.

[Official Openshift Docs](https://docs.openshift.com/container-platform/4.6/pipelines/understanding-openshift-pipelines.html)