### PR TITLE
Split out AWS service accounts in osd-serviceaccounts

### DIFF
--- a/deploy/osd-serviceaccounts/00-serviceaccounts.yaml
+++ b/deploy/osd-serviceaccounts/00-serviceaccounts.yaml
@@ -2,18 +2,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-ingress-operator
-  namespace: openshift-cloud-ingress-operator
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: custom-domains-operator
-  namespace: openshift-custom-domains-operator
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: managed-upgrade-operator
   namespace: openshift-managed-upgrade-operator
 ---

--- a/deploy/osd-serviceaccounts/00-serviceaccounts.yaml
+++ b/deploy/osd-serviceaccounts/00-serviceaccounts.yaml
@@ -2,6 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: managed-upgrade-operator
   namespace: openshift-managed-upgrade-operator
 ---

--- a/deploy/osd-serviceaccounts/aws/00-serviceaccounts.yaml
+++ b/deploy/osd-serviceaccounts/aws/00-serviceaccounts.yaml
@@ -2,11 +2,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-ingress-operator
-  namespace: openshift-cloud-ingress-operator
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
   name: custom-domains-operator
   namespace: openshift-custom-domains-operator

--- a/deploy/osd-serviceaccounts/aws/00-serviceaccounts.yaml
+++ b/deploy/osd-serviceaccounts/aws/00-serviceaccounts.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-ingress-operator
+  namespace: openshift-cloud-ingress-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: custom-domains-operator
+  namespace: openshift-custom-domains-operator

--- a/deploy/osd-serviceaccounts/aws/README.md
+++ b/deploy/osd-serviceaccounts/aws/README.md
@@ -1,0 +1,1 @@
+There are some AWS specific operators, so this SSS will apply only to AWS for those.

--- a/deploy/osd-serviceaccounts/aws/config.yaml
+++ b/deploy/osd-serviceaccounts/aws/config.yaml
@@ -1,3 +1,5 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
+    matchLabels:
+        hive.openshift.io/cluster-platform: aws
     resourceApplyMode: Upsert

--- a/deploy/osd-serviceaccounts/config.yaml
+++ b/deploy/osd-serviceaccounts/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+    resourceApplyMode: Upsert

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5462,18 +5462,13 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
         name: cloud-ingress-operator
         namespace: openshift-cloud-ingress-operator
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: custom-domains-operator
-        namespace: openshift-custom-domains-operator
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -5503,6 +5498,26 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-aws
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        hive.openshift.io/cluster-platform: aws
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: custom-domains-operator
+        namespace: openshift-custom-domains-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5462,7 +5462,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ServiceAccount

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5462,18 +5462,13 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
         name: cloud-ingress-operator
         namespace: openshift-cloud-ingress-operator
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: custom-domains-operator
-        namespace: openshift-custom-domains-operator
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -5503,6 +5498,26 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-aws
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        hive.openshift.io/cluster-platform: aws
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: custom-domains-operator
+        namespace: openshift-custom-domains-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5462,7 +5462,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ServiceAccount

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5462,18 +5462,13 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
         name: cloud-ingress-operator
         namespace: openshift-cloud-ingress-operator
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: custom-domains-operator
-        namespace: openshift-custom-domains-operator
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -5503,6 +5498,26 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-aws
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        hive.openshift.io/cluster-platform: aws
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: custom-domains-operator
+        namespace: openshift-custom-domains-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5462,7 +5462,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ServiceAccount


### PR DESCRIPTION
It is failing to apply this SSS on GCP because of missing namespaces.