### PR TITLE
Add components for observatorium token refresher

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher
+    app.kubernetes.io/version: master-2020-12-04-5504078
+  name: token-refresher
+  namespace: openshift-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: authentication-proxy
+      app.kubernetes.io/name: token-refresher
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/name: token-refresher
+        app.kubernetes.io/version: master-2020-12-04-5504078
+    spec:
+      containers:
+      - args:
+        - --oidc.audience=observatorium-telemeter
+        - --oidc.client-id string=\$\(CLIENT_ID\)
+        - --oidc.client-secret=\$\(CLIENT_SECRET\)
+        - --oidc.issuer-url=\$\(ISSUER_URL\)
+        - --url=\$\(RECEIVER_URL\)
+        env:
+        - name: CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: observatorium-credentials
+              key: client-id
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: observatorium-credentials
+              key: client-secret
+        - name: RECEIVER_URL
+          valueFrom:
+            secretKeyRef:
+              name: observatorium-credentials
+              key: receiver-url
+        - name: ISSUER_URL
+          value: "https://sso.redhat.com/auth/realms/redhat-external"
+        image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+        name: token-refresher
+        ports:
+        - containerPort: 8080
+          name: http

--- a/deploy/osd-token-refresher/02-token-refresher.Service.yaml
+++ b/deploy/osd-token-refresher/02-token-refresher.Service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher
+    app.kubernetes.io/version: master-2020-12-04-5504078
+  name: token-refresher
+  namespace: openshift-monitoring
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher

--- a/deploy/osd-token-refresher/03-token-refresher.NetworkPolicy.yaml
+++ b/deploy/osd-token-refresher/03-token-refresher.NetworkPolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher
+  name: token-refresher
+  namespace: openshift-monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: authentication-proxy
+      app.kubernetes.io/name: token-refresher
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          prometheus: k8s

--- a/deploy/osd-token-refresher/config.yaml
+++ b/deploy/osd-token-refresher/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/environment
+      operator: NotIn
+      values:
+      - "production"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -610,6 +610,25 @@ objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
+    name: osd-observatorium-credentials-secret
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: observatorium-credentials
+        namespace: observatorium-tenant
+      targetRef:
+        name: observatorium-credentials
+        namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
     labels:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
@@ -5864,6 +5883,114 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-openshift-strimzi
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-token-refresher
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+          app.kubernetes.io/version: master-2020-12-04-5504078
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: authentication-proxy
+              app.kubernetes.io/name: token-refresher
+              app.kubernetes.io/version: master-2020-12-04-5504078
+          spec:
+            containers:
+            - args:
+              - --oidc.audience=observatorium-telemeter
+              - --oidc.client-id string=\$\(CLIENT_ID\)
+              - --oidc.client-secret=\$\(CLIENT_SECRET\)
+              - --oidc.issuer-url=\$\(ISSUER_URL\)
+              - --url=\$\(RECEIVER_URL\)
+              env:
+              - name: CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-id
+              - name: CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-secret
+              - name: RECEIVER_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: receiver-url
+              - name: ISSUER_URL
+                value: https://sso.redhat.com/auth/realms/redhat-external
+              image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+              name: token-refresher
+              ports:
+              - containerPort: 8080
+                name: http
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+          app.kubernetes.io/version: master-2020-12-04-5504078
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+        selector:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        policyTypes:
+        - Ingress
+        ingress:
+        - from:
+          - podSelector:
+              matchLabels:
+                prometheus: k8s
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -610,6 +610,25 @@ objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
+    name: osd-observatorium-credentials-secret
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: observatorium-credentials
+        namespace: observatorium-tenant
+      targetRef:
+        name: observatorium-credentials
+        namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
     labels:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
@@ -5864,6 +5883,114 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-openshift-strimzi
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-token-refresher
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+          app.kubernetes.io/version: master-2020-12-04-5504078
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: authentication-proxy
+              app.kubernetes.io/name: token-refresher
+              app.kubernetes.io/version: master-2020-12-04-5504078
+          spec:
+            containers:
+            - args:
+              - --oidc.audience=observatorium-telemeter
+              - --oidc.client-id string=\$\(CLIENT_ID\)
+              - --oidc.client-secret=\$\(CLIENT_SECRET\)
+              - --oidc.issuer-url=\$\(ISSUER_URL\)
+              - --url=\$\(RECEIVER_URL\)
+              env:
+              - name: CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-id
+              - name: CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-secret
+              - name: RECEIVER_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: receiver-url
+              - name: ISSUER_URL
+                value: https://sso.redhat.com/auth/realms/redhat-external
+              image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+              name: token-refresher
+              ports:
+              - containerPort: 8080
+                name: http
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+          app.kubernetes.io/version: master-2020-12-04-5504078
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+        selector:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        policyTypes:
+        - Ingress
+        ingress:
+        - from:
+          - podSelector:
+              matchLabels:
+                prometheus: k8s
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -610,6 +610,25 @@ objects:
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
+    name: osd-observatorium-credentials-secret
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: observatorium-credentials
+        namespace: observatorium-tenant
+      targetRef:
+        name: observatorium-credentials
+        namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
     labels:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
@@ -5864,6 +5883,114 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-openshift-strimzi
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-token-refresher
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+          app.kubernetes.io/version: master-2020-12-04-5504078
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: authentication-proxy
+              app.kubernetes.io/name: token-refresher
+              app.kubernetes.io/version: master-2020-12-04-5504078
+          spec:
+            containers:
+            - args:
+              - --oidc.audience=observatorium-telemeter
+              - --oidc.client-id string=\$\(CLIENT_ID\)
+              - --oidc.client-secret=\$\(CLIENT_SECRET\)
+              - --oidc.issuer-url=\$\(ISSUER_URL\)
+              - --url=\$\(RECEIVER_URL\)
+              env:
+              - name: CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-id
+              - name: CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-secret
+              - name: RECEIVER_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: receiver-url
+              - name: ISSUER_URL
+                value: https://sso.redhat.com/auth/realms/redhat-external
+              image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+              name: token-refresher
+              ports:
+              - containerPort: 8080
+                name: http
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+          app.kubernetes.io/version: master-2020-12-04-5504078
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+        selector:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-monitoring
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        policyTypes:
+        - Ingress
+        ingress:
+        - from:
+          - podSelector:
+              matchLabels:
+                prometheus: k8s
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -610,3 +610,23 @@ objects:
       mappingMethod: claim
       name: OpenShift_SRE
       type: Google
+# SelectorSyncSet for observatorium token refresher credentials Secret
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    name: osd-observatorium-credentials-secret
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - "true"
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: observatorium-credentials
+        namespace: observatorium-tenant
+      targetRef:
+        name: observatorium-credentials
+        namespace: openshift-monitoring


### PR DESCRIPTION
As part of the epic "Observatorium Tenant for OSD" we need to deploy a [token injecting proxy](https://github.com/observatorium/token-refresher) into all clusters. This is a simply proxy which simply adds credentials into the HTTP request which is send to the observatorium tenant. The credentials for the proxy are already present on the hive clusters. So the following components need to be deployed through the managed configuration:
1. `SelectorSyncSet` which mirrors the contents of the secret into all clusters. 
2. A `Deployment` and corresponding `Service` for the proxy which mounts the secret and injects them into the requests.

In order to do a gradual rollout the `SelectorSyncSet`s are targetted only at non-production clusters. Once the metric ingestion is confirmed and working correctly the deployment will be rolled out to production clusters as well.

cc @dofinn 