### PR TITLE
Add bind and escalate clusterroles permissions to osd-sre-admins group

### DIFF
--- a/deploy/sre-authorization/03-osd-sre-admin.ClusterRole.yaml
+++ b/deploy/sre-authorization/03-osd-sre-admin.ClusterRole.yaml
@@ -159,3 +159,19 @@ rules:
   - serverstatusrequests
   verbs:
   - '*'
+# SRE can temporarily elevate to cluster-admin by patching osd-sre-cluster-admins clusterrolebinding
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+  - escalate
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  resourceNames:
+  - osd-sre-cluster-admins
+  verbs:
+  - patch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8828,6 +8828,21 @@ objects:
         - serverstatusrequests
         verbs:
         - '*'
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        verbs:
+        - bind
+        - escalate
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        resourceNames:
+        - osd-sre-cluster-admins
+        verbs:
+        - patch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8828,6 +8828,21 @@ objects:
         - serverstatusrequests
         verbs:
         - '*'
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        verbs:
+        - bind
+        - escalate
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        resourceNames:
+        - osd-sre-cluster-admins
+        verbs:
+        - patch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8828,6 +8828,21 @@ objects:
         - serverstatusrequests
         verbs:
         - '*'
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        verbs:
+        - bind
+        - escalate
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        resourceNames:
+        - osd-sre-cluster-admins
+        verbs:
+        - patch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
Permits SRE to temporarily elevate by patching the osd-sre-cluster-admins clusterrolebinding rather than the group

Required for x509 auth ([ssh](https://github.com/openshift/sre-ssh-proxy-container/blob/cf2e6bc72d475ebd594355768dd96a46e23a227e/README.md#elevation), backplane long-term) where group membership is defined in the certificate and cannot be changed


