### PR TITLE
Add workaround for bz1906584

### DIFF
--- a/deploy/bz1906584/10-osd-delete-ownerrefs.CronJob.yaml
+++ b/deploy/bz1906584/10-osd-delete-ownerrefs.CronJob.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-delete-ownerrefs-bz1906584
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-delete-ownerrefs-bz1906584
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  resourceNames:
+  - elasticsearch-metrics
+  - elasticsearch-proxy
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-delete-ownerrefs-bz1906584
+subjects:
+- kind: ServiceAccount
+  name: osd-delete-ownerrefs-bz1906584
+  namespace: openshift-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-delete-ownerrefs-bz1906584
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: osd-delete-ownerrefs-bz1906584
+  namespace: openshift-logging
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "7,37 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: osd-delete-ownerrefs-bz1906584
+          restartPolicy: Never
+          containers:
+          - name: osd-delete-ownerrefs-bz1906584
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - |
+              for object in clusterrole/elasticsearch-metrics clusterrole/elasticsearch-proxy clusterrolebinding/elaticsearch-metrics clusterrolebinding/elasticsearch-proxy; do
+                if [[ $(oc get $object --ignore-not-found -o jsonpath='{.metadata.ownerReferences[0].name}') == "elasticsearch" ]]; then
+                  oc patch $object --type=json -p '[{"op":"remove","path":"/metadata/ownerReferences"}]'
+                fi
+              done

--- a/deploy/bz1906584/OWNERS
+++ b/deploy/bz1906584/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- cblecker

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1230,6 +1230,84 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1906584
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        - clusterroles
+        resourceNames:
+        - elasticsearch-metrics
+        - elasticsearch-proxy
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-ownerrefs-bz1906584
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 7,37 * * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: osd-delete-ownerrefs-bz1906584
+                restartPolicy: Never
+                containers:
+                - name: osd-delete-ownerrefs-bz1906584
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "for object in clusterrole/elasticsearch-metrics clusterrole/elasticsearch-proxy\
+                    \ clusterrolebinding/elaticsearch-metrics clusterrolebinding/elasticsearch-proxy;\
+                    \ do\n  if [[ $(oc get $object --ignore-not-found -o jsonpath='{.metadata.ownerReferences[0].name}')\
+                    \ == \"elasticsearch\" ]]; then\n    oc patch $object --type=json\
+                    \ -p '[{\"op\":\"remove\",\"path\":\"/metadata/ownerReferences\"\
+                    }]'\n  fi\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1230,6 +1230,84 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1906584
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        - clusterroles
+        resourceNames:
+        - elasticsearch-metrics
+        - elasticsearch-proxy
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-ownerrefs-bz1906584
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 7,37 * * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: osd-delete-ownerrefs-bz1906584
+                restartPolicy: Never
+                containers:
+                - name: osd-delete-ownerrefs-bz1906584
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "for object in clusterrole/elasticsearch-metrics clusterrole/elasticsearch-proxy\
+                    \ clusterrolebinding/elaticsearch-metrics clusterrolebinding/elasticsearch-proxy;\
+                    \ do\n  if [[ $(oc get $object --ignore-not-found -o jsonpath='{.metadata.ownerReferences[0].name}')\
+                    \ == \"elasticsearch\" ]]; then\n    oc patch $object --type=json\
+                    \ -p '[{\"op\":\"remove\",\"path\":\"/metadata/ownerReferences\"\
+                    }]'\n  fi\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1230,6 +1230,84 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1906584
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        - clusterroles
+        resourceNames:
+        - elasticsearch-metrics
+        - elasticsearch-proxy
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-ownerrefs-bz1906584
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-ownerrefs-bz1906584
+        namespace: openshift-logging
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 7,37 * * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: osd-delete-ownerrefs-bz1906584
+                restartPolicy: Never
+                containers:
+                - name: osd-delete-ownerrefs-bz1906584
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "for object in clusterrole/elasticsearch-metrics clusterrole/elasticsearch-proxy\
+                    \ clusterrolebinding/elaticsearch-metrics clusterrolebinding/elasticsearch-proxy;\
+                    \ do\n  if [[ $(oc get $object --ignore-not-found -o jsonpath='{.metadata.ownerReferences[0].name}')\
+                    \ == \"elasticsearch\" ]]; then\n    oc patch $object --type=json\
+                    \ -p '[{\"op\":\"remove\",\"path\":\"/metadata/ownerReferences\"\
+                    }]'\n  fi\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This adds a cronjob that removes ownerrefs from 4 objects elasticsearch rbac objects. This is a workaround for BZ1906584.