### PR TITLE
Give dedicated-admins ability to create CMs in openshift-user-workload-monitoring

### DIFF
--- a/deploy/osd-user-workload-monitoring/02-dedicated-admins-uwm-cm-role.Role.yaml
+++ b/deploy/osd-user-workload-monitoring/02-dedicated-admins-uwm-cm-role.Role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-user-workload-monitoring-create-cm
+  namespace: openshift-user-workload-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - '*'

--- a/deploy/osd-user-workload-monitoring/03-dedicated-admins-uwm-cm-rolebinding.RoleBinding.yaml
+++ b/deploy/osd-user-workload-monitoring/03-dedicated-admins-uwm-cm-rolebinding.RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-uwm-config-create
+  namespace: openshift-user-workload-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-user-workload-monitoring-create-cm

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7561,6 +7561,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: user-workload-monitoring-config-edit
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-user-workload-monitoring-create-cm
+        namespace: openshift-user-workload-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-uwm-config-create
+        namespace: openshift-user-workload-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-user-workload-monitoring-create-cm
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7561,6 +7561,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: user-workload-monitoring-config-edit
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-user-workload-monitoring-create-cm
+        namespace: openshift-user-workload-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-uwm-config-create
+        namespace: openshift-user-workload-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-user-workload-monitoring-create-cm
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7561,6 +7561,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: user-workload-monitoring-config-edit
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-user-workload-monitoring-create-cm
+        namespace: openshift-user-workload-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-uwm-config-create
+        namespace: openshift-user-workload-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-user-workload-monitoring-create-cm
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Dedicated admins need to be able to create the `user-workload-monitoring-config` configmap as its not created by default. However, the `user-workload-monitoring-config-edit` role does not provide sufficient permission. This PR enables dedicated-admin to create the CM in the meantime while I attempt to get it fixed upstream. 