### PR TITLE
Osd 3075 image registry afinity settings

### DIFF
--- a/deploy/osd-registry/cluster.Config.removeNodeSelector.patch.yaml
+++ b/deploy/osd-registry/cluster.Config.removeNodeSelector.patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+applyMode: AlwaysApply
+kind: Config
+name: cluster
+# patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
+# patch registry to expose default route: https://docs.openshift.com/container-platform/4.1/registry/configuring-registry-operator.html#registry-operator-default-crd_configuring-registry-operator
+patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
+patchType: json

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6890,6 +6890,12 @@ objects:
       name: cluster
       patch: '{"spec":{"defaultRoute":true,"nodeSelector":{"node-role.kubernetes.io/infra":""},"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
       patchType: merge
+    - apiVersion: imageregistry.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: Config
+      name: cluster
+      patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
+      patchType: json
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6890,6 +6890,12 @@ objects:
       name: cluster
       patch: '{"spec":{"defaultRoute":true,"nodeSelector":{"node-role.kubernetes.io/infra":""},"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
       patchType: merge
+    - apiVersion: imageregistry.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: Config
+      name: cluster
+      patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
+      patchType: json
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6890,6 +6890,12 @@ objects:
       name: cluster
       patch: '{"spec":{"defaultRoute":true,"nodeSelector":{"node-role.kubernetes.io/infra":""},"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
       patchType: merge
+    - apiVersion: imageregistry.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: Config
+      name: cluster
+      patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
+      patchType: json
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Added a patch to remove the nodeSelector from the image-registry. this will allow for the nodeAffinity rule to function correctly.