### PR TITLE
Add workaround for BZ1915661

### DIFF
--- a/deploy/bz1915661/10-osd-pruner.ClusterRole.yaml
+++ b/deploy/bz1915661/10-osd-pruner.ClusterRole.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-pruner-bz1915661
+rules:
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - batch
+    resources:
+    - cronjobs
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - apps
+    - extensions
+    resources:
+    - statefulsets
+    verbs:
+    - get
+    - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-pruner-bz1915661
+subjects:
+- kind: ServiceAccount
+  name: pruner
+  namespace: openshift-image-registry
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-pruner-bz1915661

--- a/deploy/bz1915661/OWNERS
+++ b/deploy/bz1915661/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- cblecker

--- a/deploy/bz1915661/config.yaml
+++ b/deploy/bz1915661/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor-patch
+    operator: In
+    values: ["4.7.0"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1972,6 +1972,64 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1915661
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.7.0
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-pruner-bz1915661
+      rules:
+      - apiGroups:
+        - batch
+        resources:
+        - jobs
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - apps
+        - extensions
+        resources:
+        - statefulsets
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-pruner-bz1915661
+      subjects:
+      - kind: ServiceAccount
+        name: pruner
+        namespace: openshift-image-registry
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-pruner-bz1915661
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1972,6 +1972,64 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1915661
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.7.0
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-pruner-bz1915661
+      rules:
+      - apiGroups:
+        - batch
+        resources:
+        - jobs
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - apps
+        - extensions
+        resources:
+        - statefulsets
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-pruner-bz1915661
+      subjects:
+      - kind: ServiceAccount
+        name: pruner
+        namespace: openshift-image-registry
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-pruner-bz1915661
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1972,6 +1972,64 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1915661
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.7.0
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-pruner-bz1915661
+      rules:
+      - apiGroups:
+        - batch
+        resources:
+        - jobs
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - apps
+        - extensions
+        resources:
+        - statefulsets
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-pruner-bz1915661
+      subjects:
+      - kind: ServiceAccount
+        name: pruner
+        namespace: openshift-image-registry
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-pruner-bz1915661
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
On 4.7.0 clusters, add missing RBAC per BZ1915661.

ref:
https://bugzilla.redhat.com/show_bug.cgi?id=1915661
https://github.com/openshift/openshift-apiserver/pull/177