### PR TITLE
OSD-6102 Extend HAProxyReload timeout to reduce noise

### DIFF
--- a/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
+++ b/deploy/sre-prometheus/100-haproxy-reload-fails.Prometheusrule.yaml
@@ -23,9 +23,9 @@ spec:
     rules:
     - alert: HAProxyReloadFailSRE
       expr: increase(template_router_reload_fails[5m]) > 0
-      for: 12m
+      for: 15m
       labels:
-        severity: critical
+        severity: warning
         namespace: "{{ $labels.namespace }}"
       annotations:
         message: "HAProxy reloads have failed on {{ $labels.pod }}. Router is not respecting recently created or modified routes"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9524,9 +9524,9 @@ objects:
           rules:
           - alert: HAProxyReloadFailSRE
             expr: increase(template_router_reload_fails[5m]) > 0
-            for: 12m
+            for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: '{{ $labels.namespace }}'
             annotations:
               message: HAProxy reloads have failed on {{ $labels.pod }}. Router is

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9524,9 +9524,9 @@ objects:
           rules:
           - alert: HAProxyReloadFailSRE
             expr: increase(template_router_reload_fails[5m]) > 0
-            for: 12m
+            for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: '{{ $labels.namespace }}'
             annotations:
               message: HAProxy reloads have failed on {{ $labels.pod }}. Router is

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9524,9 +9524,9 @@ objects:
           rules:
           - alert: HAProxyReloadFailSRE
             expr: increase(template_router_reload_fails[5m]) > 0
-            for: 12m
+            for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: '{{ $labels.namespace }}'
             annotations:
               message: HAProxy reloads have failed on {{ $labels.pod }}. Router is


### PR DESCRIPTION
This PR extends the threshold for the HAProxyReloadFailSRE alert from 12m to 15m.

A previous PR (#688) extended from 10 to 12, however this may have been too conservative, as some subsequent self-resolving alerts have done so just briefly after 12 minutes have elapsed. By bumping this to 15 minutes we stand a better chance of filtering out unactionable and self-resolving alert noise.

Due to bug BZ1892338 this alert is more than likely a no-op as it is can fire prematurely. It has also been dropped to a severity level of `warning` ([link](https://github.com/openshift/cluster-ingress-operator/blob/5f5112d17daee041a30343319fe8b1855979878d/manifests/0000_90_ingress-operator_03_prometheusrules.yaml#L20)). This severity change has also been reflected in the temporary SRE port with this PR.

Once all clusters are on 4.6.18 or above, this alert can be removed altogether and the original product rule retained.

SOP: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyReloadFailSRE.md