### PR TITLE
Jira OSD-6173: deploy/osd-logging: prepare for logging 4.5+

### DIFF
--- a/deploy/osd-logging/00-namespace.yaml
+++ b/deploy/osd-logging/00-namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,4 +9,13 @@ metadata:
     managed.openshift.io/service-lb-quota-exempt: "true"
     managed.openshift.io/storage-pv-quota-exempt: "true"
     openshift.io/cluster-logging: "true"
+    openshift.io/cluster-monitoring: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators-redhat
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
     openshift.io/cluster-monitoring: "true"

--- a/deploy/osd-logging/01-operatorgroup.yaml
+++ b/deploy/osd-logging/01-operatorgroup.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -11,3 +12,12 @@ spec:
       creationTimestamp: null
   targetNamespaces:
   - openshift-logging
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: Elasticsearch.v1.logging.openshift.io
+    olm.providedAPIs: Kibana.v1.logging.openshift.io
+  name: elasticsearch
+  namespace: openshift-operators-redhat

--- a/deploy/osd-logging/01-operatorgroup.yaml
+++ b/deploy/osd-logging/01-operatorgroup.yaml
@@ -16,8 +16,5 @@ spec:
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  annotations:
-    olm.providedAPIs: Elasticsearch.v1.logging.openshift.io
-    olm.providedAPIs: Kibana.v1.logging.openshift.io
-  name: elasticsearch
+  name: openshift-operators-redhat
   namespace: openshift-operators-redhat

--- a/deploy/osd-logging/05-role.yaml
+++ b/deploy/osd-logging/05-role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -65,4 +66,51 @@ rules:
   - list
   - patch
   - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-openshift-operators-redhat
+  namespace: openshift-operators-redhat
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - installplans
+  verbs:
+  - update
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearch
+  - kibana
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - clusterserviceversions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - pods/log
+  verbs:
+  - list
+  - get
   - watch

--- a/deploy/osd-logging/06-rolebinding.yaml
+++ b/deploy/osd-logging/06-rolebinding.yaml
@@ -31,4 +31,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: dedicated-admins-openshif-operators-redhat
+  name: dedicated-admins-openshift-operators-redhat

--- a/deploy/osd-logging/06-rolebinding.yaml
+++ b/deploy/osd-logging/06-rolebinding.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -14,3 +15,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: dedicated-admins-openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-openshift-operators-redhat
+  namespace: openshift-operators-redhat
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-openshif-operators-redhat

--- a/deploy/osd-logging/OWNERS
+++ b/deploy/osd-logging/OWNERS
@@ -2,3 +2,4 @@ reviewers:
 - jewzaam
 - mwoodson
 - wanghaoran1988
+- RiRa12621

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5012,6 +5012,14 @@ objects:
           managed.openshift.io/storage-pv-quota-exempt: 'true'
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'true'
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-operators-redhat
+        annotations:
+          openshift.io/node-selector: ''
+        labels:
+          openshift.io/cluster-monitoring: 'true'
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
@@ -5025,6 +5033,13 @@ objects:
             creationTimestamp: null
         targetNamespaces:
         - openshift-logging
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        annotations:
+          olm.providedAPIs: Kibana.v1.logging.openshift.io
+        name: elasticsearch
+        namespace: openshift-operators-redhat
     - apiVersion: v1
       data:
         actions.yaml: '# ---
@@ -5196,6 +5211,52 @@ objects:
         - update
         - watch
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-openshift-operators-redhat
+        namespace: openshift-operators-redhat
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - update
+      - apiGroups:
+        - logging.openshift.io
+        resources:
+        - elasticsearch
+        - kibana
+        verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - subscriptions
+        - clusterserviceversions
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - events
+        - namespaces
+        - persistentvolumeclaims
+        - persistentvolumes
+        - pods
+        - pods/log
+        verbs:
+        - list
+        - get
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
         name: dedicated-admins-openshift-logging
@@ -5211,6 +5272,22 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-openshift-logging
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-operators-redhat
+        namespace: openshift-operators-redhat
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshif-operators-redhat
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5036,9 +5036,7 @@ objects:
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
-        annotations:
-          olm.providedAPIs: Kibana.v1.logging.openshift.io
-        name: elasticsearch
+        name: openshift-operators-redhat
         namespace: openshift-operators-redhat
     - apiVersion: v1
       data:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5287,7 +5287,7 @@ objects:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: dedicated-admins-openshif-operators-redhat
