### PR TITLE
Add PoC for Cluster Readiness

### DIFF
--- a/deploy/osd-cluster-ready/10-osd-ready.ServiceAccount.yaml
+++ b/deploy/osd-cluster-ready/10-osd-ready.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-cluster-ready
+  namespace: openshift-monitoring

--- a/deploy/osd-cluster-ready/20-osd-ready.Role.yaml
+++ b/deploy/osd-cluster-ready/20-osd-ready.Role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-cluster-ready
+  namespace: openshift-monitoring
+rules:
+# SRE can get, list, and watch all resources
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create

--- a/deploy/osd-cluster-ready/20-osd-ready.Role.yaml
+++ b/deploy/osd-cluster-ready/20-osd-ready.Role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: osd-cluster-ready
   namespace: openshift-monitoring
 rules:
-# SRE can get, list, and watch all resources
+# Service account needs to be able to get pods and exec on them
 - apiGroups:
   - ""
   resources:

--- a/deploy/osd-cluster-ready/40-osd-ready.RoleBinding.yaml
+++ b/deploy/osd-cluster-ready/40-osd-ready.RoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osd-cluster-ready
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-cluster-ready
+subjects:
+- kind: ServiceAccount
+  name: osd-cluster-ready
+  namespace: openshift-monitoring

--- a/deploy/osd-cluster-ready/50-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/50-osd-ready.Job.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: osd-cluster-ready
+    namespace: openshift-monitoring
+spec:
+    activeDeadlineSeconds: 3900 # 1 hour for the silence, 5 minutes for processing/data completion
+    backoffLimit: 0
+    template:
+        metadata:
+            name: osd-cluster-ready
+        spec:
+            containers:
+            - name: osd-cluster-ready
+              image: quay.io/kbater/openshift-cli
+              command: ["/root/main"]
+            restartPolicy: Never
+            serviceAccountName: osd-cluster-ready

--- a/deploy/osd-cluster-ready/50-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/50-osd-ready.Job.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/kbater/openshift-cli
+              image: quay.io/openshift-sre/osd-cluster-ready
               command: ["/root/main"]
             restartPolicy: Never
             serviceAccountName: osd-cluster-ready

--- a/deploy/osd-cluster-ready/config.yaml
+++ b/deploy/osd-cluster-ready/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/environment
+    operator: In
+    values: ["staging"]

--- a/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
@@ -15,7 +15,7 @@ spec:
       # upgrade process will generate a silence itself. (OSD-3426)
       # Use an average as without instance,pod, so that all AM pods are taken
       # into consideration
-      expr: avg without (instance,pod)(alertmanager_silences{state="active"}) > 0 unless (count(cluster_version{type="updating"}) > 0)
+      expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"}) > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace) (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"} < 4500))
       for: 15m
       labels:
         severity: warning

--- a/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
@@ -15,6 +15,9 @@ spec:
       # upgrade process will generate a silence itself. (OSD-3426)
       # Use an average as without instance,pod, so that all AM pods are taken
       # into consideration
+      # Also ignores alerting on silences if the cluster readiness job is 
+      # less than 1 hour 15 mins (4500s) old, in order to not alert when
+      # clusters are being spun up and initial alerts are silenced
       expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"}) > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace) (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"} < 4500))
       for: 15m
       labels:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3838,6 +3838,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-ready
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-cluster-ready
+      subjects:
+      - kind: ServiceAccount
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      spec:
+        activeDeadlineSeconds: 3900
+        backoffLimit: 0
+        template:
+          metadata:
+            name: osd-cluster-ready
+          spec:
+            containers:
+            - name: osd-cluster-ready
+              image: quay.io/kbater/openshift-cli
+              command:
+              - /root/main
+            restartPolicy: Never
+            serviceAccountName: osd-cluster-ready
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-codeready-workspaces
   spec:
     clusterDeploymentSelector:
@@ -7362,8 +7437,10 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: avg without (instance,pod)(alertmanager_silences{state="active"})
-              > 0 unless (count(cluster_version{type="updating"}) > 0)
+            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"})
+              > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace)
+              (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
+              < 4500))
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3901,7 +3901,7 @@ objects:
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/kbater/openshift-cli
+              image: quay.io/openshift-sre/osd-cluster-ready
               command:
               - /root/main
             restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3838,6 +3838,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-ready
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-cluster-ready
+      subjects:
+      - kind: ServiceAccount
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      spec:
+        activeDeadlineSeconds: 3900
+        backoffLimit: 0
+        template:
+          metadata:
+            name: osd-cluster-ready
+          spec:
+            containers:
+            - name: osd-cluster-ready
+              image: quay.io/kbater/openshift-cli
+              command:
+              - /root/main
+            restartPolicy: Never
+            serviceAccountName: osd-cluster-ready
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-codeready-workspaces
   spec:
     clusterDeploymentSelector:
@@ -7362,8 +7437,10 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: avg without (instance,pod)(alertmanager_silences{state="active"})
-              > 0 unless (count(cluster_version{type="updating"}) > 0)
+            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"})
+              > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace)
+              (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
+              < 4500))
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3901,7 +3901,7 @@ objects:
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/kbater/openshift-cli
+              image: quay.io/openshift-sre/osd-cluster-ready
               command:
               - /root/main
             restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3838,6 +3838,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-ready
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-cluster-ready
+      subjects:
+      - kind: ServiceAccount
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: osd-cluster-ready
+        namespace: openshift-monitoring
+      spec:
+        activeDeadlineSeconds: 3900
+        backoffLimit: 0
+        template:
+          metadata:
+            name: osd-cluster-ready
+          spec:
+            containers:
+            - name: osd-cluster-ready
+              image: quay.io/kbater/openshift-cli
+              command:
+              - /root/main
+            restartPolicy: Never
+            serviceAccountName: osd-cluster-ready
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-codeready-workspaces
   spec:
     clusterDeploymentSelector:
@@ -7362,8 +7437,10 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: avg without (instance,pod)(alertmanager_silences{state="active"})
-              > 0 unless (count(cluster_version{type="updating"}) > 0)
+            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"})
+              > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace)
+              (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
+              < 4500))
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3901,7 +3901,7 @@ objects:
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/kbater/openshift-cli
+              image: quay.io/openshift-sre/osd-cluster-ready
               command:
               - /root/main
             restartPolicy: Never


### PR DESCRIPTION
This PR aims to satisfy [OSD-6048](https://issues.redhat.com/browse/OSD-6048) and silences alerts on a cluster as it's applying day 2 OSD configurations on startup. 

This job will exit cleanly if the cluster is more than an hour old and will not apply a silence. 