### PR TITLE
OSD-6746 Set clusterversion upstream in 4.7+ clusters

### DIFF
--- a/deploy/osd-upstream-update-patch/01-patch.clusterversion.yaml
+++ b/deploy/osd-upstream-update-patch/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"upstream":"https://api.openshift.com/api/upgrades_info/v1/graph"}}'
+patchType: merge

--- a/deploy/osd-upstream-update-patch/OWNERS
+++ b/deploy/osd-upstream-update-patch/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- dofinn
+- mrbarge
+- cblecker

--- a/deploy/osd-upstream-update-patch/README.md
+++ b/deploy/osd-upstream-update-patch/README.md
@@ -1,0 +1,18 @@
+https://issues.redhat.com/browse/OSD-6746
+
+# Overview
+
+This patch (re-)introduces the `upstream` field into the `clusterversion` CR.
+
+This field has been removed as a default setting in `clusterversion` in OCP 4.7, meaning that `managed-upgrade-operator` no longer has a source for retrieving the upstream URL. [0]
+
+The managed-upgrade-operator uses the upstream field in the cluster's clusterversion CR to validate that a valid edge exists in Cincinnati between the FROM and TO versions of the cluster's upgrade policy.
+
+The `managed-upgrade-operator` performs the Cincinnati validation as a failsafe check to ensure that an edge has not been pulled in the time between an upgrade policy being scheduled and the time that the upgrade commences. It cannot rely on the `clusterversion`'s `availableUpdates` information to perform this validation when performing a Y-Stream upgrade, as the edge will not appear in `availableUpdates` without the cluster being on the new Y-Stream channel.
+
+As an interim measure, the field is being explicitly set in OSD clusters. A Bugzilla has been raised to work through this issue long-term. [1]
+
+# References
+
+[0] https://github.com/openshift/installer/pull/4112
+[1] https://bugzilla.redhat.com/show_bug.cgi?id=1939755

--- a/deploy/osd-upstream-update-patch/config.yaml
+++ b/deploy/osd-upstream-update-patch/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.7","4.8","4.9"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8033,6 +8033,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-upstream-update-patch
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.7'
+        - '4.8'
+        - '4.9'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"upstream":"https://api.openshift.com/api/upgrades_info/v1/graph"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-user-workload-monitoring
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8033,6 +8033,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-upstream-update-patch
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.7'
+        - '4.8'
+        - '4.9'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"upstream":"https://api.openshift.com/api/upgrades_info/v1/graph"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-user-workload-monitoring
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8033,6 +8033,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-upstream-update-patch
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.7'
+        - '4.8'
+        - '4.9'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"upstream":"https://api.openshift.com/api/upgrades_info/v1/graph"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-user-workload-monitoring
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This patch (re-)introduces the `upstream` field into the `clusterversion` CR.

This field has been removed as a default setting in `clusterversion` in OCP 4.7, meaning that `managed-upgrade-operator` no longer has a source for retrieving the upstream URL. [0]

The managed-upgrade-operator uses the upstream field in the cluster's clusterversion CR to validate that a valid edge exists in Cincinnati between the FROM and TO versions of the cluster's upgrade policy.

The `managed-upgrade-operator` performs the Cincinnati validation as a failsafe check to ensure that an edge has not been pulled in the time between an upgrade policy being scheduled and the time that the upgrade commences. It cannot rely on the `clusterversion`'s `availableUpdates` information to perform this validation when performing a Y-Stream upgrade, as the edge will not appear in `availableUpdates` without the cluster being on the new Y-Stream channel.

As an interim measure, the field is being explicitly set in OSD clusters.[1]

Refs: [OSD-6746](https://issues.redhat.com/browse/OSD-6746)

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1939755