### PR TITLE
Delete backplane serviceaccounts after expiry time

### DIFF
--- a/deploy/osd-delete-backplane-serviceaccounts/00-delete-backplane-serviceaccounts.namespace.yml
+++ b/deploy/osd-delete-backplane-serviceaccounts/00-delete-backplane-serviceaccounts.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane

--- a/deploy/osd-delete-backplane-serviceaccounts/10-delete-backplane-serviceaccounts.rbac.yaml
+++ b/deploy/osd-delete-backplane-serviceaccounts/10-delete-backplane-serviceaccounts.rbac.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-delete-backplane-serviceaccounts
+  namespace: openshift-backplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-delete-serviceaccounts
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-get-namespace
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+---
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: osd-delete-backplane-serviceaccounts
+  namespace: openshift-rbac-permissions
+spec:
+  clusterPermissions:
+    - osd-get-namespace
+  permissions:
+    - allowFirst: true
+      clusterRoleName: osd-delete-serviceaccounts
+      namespacesAllowedRegex: "(^openshift-backplane-.*)"
+  subjectKind: User
+  subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts

--- a/deploy/osd-delete-backplane-serviceaccounts/10-delete-backplane-serviceaccounts.rbac.yaml
+++ b/deploy/osd-delete-backplane-serviceaccounts/10-delete-backplane-serviceaccounts.rbac.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: osd-delete-serviceaccounts
+  name: osd-delete-backplane-serviceaccounts
 rules:
   - apiGroups:
       - ""
@@ -41,7 +41,7 @@ spec:
     - osd-get-namespace
   permissions:
     - allowFirst: true
-      clusterRoleName: osd-delete-serviceaccounts
+      clusterRoleName: osd-delete-backplane-serviceaccounts
       namespacesAllowedRegex: "(^openshift-backplane-.*)"
   subjectKind: User
   subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts

