### PR TITLE
osd-cluster-ready: restartPolicy: OnFailure

### DIFF
--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -4,8 +4,6 @@ metadata:
     name: osd-cluster-ready
     namespace: openshift-monitoring
 spec:
-    activeDeadlineSeconds: 3900 # 1 hour for the silence, 5 minutes for processing/data completion
-    backoffLimit: 0
     template:
         metadata:
             name: osd-cluster-ready
@@ -20,5 +18,5 @@ spec:
               name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready
               command: ["/root/main"]
-            restartPolicy: Never
+            restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4586,8 +4586,6 @@ objects:
         name: osd-cluster-ready
         namespace: openshift-monitoring
       spec:
-        activeDeadlineSeconds: 3900
-        backoffLimit: 0
         template:
           metadata:
             name: osd-cluster-ready
@@ -4600,7 +4598,7 @@ objects:
               image: quay.io/openshift-sre/osd-cluster-ready
               command:
               - /root/main
-            restartPolicy: Never
+            restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4586,8 +4586,6 @@ objects:
         name: osd-cluster-ready
         namespace: openshift-monitoring
       spec:
-        activeDeadlineSeconds: 3900
-        backoffLimit: 0
         template:
           metadata:
             name: osd-cluster-ready
@@ -4600,7 +4598,7 @@ objects:
               image: quay.io/openshift-sre/osd-cluster-ready
               command:
               - /root/main
-            restartPolicy: Never
+            restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4586,8 +4586,6 @@ objects:
         name: osd-cluster-ready
         namespace: openshift-monitoring
       spec:
-        activeDeadlineSeconds: 3900
-        backoffLimit: 0
         template:
           metadata:
             name: osd-cluster-ready
@@ -4600,7 +4598,7 @@ objects:
               image: quay.io/openshift-sre/osd-cluster-ready
               command:
               - /root/main
-            restartPolicy: Never
+            restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
Change the `restartPolicy` for osd-cluster-ready to `OnFailure` so that it will restart if errors occur. Remove the overrides for `backoffLimit` and `activeDeadlineSeconds` to let the defaults for those take over.

(Note that this is not really related to the maximum cluster age observed by the job. The job only fails if an error occurs, not if health checks are unsuccessful. They tie together only in the sense that, if the job restarts after one or more failures, it still uses the inception of the cluster (not the job) to determine the maximum age.)