### PR TITLE
Fix token-refresher deployment with correct escaping and flag name

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -23,10 +23,10 @@ spec:
       containers:
       - args:
         - --oidc.audience=observatorium-telemeter
-        - --oidc.client-id string=\$\(CLIENT_ID\)
-        - --oidc.client-secret=\$\(CLIENT_SECRET\)
-        - --oidc.issuer-url=\$\(ISSUER_URL\)
-        - --url=\$\(RECEIVER_URL\)
+        - --oidc.client-id=$(CLIENT_ID)
+        - --oidc.client-secret=$(CLIENT_SECRET)
+        - --oidc.issuer-url=$(ISSUER_URL)
+        - --url=$(RECEIVER_URL)
         env:
         - name: CLIENT_ID
           valueFrom:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5933,10 +5933,10 @@ objects:
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
-              - --oidc.client-id string=\$\(CLIENT_ID\)
-              - --oidc.client-secret=\$\(CLIENT_SECRET\)
-              - --oidc.issuer-url=\$\(ISSUER_URL\)
-              - --url=\$\(RECEIVER_URL\)
+              - --oidc.client-id=$(CLIENT_ID)
+              - --oidc.client-secret=$(CLIENT_SECRET)
+              - --oidc.issuer-url=$(ISSUER_URL)
+              - --url=$(RECEIVER_URL)
               env:
               - name: CLIENT_ID
                 valueFrom:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5933,10 +5933,10 @@ objects:
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
-              - --oidc.client-id string=\$\(CLIENT_ID\)
-              - --oidc.client-secret=\$\(CLIENT_SECRET\)
-              - --oidc.issuer-url=\$\(ISSUER_URL\)
-              - --url=\$\(RECEIVER_URL\)
+              - --oidc.client-id=$(CLIENT_ID)
+              - --oidc.client-secret=$(CLIENT_SECRET)
+              - --oidc.issuer-url=$(ISSUER_URL)
+              - --url=$(RECEIVER_URL)
               env:
               - name: CLIENT_ID
                 valueFrom:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5933,10 +5933,10 @@ objects:
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
-              - --oidc.client-id string=\$\(CLIENT_ID\)
-              - --oidc.client-secret=\$\(CLIENT_SECRET\)
-              - --oidc.issuer-url=\$\(ISSUER_URL\)
-              - --url=\$\(RECEIVER_URL\)
+              - --oidc.client-id=$(CLIENT_ID)
+              - --oidc.client-secret=$(CLIENT_SECRET)
+              - --oidc.issuer-url=$(ISSUER_URL)
+              - --url=$(RECEIVER_URL)
               env:
               - name: CLIENT_ID
                 valueFrom:


### PR DESCRIPTION
Followup to #619 . Fixed the incorrect escaping of interpolated environment variables in the token refresher deployment.