### PR TITLE
Expand SREP backplane privileges

### DIFF
--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -28,6 +28,7 @@ rules:
   - project.openshift.io
   resources:
   - projects
+  - projectrequests
   verbs:
   - '*'
 # SRE can manage namespaces
@@ -60,27 +61,36 @@ rules:
   - '*'
 #### Start - more perms for srep
 # https://issues.redhat.com/browse/OSD-5537
+# SRE can create authz/n reviews
 - apiGroups:
   - authentication.k8s.io
   resources:
   - tokenreviews
-  - selfsubjectaccessreviews
-  - selfsubjectrulesreviews
   verbs:
-  - '*'
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 - apiGroups:
   - authorization.openshift.io
   resources:
   - resourceaccessreviews
   - subjectaccessreviews
+  - subjectrulesreviews
   verbs:
-  - '*'
+  - create
+# SRE can delete users and identities
 - apiGroups:
   - user.openshift.io
   resources:
   - users
+  - identities
   verbs:
   - delete
+  - deletecollection
 # SREP can view machineconfigs, machineconfigpools, kubeletconfigs,
 #    controllerconfigs
 - apiGroups:
@@ -91,4 +101,18 @@ rules:
   - get
   - list
   - watch
+# SRE can delete machines
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machines
+  verbs:
+  - delete
+# SRE can delete crds
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - delete
 ### End

--- a/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
@@ -40,7 +40,7 @@ rules:
   - jobs
   verbs:
   - delete
-  - deletecollections
+  - deletecollection
   - create
 - apiGroups:
   - build.openshift.io
@@ -49,7 +49,6 @@ rules:
   verbs:
   - delete
   - deletecollection
-
 # SRE can use oc debug
 - apiGroups:
   - ""
@@ -65,6 +64,7 @@ rules:
   - pods
   verbs:
   - delete
+  - deletecollection
 # SRE can review pod security policies
 - apiGroups:
   - security.openshift.io
@@ -79,6 +79,7 @@ rules:
   - authorization.openshift.io
   resources:
   - localresourceaccessreviews
+  - localsubjectaccessreviews
   verbs:
   - create
 # SRE can manage Logging (ClusterLogging and ElasticSearch CRs)
@@ -103,6 +104,69 @@ rules:
   - serverstatusrequests
   verbs:
   - '*'
+# SRE can resize and delete pvcs
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - patch
+# SRE can scale apps
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers/scale
+  verbs:
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  - replicasets/scale
+  - statefulsets/scale
+  verbs:
+  - patch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs/scale
+  verbs:
+  - patch
+# SRE can delete replicasets
+- apiGroups:
+  - ""
+  resources:
+  - replicasets
+  verbs:
+  - delete
+  - deletecollection
+# SRE can pause machinehealthchecks
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machinehealthchecks
+  verbs:
+  - patch
+# SRE can scale machinesets
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - machinesets/scale
+  verbs:
+  - patch
+# SRE can scale prometheuses
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - prometheuses
+  verbs:
+  - patch
+# SRE can delete upgradeconfigs
+- apiGroups:
+  - upgrade.managed.openshift.io
+  resources:
+  - upgradeconfigs
 # SRE can delete csv, installplans, and subscriptions
 - apiGroups:
   - operators.coreos.com

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1676,6 +1676,7 @@ objects:
         - project.openshift.io
         resources:
         - projects
+        - projectrequests
         verbs:
         - '*'
       - apiGroups:
@@ -1706,23 +1707,30 @@ objects:
         - authentication.k8s.io
         resources:
         - tokenreviews
-        - selfsubjectaccessreviews
-        - selfsubjectrulesreviews
         verbs:
-        - '*'
+        - create
+      - apiGroups:
+        - authorization.k8s.io
+        resources:
+        - subjectaccessreviews
+        verbs:
+        - create
       - apiGroups:
         - authorization.openshift.io
         resources:
         - resourceaccessreviews
         - subjectaccessreviews
+        - subjectrulesreviews
         verbs:
-        - '*'
+        - create
       - apiGroups:
         - user.openshift.io
         resources:
         - users
+        - identities
         verbs:
         - delete
+        - deletecollection
       - apiGroups:
         - machineconfiguration.openshift.io
         resources:
@@ -1731,6 +1739,18 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machines
+        verbs:
+        - delete
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -1768,7 +1788,7 @@ objects:
         - jobs
         verbs:
         - delete
