### PR TITLE
Add Infra Node Imbalance SRE Alert

### DIFF
--- a/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-infra-node-imbalance
+    role: alert-rules
+  name: sre-infra-node-imbalance
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-infra-node-imbalance
+    rules:
+    - alert: KubeInfraNodeImbalanceSRE
+      expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})) != count(cluster:infra_nodes)
+      for: 1h
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+      annotations:
+        message: "The infra node prometheus scheduling has been imbalanced for more than an hour."
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8881,6 +8881,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-infra-node-imbalance
+          role: alert-rules
+        name: sre-infra-node-imbalance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-infra-node-imbalance
+          rules:
+          - alert: KubeInfraNodeImbalanceSRE
+            expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
+              != count(cluster:infra_nodes)
+            for: 1h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The infra node prometheus scheduling has been imbalanced for
+                more than an hour.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubequotaexceeded
           role: alert-rules
         name: sre-kubequotaexceeded

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8881,6 +8881,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-infra-node-imbalance
+          role: alert-rules
+        name: sre-infra-node-imbalance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-infra-node-imbalance
+          rules:
+          - alert: KubeInfraNodeImbalanceSRE
+            expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
+              != count(cluster:infra_nodes)
+            for: 1h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The infra node prometheus scheduling has been imbalanced for
+                more than an hour.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubequotaexceeded
           role: alert-rules
         name: sre-kubequotaexceeded

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8881,6 +8881,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-infra-node-imbalance
+          role: alert-rules
+        name: sre-infra-node-imbalance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-infra-node-imbalance
+          rules:
+          - alert: KubeInfraNodeImbalanceSRE
+            expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
+              != count(cluster:infra_nodes)
+            for: 1h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The infra node prometheus scheduling has been imbalanced for
+                more than an hour.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubequotaexceeded
           role: alert-rules
         name: sre-kubequotaexceeded


### PR DESCRIPTION
This adds an SRE alert to detect when infra nodes become imbalanced (due to the timing of node readiness during install time). The promQL is to count the pods based on the name (`prometheus-k8s-*`) per node. If the node count does not match the infra node count, then this will trigger an alert.

Related SOP PR for link: https://github.com/openshift/ops-sop/pull/1185