### PR TITLE
osd-cluster-ready: Remove MAX_CLUSTER_AGE_MINUTES

### DIFF
--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -4,23 +4,16 @@ metadata:
     name: osd-cluster-ready
     namespace: openshift-monitoring
 spec:
-    # NOTE: We're making this ridiculously high to ensure that
-    # we exceed MAX_CLUSTER_AGE_MINUTES even in the fastest
-    # case. We rely on the logic in the job to exit cleanly when
-    # that max age is reached.
+    # NOTE: We're making this ridiculously high to ensure that the
+    # actual code gets a chance to run to completion. However, consumers
+    # should implement a sensible timeout rather than waiting forever.
     backoffLimit: 500
     template:
         metadata:
             name: osd-cluster-ready
         spec:
             containers:
-            # TODO: Remove this override once
-            # https://bugzilla.redhat.com/show_bug.cgi?id=1921413
-            # is resolved
-            - env:
-              - name: MAX_CLUSTER_AGE_MINUTES
-                value: "240"
-              name: osd-cluster-ready
+            - name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
               command: ["/root/main"]
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5193,10 +5193,7 @@ objects:
             name: osd-cluster-ready
           spec:
             containers:
-            - env:
-              - name: MAX_CLUSTER_AGE_MINUTES
-                value: '240'
-              name: osd-cluster-ready
+            - name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
               command:
               - /root/main

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5193,10 +5193,7 @@ objects:
             name: osd-cluster-ready
           spec:
             containers:
-            - env:
-              - name: MAX_CLUSTER_AGE_MINUTES
-                value: '240'
-              name: osd-cluster-ready
+            - name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
               command:
               - /root/main

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5193,10 +5193,7 @@ objects:
             name: osd-cluster-ready
           spec:
             containers:
-            - env:
-              - name: MAX_CLUSTER_AGE_MINUTES
-                value: '240'
-              name: osd-cluster-ready
+            - name: osd-cluster-ready
               image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
               command:
               - /root/main


### PR DESCRIPTION
This was missed in #760 when we bumped osd-cluster-ready to include https://github.com/openshift/osd-cluster-ready/pull/7, which removed max cluster age logic.

[OSD-6646](https://issues.redhat.com/browse/OSD-6646)