### PR TITLE
Update Infra Node Imbalance Alert For Multi-Az

### DIFF
--- a/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-infra-node-imbalance
     rules:
     - alert: KubeInfraNodeImbalanceSRE
-      expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})) != count(cluster:infra_nodes)
+      expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})) < 2
       for: 1h
       labels:
         severity: warning

--- a/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-infra-node-imbalance
     rules:
     - alert: KubeInfraNodeImbalanceSRE
-      expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})) < 2
+      expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}) > 1
       for: 1h
       labels:
         severity: warning

--- a/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
@@ -18,4 +18,3 @@ spec:
         namespace: openshift-monitoring
       annotations:
         message: "The infra node prometheus scheduling has been imbalanced for more than an hour."
-        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9200,7 +9200,6 @@ objects:
             annotations:
               message: The infra node prometheus scheduling has been imbalanced for
                 more than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9192,7 +9192,7 @@ objects:
           rules:
           - alert: KubeInfraNodeImbalanceSRE
             expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
-              != count(cluster:infra_nodes)
+              < 2
             for: 1h
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9191,8 +9191,8 @@ objects:
         - name: sre-infra-node-imbalance
           rules:
           - alert: KubeInfraNodeImbalanceSRE
-            expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
-              < 2
+            expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})
+              > 1
             for: 1h
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9200,7 +9200,6 @@ objects:
             annotations:
               message: The infra node prometheus scheduling has been imbalanced for
                 more than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9192,7 +9192,7 @@ objects:
           rules:
           - alert: KubeInfraNodeImbalanceSRE
             expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
-              != count(cluster:infra_nodes)
+              < 2
             for: 1h
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9191,8 +9191,8 @@ objects:
         - name: sre-infra-node-imbalance
           rules:
           - alert: KubeInfraNodeImbalanceSRE
-            expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
-              < 2
+            expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})
+              > 1
             for: 1h
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9200,7 +9200,6 @@ objects:
             annotations:
               message: The infra node prometheus scheduling has been imbalanced for
                 more than an hour.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeInfraNodeImbalanceSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9192,7 +9192,7 @@ objects:
           rules:
           - alert: KubeInfraNodeImbalanceSRE
             expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
-              != count(cluster:infra_nodes)
+              < 2
             for: 1h
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9191,8 +9191,8 @@ objects:
         - name: sre-infra-node-imbalance
           rules:
           - alert: KubeInfraNodeImbalanceSRE
-            expr: count(count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}))
-              < 2
+            expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})
+              > 1
             for: 1h
             labels:
               severity: warning


### PR DESCRIPTION
After further testing, it was observed that the alert would fire on multi-az clusters. Updating the query to check for a value of 2 or less before firing.