### PR TITLE
OSD-6387: osd-cluster-ready: Actually bump backoffLimit

### DIFF
--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -4,15 +4,15 @@ metadata:
     name: osd-cluster-ready
     namespace: openshift-monitoring
 spec:
+    # NOTE: We're making this ridiculously high to ensure that
+    # we exceed MAX_CLUSTER_AGE_MINUTES even in the fastest
+    # case. We rely on the logic in the job to exit cleanly when
+    # that max age is reached.
+    backoffLimit: 500
     template:
         metadata:
             name: osd-cluster-ready
         spec:
-            # NOTE: We're making this ridiculously high to ensure that
-            # we exceed MAX_CLUSTER_AGE_MINUTES even in the fastest
-            # case. We rely on the logic in the job to exit cleanly when
-            # that max age is reached.
-            backoffLimit: 500
             containers:
             # TODO: Remove this override once
             # https://bugzilla.redhat.com/show_bug.cgi?id=1921413

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4954,11 +4954,11 @@ objects:
         name: osd-cluster-ready
         namespace: openshift-monitoring
       spec:
+        backoffLimit: 500
         template:
           metadata:
             name: osd-cluster-ready
           spec:
-            backoffLimit: 500
             containers:
             - env:
               - name: MAX_CLUSTER_AGE_MINUTES

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4954,11 +4954,11 @@ objects:
         name: osd-cluster-ready
         namespace: openshift-monitoring
       spec:
+        backoffLimit: 500
         template:
           metadata:
             name: osd-cluster-ready
           spec:
-            backoffLimit: 500
             containers:
             - env:
               - name: MAX_CLUSTER_AGE_MINUTES

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4954,11 +4954,11 @@ objects:
         name: osd-cluster-ready
         namespace: openshift-monitoring
       spec:
+        backoffLimit: 500
         template:
           metadata:
             name: osd-cluster-ready
           spec:
-            backoffLimit: 500
             containers:
             - env:
               - name: MAX_CLUSTER_AGE_MINUTES


### PR DESCRIPTION
In PR #681 we mistakenly put the `backoffLimit` in the Pod spec instead of the Job spec, so it had no effect. Fix.

[OSD-6387](https://issues.redhat.com/browse/OSD-6387)