### PR TITLE
Fall back to docker hub image

### DIFF
--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -1,21 +1,21 @@
 name: Make Generate
 on: push
 
-jobs: 
+jobs:
   run:
     name: Make Generate Template
     runs-on: ubuntu-latest
-    steps: 
+    steps:
     - name: Checkout repo
       uses: actions/checkout@v2
 
     - name: Make
-      run: make clean generate-hive-templates
+      run: make
 
     - name: Commit changes
       uses: EndBug/add-and-commit@v4
       with:
-        message: "on push: make generate-hive-templates"
+        message: "on push: make"
         add: "hack/00-osd-managed-cluster-config*.yaml.tmpl"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ endif
 CONTAINER_ENGINE?=docker
 
 .PHONY: default
-default: clean generate-hive-templates
+default: generate-oauth-templates generate-hive-templates
 
 .PHONY: generate-oauth-templates
 generate-oauth-templates:
@@ -43,12 +43,3 @@ generate-hive-templates: generate-oauth-templates
 	else \
 		${GEN_TEMPLATE}; \
 	fi
-
-.PHONY: clean
-clean:
-	rm -rf ${SELECTOR_SYNC_SET_DESTINATION}
-
-.PHONY: git-commit
-git-commit:
-	git add ${SELECTOR_SYNC_SET_DESTINATION}
-	git commit -m "Updated selectorsynceset template added"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ generate-oauth-templates:
 .PHONY: generate-hive-templates
 generate-hive-templates: generate-oauth-templates
 	if [ -z ${IN_CONTAINER} ]; then \
-			$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P`:z quay.io/app-sre/python:3.4.2 /bin/sh -c "cd `pwd -P`; pip install oyaml; ${GEN_TEMPLATE}"; \
+		$(CONTAINER_ENGINE) pull quay.io/app-sre/python:3 && $(CONTAINER_ENGINE) tag quay.io/app-sre/python:3 python:3 || true; \
+		$(CONTAINER_ENGINE) run --rm -v `pwd -P`:`pwd -P`:z python:3 /bin/sh -c "cd `pwd -P`; pip install oyaml; ${GEN_TEMPLATE}"; \
 	else \
 		${GEN_TEMPLATE}; \
 	fi


### PR DESCRIPTION
As the `quay.io/app-sre/python` image is private, this provides for the ability to fall back to the docker hub image if it's unable to pull the app-sre image.