### PR TITLE
Add workaround for BZ1915081

### DIFF
--- a/deploy/bz1915081/10-node-ca-tolerations.daemonset.patch.yaml
+++ b/deploy/bz1915081/10-node-ca-tolerations.daemonset.patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: DaemonSet
+name: node-ca
+namespace: openshift-image-registry
+applyMode: AlwaysApply
+# https://bugzilla.redhat.com/show_bug.cgi?id=1915081#c3
+patch: '{"spec":{"template":{"spec":{"tolerations":[{"operator":"Exists"}]}}}}'
+patchType: merge

--- a/deploy/bz1915081/OWNERS
+++ b/deploy/bz1915081/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- cblecker

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2075,6 +2075,27 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1915081
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: node-ca
+      namespace: openshift-image-registry
+      applyMode: AlwaysApply
+      patch: '{"spec":{"template":{"spec":{"tolerations":[{"operator":"Exists"}]}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1915661
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2075,6 +2075,27 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1915081
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: node-ca
+      namespace: openshift-image-registry
+      applyMode: AlwaysApply
+      patch: '{"spec":{"template":{"spec":{"tolerations":[{"operator":"Exists"}]}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1915661
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2075,6 +2075,27 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1915081
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      name: node-ca
+      namespace: openshift-image-registry
+      applyMode: AlwaysApply
+      patch: '{"spec":{"template":{"spec":{"tolerations":[{"operator":"Exists"}]}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1915661
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Add workaround to ensure the node-ca daemonset is patched with the correct toleration. This will be a noop on most clusters, and matches the intended config from the image-registry-operator.

part of [OSD-2927](https://issues.redhat.com/browse/OSD-2927)