### PR TITLE
Update cluster-monitoring-config.yaml to add killswitch note

### DIFF
--- a/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
@@ -7,6 +7,9 @@ data:
   config.yaml: |
     enableUserWorkload: true 
     prometheusK8s:
+    # If the location of this config changes,
+    # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md
+    # so that killswitch instructions point to the right file!
       remoteWrite:
         - url: http://token-refresher.openshift-monitoring.svc.cluster.local
           writeRelabelConfigs:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2406,7 +2406,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  remoteWrite:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n# If the location\
+          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2406,7 +2406,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  remoteWrite:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n# If the location\
+          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2406,7 +2406,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n  remoteWrite:\n\
+        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n# If the location\
+          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\


### PR DESCRIPTION
We want the killswitch instruction to be up to date.
if the location of this section changes to a different file, the SOP **has to** be updated.


Depends on https://github.com/openshift/ops-sop/pull/1207/files