### PR TITLE
Unbreak backplane-srep clusterrole

### DIFF
--- a/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
@@ -167,6 +167,8 @@ rules:
   - upgrade.managed.openshift.io
   resources:
   - upgradeconfigs
+  verbs:
+  - delete
 # SRE can delete csv, installplans, and subscriptions
 - apiGroups:
   - operators.coreos.com

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1909,6 +1909,8 @@ objects:
         - upgrade.managed.openshift.io
         resources:
         - upgradeconfigs
+        verbs:
+        - delete
       - apiGroups:
         - operators.coreos.com
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1909,6 +1909,8 @@ objects:
         - upgrade.managed.openshift.io
         resources:
         - upgradeconfigs
+        verbs:
+        - delete
       - apiGroups:
         - operators.coreos.com
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1909,6 +1909,8 @@ objects:
         - upgrade.managed.openshift.io
         resources:
         - upgradeconfigs
+        verbs:
+        - delete
       - apiGroups:
         - operators.coreos.com
         resources:


### PR DESCRIPTION
I accidentally introduced rule without a verb in https://github.com/openshift/managed-cluster-config/pull/697