### PR TITLE
OSD-6387: osd-cluster-ready: Bump backoffLimit

### DIFF
--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -8,6 +8,11 @@ spec:
         metadata:
             name: osd-cluster-ready
         spec:
+            # NOTE: We're making this ridiculously high to ensure that
+            # we exceed MAX_CLUSTER_AGE_MINUTES even in the fastest
+            # case. We rely on the logic in the job to exit cleanly when
+            # that max age is reached.
+            backoffLimit: 500
             containers:
             # TODO: Remove this override once
             # https://bugzilla.redhat.com/show_bug.cgi?id=1921413

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4633,6 +4633,7 @@ objects:
           metadata:
             name: osd-cluster-ready
           spec:
+            backoffLimit: 500
             containers:
             - env:
               - name: MAX_CLUSTER_AGE_MINUTES

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4633,6 +4633,7 @@ objects:
           metadata:
             name: osd-cluster-ready
           spec:
+            backoffLimit: 500
             containers:
             - env:
               - name: MAX_CLUSTER_AGE_MINUTES

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4633,6 +4633,7 @@ objects:
           metadata:
             name: osd-cluster-ready
           spec:
+            backoffLimit: 500
             containers:
             - env:
               - name: MAX_CLUSTER_AGE_MINUTES


### PR DESCRIPTION
During the 1000-cluster scale test, we still saw some instances of the osd-cluster-ready job exceeding the default six retries. With this commit, we're bumping it up to a number that should comfortably exceed the configured `MAX_CLUSTER_AGE_MINUTES`, thus giving that value full control over timing out the job.

[OSD-6387](https://issues.redhat.com/browse/OSD-6387)