### PR TITLE
Added annotation to force recreation of token-refresher pods

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -15,6 +15,8 @@ spec:
       app.kubernetes.io/name: token-refresher
   template:
     metadata:
+      annotations:
+        last-updated: "2021-19-02"
       labels:
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/name: token-refresher

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7455,6 +7455,8 @@ objects:
             app.kubernetes.io/name: token-refresher
         template:
           metadata:
+            annotations:
+              last-updated: '2021-19-02'
             labels:
               app.kubernetes.io/component: authentication-proxy
               app.kubernetes.io/name: token-refresher

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7455,6 +7455,8 @@ objects:
             app.kubernetes.io/name: token-refresher
         template:
           metadata:
+            annotations:
+              last-updated: '2021-19-02'
             labels:
               app.kubernetes.io/component: authentication-proxy
               app.kubernetes.io/name: token-refresher

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7455,6 +7455,8 @@ objects:
             app.kubernetes.io/name: token-refresher
         template:
           metadata:
+            annotations:
+              last-updated: '2021-19-02'
             labels:
               app.kubernetes.io/component: authentication-proxy
               app.kubernetes.io/name: token-refresher


### PR DESCRIPTION
Since the `token-refresher` pods use values from a secret which is pushed through app-interface the pods themselves do not get recreated when the secret values are updated. The only way to force the pods to use the new values is to recreate the pods and adding this annotation will force that.