### PR TITLE
Adds patch for global fluentd toleration

### DIFF
--- a/deploy/osd-logging/infra-node-taint/00-patch.yaml
+++ b/deploy/osd-logging/infra-node-taint/00-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: logging.openshift.io/v1
+applyMode: AlwaysApply
+kind: ClusterLogging
+name: instance
+namespace: openshift-logging
+patch: '{"spec":{"collection":{"logs":{"fluentd":{"tolerations":[{"operator": "Exists"}]}}}}}'
+patchType: merge
+

--- a/deploy/osd-logging/infra-node-taint/config.yaml
+++ b/deploy/osd-logging/infra-node-taint/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/environment
+    operator: NotIn
+    values: ["production"]
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5957,6 +5957,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-logging-infra-node-taint
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: logging.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: ClusterLogging
+      name: instance
+      namespace: openshift-logging
+      patch: '{"spec":{"collection":{"logs":{"fluentd":{"tolerations":[{"operator":
+        "Exists"}]}}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-logging-supported
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5957,6 +5957,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-logging-infra-node-taint
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: logging.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: ClusterLogging
+      name: instance
+      namespace: openshift-logging
+      patch: '{"spec":{"collection":{"logs":{"fluentd":{"tolerations":[{"operator":
+        "Exists"}]}}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-logging-supported
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5957,6 +5957,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-logging-infra-node-taint
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: logging.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: ClusterLogging
+      name: instance
+      namespace: openshift-logging
+      patch: '{"spec":{"collection":{"logs":{"fluentd":{"tolerations":[{"operator":
+        "Exists"}]}}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-logging-supported
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Attempts to add a patch for fluentd tolerations to allow fluentd to be on infra nodes with the new NoSchedule taint.

Helps remove blockers for [OSD-2927](https://issues.redhat.com/browse/OSD-2927)