+        name: dedicated-admins-openshift-operators-redhat
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5012,6 +5012,14 @@ objects:
           managed.openshift.io/storage-pv-quota-exempt: 'true'
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'true'
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-operators-redhat
+        annotations:
+          openshift.io/node-selector: ''
+        labels:
+          openshift.io/cluster-monitoring: 'true'
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
@@ -5025,6 +5033,13 @@ objects:
             creationTimestamp: null
         targetNamespaces:
         - openshift-logging
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        annotations:
+          olm.providedAPIs: Kibana.v1.logging.openshift.io
+        name: elasticsearch
+        namespace: openshift-operators-redhat
     - apiVersion: v1
       data:
         actions.yaml: '# ---
@@ -5196,6 +5211,52 @@ objects:
         - update
         - watch
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-openshift-operators-redhat
+        namespace: openshift-operators-redhat
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - update
+      - apiGroups:
+        - logging.openshift.io
+        resources:
+        - elasticsearch
+        - kibana
+        verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - subscriptions
+        - clusterserviceversions
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - events
+        - namespaces
+        - persistentvolumeclaims
+        - persistentvolumes
+        - pods
+        - pods/log
+        verbs:
+        - list
+        - get
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
         name: dedicated-admins-openshift-logging
@@ -5211,6 +5272,22 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-openshift-logging
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-operators-redhat
+        namespace: openshift-operators-redhat
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshif-operators-redhat
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5036,9 +5036,7 @@ objects:
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
-        annotations:
-          olm.providedAPIs: Kibana.v1.logging.openshift.io
-        name: elasticsearch
+        name: openshift-operators-redhat
         namespace: openshift-operators-redhat
     - apiVersion: v1
       data:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5287,7 +5287,7 @@ objects:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: dedicated-admins-openshif-operators-redhat
+        name: dedicated-admins-openshift-operators-redhat
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5012,6 +5012,14 @@ objects:
           managed.openshift.io/storage-pv-quota-exempt: 'true'
           openshift.io/cluster-logging: 'true'
           openshift.io/cluster-monitoring: 'true'
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-operators-redhat
+        annotations:
+          openshift.io/node-selector: ''
+        labels:
+          openshift.io/cluster-monitoring: 'true'
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
@@ -5025,6 +5033,13 @@ objects:
             creationTimestamp: null
         targetNamespaces:
         - openshift-logging
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        annotations:
+          olm.providedAPIs: Kibana.v1.logging.openshift.io
+        name: elasticsearch
+        namespace: openshift-operators-redhat
     - apiVersion: v1
       data:
         actions.yaml: '# ---
@@ -5196,6 +5211,52 @@ objects:
         - update
         - watch
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-openshift-operators-redhat
+        namespace: openshift-operators-redhat
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - installplans
+        verbs:
+        - update
+      - apiGroups:
+        - logging.openshift.io
+        resources:
+        - elasticsearch
+        - kibana
+        verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - subscriptions
+        - clusterserviceversions
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - events
+        - namespaces
+        - persistentvolumeclaims
+        - persistentvolumes
+        - pods
+        - pods/log
+        verbs:
+        - list
+        - get
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
         name: dedicated-admins-openshift-logging
@@ -5211,6 +5272,22 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-openshift-logging
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-operators-redhat
+        namespace: openshift-operators-redhat
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshif-operators-redhat
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5036,9 +5036,7 @@ objects:
     - apiVersion: operators.coreos.com/v1
       kind: OperatorGroup
       metadata:
-        annotations:
-          olm.providedAPIs: Kibana.v1.logging.openshift.io
-        name: elasticsearch
+        name: openshift-operators-redhat
         namespace: openshift-operators-redhat
     - apiVersion: v1
       data:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5287,7 +5287,7 @@ objects:
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
-        name: dedicated-admins-openshif-operators-redhat
+        name: dedicated-admins-openshift-operators-redhat
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Logging has changed it's structure. The elasticsearch operator is expected to live in `openshift-operators-redhat`. We don't want to allow dedicated admins to create `openshift-*` namespaces, so we have to create it as well as the rules accordingly, so they can add the subscription and an `elasticsearch` instance.
The elasticsearch cluster itself however will stay in `openshift-logging` by design