### PR TITLE
Apply UWM to clusters without a uwm-disabled label

### DIFF
--- a/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
+    enableUserWorkload: true 
     prometheusK8s:
       nodeSelector:
         node-role.kubernetes.io/infra: ""

--- a/deploy/cluster-monitoring-config-uwm/config.yaml
+++ b/deploy/cluster-monitoring-config-uwm/config.yaml
@@ -4,3 +4,7 @@ selectorSyncSet:
     - key: hive.openshift.io/version-major-minor
       operator: In
       values: ["4.6", "4.7", "4.8"]
+    - key: hive.openshift.io/uwm-disabled
+      operator: NotIn
+      values: ["true"]
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2329,6 +2329,10 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
+      - key: hive.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -2337,10 +2341,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations: \n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
+          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2329,6 +2329,10 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
+      - key: hive.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -2337,10 +2341,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations: \n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
+          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2329,6 +2329,10 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
+      - key: hive.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -2337,10 +2341,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations: \n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
+          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\


### PR DESCRIPTION
This will roll out UWM to all 4.6+ clusters, excluding any that have a `uwm-diabled` label applied to the ClusterDeployment.

NOTE: This is a spike, not meant to go to prod, as an option for UWM roll out