### PR TITLE
Enable remote writes for non-UWM clusters with correct queue config

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/cluster-monitoring-config.yaml
@@ -6,6 +6,17 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
+    # If the location of this config changes,
+    # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md
+    # so that killswitch instructions point to the right file!
+      remoteWrite:
+        - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+          queueConfig:
+            maxSamplesPerSend: 500
+          writeRelabelConfigs:
+            - action: keep
+              sourceLabels: [__name__]
+              regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:

--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -12,7 +12,8 @@ data:
     # so that killswitch instructions point to the right file!
       remoteWrite:
         - url: http://token-refresher.openshift-monitoring.svc.cluster.local
-          max_samples_per_send: 100
+          queueConfig:
+            maxSamplesPerSend: 500
           writeRelabelConfigs:
             - action: keep
               sourceLabels: [__name__]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2260,8 +2260,9 @@ objects:
           \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
           \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
           \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
@@ -2312,9 +2313,16 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -2360,9 +2368,16 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2260,8 +2260,9 @@ objects:
           \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
           \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
           \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
@@ -2312,9 +2313,16 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -2360,9 +2368,16 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2260,8 +2260,9 @@ objects:
           \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \      max_samples_per_send: 100\n      writeRelabelConfigs:\n        -\
-          \ action: keep\n          sourceLabels: [__name__]\n          regex: '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
           \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
           \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
@@ -2312,9 +2313,16 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -2360,9 +2368,16 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
+        config.yaml: "prometheusK8s:\n# If the location of this config changes,\n\
+          # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      queueConfig:\n        maxSamplesPerSend: 500\n      writeRelabelConfigs:\n\
+          \        - action: keep\n          sourceLabels: [__name__]\n          regex:\
+          \ '(cluster_admin_enabled|identity_provider|kube_node_info|kube_node_created|kube_node_role)'\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n\
           \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\


### PR DESCRIPTION
The `maxSamplesPerSend` configuration item was not set correctly. So it's value was not applied. Also for cluster versions <= 4.5 the default value was 100 and this was not high enough. Newer versions of prometheus have a default value of 500 and this is now the value we will use.