### PR TITLE
Cluster role to give permissions required for CEE to run must-gather

### DIFF
--- a/deploy/backplane/cee/20-cee-mustgather.Role.yml
+++ b/deploy/backplane/cee/20-cee-mustgather.Role.yml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-cee-mustgather
+  namespace: openshift-must-gather-operator
+rules:
+# can create cred secret for mustgathers
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create 
+# can create mustgathers CR
+- apiGroups:
+  - managed.openshift.io
+  resources:
+  - mustgathers
+  verbs:
+  - create 
+### END

--- a/deploy/backplane/cee/30-cee-mustgather.RoleBinding.yml
+++ b/deploy/backplane/cee/30-cee-mustgather.RoleBinding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-cee-mustgather
+  namespace: openshift-must-gather-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-cee
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-cee-mustgather
+  namespace: openshift-must-gather-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -664,6 +664,38 @@ objects:
         name: backplane-cee-readers-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-cee
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         name: backplane-cee-readers

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -664,6 +664,38 @@ objects:
         name: backplane-cee-readers-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-cee
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         name: backplane-cee-readers

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -664,6 +664,38 @@ objects:
         name: backplane-cee-readers-cluster
       rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-cee
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-cee-mustgather
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         name: backplane-cee-readers


### PR DESCRIPTION
This change adds the following to CEE RBAC for backplane to allow execution of must-gather

- Added "cee-mustgather" cluster role
- Added subject permission to apply cee-mustgather role only in openshift-must-gather-operator namespace
 - rules create secrets in apiGroup ""
 - rules create mustgathers in apiGroup "managed.openshift.io"