### PR TITLE
OSD-6102 Extend HAProxyReload alert threshold

### DIFF
--- a/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
+++ b/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
@@ -23,7 +23,7 @@ spec:
     rules:
     - alert: HAProxyReloadFailSRE
       expr: increase(template_router_reload_fails[5m]) > 0
-      for: 10m
+      for: 12m
       labels:
         severity: critical
         namespace: "{{ $labels.namespace }}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9199,7 +9199,7 @@ objects:
           rules:
           - alert: HAProxyReloadFailSRE
             expr: increase(template_router_reload_fails[5m]) > 0
-            for: 10m
+            for: 12m
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9199,7 +9199,7 @@ objects:
           rules:
           - alert: HAProxyReloadFailSRE
             expr: increase(template_router_reload_fails[5m]) > 0
-            for: 10m
+            for: 12m
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9199,7 +9199,7 @@ objects:
           rules:
           - alert: HAProxyReloadFailSRE
             expr: increase(template_router_reload_fails[5m]) > 0
-            for: 10m
+            for: 12m
             labels:
               severity: critical
               namespace: '{{ $labels.namespace }}'


### PR DESCRIPTION
This PR extends the threshold for the HAProxyReload alert from 10m to 12m.

Through analysis of recent false alarms of this alert ([OSD-6102](https://issues.redhat.com/browse/OSD-6102)), it seems that 12m is the sweet spot for reducing the number of potential alerts that page SRE.
