### PR TITLE
Updated the token refresher image version

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -45,7 +45,7 @@ spec:
               key: receiver-url
         - name: ISSUER_URL
           value: "https://sso.redhat.com/auth/realms/redhat-external"
-        image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+        image: quay.io/observatorium/token-refresher:master-2021-02-05-5da9663
         name: token-refresher
         ports:
         - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7300,7 +7300,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+              image: quay.io/observatorium/token-refresher:master-2021-02-05-5da9663
               name: token-refresher
               ports:
               - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7300,7 +7300,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+              image: quay.io/observatorium/token-refresher:master-2021-02-05-5da9663
               name: token-refresher
               ports:
               - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7300,7 +7300,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher:master-2020-12-04-5504078
+              image: quay.io/observatorium/token-refresher:master-2021-02-05-5da9663
               name: token-refresher
               ports:
               - containerPort: 8080


### PR DESCRIPTION
A new version of the token-refresher has been released with fixes which are required for functionality. This is [PR](https://github.com/observatorium/token-refresher/pull/3) in the repo.