### PR TITLE
permissions for dedicated admins to launch pcaps

### DIFF
--- a/deploy/osd-pcap-collector/04-pcap-dedicated-admins-scc.yaml
+++ b/deploy/osd-pcap-collector/04-pcap-dedicated-admins-scc.yaml
@@ -1,0 +1,13 @@
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: pcap-dedicated-admins
+allowPrivilegedContainer: false
+allowHostNetwork: false
+allowedCapabilities:
+- 'NET_ADMIN'
+- 'NET_RAW'
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny

--- a/deploy/osd-pcap-collector/05-pcap-dedicated-admins-ClusterRole.yaml
+++ b/deploy/osd-pcap-collector/05-pcap-dedicated-admins-ClusterRole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pcap-dedicated-admins
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - "pcap-dedicated-admins"
+  verbs:
+  - use

--- a/deploy/osd-pcap-collector/06-pcap-dedicated-admins-ClusterRoleBind.yaml
+++ b/deploy/osd-pcap-collector/06-pcap-dedicated-admins-ClusterRoleBind.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pcap-dedicated-admins
+subjects:
+- kind: Group
+  name: dedicated-admins
+roleRef:
+  kind: ClusterRole
+  name: pcap-dedicated-admins
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7573,6 +7573,43 @@ objects:
         kind: ClusterRole
         name: pcap-collector
         apiGroup: rbac.authorization.k8s.io
+    - kind: SecurityContextConstraints
+      apiVersion: v1
+      metadata:
+        name: pcap-dedicated-admins
+      allowPrivilegedContainer: false
+      allowHostNetwork: false
+      allowedCapabilities:
+      - NET_ADMIN
+      - NET_RAW
+      runAsUser:
+        type: RunAsAny
+      seLinuxContext:
+        type: RunAsAny
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: pcap-dedicated-admins
+      rules:
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        resourceNames:
+        - pcap-dedicated-admins
+        verbs:
+        - use
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: pcap-dedicated-admins
+      subjects:
+      - kind: Group
+        name: dedicated-admins
+      roleRef:
+        kind: ClusterRole
+        name: pcap-dedicated-admins
+        apiGroup: rbac.authorization.k8s.io
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7573,6 +7573,43 @@ objects:
         kind: ClusterRole
         name: pcap-collector
         apiGroup: rbac.authorization.k8s.io
+    - kind: SecurityContextConstraints
+      apiVersion: v1
+      metadata:
+        name: pcap-dedicated-admins
+      allowPrivilegedContainer: false
+      allowHostNetwork: false
+      allowedCapabilities:
+      - NET_ADMIN
+      - NET_RAW
+      runAsUser:
+        type: RunAsAny
+      seLinuxContext:
+        type: RunAsAny
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: pcap-dedicated-admins
+      rules:
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        resourceNames:
+        - pcap-dedicated-admins
+        verbs:
+        - use
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: pcap-dedicated-admins
+      subjects:
+      - kind: Group
+        name: dedicated-admins
+      roleRef:
+        kind: ClusterRole
+        name: pcap-dedicated-admins
+        apiGroup: rbac.authorization.k8s.io
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7573,6 +7573,43 @@ objects:
         kind: ClusterRole
         name: pcap-collector
         apiGroup: rbac.authorization.k8s.io
+    - kind: SecurityContextConstraints
+      apiVersion: v1
+      metadata:
+        name: pcap-dedicated-admins
+      allowPrivilegedContainer: false
+      allowHostNetwork: false
+      allowedCapabilities:
+      - NET_ADMIN
+      - NET_RAW
+      runAsUser:
+        type: RunAsAny
+      seLinuxContext:
+        type: RunAsAny
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: pcap-dedicated-admins
+      rules:
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        resourceNames:
+        - pcap-dedicated-admins
+        verbs:
+        - use
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: pcap-dedicated-admins
+      subjects:
+      - kind: Group
+        name: dedicated-admins
+      roleRef:
+        kind: ClusterRole
+        name: pcap-dedicated-admins
+        apiGroup: rbac.authorization.k8s.io
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Added permissions for dedicated admins to launch pcaps at the POD interface in their own namespaces