### PR TITLE
Enable production to send metrics to new observatorium tenant

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
+    # If the location of this config changes,
+    # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md
+    # so that killswitch instructions point to the right file!
       remoteWrite:
         - url: http://token-refresher.openshift-monitoring.svc.cluster.local
           writeRelabelConfigs:

--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -6,6 +6,12 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
+      remoteWrite:
+        - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+          writeRelabelConfigs:
+            - action: keep
+              sourceLabels: [__name__]
+              regex: '(cluster_admin_enabled|identity_provider)'
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations: 

--- a/deploy/osd-token-refresher/config.yaml
+++ b/deploy/osd-token-refresher/config.yaml
@@ -1,7 +1,0 @@
-deploymentMode: "SelectorSyncSet"
-selectorSyncSet:
-  matchExpressions:
-    - key: api.openshift.com/environment
-      operator: NotIn
-      values:
-      - "production"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2252,8 +2252,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2300,8 +2303,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2348,8 +2354,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -7436,11 +7445,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/environment
-        operator: NotIn
-        values:
-        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: apps/v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2252,7 +2252,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
@@ -2303,7 +2306,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
@@ -2354,7 +2360,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2252,8 +2252,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2300,8 +2303,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2348,8 +2354,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -7436,11 +7445,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/environment
-        operator: NotIn
-        values:
-        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: apps/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2252,7 +2252,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
@@ -2303,7 +2306,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
@@ -2354,7 +2360,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2252,8 +2252,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2300,8 +2303,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -2348,8 +2354,11 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations: \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
+          \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
+          \ \n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -7436,11 +7445,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/environment
-        operator: NotIn
-        values:
-        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: apps/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2252,7 +2252,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
@@ -2303,7 +2306,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\
@@ -2354,7 +2360,10 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  remoteWrite:\n    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      writeRelabelConfigs:\n        - action: keep\n          sourceLabels:\
           \ [__name__]\n          regex: '(cluster_admin_enabled|identity_provider)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\


### PR DESCRIPTION
The new observatorium tenant is ready and we want to start sending metrics.

This PR enabled remote_write in production and removes the limitation on the token-refresher deployment