### PR TITLE
Remove last-updated annotation from token-refresher

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -15,8 +15,6 @@ spec:
       app.kubernetes.io/name: token-refresher
   template:
     metadata:
-      annotations:
-        last-updated: "2021-19-02"
       labels:
         app.kubernetes.io/component: authentication-proxy
         app.kubernetes.io/name: token-refresher

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7534,8 +7534,6 @@ objects:
             app.kubernetes.io/name: token-refresher
         template:
           metadata:
-            annotations:
-              last-updated: '2021-19-02'
             labels:
               app.kubernetes.io/component: authentication-proxy
               app.kubernetes.io/name: token-refresher

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7534,8 +7534,6 @@ objects:
             app.kubernetes.io/name: token-refresher
         template:
           metadata:
-            annotations:
-              last-updated: '2021-19-02'
             labels:
               app.kubernetes.io/component: authentication-proxy
               app.kubernetes.io/name: token-refresher

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7534,8 +7534,6 @@ objects:
             app.kubernetes.io/name: token-refresher
         template:
           metadata:
-            annotations:
-              last-updated: '2021-19-02'
             labels:
               app.kubernetes.io/component: authentication-proxy
               app.kubernetes.io/name: token-refresher


### PR DESCRIPTION
Removed the `last-updated` annotation which was added in #707 to force the pods to be recreated and update the secret value. This is not required anymore and can be removed. It's also causing [failures in osde2e](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-stage-aws-addon-ocs-converged/1366176564076613632) CI tests.