--- a/deploy/osd-delete-backplane-serviceaccounts/20-delete-backplane-serviceaccounts.CronJob.yaml
+++ b/deploy/osd-delete-backplane-serviceaccounts/20-delete-backplane-serviceaccounts.CronJob.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: osd-delete-backplane-serviceaccounts
+  namespace: openshift-backplane
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: osd-delete-backplane-serviceaccounts
+          containers:
+            - name: osd-delete-backplane-serviceaccounts
+              imagePullPolicy: Always
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              args:
+                - /bin/bash
+                - -c
+                - |
+                  for ns in $(oc get ns --no-headers | grep -e ^openshift-backplane-.* | awk '{print $1}');do
+                      for sa in $(oc get sa -n $ns -l managed.openshift.io/backplane=true --no-headers | awk '{print $1}');do
+                        creation=$(date -d $(oc get sa $sa -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                        now=$(date +%s);
+                        expiryMins=$(oc get sa $sa -n $ns -o jsonpath='{.metadata.annotations.managed\.openshift\.io/backplane-expiry-duration}');
+                        if [[ $(expr $((now-creation)) \> ${expiryMins:=720} \* 60) == 1 ]]; then
+                          oc delete sa $sa -n $ns
+                        fi
+                      done;
+                  done;

--- a/deploy/osd-delete-backplane-serviceaccounts/config.yaml
+++ b/deploy/osd-delete-backplane-serviceaccounts/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/environment
+      operator: NotIn
+      values: ["production"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5552,6 +5552,105 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-serviceaccounts
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-backplane
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-serviceaccounts
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-get-namespace
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - osd-get-namespace
+        permissions:
+        - allowFirst: true
+          clusterRoleName: osd-delete-serviceaccounts
+          namespacesAllowedRegex: (^openshift-backplane-.*)
+        subjectKind: User
+        subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-backplane
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                serviceAccountName: osd-delete-backplane-serviceaccounts
+                containers:
+                - name: osd-delete-backplane-serviceaccounts
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "for ns in $(oc get ns --no-headers | grep -e ^openshift-backplane-.*\
+                    \ | awk '{print $1}');do\n    for sa in $(oc get sa -n $ns -l\
+                    \ managed.openshift.io/backplane=true --no-headers | awk '{print\
+                    \ $1}');do\n      creation=$(date -d $(oc get sa $sa -n $ns -o\
+                    \ jsonpath='{.metadata.creationTimestamp}') '+%s');\n      now=$(date\
+                    \ +%s);\n      expiryMins=$(oc get sa $sa -n $ns -o jsonpath='{.metadata.annotations.managed\\\
+                    .openshift\\.io/backplane-expiry-duration}');\n      if [[ $(expr\
+                    \ $((now-creation)) \\> ${expiryMins:=720} \\* 60) == 1 ]]; then\n\
+                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-devaccess
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5576,7 +5576,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: osd-delete-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts
       rules:
       - apiGroups:
         - ''
@@ -5608,7 +5608,7 @@ objects:
         - osd-get-namespace
         permissions:
         - allowFirst: true
-          clusterRoleName: osd-delete-serviceaccounts
+          clusterRoleName: osd-delete-backplane-serviceaccounts
           namespacesAllowedRegex: (^openshift-backplane-.*)
         subjectKind: User
         subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5552,6 +5552,105 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-serviceaccounts
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-backplane
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-serviceaccounts
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-get-namespace
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - osd-get-namespace
+        permissions:
+        - allowFirst: true
+          clusterRoleName: osd-delete-serviceaccounts
+          namespacesAllowedRegex: (^openshift-backplane-.*)
+        subjectKind: User
+        subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-backplane
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                serviceAccountName: osd-delete-backplane-serviceaccounts
+                containers:
+                - name: osd-delete-backplane-serviceaccounts
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "for ns in $(oc get ns --no-headers | grep -e ^openshift-backplane-.*\
+                    \ | awk '{print $1}');do\n    for sa in $(oc get sa -n $ns -l\
+                    \ managed.openshift.io/backplane=true --no-headers | awk '{print\
+                    \ $1}');do\n      creation=$(date -d $(oc get sa $sa -n $ns -o\
+                    \ jsonpath='{.metadata.creationTimestamp}') '+%s');\n      now=$(date\
+                    \ +%s);\n      expiryMins=$(oc get sa $sa -n $ns -o jsonpath='{.metadata.annotations.managed\\\
+                    .openshift\\.io/backplane-expiry-duration}');\n      if [[ $(expr\
+                    \ $((now-creation)) \\> ${expiryMins:=720} \\* 60) == 1 ]]; then\n\
+                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-devaccess
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5576,7 +5576,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: osd-delete-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts
       rules:
       - apiGroups:
         - ''
@@ -5608,7 +5608,7 @@ objects:
         - osd-get-namespace
         permissions:
         - allowFirst: true
-          clusterRoleName: osd-delete-serviceaccounts
+          clusterRoleName: osd-delete-backplane-serviceaccounts
           namespacesAllowedRegex: (^openshift-backplane-.*)
         subjectKind: User
         subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5552,6 +5552,105 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-serviceaccounts
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-backplane
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-serviceaccounts
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-get-namespace
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - osd-get-namespace
+        permissions:
+        - allowFirst: true
+          clusterRoleName: osd-delete-serviceaccounts
+          namespacesAllowedRegex: (^openshift-backplane-.*)
+        subjectKind: User
+        subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-serviceaccounts
+        namespace: openshift-backplane
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                serviceAccountName: osd-delete-backplane-serviceaccounts
+                containers:
+                - name: osd-delete-backplane-serviceaccounts
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "for ns in $(oc get ns --no-headers | grep -e ^openshift-backplane-.*\
+                    \ | awk '{print $1}');do\n    for sa in $(oc get sa -n $ns -l\
+                    \ managed.openshift.io/backplane=true --no-headers | awk '{print\
+                    \ $1}');do\n      creation=$(date -d $(oc get sa $sa -n $ns -o\
+                    \ jsonpath='{.metadata.creationTimestamp}') '+%s');\n      now=$(date\
+                    \ +%s);\n      expiryMins=$(oc get sa $sa -n $ns -o jsonpath='{.metadata.annotations.managed\\\
+                    .openshift\\.io/backplane-expiry-duration}');\n      if [[ $(expr\
+                    \ $((now-creation)) \\> ${expiryMins:=720} \\* 60) == 1 ]]; then\n\
+                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-devaccess
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5576,7 +5576,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: osd-delete-serviceaccounts
+        name: osd-delete-backplane-serviceaccounts
       rules:
       - apiGroups:
         - ''
@@ -5608,7 +5608,7 @@ objects:
         - osd-get-namespace
         permissions:
         - allowFirst: true
-          clusterRoleName: osd-delete-serviceaccounts
+          clusterRoleName: osd-delete-backplane-serviceaccounts
           namespacesAllowedRegex: (^openshift-backplane-.*)
         subjectKind: User
         subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSD-5914

Backplane leaves serviceaccounts indefinitely atm but they should expire. This cronjob removes them after an expiry time.