### PR TITLE
OSD-6329 MUO to ignore CannotRetrieveUpdates for healthcheck

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -34,6 +34,7 @@ data:
       - UpgradeNodeScalingFailedSRE
       - UpgradeClusterCheckFailedSRE
       - PrometheusRuleFailures
+      - CannotRetrieveUpdates
     extDependencyAvailabilityChecks:
       http:
         timeout: 10

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3328,10 +3328,10 @@ objects:
           \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
-          \ PrometheusRuleFailures\nextDependencyAvailabilityChecks:\n  http:\n  \
-          \  timeout: 10\n    urls:\n      - https://quay.io/health\n      - ${OCM_BASE_URL}\n\
-          verification:\n  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+          \ PrometheusRuleFailures\n  - CannotRetrieveUpdates\nextDependencyAvailabilityChecks:\n\
+          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
+          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3328,10 +3328,10 @@ objects:
           \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
-          \ PrometheusRuleFailures\nextDependencyAvailabilityChecks:\n  http:\n  \
-          \  timeout: 10\n    urls:\n      - https://quay.io/health\n      - ${OCM_BASE_URL}\n\
-          verification:\n  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+          \ PrometheusRuleFailures\n  - CannotRetrieveUpdates\nextDependencyAvailabilityChecks:\n\
+          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
+          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3328,10 +3328,10 @@ objects:
           \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
-          \ PrometheusRuleFailures\nextDependencyAvailabilityChecks:\n  http:\n  \
-          \  timeout: 10\n    urls:\n      - https://quay.io/health\n      - ${OCM_BASE_URL}\n\
-          verification:\n  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+          \ PrometheusRuleFailures\n  - CannotRetrieveUpdates\nextDependencyAvailabilityChecks:\n\
+          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
+          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
This PR adds the `CannotRetrieveUpdates` alert to the `managed-upgrade-operator`'s cluster health check ignore list.

The `CannotRetrieveUpdates` alert occurs on a cluster when it can't find updates in Cincinnati for its currently-set channel.

As MUO sets the cluster's channel as part of an upgrade (using OCM's `upgrade_channel_group` cluster setting) and performs its own separate Cincinnati validation, it is safe to ignore this alert as part of the health-check.

Refs [OSD-6329](https://issues.redhat.com/browse/OSD-6329)