### PR TITLE
feat: allow crud for dedicated-admin on CRQ

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -295,3 +295,12 @@ rules:
   - list
   - watch
 ### END
+### Start - allow crud for dedicated-admins on clusterresourcequotas
+# https://issues.redhat.com/browse/OSD-6180
+- apiGroups:
+  - clusterresourcequotas.quota.openshift.io
+  resources:
+  - ClusterResourceQuota
+  verbs:
+  - "*"
+### END

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6232,6 +6232,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - clusterresourcequotas.quota.openshift.io
+        resources:
+        - ClusterResourceQuota
+        verbs:
+        - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6232,6 +6232,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - clusterresourcequotas.quota.openshift.io
+        resources:
+        - ClusterResourceQuota
+        verbs:
+        - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6232,6 +6232,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - clusterresourcequotas.quota.openshift.io
+        resources:
+        - ClusterResourceQuota
+        verbs:
+        - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OSD-6180  
Tests: https://github.com/openshift/osde2e/pull/705

Hook: https://github.com/openshift/managed-cluster-validating-webhooks/pull/131
considering managed resources are already excluded [here](https://github.com/boranx/managed-cluster-config/blob/master/deploy/rbac-permissions-operator-config/50-dedicated-admins.SubjectPermission.yaml), I expect this PR define required perms for clusterresourcequota