### PR TITLE
OHSS-2561 revise targeting of hive integration clusters

### DIFF
--- a/deploy/osd-oauth-templates/ohss-2561/config.yaml
+++ b/deploy/osd-oauth-templates/ohss-2561/config.yaml
@@ -1,9 +1,9 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchExpressions:
-  - key: environment
+  - key: api.openshift.com/id
     operator: In
-    values: ["integration"]
+    values: ["1g268u7pp694gj152nj16me4sv615lpv"]  # any Hive integration cluster IDs
   - key: ext-managed.openshift.io/hive-shard
     operator: In
     values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6248,10 +6248,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: environment
+      - key: api.openshift.com/id
         operator: In
         values:
-        - integration
+        - 1g268u7pp694gj152nj16me4sv615lpv
       - key: ext-managed.openshift.io/hive-shard
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6248,10 +6248,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: environment
+      - key: api.openshift.com/id
         operator: In
         values:
-        - integration
+        - 1g268u7pp694gj152nj16me4sv615lpv
       - key: ext-managed.openshift.io/hive-shard
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6248,10 +6248,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: environment
+      - key: api.openshift.com/id
         operator: In
         values:
-        - integration
+        - 1g268u7pp694gj152nj16me4sv615lpv
       - key: ext-managed.openshift.io/hive-shard
         operator: In
         values:


### PR DESCRIPTION
This PR updates the targeting of Hive integration clusters for [OHSS-2561](https://issues.redhat.com/browse/OHSS-2561) to be based on a list of cluster IDs.

PR #639 was intended to target any Hive integration clusters through `clusterdeployment` labelling; it did not succeed because Hive integration clusters are production clusters, and so their `environment` label is set to `production`. There does not appear to be any way in a `clusterdeployment` to target any/all Hive integration clusters, so the fallback option is a list of cluster IDs.

As the number of Hive integration clusters is hopefully low, the maintenance overhead on this should be low until the change can eventually be replaced by an OCM-configurable way of managing this configuration.