### PR TITLE
OSD-5713 Add MUO upgrade state metrics to MST

### DIFF
--- a/deploy/cluster-monitoring-config-observatoirum-enabled/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-observatoirum-enabled/cluster-monitoring-config.yaml
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(cluster_admin_enabled|identity_provider)'
+            regex: '(cluster_admin_enabled|identity_provider|upgradeoperator_upgrade_state_timestamp)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2653,7 +2653,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|upgradeoperator_upgrade_state_timestamp)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2653,7 +2653,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|upgradeoperator_upgrade_state_timestamp)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2653,7 +2653,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|upgradeoperator_upgrade_state_timestamp)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\


### PR DESCRIPTION
We currently have no insights into:

* how many clusters have scheduled upgrades
* average time a cluster is taking to complete a managed upgrade
* average time of state transitions within an upgrade

These metrics enable us to ascertain these findings from observatorium.

Example

```
  "__name__": "upgradeoperator_upgrade_state_timestamp",
  "endpoint": "metrics",
  "instance": "10.128.4.13:8089",
  "job": "managed-upgrade-operator-custom-metrics",
  "namespace": "openshift-managed-upgrade-operator",
  "pod": "managed-upgrade-operator-66859dd87b-tdw99",
  "prometheus": "openshift-monitoring/k8s",
  "receive": "true",
  "service": "managed-upgrade-operator-custom-metrics",
  "state": "scheduled",
  "tenant_id": "770c1124-6ae8-4324-a9d4-9ce08590094b",
  "version": "4.6.3"
}
```

The major moving parts of this metric are the state and version labels.
Both of these keys have a finate number of values to minimize
cardinately.

cc @jharrington22 @arjunrn @jeremyeder 