### PR TITLE
Added temporary metrics for observatorium for scale tests

### DIFF
--- a/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-uwm/cluster-monitoring-config.yaml
@@ -15,7 +15,7 @@ data:
           writeRelabelConfigs:
             - action: keep
               sourceLabels: [__name__]
-              regex: '(cluster_admin_enabled|identity_provider)'
+              regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations: 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2411,7 +2411,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
-          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
           \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2411,7 +2411,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
-          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
           \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2411,7 +2411,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
-          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
           \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\


### PR DESCRIPTION
Added metrics `kube_node_info` and `kube_node_created` and `kube_node_role` which consists of a timeseries for
every node in the cluster.
