### PR TITLE
Added SSS to patch stable channels

### DIFF
--- a/deploy/osd-channel-patch/README.md
+++ b/deploy/osd-channel-patch/README.md
@@ -21,11 +21,17 @@ Because there are 2 systems that are managing the in-cluster channel I wanted to
 
 NOTE managed-upgrade-operator (MUO) is used in cluster to perform channel updates and initiate upgrade.
 
+**Assumptions**
+
+* OCM sets channel label on CD at provision time.
+* OCM sets channel label on CD whenever it's changed via OCM.
+
+
 ## Install stable, upgrade to stable
 
 1. Install to stable channel.
 2. OCM set CD to stable.
-3. Hive does **not** sync any channel.
+5. Hive sync stable-major.minor to cluster channel.
 4. Customer sets upgrade schedule.
 5. MUO sets channel to stable-major.minor. (noop)
 6. Upgrade started.
@@ -76,15 +82,15 @@ This path works.
 Worst case, hive syncs old channel in the middle of things.
 
 1. Install to stable channel.
-2. OCM set CD to candidate. (part of upgrade)
+2. OCM set CD to candidate. (prior to upgrade)
 3. Hive sync candidate-major.minor to cluster channel.
 4. Customer sets upgrade schedule
 5. MUO sets channel to candidate-major.minor**+1**
-7. Hive sync candidate-major.minor to cluster channel.
-8. MUO or OCP fails to find upgrade edge.
-9. MUO retries upgrade.
-10. MUO sets channel to candidate-major.minor**+1**
-11. Upgrade started.
+6. Hive sync candidate-major.minor to cluster channel.
+7. MUO or OCP fails to find upgrade edge.
+8. MUO retries upgrade.
+9.  MUO sets channel to candidate-major.minor**+1**
+10. Upgrade started.
 
 This path works with a retry at worst case.
 
@@ -95,13 +101,10 @@ Worst case, hive syncs old channel in the middle of things.
 1. Install to stable channel.
 2. OCM set CD to candidate. (part of provision)
 3. Hive sync candidate-major.minor to cluster channel.
-4. Customer sets upgrade schedule
-5. MUO sets channel to stable-major.minor
-6. Hive sync candidate-major.minor to cluster channel.
-7. MUO or OCP fails to find upgrade edge.
-8. MUO retries upgrade.
-9.  MUO sets channel to stable-major.minor
-10. Upgrade started.
+4. OCM set CD to stable. (prior to upgrade)
+5. Hive sync stable-major.minor to cluster channel.
+6. Customer sets upgrade schedule
+7. Upgrade started.
 
 This path works with a retry at worst case.
 
@@ -112,12 +115,20 @@ Worst case, hive syncs old channel in the middle of things.
 1. Install to stable channel.
 2. OCM set CD to candidate. (part of provision)
 3. Hive sync candidate-major.minor to cluster channel.
-4. Customer sets upgrade schedule
-5. MUO sets channel to stable-major.minor**+1**
-7. Hive sync candidate-major.minor to cluster channel.
-8. MUO or OCP fails to find upgrade edge.
-9. MUO retries upgrade.
-10. MUO sets channel to stable-major.minor**+1**
-11. Upgrade started.
+4. OCM set CD to stable. (prior to upgrade)
+5. Hive sync stable-major.minor to cluster channel.
+6. Customer sets upgrade schedule
+7. OCM set CD to stable.
+8. MUO sets channel to stable-major.minor**+1**
+9. Hive sync stable-major.minor to cluster channel.
+10. MUO or OCP fails to find upgrade edge.
+11. MUO retries upgrade.
+12. MUO sets channel to stable-major.minor**+1**
+13. Upgrade started.
+14. Hive sync stable-major.minor to cluster channel.
+15. Upgrade completed.
+16. Telemeter updated with cluster version.
+17. OCM updates CD with cluster version.
+18. Hive sync stable-major.minor**+1** to cluster channel.
 
 This path works with a retry at worst case.

--- a/deploy/osd-channel-patch/stable-4.5/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.5/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.5"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.5/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.5/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.5"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast"]

--- a/deploy/osd-channel-patch/stable-4.6/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.6/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.6"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.6/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.6/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.6"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast"]

--- a/deploy/osd-channel-patch/stable-4.7/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.7/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.7"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.7/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.7/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.7"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast"]

--- a/deploy/osd-channel-patch/stable-4.8/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.8/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.8"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.8/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.8/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.8"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast"]

--- a/deploy/osd-channel-patch/stable-4.9/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.9/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.9"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.9/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.9/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.9"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4241,6 +4241,161 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.5
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.5"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.6
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.6"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.7
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.7'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.7"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.8
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.8"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.9
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.9'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.9"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-admin
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4241,6 +4241,161 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.5
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.5"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.6
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.6"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.7
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.7'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.7"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.8
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.8"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.9
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.9'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.9"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-admin
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4241,6 +4241,161 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.5
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.5"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.6
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.6"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.7
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.7'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.7"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.8
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.8"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.9
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.9'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.9"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-admin
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-6205

Realized for going from candidate/fast to stable we need to patch the channel else OCM may show more edges than it should.  Also, just good house keeping.  Use cases updated to reflect the change.