### PR TITLE
Fix sre-build-test toleration of infra taints

### DIFF
--- a/deploy/sre-build-test/50-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-build-test.CronJob.yaml
@@ -18,14 +18,11 @@ spec:
               requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                 - matchExpressions:
-                  - key: "node-role.kubernetes.io"
-                    operator: In
-                    values:
-                      - infra
+                  - key: "node-role.kubernetes.io/infra"
+                    operator: Exists
           tolerations:
-          - operator: Equal
-            key: node-role.kubernetes.io
-            value: infra
+          - operator: Exists
+            key: node-role.kubernetes.io/infra
             effect: NoSchedule
           serviceAccountName: sre-build-test
           restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5242,7 +5242,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: osd-logging-freeze
-                  image: quay.io/openshift/origin-cli:4.7.0
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash
@@ -7200,14 +7200,11 @@ objects:
                     requiredDuringSchedulingIgnoredDuringExecution:
                       nodeSelectorTerms:
                       - matchExpressions:
-                        - key: node-role.kubernetes.io
-                          operator: In
-                          values:
-                          - infra
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
                 tolerations:
-                - operator: Equal
-                  key: node-role.kubernetes.io
-                  value: infra
+                - operator: Exists
+                  key: node-role.kubernetes.io/infra
                   effect: NoSchedule
                 serviceAccountName: sre-build-test
                 restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5242,7 +5242,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: osd-logging-freeze
-                  image: quay.io/openshift/origin-cli:4.7.0
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash
@@ -7200,14 +7200,11 @@ objects:
                     requiredDuringSchedulingIgnoredDuringExecution:
                       nodeSelectorTerms:
                       - matchExpressions:
-                        - key: node-role.kubernetes.io
-                          operator: In
-                          values:
-                          - infra
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
                 tolerations:
-                - operator: Equal
-                  key: node-role.kubernetes.io
-                  value: infra
+                - operator: Exists
+                  key: node-role.kubernetes.io/infra
                   effect: NoSchedule
                 serviceAccountName: sre-build-test
                 restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5242,7 +5242,7 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: osd-logging-freeze
-                  image: quay.io/openshift/origin-cli:4.7.0
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash
@@ -7200,14 +7200,11 @@ objects:
                     requiredDuringSchedulingIgnoredDuringExecution:
                       nodeSelectorTerms:
                       - matchExpressions:
-                        - key: node-role.kubernetes.io
-                          operator: In
-                          values:
-                          - infra
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
                 tolerations:
-                - operator: Equal
-                  key: node-role.kubernetes.io
-                  value: infra
+                - operator: Exists
+                  key: node-role.kubernetes.io/infra
                   effect: NoSchedule
                 serviceAccountName: sre-build-test
                 restartPolicy: Never


### PR DESCRIPTION
Staging clusters now have infra nodes with a `NoSchedule` taint instead of `PreferNoSchedule`. [0]

Since this change was implemented, the `sre-build-test` job has not been running on staging clusters as it can't find a node to schedule to, so it stays permanently `Pending`. Its toleration settings for infra nodes do not look correct. This PR addresses the `toleration` of the `sre-build-test` cronjob so that it correctly tolerates the Infra node taint.

I've successfully tested this on a staging cluster and verified scheduling to infra nodes.

refs [OSD-2927](https://issues.redhat.com/browse/OSD-2927); cc @jewzaam 

[0] https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/2008