### PR TITLE
Remove remote write for 4.5 OSD clusters

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/cluster-monitoring-config.yaml
@@ -6,16 +6,6 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
-    # If the location of this config changes,
-    # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md
-    # so that killswitch instructions point to the right file!
-      remoteWrite:
-        - url: http://token-refresher.openshift-monitoring.svc.cluster.local
-          max_samples_per_send: 100
-          writeRelabelConfigs:
-            - action: keep
-              sourceLabels: [__name__]
-              regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2312,15 +2312,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
-          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
-          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
-          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
-          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
-          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
-          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -2366,15 +2360,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
-          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
-          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
-          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
-          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
-          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
-          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2312,15 +2312,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
-          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
-          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
-          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
-          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
-          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
-          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -2366,15 +2360,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
-          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
-          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
-          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
-          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
-          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
-          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2312,15 +2312,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
-          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
-          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
-          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
-          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
-          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
-          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -2366,15 +2360,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
-          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
-          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
-          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
-          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
-          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
-          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\


### PR DESCRIPTION
This PR disables remote write for 4.5 OSD clusters. 4.5 clusters were alerting with "PrometheusRemoteWriteDesiredShards"

4.6 and above clusters have different configuration to below. 

Looking at the cluster-monitoring-config map the `max_samples_per_send` is not configuring prometheus as we attempted to change it to 150 with no effect.

Alert on cluster:

```
Prometheus openshift-monitoring/prometheus-k8s-0 remote write desired shards calculation wants to run 1100.098676111229 shards for queue 7c851a:http://token-refresher.openshift-monitoring.svc.cluster.local, which is more than the max of 1000.
```

4.5 prometheus config

```
  queue_config:
    capacity: 500
    max_shards: 1000
    min_shards: 1
    max_samples_per_send: 100
    batch_send_deadline: 5s
    min_backoff: 30ms
    max_backoff: 100ms
```

Disabling remote write on 4.5 and waiting for the monitoring team to investigate.

4.6 prometheus config - clusters are not alerting

```
  queue_config:
    capacity: 2500
    max_shards: 200
    min_shards: 1
    max_samples_per_send: 500
    batch_send_deadline: 5s
    min_backoff: 30ms
    max_backoff: 100ms
```