### PR TITLE
Remove MUO WindowBreach alert

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -70,16 +70,6 @@ spec:
       annotations:
         summary: "Nodes upgrade timeout for {{ $labels.version }}"
         description: "nodes upgrade for {{ $labels.version }} cannot be finished after the silence expired"
-    - alert: UpgradeWindowBreachedSRE
-      # Get alert if the upgrade window breached
-      expr: upgradeoperator_upgrade_window_breached > 0
-      for: 5m
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
-      annotations:
-        summary: "Cluster upgrade window breached"
-        description: "A cluster has not commenced upgrading during its scheduled upgrade window."
     - alert: UpgradeNodeDrainFailedSRE
       # Get alert if the node drain takes too long during the upgrade
       expr: upgradeoperator_node_drain_timeout > 0

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6437,16 +6437,6 @@ objects:
               summary: Nodes upgrade timeout for {{ $labels.version }}
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
-          - alert: UpgradeWindowBreachedSRE
-            expr: upgradeoperator_upgrade_window_breached > 0
-            for: 5m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: Cluster upgrade window breached
-              description: A cluster has not commenced upgrading during its scheduled
-                upgrade window.
           - alert: UpgradeNodeDrainFailedSRE
             expr: upgradeoperator_node_drain_timeout > 0
             for: 5m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6437,16 +6437,6 @@ objects:
               summary: Nodes upgrade timeout for {{ $labels.version }}
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
-          - alert: UpgradeWindowBreachedSRE
-            expr: upgradeoperator_upgrade_window_breached > 0
-            for: 5m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: Cluster upgrade window breached
-              description: A cluster has not commenced upgrading during its scheduled
-                upgrade window.
           - alert: UpgradeNodeDrainFailedSRE
             expr: upgradeoperator_node_drain_timeout > 0
             for: 5m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6437,16 +6437,6 @@ objects:
               summary: Nodes upgrade timeout for {{ $labels.version }}
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
-          - alert: UpgradeWindowBreachedSRE
-            expr: upgradeoperator_upgrade_window_breached > 0
-            for: 5m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: Cluster upgrade window breached
-              description: A cluster has not commenced upgrading during its scheduled
-                upgrade window.
           - alert: UpgradeNodeDrainFailedSRE
             expr: upgradeoperator_node_drain_timeout > 0
             for: 5m


### PR DESCRIPTION
This PR removes the `UpgradeWindowBreachedSRE` Prometheus alert.

There is no longer any action for SRE in the event of an upgrade window breach. When this event occurs, the operator sends a failure notice automatically to OCM and the upgrade is cancelled. In the event that a cluster is subscribed to automatic upgrades, they will automatically be shifted onto the next upgrade window.

As there is now full automation around this event, there should be no need for an SRE alert.

The corresponding SOP will be removed upon approval of this PR.

cc @dofinn @bmeng 