### PR TITLE
OSD-5555: Change maxUnhealthy to 2 so MHC works in 2-worker clusters

### DIFF
--- a/deploy/osd-machine-api/010-machine-api.srep-infra-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/010-machine-api.srep-infra-healthcheck.MachineHealthCheck.yaml
@@ -14,4 +14,4 @@ spec:
   - type:    "Ready"
     timeout: "480s"
     status: "Unknown"
-  maxUnhealthy: "40%"
+  maxUnhealthy: 2

--- a/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -14,4 +14,4 @@ spec:
   - type:    "Ready"
     timeout: "480s"
     status: "Unknown"
-  maxUnhealthy: "40%"
+  maxUnhealthy: 2

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5304,7 +5304,7 @@ objects:
         - type: Ready
           timeout: 480s
           status: Unknown
-        maxUnhealthy: 40%
+        maxUnhealthy: 2
     - apiVersion: machine.openshift.io/v1beta1
       kind: MachineHealthCheck
       metadata:
@@ -5321,7 +5321,7 @@ objects:
         - type: Ready
           timeout: 480s
           status: Unknown
-        maxUnhealthy: 40%
+        maxUnhealthy: 2
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5304,7 +5304,7 @@ objects:
         - type: Ready
           timeout: 480s
           status: Unknown
-        maxUnhealthy: 40%
+        maxUnhealthy: 2
     - apiVersion: machine.openshift.io/v1beta1
       kind: MachineHealthCheck
       metadata:
@@ -5321,7 +5321,7 @@ objects:
         - type: Ready
           timeout: 480s
           status: Unknown
-        maxUnhealthy: 40%
+        maxUnhealthy: 2
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5304,7 +5304,7 @@ objects:
         - type: Ready
           timeout: 480s
           status: Unknown
-        maxUnhealthy: 40%
+        maxUnhealthy: 2
     - apiVersion: machine.openshift.io/v1beta1
       kind: MachineHealthCheck
       metadata:
@@ -5321,7 +5321,7 @@ objects:
         - type: Ready
           timeout: 480s
           status: Unknown
-        maxUnhealthy: 40%
+        maxUnhealthy: 2
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Currently, in MHC maxUnhealthy=40%, this will lead to two problems:
- MHC won't work for 2-infra/2-worker clusters, as floor(2*40%)=0.
- 40% is too large for MHC to short-circuit. Eg. for a 3-AZ cluster, if one AZ (1/3 nodes) has network connectivity issue, MHC will run into a hot loop which keep re-creating instances in that AZ.

With change to maxUnhealthy=2,
- MHC can work for 2-infra/2-worker clusters.
- MHC can short-circuit early to prevent hot loop.
- Con: In case there's an AZ issue that brings all instances down and instances remain in stopped state after the AZ issue (rare), MHC won't reconcile and need human to bring them up.