### PR TITLE
OSD-6348: Add CuratorJobFailedSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-curator-jobs.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-curator-jobs.PrometheusRule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-curator-jobs
+    role: alert-rules
+  name: sre-curator-jobs
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-curator-jobs
+    rules:
+    # https://issues.redhat.com/browse/OSD-6348
+    - alert: CuratorJobFailedSRE
+      expr: kube_job_failed{job="kube-state-metrics",namespace="openshift-logging",job_name=~"^curator-.*"} > 1
+      # The cronjob runs this once an hour; and (anecdotally) the job
+      # takes close to an hour to run.
+      for: 120m
+      labels:
+        severity: warning
+        namespace: '{{ $labels.namespace }}'
+      annotations:
+        message: Curator job {{ $labels.job_name }} has failed 2 or more times in the last two hours in namespace {{ $labels.namespace }}.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8977,6 +8977,28 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-curator-jobs
+          role: alert-rules
+        name: sre-curator-jobs
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-curator-jobs
+          rules:
+          - alert: CuratorJobFailedSRE
+            expr: kube_job_failed{job="kube-state-metrics",namespace="openshift-logging",job_name=~"^curator-.*"}
+              > 1
+            for: 120m
+            labels:
+              severity: warning
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: Curator job {{ $labels.job_name }} has failed 2 or more times
+                in the last two hours in namespace {{ $labels.namespace }}.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-dns-alerts
           role: alert-rules
         name: sre-dns-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8977,6 +8977,28 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-curator-jobs
+          role: alert-rules
+        name: sre-curator-jobs
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-curator-jobs
+          rules:
+          - alert: CuratorJobFailedSRE
+            expr: kube_job_failed{job="kube-state-metrics",namespace="openshift-logging",job_name=~"^curator-.*"}
+              > 1
+            for: 120m
+            labels:
+              severity: warning
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: Curator job {{ $labels.job_name }} has failed 2 or more times
+                in the last two hours in namespace {{ $labels.namespace }}.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-dns-alerts
           role: alert-rules
         name: sre-dns-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8977,6 +8977,28 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-curator-jobs
+          role: alert-rules
+        name: sre-curator-jobs
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-curator-jobs
+          rules:
+          - alert: CuratorJobFailedSRE
+            expr: kube_job_failed{job="kube-state-metrics",namespace="openshift-logging",job_name=~"^curator-.*"}
+              > 1
+            for: 120m
+            labels:
+              severity: warning
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: Curator job {{ $labels.job_name }} has failed 2 or more times
+                in the last two hours in namespace {{ $labels.namespace }}.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-dns-alerts
           role: alert-rules
         name: sre-dns-alerts


### PR DESCRIPTION
Peel out a special case of KubeJobFailed for logging curator jobs, which alert when a Job fails.

The curator job runs on a 1h interval. If one fails, but the next succeeds, that constitutes a "recovery" which should be considered a happy path in a k8s context. So this alert only fires if we see two consecutive failures (over two hours, to account for the cronjob
interval).

CF:
- Disable KubeJobFailed for curator: https://github.com/openshift/configure-alertmanager-operator/pull/140
- SOP: https://github.com/openshift/ops-sop/pull/1202

[OSD-6348](https://issues.redhat.com/browse/OSD-6348)