### PR TITLE
OHSS-2561 Extend hive integration token timeout

### DIFF
--- a/deploy/osd-oauth-templates/ohss-2561/README.md
+++ b/deploy/osd-oauth-templates/ohss-2561/README.md
@@ -1,0 +1,5 @@
+This is a temporary measure undertaken as part of [OHSS-2561](https://issues.redhat.com/browse/OHSS-2561) whilst a longer-term solution is sought to make this configurable by cluster owners.
+
+This change applies an extended login session duration of 7d to Hive Integration clusters.
+
+This change should _not_ be applied to any cluster other than Hive Integration clusters.

--- a/deploy/osd-oauth-templates/ohss-2561/config.yaml
+++ b/deploy/osd-oauth-templates/ohss-2561/config.yaml
@@ -1,3 +1,9 @@
-deploymentMode: "Direct"
-direct:
-  environments: ["integration"]
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: environment
+    operator: In
+    values: ["integration"]
+  - key: ext-managed.openshift.io/hive-shard
+    operator: In
+    values: ["true"]

--- a/deploy/osd-oauth-templates/ohss-2561/config.yaml
+++ b/deploy/osd-oauth-templates/ohss-2561/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "Direct"
+direct:
+  environments: ["integration"]

--- a/deploy/osd-oauth-templates/ohss-2561/hive-integration-oauth.patch.yaml
+++ b/deploy/osd-oauth-templates/ohss-2561/hive-integration-oauth.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.openshift.io/v1
+applyMode: AlwaysApply
+kind: OAuth
+name: cluster
+namespace: default
+patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout": "168h"}}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6220,6 +6220,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-oauth-templates-ohss-2561
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - integration
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: OAuth
+      name: cluster
+      namespace: default
+      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
+        "168h"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-project-request-template
   spec:
     clusterDeploymentSelector:
@@ -9376,11 +9407,3 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
-- apiVersion: config.openshift.io/v1
-  applyMode: AlwaysApply
-  kind: OAuth
-  name: cluster
-  namespace: default
-  patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
-    "168h"}}}'
-  patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9376,3 +9376,11 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
+- apiVersion: config.openshift.io/v1
+  applyMode: AlwaysApply
+  kind: OAuth
+  name: cluster
+  namespace: default
+  patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
+    "168h"}}}'
+  patchType: merge

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6220,6 +6220,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-oauth-templates-ohss-2561
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - integration
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: OAuth
+      name: cluster
+      namespace: default
+      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
+        "168h"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-project-request-template
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6220,6 +6220,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-oauth-templates-ohss-2561
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - integration
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: OAuth
+      name: cluster
+      namespace: default
+      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
+        "168h"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-project-request-template
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This PR extends the authentication token timeout for Hive integration clusters to a week.

The change has been successfully tested (in `SyncSet` form) on a test cluster to verify correct syntax of the patch.

Refs: [OHSS-2561](https://issues.redhat.com/browse/OHSS-2561) where this has been discussed.