-        - deletecollections
+        - deletecollection
         - create
       - apiGroups:
         - build.openshift.io
@@ -1790,6 +1810,7 @@ objects:
         - pods
         verbs:
         - delete
+        - deletecollection
       - apiGroups:
         - security.openshift.io
         resources:
@@ -1802,6 +1823,7 @@ objects:
         - authorization.openshift.io
         resources:
         - localresourceaccessreviews
+        - localsubjectaccessreviews
         verbs:
         - create
       - apiGroups:
@@ -1824,6 +1846,62 @@ objects:
         - serverstatusrequests
         verbs:
         - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - persistentvolumeclaims
+        verbs:
+        - delete
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - replicationcontrollers/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments/scale
+        - replicasets/scale
+        - statefulsets/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - replicasets
+        verbs:
+        - delete
+        - deletecollection
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machinehealthchecks
+        verbs:
+        - patch
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machinesets/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - prometheuses
+        verbs:
+        - patch
+      - apiGroups:
+        - upgrade.managed.openshift.io
+        resources:
+        - upgradeconfigs
       - apiGroups:
         - operators.coreos.com
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1676,6 +1676,7 @@ objects:
         - project.openshift.io
         resources:
         - projects
+        - projectrequests
         verbs:
         - '*'
       - apiGroups:
@@ -1706,23 +1707,30 @@ objects:
         - authentication.k8s.io
         resources:
         - tokenreviews
-        - selfsubjectaccessreviews
-        - selfsubjectrulesreviews
         verbs:
-        - '*'
+        - create
+      - apiGroups:
+        - authorization.k8s.io
+        resources:
+        - subjectaccessreviews
+        verbs:
+        - create
       - apiGroups:
         - authorization.openshift.io
         resources:
         - resourceaccessreviews
         - subjectaccessreviews
+        - subjectrulesreviews
         verbs:
-        - '*'
+        - create
       - apiGroups:
         - user.openshift.io
         resources:
         - users
+        - identities
         verbs:
         - delete
+        - deletecollection
       - apiGroups:
         - machineconfiguration.openshift.io
         resources:
@@ -1731,6 +1739,18 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machines
+        verbs:
+        - delete
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -1768,7 +1788,7 @@ objects:
         - jobs
         verbs:
         - delete
-        - deletecollections
+        - deletecollection
         - create
       - apiGroups:
         - build.openshift.io
@@ -1790,6 +1810,7 @@ objects:
         - pods
         verbs:
         - delete
+        - deletecollection
       - apiGroups:
         - security.openshift.io
         resources:
@@ -1802,6 +1823,7 @@ objects:
         - authorization.openshift.io
         resources:
         - localresourceaccessreviews
+        - localsubjectaccessreviews
         verbs:
         - create
       - apiGroups:
@@ -1824,6 +1846,62 @@ objects:
         - serverstatusrequests
         verbs:
         - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - persistentvolumeclaims
+        verbs:
+        - delete
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - replicationcontrollers/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments/scale
+        - replicasets/scale
+        - statefulsets/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - replicasets
+        verbs:
+        - delete
+        - deletecollection
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machinehealthchecks
+        verbs:
+        - patch
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machinesets/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - prometheuses
+        verbs:
+        - patch
+      - apiGroups:
+        - upgrade.managed.openshift.io
+        resources:
+        - upgradeconfigs
       - apiGroups:
         - operators.coreos.com
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1676,6 +1676,7 @@ objects:
         - project.openshift.io
         resources:
         - projects
+        - projectrequests
         verbs:
         - '*'
       - apiGroups:
@@ -1706,23 +1707,30 @@ objects:
         - authentication.k8s.io
         resources:
         - tokenreviews
-        - selfsubjectaccessreviews
-        - selfsubjectrulesreviews
         verbs:
-        - '*'
+        - create
+      - apiGroups:
+        - authorization.k8s.io
+        resources:
+        - subjectaccessreviews
+        verbs:
+        - create
       - apiGroups:
         - authorization.openshift.io
         resources:
         - resourceaccessreviews
         - subjectaccessreviews
+        - subjectrulesreviews
         verbs:
-        - '*'
+        - create
       - apiGroups:
         - user.openshift.io
         resources:
         - users
+        - identities
         verbs:
         - delete
+        - deletecollection
       - apiGroups:
         - machineconfiguration.openshift.io
         resources:
@@ -1731,6 +1739,18 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machines
+        verbs:
+        - delete
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -1768,7 +1788,7 @@ objects:
         - jobs
         verbs:
         - delete
