### PR TITLE
Tuned thanosQuerier cpu limit up to allow some room for larger workloads

### DIFF
--- a/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
@@ -75,7 +75,7 @@ data:
     thanosQuerier:
       resources:
         limits:
-          cpu: 250m
+          cpu: 500m
           memory: 2048Mi
         requests:
           cpu: 5m

--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -75,7 +75,7 @@ data:
     thanosQuerier:
       resources:
         limits:
-          cpu: 250m
+          cpu: 500m
           memory: 2048Mi
         requests:
           cpu: 5m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2287,7 +2287,7 @@ objects:
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
-          \  resources:\n    limits:\n      cpu: 250m\n      memory: 2048Mi\n    requests:\n\
+          \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
           \      cpu: 5m\n      memory: 125Mi\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -2337,7 +2337,7 @@ objects:
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
-          \  resources:\n    limits:\n      cpu: 250m\n      memory: 2048Mi\n    requests:\n\
+          \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
           \      cpu: 5m\n      memory: 125Mi\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2287,7 +2287,7 @@ objects:
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
-          \  resources:\n    limits:\n      cpu: 250m\n      memory: 2048Mi\n    requests:\n\
+          \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
           \      cpu: 5m\n      memory: 125Mi\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -2337,7 +2337,7 @@ objects:
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
-          \  resources:\n    limits:\n      cpu: 250m\n      memory: 2048Mi\n    requests:\n\
+          \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
           \      cpu: 5m\n      memory: 125Mi\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2287,7 +2287,7 @@ objects:
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
-          \  resources:\n    limits:\n      cpu: 250m\n      memory: 2048Mi\n    requests:\n\
+          \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
           \      cpu: 5m\n      memory: 125Mi\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -2337,7 +2337,7 @@ objects:
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
-          \  resources:\n    limits:\n      cpu: 250m\n      memory: 2048Mi\n    requests:\n\
+          \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
           \      cpu: 5m\n      memory: 125Mi\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
We have a few larger clusters that are still tripping up the throttle alert for thanosQuerier. 
Tuning this value to allow a little room for larger workloads.
Further tuning might be required later if we find heavy used clusters still trip this alert.