### PR TITLE
osd-cluster-ready: Bump version

### DIFF
--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -21,7 +21,7 @@ spec:
               - name: MAX_CLUSTER_AGE_MINUTES
                 value: "240"
               name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.38-614bf59
+              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.44-6712aec
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4989,7 +4989,7 @@ objects:
               - name: MAX_CLUSTER_AGE_MINUTES
                 value: '240'
               name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.38-614bf59
+              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.44-6712aec
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4989,7 +4989,7 @@ objects:
               - name: MAX_CLUSTER_AGE_MINUTES
                 value: '240'
               name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.38-614bf59
+              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.44-6712aec
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4989,7 +4989,7 @@ objects:
               - name: MAX_CLUSTER_AGE_MINUTES
                 value: '240'
               name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.38-614bf59
+              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.44-6712aec
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
Update osd-cluster-ready image to pull in the following commits:

```
commit a2d26bfdbf0dfb567ebf995d3233ae96c92d6a1c
Author: Eric Fried <efried@redhat.com>
Date:   Fri Feb 19 16:33:08 2021 -0600

    Calculate maxHealthCheckDuration

    Calculate the maximum expected time it should take to run the full
    health check loop, and use both to initialize the silence and to extend
    it on any failure.

commit 9fe95105a8395c02bc6c184da97a2fff3464dfe9
Author: Eric Fried <efried@redhat.com>
Date:   Thu Feb 18 15:16:47 2021 -0600

    Minor refactoring

    - Do maxClusterAge check first.
    - Pull maxHealthCheckDurationMinutes into a variable for easier changing
    later when we want to calculate it.
    - Start cleaning up silence module to allow crisper public/private
    boundary. (More work to do here.)
    - Change module name from osd-cluster-ready-job to osd-cluster-ready
    (left over from iamkirbater origins).
    - Rename some things in the 'silence' module to be less stuttery.
    - Correct the README wrt extending silences (missed in #2).
    - Fix some comment typos. Add & flesh out other comments.

commit 78224683c44ce6135f4d3c4d7995716c92f4b654
Author: Eric Fried <efried@redhat.com>
Date:   Fri Feb 19 13:33:32 2021 -0600

    Update deployment target and script

    Tidy up Makefile variables. Tighten up and document the deploy.sh
    script. Add some features, including the ability to skip RBAC and to do
    dry runs.
```