### PR TITLE
OHSS-2615 ded-admin can update installplan in openshift-operators

### DIFF
--- a/deploy/rbac-permissions-operator-config/10-dedicated-admins-operators.Role.yaml
+++ b/deploy/rbac-permissions-operator-config/10-dedicated-admins-operators.Role.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
+  - installplans
   - subscriptions
   - clusterserviceversions
   verbs:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6718,6 +6718,7 @@ objects:
       - apiGroups:
         - operators.coreos.com
         resources:
+        - installplans
         - subscriptions
         - clusterserviceversions
         verbs:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6718,6 +6718,7 @@ objects:
       - apiGroups:
         - operators.coreos.com
         resources:
+        - installplans
         - subscriptions
         - clusterserviceversions
         verbs:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6718,6 +6718,7 @@ objects:
       - apiGroups:
         - operators.coreos.com
         resources:
+        - installplans
         - subscriptions
         - clusterserviceversions
         verbs:


### PR DESCRIPTION
This change allows `dedicated-admin` permissions to read/update `installplans` in the `openshift-operators` namespace.

Refs [OHSS-2615](https://issues.redhat.com/browse/OHSS-2615)