### PR TITLE
Don't back up unnecessary objects

### DIFF
--- a/deploy/velero-configuration/110-velero.Schedules.yaml
+++ b/deploy/velero-configuration/110-velero.Schedules.yaml
@@ -8,6 +8,20 @@ spec:
   template:
     includedNamespaces:
     - '*'
+    excludedResources:
+    - imagetags
+    - images
+    - templateinstances
+    - clusterserviceversions
+    - packagemanifests
+    - subscriptions
+    - servicebrokers
+    - servicebindings
+    - serviceclasses
+    - serviceinstances
+    - serviceplans
+    - operatorgroups
+    - events
     ttl: 168h0m0s
 ---
 apiVersion: velero.io/v1
@@ -20,6 +34,20 @@ spec:
   template:
     includedNamespaces:
     - '*'
+    excludedResources:
+    - imagetags
+    - images
+    - templateinstances
+    - clusterserviceversions
+    - packagemanifests
+    - subscriptions
+    - servicebrokers
+    - servicebindings
+    - serviceclasses
+    - serviceinstances
+    - serviceplans
+    - operatorgroups
+    - events
     snapshotVolumes: false
     ttl: 24h0m0s
 ---
@@ -33,4 +61,18 @@ spec:
   template:
     includedNamespaces:
     - '*'
+    excludedResources:
+    - imagetags
+    - images
+    - templateinstances
+    - clusterserviceversions
+    - packagemanifests
+    - subscriptions
+    - servicebrokers
+    - servicebindings
+    - serviceclasses
+    - serviceinstances
+    - serviceplans
+    - operatorgroups
+    - events
     ttl: 720h0m0s

--- a/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
+++ b/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
@@ -8,5 +8,19 @@ spec:
   template:
     includedNamespaces:
     - '*'
+    excludedResources:
+    - imagetags
+    - images
+    - templateinstances
+    - clusterserviceversions
+    - packagemanifests
+    - subscriptions
+    - servicebrokers
+    - servicebindings
+    - serviceclasses
+    - serviceinstances
+    - serviceplans
+    - operatorgroups
+    - events
     snapshotVolumes: false
     ttl: 0h25m0s

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8361,6 +8361,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
       kind: Schedule
@@ -8372,6 +8386,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           snapshotVolumes: false
           ttl: 24h0m0s
     - apiVersion: velero.io/v1
@@ -8384,6 +8412,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           ttl: 720h0m0s
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -8424,6 +8466,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           snapshotVolumes: false
           ttl: 0h25m0s
 - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8361,6 +8361,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
       kind: Schedule
@@ -8372,6 +8386,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           snapshotVolumes: false
           ttl: 24h0m0s
     - apiVersion: velero.io/v1
@@ -8384,6 +8412,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           ttl: 720h0m0s
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -8424,6 +8466,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           snapshotVolumes: false
           ttl: 0h25m0s
 - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8361,6 +8361,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
       kind: Schedule
@@ -8372,6 +8386,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           snapshotVolumes: false
           ttl: 24h0m0s
     - apiVersion: velero.io/v1
@@ -8384,6 +8412,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           ttl: 720h0m0s
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -8424,6 +8466,20 @@ objects:
         template:
           includedNamespaces:
           - '*'
+          excludedResources:
+          - imagetags
+          - images
+          - templateinstances
+          - clusterserviceversions
+          - packagemanifests
+          - subscriptions
+          - servicebrokers
+          - servicebindings
+          - serviceclasses
+          - serviceinstances
+          - serviceplans
+          - operatorgroups
+          - events
           snapshotVolumes: false
           ttl: 0h25m0s
 - apiVersion: v1


### PR DESCRIPTION
Events are unnecessary for backup and create a large number of API calls. This will both shrink and speed up backups.

List based on https://github.com/konveyor/mig-operator/blob/master/docs/usage/ExcludeResources.md