### PR TITLE
OSD-5751 Suppress HAProxyReload OCP alert for SREP alert

### DIFF
--- a/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
+++ b/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
@@ -25,6 +25,7 @@ spec:
       for: 10m
       labels:
         severity: critical
+        namespace: "{{ $labels.namespace }}"
       annotations:
         message: "HAProxy reloads have failed on {{ $labels.pod }}. Router is not respecting recently created or modified routes"
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyReloadFailSRE.md"

--- a/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
+++ b/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
@@ -1,0 +1,30 @@
+---
+# The current HAProxyReloadFail within 4.5.x, 4.6.x is currently a no-op.
+# This alert self resolves ~ 5 mins. This alert will not be back ported until
+# after the company recharge. Until backport is complete, the original alert
+# will be sent to null reciver in CAM-operator and a custom SREP alert will
+# replace it with a higher duration. 
+# https://issues.redhat.com/browse/OSD-5751
+# 4.7: https://bugzilla.redhat.com/show_bug.cgi?id=1892338 (in qa)
+# 4.6 backport: https://bugzilla.redhat.com/show_bug.cgi?id=1896167  (assigned)
+# 4.5 backport: https://bugzilla.redhat.com/show_bug.cgi?id=1896168 (assigned)
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-haproxy-reload-fail
+    role: alert-rules
+  name: sre-haproxy-reload-fail
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-haproxy-reload-fails
+    rules:
+    - alert: HAProxyReloadFailSRE
+      expr: increase(template_router_reload_fails[5m])
+      for: 10m
+      labels:
+        severity: critical
+      annotations:
+        message: "HAProxy reloads have failed on {{ $labels.pod }}. Router is not respecting recently created or modified routes"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyReloadFailSRE.md"

--- a/deploy/sre-prometheus/OWNERS
+++ b/deploy/sre-prometheus/OWNERS
@@ -2,3 +2,4 @@ reviewers:
 - jewzaam
 - mbarnes
 - cblecker
+- dofinn

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6513,6 +6513,7 @@ objects:
             for: 10m
             labels:
               severity: critical
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: HAProxy reloads have failed on {{ $labels.pod }}. Router is
                 not respecting recently created or modified routes

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6500,6 +6500,27 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-haproxy-reload-fail
+          role: alert-rules
+        name: sre-haproxy-reload-fail
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxy-reload-fails
+          rules:
+          - alert: HAProxyReloadFailSRE
+            expr: increase(template_router_reload_fails[5m])
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              message: HAProxy reloads have failed on {{ $labels.pod }}. Router is
+                not respecting recently created or modified routes
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyReloadFailSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-upgrade-operator-alerts
           role: alert-rules
         name: sre-managed-upgrade-operator-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6513,6 +6513,7 @@ objects:
             for: 10m
             labels:
               severity: critical
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: HAProxy reloads have failed on {{ $labels.pod }}. Router is
                 not respecting recently created or modified routes

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6500,6 +6500,27 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-haproxy-reload-fail
+          role: alert-rules
+        name: sre-haproxy-reload-fail
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxy-reload-fails
+          rules:
+          - alert: HAProxyReloadFailSRE
+            expr: increase(template_router_reload_fails[5m])
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              message: HAProxy reloads have failed on {{ $labels.pod }}. Router is
+                not respecting recently created or modified routes
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyReloadFailSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-upgrade-operator-alerts
           role: alert-rules
         name: sre-managed-upgrade-operator-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6513,6 +6513,7 @@ objects:
             for: 10m
             labels:
               severity: critical
+              namespace: '{{ $labels.namespace }}'
             annotations:
               message: HAProxy reloads have failed on {{ $labels.pod }}. Router is
                 not respecting recently created or modified routes

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6500,6 +6500,27 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-haproxy-reload-fail
+          role: alert-rules
+        name: sre-haproxy-reload-fail
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxy-reload-fails
+          rules:
+          - alert: HAProxyReloadFailSRE
+            expr: increase(template_router_reload_fails[5m])
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              message: HAProxy reloads have failed on {{ $labels.pod }}. Router is
+                not respecting recently created or modified routes
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyReloadFailSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-upgrade-operator-alerts
           role: alert-rules
         name: sre-managed-upgrade-operator-alerts


### PR DESCRIPTION
HAProxyReload fails is currently a self resolving NO-OP. This PR creates
an SREP implemenation of the alert that we can tune easily
if required while we await backporting of the fix.

The current alert will be sent to nullReceiver as per:
https://github.com/openshift/configure-alertmanager-operator/pull/125