### PR TITLE
Quick fixes for broken CSSRE rbac and a missing NS for SA cronjob

### DIFF
--- a/deploy/layered-sre-authorization/02-layered-cs-sre-admins.ClusterRoleBinding.yaml
+++ b/deploy/layered-sre-authorization/02-layered-cs-sre-admins.ClusterRoleBinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: layered-cs-sre-admins
+  name: backplane-cssre-admins-legacy
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/osd-serviceaccounts/00-srep.namespace.yml
+++ b/deploy/osd-serviceaccounts/00-srep.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane-srep

--- a/deploy/osd-serviceaccounts/README.md
+++ b/deploy/osd-serviceaccounts/README.md
@@ -7,3 +7,5 @@ TL;DR:
 2. make sure SA does _not_ have an owner reference
 
 The SSS are broke into 2 so that when we delete the SA SSS it does _not_ delete the SA's!  This is critical...
+
+NOTE the `openshift-backplane-srep` namespace is included in the Upsert SSS because backplane for srep was removed from prod, breaking the cronjob SSS.  When backplane is promoted for good this file `00-srep.namespace.yml` can safely be removed.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2323,7 +2323,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -2387,7 +2387,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -2451,7 +2451,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -5499,6 +5499,10 @@ objects:
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2323,7 +2323,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -2387,7 +2387,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -2451,7 +2451,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -5499,6 +5499,10 @@ objects:
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2323,7 +2323,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -2387,7 +2387,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -2451,7 +2451,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: layered-cs-sre-admins
+        name: backplane-cssre-admins-legacy
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
@@ -5499,6 +5499,10 @@ objects:
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
The clusterrole for CSSRE was renamed with backplane work.  You cannot change roleRef in an clusterrolebinding, so this broken existing cluster RBAC.  The fix is simply rename the clusterrolebinding which will delete the old one and create the new one.  It will use a unique name.

The namespace used by SA cronjob was removed.  Added it back to a SSS w/ Upsert mode so it can safely be deleted in the future.