### PR TITLE
Fix apiversion of the scc. Removed dedicated admins from rolebinding.…

### DIFF
--- a/deploy/osd-pcap-collector/01-pcap-collector-scc.yaml
+++ b/deploy/osd-pcap-collector/01-pcap-collector-scc.yaml
@@ -1,5 +1,5 @@
 kind: SecurityContextConstraints
-apiVersion: v1
+apiVersion: security.openshift.io/v1
 metadata:
   name: pcap-collector
 allowPrivilegedContainer: true 

--- a/deploy/osd-pcap-collector/03-pcap-collector-ClusterRoleBind.yaml
+++ b/deploy/osd-pcap-collector/03-pcap-collector-ClusterRoleBind.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pcap-collector 
 subjects:
 - kind: Group
-  name: dedicated-admins
+  name: osd-sre-admins 
   apiGroup: rbac.authorization.k8s.io
 - kind: Group
   name: osd-devaccess


### PR DESCRIPTION
Fix apiversion of the scc. Removed dedicated admins from rolebinding Dedicated admins should not be able to perform node level pcaps