### PR TITLE
Let dedicated-admins fully manage openshift-operators and openshift-operators-redhat

### DIFF
--- a/deploy/rbac-permissions-operator-config/60-dedicated-admin-openshift-namespaces.SubjectPermission.yaml
+++ b/deploy/rbac-permissions-operator-config/60-dedicated-admin-openshift-namespaces.SubjectPermission.yaml
@@ -1,0 +1,17 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: dedicated-admins-core-ns
+  namespace: openshift-rbac-permissions
+spec:
+  subjectKind: Group
+  subjectName: dedicated-admins
+  permissions:
+    -
+      clusterRoleName: dedicated-admins-project
+      namespacesAllowedRegex: "(^openshift-operators$|^openshift-operators-redhat$)"
+      allowFirst: true
+    -
+      clusterRoleName: admin
+      namespacesAllowedRegex: "(^openshift-operators$|^openshift-operators-redhat$)"
+      allowFirst: true

--- a/deploy/rbac-permissions-operator-config/60-dedicated-admins-openshift-namespaces-serviceaccounts.SubjectPermission.yaml
+++ b/deploy/rbac-permissions-operator-config/60-dedicated-admins-openshift-namespaces-serviceaccounts.SubjectPermission.yaml
@@ -1,0 +1,17 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: dedicated-admin-serviceaccounts-core-ns
+  namespace: openshift-rbac-permissions
+spec:
+  subjectKind: Group
+  subjectName: system:serviceaccounts:dedicated-admin
+  permissions:
+    -
+      clusterRoleName: dedicated-admins-project
+      namespacesAllowedRegex: "(^openshift-operators$|^openshift-operators-redhat$)"
+      allowFirst: true
+    -
+      clusterRoleName: admin
+      namespacesAllowedRegex: "(^openshift-operators$|^openshift-operators-redhat$)"
+      allowFirst: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8487,6 +8487,36 @@ objects:
           namespacesAllowedRegex: .*
           namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
           allowFirst: true
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admins-core-ns
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: dedicated-admins
+        permissions:
+        - clusterRoleName: dedicated-admins-project
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admin-serviceaccounts-core-ns
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: system:serviceaccounts:dedicated-admin
+        permissions:
+        - clusterRoleName: dedicated-admins-project
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8487,6 +8487,36 @@ objects:
           namespacesAllowedRegex: .*
           namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
           allowFirst: true
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admins-core-ns
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: dedicated-admins
+        permissions:
+        - clusterRoleName: dedicated-admins-project
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admin-serviceaccounts-core-ns
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: system:serviceaccounts:dedicated-admin
+        permissions:
+        - clusterRoleName: dedicated-admins-project
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8487,6 +8487,36 @@ objects:
           namespacesAllowedRegex: .*
           namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
           allowFirst: true
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admins-core-ns
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: dedicated-admins
+        permissions:
+        - clusterRoleName: dedicated-admins-project
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admin-serviceaccounts-core-ns
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: system:serviceaccounts:dedicated-admin
+        permissions:
+        - clusterRoleName: dedicated-admins-project
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+          allowFirst: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Reference: https://issues.redhat.com/browse/OSD-6382

Since operators are no longer curated from OperatorHub, dedicated-admins should be able to manage resources inside openshift-operators namespace. This will enable the ServiceMesh team to make ServiceMesh available on OSD.