### PR TITLE
Increase Node Infra Imbalance Alert Sample Duration to 4 hours

### DIFF
--- a/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-infra-node-imbalance.PrometheusRule.yaml
@@ -12,9 +12,9 @@ spec:
     rules:
     - alert: KubeInfraNodeImbalanceSRE
       expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"}) > 1
-      for: 1h
+      for: 4h
       labels:
         severity: warning
         namespace: openshift-monitoring
       annotations:
-        message: "The infra node prometheus scheduling has been imbalanced for more than an hour."
+        message: "The infra node prometheus scheduling has been imbalanced for more than 4 hours."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9321,13 +9321,13 @@ objects:
           - alert: KubeInfraNodeImbalanceSRE
             expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})
               > 1
-            for: 1h
+            for: 4h
             labels:
               severity: warning
               namespace: openshift-monitoring
             annotations:
               message: The infra node prometheus scheduling has been imbalanced for
-                more than an hour.
+                more than 4 hours.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9321,13 +9321,13 @@ objects:
           - alert: KubeInfraNodeImbalanceSRE
             expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})
               > 1
-            for: 1h
+            for: 4h
             labels:
               severity: warning
               namespace: openshift-monitoring
             annotations:
               message: The infra node prometheus scheduling has been imbalanced for
-                more than an hour.
+                more than 4 hours.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9321,13 +9321,13 @@ objects:
           - alert: KubeInfraNodeImbalanceSRE
             expr: count by (node) (kube_pod_info{namespace="openshift-monitoring",pod=~"prometheus-k8s-.*"})
               > 1
-            for: 1h
+            for: 4h
             labels:
               severity: warning
               namespace: openshift-monitoring
             annotations:
               message: The infra node prometheus scheduling has been imbalanced for
-                more than an hour.
+                more than 4 hours.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
This should hopefully suppress alerts showing up during scale test and/or installation time.