### PR TITLE
osd-cluster-ready: CreateOnly

### DIFF
--- a/deploy/osd-cluster-ready/config.yaml
+++ b/deploy/osd-cluster-ready/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  applyBehavior: "CreateOnly"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4456,6 +4456,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: ServiceAccount

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4456,6 +4456,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: ServiceAccount

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4456,6 +4456,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: ServiceAccount


### PR DESCRIPTION
Since Jobs are immutable, the default `applyBehavior` (`Apply`) will cause the SelectorSyncSet to fail.

Since osd-cluster-ready is intended to be deployed only once anyway, we're setting it to `CreateOnly`.

This carries a small risk of a new-enough cluster needing an updated configuration and not getting it.