### PR TITLE
Add impersonation perms for elevation

### DIFF
--- a/deploy/backplane/elevated-sre/00-cluster-admin.namespace.yml
+++ b/deploy/backplane/elevated-sre/00-cluster-admin.namespace.yml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-backplane-cluster-admin

--- a/deploy/backplane/elevated-sre/00-impersonate-cluster-admin.ClusterRole.yml
+++ b/deploy/backplane/elevated-sre/00-impersonate-cluster-admin.ClusterRole.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-impersonate-cluster-admin
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - users
+    verbs:
+      - impersonate
+    resourceNames:
+      - backplane-cluster-admin

--- a/deploy/backplane/elevated-sre/10-impersonate-cluster-admin.ClusterRoleBinding.yml
+++ b/deploy/backplane/elevated-sre/10-impersonate-cluster-admin.ClusterRoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backplane-impersonate-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backplane-impersonate-cluster-admin
+subjects:
+- kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep
+- kind: Group
+  name: system:serviceaccounts:openshift-backplane-cssre

--- a/deploy/backplane/elevated-sre/20-cluster-admin.User.yml
+++ b/deploy/backplane/elevated-sre/20-cluster-admin.User.yml
@@ -1,0 +1,4 @@
+apiVersion: user.openshift.io/v1
+kind: User
+metadata:
+  name: backplane-cluster-admin

--- a/deploy/backplane/elevated-sre/30-cluster-admin.ClusterRoleBinding.yml
+++ b/deploy/backplane/elevated-sre/30-cluster-admin.ClusterRoleBinding.yml
@@ -7,5 +7,5 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: Group
-  name: system:serviceaccounts:openshift-backplane-cluster-admin
+- kind: User
+  name: backplane-cluster-admin

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1618,10 +1618,36 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: v1
-      kind: Namespace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
       metadata:
-        name: openshift-backplane-cluster-admin
+        name: backplane-impersonate-cluster-admin
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - users
+        verbs:
+        - impersonate
+        resourceNames:
+        - backplane-cluster-admin
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-impersonate-cluster-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-impersonate-cluster-admin
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-cssre
+    - apiVersion: user.openshift.io/v1
+      kind: User
+      metadata:
+        name: backplane-cluster-admin
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -1631,8 +1657,8 @@ objects:
         kind: ClusterRole
         name: cluster-admin
       subjects:
-      - kind: Group
-        name: system:serviceaccounts:openshift-backplane-cluster-admin
+      - kind: User
+        name: backplane-cluster-admin
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1618,10 +1618,36 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: v1
-      kind: Namespace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
       metadata:
-        name: openshift-backplane-cluster-admin
+        name: backplane-impersonate-cluster-admin
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - users
+        verbs:
+        - impersonate
+        resourceNames:
+        - backplane-cluster-admin
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-impersonate-cluster-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-impersonate-cluster-admin
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-cssre
+    - apiVersion: user.openshift.io/v1
+      kind: User
+      metadata:
+        name: backplane-cluster-admin
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -1631,8 +1657,8 @@ objects:
         kind: ClusterRole
         name: cluster-admin
       subjects:
-      - kind: Group
-        name: system:serviceaccounts:openshift-backplane-cluster-admin
+      - kind: User
+        name: backplane-cluster-admin
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1618,10 +1618,36 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: v1
-      kind: Namespace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
       metadata:
-        name: openshift-backplane-cluster-admin
+        name: backplane-impersonate-cluster-admin
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - users
+        verbs:
+        - impersonate
+        resourceNames:
+        - backplane-cluster-admin
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-impersonate-cluster-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-impersonate-cluster-admin
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-cssre
+    - apiVersion: user.openshift.io/v1
+      kind: User
+      metadata:
+        name: backplane-cluster-admin
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -1631,8 +1657,8 @@ objects:
         kind: ClusterRole
         name: cluster-admin
       subjects:
-      - kind: Group
-        name: system:serviceaccounts:openshift-backplane-cluster-admin
+      - kind: User
+        name: backplane-cluster-admin
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSD-6373
Perms to allow in cluster elevation through backplane. This should allow SRE and CSSRE to do:

`oc <not-allowed-command> --as backplane-cluster-admin`

to elevate perms.