-        - deletecollections
+        - deletecollection
         - create
       - apiGroups:
         - build.openshift.io
@@ -1790,6 +1810,7 @@ objects:
         - pods
         verbs:
         - delete
+        - deletecollection
       - apiGroups:
         - security.openshift.io
         resources:
@@ -1802,6 +1823,7 @@ objects:
         - authorization.openshift.io
         resources:
         - localresourceaccessreviews
+        - localsubjectaccessreviews
         verbs:
         - create
       - apiGroups:
@@ -1824,6 +1846,62 @@ objects:
         - serverstatusrequests
         verbs:
         - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - persistentvolumeclaims
+        verbs:
+        - delete
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - replicationcontrollers/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments/scale
+        - replicasets/scale
+        - statefulsets/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - replicasets
+        verbs:
+        - delete
+        - deletecollection
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machinehealthchecks
+        verbs:
+        - patch
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machinesets/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - prometheuses
+        verbs:
+        - patch
+      - apiGroups:
+        - upgrade.managed.openshift.io
+        resources:
+        - upgradeconfigs
       - apiGroups:
         - operators.coreos.com
         resources:


### PR DESCRIPTION
Widens the effective write-related permissions for SREP backplane access to:

```
VERB              GROUP                                 KIND                                 NAME
*                                                       configmaps                           *
*                                                       limitranges                          *
*                                                       namespaces                           *
*                                                       namespaces/finalize                  *
patch                                                   nodes                                *
delete                                                  persistentvolumeclaims               *
patch                                                   persistentvolumeclaims               *
create                                                  pods                                 *
deletecollection                                        pods                                 *
delete                                                  pods                                 *
create                                                  pods/attach                          *
create                                                  pods/eviction                        *
create                                                  pods/exec                            *
create                                                  pods/portforward                     *
patch                                                   replicationcontrollers/scale         *
*                                                       resourcequotas                       *
*                                                       secrets                              case-management-creds
*                                                       secrets                              pull-secret
create                                                  serviceaccounts                      *
delete                                                  serviceaccounts                      *
*                                                       services                             *
delete            apiextensions.k8s.io                  customresourcedefinitions            *
patch             apps                                  deployments/scale                    *
patch             apps                                  replicasets/scale                    *
patch             apps                                  statefulsets/scale                   *
patch             apps.openshift.io                     deploymentconfigs/scale              *
patch             batch                                 cronjobs                             *
create            batch                                 jobs                                 *
delete            batch                                 jobs                                 *
deletecollection  batch                                 jobs                                 *
delete            build.openshift.io                    builds                               *
deletecollection  build.openshift.io                    builds                               *
update            certificates.k8s.io                   certificatesigningrequests/approval  *
patch             config.openshift.io                   clusterversions                      *
*                 config.openshift.io                   projects                             *
delete            hiveinternal.openshift.io             clustersyncs                         *
patch             hive.openshift.io                     clusterdeployments                   *
patch             hive.openshift.io                     machinepools                         *
*                 logging.openshift.io                  *                                    *
patch             machineconfiguration.openshift.io     machineconfigpools                   *
patch             machine.openshift.io                  machinehealthchecks                  *
*                 machine.openshift.io                  machines                             *
patch             machine.openshift.io                  machinesets/scale                    *
patch             monitoring.coreos.com                 prometheuses                         *
*                 operators.coreos.com                  catalogsources                       *
*                 operators.coreos.com                  clusterserviceversions               *
*                 operators.coreos.com                  installplans                         *
*                 operators.coreos.com                  operatorgroups                       *
*                 operators.coreos.com                  subscriptions                        *
*                 project.openshift.io                  projectrequests                      *
*                 project.openshift.io                  projects                             *
patch             storage.k8s.io                        storageclasses                       *
delete            upgrade.managed.openshift.io          upgradeconfigs                       *
patch             user.openshift.io                     groups                               *
update            user.openshift.io                     groups                               *
deletecollection  user.openshift.io                     identities                           *
delete            user.openshift.io                     identities                           *
deletecollection  user.openshift.io                     users                                *
delete            user.openshift.io                     users                                *
create            velero.io                             backups                              *
*                 velero.io                             deletebackuprequests                 *
*                 velero.io                             downloadrequests                     *
*                 velero.io                             serverstatusrequests                 *

```

This list is based on `oc` commands found in ops-sop and the most common 403s found in audit logs.