### PR TITLE
Add remote write configuration for staging environment telemeter

### DIFF
--- a/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
@@ -7,6 +7,12 @@ data:
   config.yaml: |
     enableUserWorkload: true 
     prometheusK8s:
+      remoteWrite:
+        - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+          writeRelabelConfigs:
+            - action: keep
+              sourceLabels: [__name__]
+              regex: '(cluster_admin_enabled|identity_provider)'
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations: 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2406,11 +2406,14 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: \"\"\n  tolerations: \n    - effect:\
-          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
-          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2406,11 +2406,14 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: \"\"\n  tolerations: \n    - effect:\
-          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
-          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2406,11 +2406,14 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: \"\"\n  tolerations: \n    - effect:\
-          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
-          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\


### PR DESCRIPTION
This closes #685 and adds the configuration to staging clusters above OCP version 4.5. 

Likely this may need to be reverted if UWM goes to production before production telemeter tenant is ready. This MR needs to merge before this can go to prod https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/14785 

Alternative is to split this up into environment specific directories. 

cc/ @fahlmant @jewzaam @cblecker @arjunrn 