### PR TITLE
Changing SOP link for v4 KubeNodeUnschedulableSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -18,4 +18,4 @@ spec:
         namespace: openshift-monitoring
       annotations:
         message: "The node {{ $labels.node }} has been unscedulable for more than an hour."
-        link: "https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_node_not_schedulable.asciidoc"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md"

--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -18,4 +18,3 @@ spec:
         namespace: openshift-monitoring
       annotations:
         message: "The node {{ $labels.node }} has been unscedulable for more than an hour."
-        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7634,7 +7634,6 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unscedulable for more
                 than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7634,7 +7634,7 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unscedulable for more
                 than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_node_not_schedulable.asciidoc
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7634,7 +7634,6 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unscedulable for more
                 than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7634,7 +7634,7 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unscedulable for more
                 than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_node_not_schedulable.asciidoc
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7634,7 +7634,6 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unscedulable for more
                 than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7634,7 +7634,7 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unscedulable for more
                 than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v3/alerts/openshift_node_not_schedulable.asciidoc
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Changing SOP link as per https://issues.redhat.com/browse/OSD-6177
The v4 alert pointed to SOP which wasn't relevant for `oc` v4 CLI.