### PR TITLE
remove quick fix to add backplane-srep ns

### DIFF
--- a/deploy/osd-serviceaccounts/00-srep.namespace.yml
+++ b/deploy/osd-serviceaccounts/00-srep.namespace.yml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-backplane-srep

--- a/deploy/osd-serviceaccounts/README.md
+++ b/deploy/osd-serviceaccounts/README.md
@@ -7,5 +7,3 @@ TL;DR:
 2. make sure SA does _not_ have an owner reference
 
 The SSS are broke into 2 so that when we delete the SA SSS it does _not_ delete the SA's!  This is critical...
-
-NOTE the `openshift-backplane-srep` namespace is included in the Upsert SSS because backplane for srep was removed from prod, breaking the cronjob SSS.  When backplane is promoted for good this file `00-srep.namespace.yml` can safely be removed.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5607,10 +5607,6 @@ objects:
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5607,10 +5607,6 @@ objects:
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5607,10 +5607,6 @@ objects:
       metadata:
         name: managed-velero-operator
         namespace: openshift-velero
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Removing the backplane-sre ns now that MCC with backplane prod RBAC files has been promoted.
As per : https://github.com/openshift/managed-cluster-config/blob/master/deploy/osd-serviceaccounts/README.md