### PR TITLE
Re-enable old elevatation

### DIFF
--- a/deploy/backplane/elevated-sre/00-cluster-admin.namespace.yml
+++ b/deploy/backplane/elevated-sre/00-cluster-admin.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane-cluster-admin

--- a/deploy/backplane/elevated-sre/30-cluster-admin.ClusterRoleBinding.yml
+++ b/deploy/backplane/elevated-sre/30-cluster-admin.ClusterRoleBinding.yml
@@ -9,3 +9,5 @@ roleRef:
 subjects:
 - kind: User
   name: backplane-cluster-admin
+- kind: Group
+  name: system:serviceaccounts:openshift-backplane-cluster-admin  

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1618,6 +1618,10 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-cluster-admin
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -1659,6 +1663,8 @@ objects:
       subjects:
       - kind: User
         name: backplane-cluster-admin
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-cluster-admin
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1618,6 +1618,10 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-cluster-admin
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -1659,6 +1663,8 @@ objects:
       subjects:
       - kind: User
         name: backplane-cluster-admin
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-cluster-admin
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1618,6 +1618,10 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-cluster-admin
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -1659,6 +1663,8 @@ objects:
       subjects:
       - kind: User
         name: backplane-cluster-admin
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-cluster-admin
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
We still have requirement that people need permanent cluster-admin without using the impersonation param. 