### PR TITLE
[WIP] Added prometheus remote write endpoint

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -6,6 +6,12 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
+      remoteWrite:
+        - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+          writeRelabelConfigs:
+            - action: keep
+              sourceLabels: [__name__]
+              regex: '(cluster_admin_enabled|identity_provider)'
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations: 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2392,8 +2392,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2440,8 +2443,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2392,8 +2392,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2440,8 +2443,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2392,8 +2392,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2440,8 +2443,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\


### PR DESCRIPTION
This enable remote writes for the in-cluster prometheus for select metrics configured through the relabel configuration. The `token-refresher` mentioned here was deployed in #630 