### PR TITLE
OSD-6549 hive specific operations on backplane

### DIFF
--- a/deploy/backplane/srep/hive/10-srep-hive-project.ClusterRole.yml
+++ b/deploy/backplane/srep/hive/10-srep-hive-project.ClusterRole.yml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-srep-hive-project
+rules:
+# SRE can patch clusterdeployments (usually pause syncset)
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - patch
+# SRE can force re-sync a cluster
+- apiGroups:
+  - hiveinternal.openshift.io
+  resources:
+  - clustersyncs
+  verbs:
+  - delete

--- a/deploy/backplane/srep/hive/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hive/20-srep.SubjectPermission.yml
@@ -1,0 +1,12 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-srep-hive
+  namespace: openshift-rbac-permissions
+spec:
+  permissions:
+  - allowFirst: true
+    clusterRoleName: backplane-srep-hive-project
+    namespacesAllowedRegex: "(^uhc-.*)"
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/deploy/backplane/srep/hive/config.yaml
+++ b/deploy/backplane/srep/hive/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-managed.openshift.io/hive-shard
+    operator: In
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1961,6 +1961,54 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-hive
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-hive-project
+      rules:
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - patch
+      - apiGroups:
+        - hiveinternal.openshift.io
+        resources:
+        - clustersyncs
+        verbs:
+        - delete
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-hive
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-hive-project
+          namespacesAllowedRegex: (^uhc-.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1883589-kubeapiserver-revert
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1961,6 +1961,54 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-hive
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-hive-project
+      rules:
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - patch
+      - apiGroups:
+        - hiveinternal.openshift.io
+        resources:
+        - clustersyncs
+        verbs:
+        - delete
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-hive
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-hive-project
+          namespacesAllowedRegex: (^uhc-.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1883589-kubeapiserver-revert
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1961,6 +1961,54 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-hive
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-hive-project
+      rules:
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - patch
+      - apiGroups:
+        - hiveinternal.openshift.io
+        resources:
+        - clustersyncs
+        verbs:
+        - delete
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-hive
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-hive-project
+          namespacesAllowedRegex: (^uhc-.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1883589-kubeapiserver-revert
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Add permissions for backplane on hive clusters.

WIP:
- Need to rebase after https://github.com/openshift/managed-cluster-config/pull/697/ merged.
