### PR TITLE
Install file-integrity-operator into staging

### DIFF
--- a/deploy/osd-file-integrity-operator/00-fileIntegrityOperator-Namespace.yml
+++ b/deploy/osd-file-integrity-operator/00-fileIntegrityOperator-Namespace.yml
@@ -1,0 +1,7 @@
+# Openshift File Integrity Operator
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-file-integrity
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/deploy/osd-file-integrity-operator/10-fileIntegrityOperator-OperatorGroup.yml
+++ b/deploy/osd-file-integrity-operator/10-fileIntegrityOperator-OperatorGroup.yml
@@ -1,0 +1,9 @@
+# Openshift File Integrity Operator
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: file-integrity-operator
+  namespace: openshift-file-integrity
+spec:
+  targetNamespaces:
+  - openshift-file-integrity

--- a/deploy/osd-file-integrity-operator/20-fileIntegrityOperator-Subscription.yml
+++ b/deploy/osd-file-integrity-operator/20-fileIntegrityOperator-Subscription.yml
@@ -1,0 +1,12 @@
+# Openshift File Integrity Operator
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: "file-integrity-operator"
+  namespace: "openshift-file-integrity"
+spec:
+  channel: "4.6"
+  installPlanApproval: "Automatic"
+  source: "redhat-operators"
+  sourceNamespace: "openshift-marketplace"
+  name: "file-integrity-operator"

--- a/deploy/osd-file-integrity-operator/40-fileIntegrityOperator-ClusterMonitoring-Role.yml
+++ b/deploy/osd-file-integrity-operator/40-fileIntegrityOperator-ClusterMonitoring-Role.yml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cloud-ingress-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/osd-file-integrity-operator/40-fileIntegrityOperator-ClusterMonitoring-RoleBinding.yml
+++ b/deploy/osd-file-integrity-operator/40-fileIntegrityOperator-ClusterMonitoring-RoleBinding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-file-integrity
+roleRef:
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy/osd-file-integrity-operator/50-fileIntegrityOperator-FileIntegrity.yml
+++ b/deploy/osd-file-integrity-operator/50-fileIntegrityOperator-FileIntegrity.yml
@@ -1,0 +1,15 @@
+apiVersion: fileintegrity.openshift.io/v1alpha1
+kind: FileIntegrity
+metadata:
+  name: fileintegrity
+  namespace: openshift-file-integrity
+spec:
+  config:
+    gracePeriod: 900
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists

--- a/deploy/osd-file-integrity-operator/OWNERS
+++ b/deploy/osd-file-integrity-operator/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+- clcollins
+- treymer

--- a/deploy/osd-file-integrity-operator/config.yml
+++ b/deploy/osd-file-integrity-operator/config.yml
@@ -1,0 +1,11 @@
+# Openshift File Integrity Operator
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/environment
+    operator: In
+    values: ["staging"]
+  matchLabels:
+    # Only apply on clusters owned by (SREP)
+    api.openshift.com/legal-entity-id: "${{SREP_LEGAL_ENTITY_ID}}"
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6395,6 +6395,97 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-file-integrity-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-file-integrity
+        labels:
+          openshift.io/cluster-monitoring: 'true'
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: file-integrity-operator
+        namespace: openshift-file-integrity
+      spec:
+        targetNamespaces:
+        - openshift-file-integrity
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: file-integrity-operator
+        namespace: openshift-file-integrity
+      spec:
+        channel: '4.6'
+        installPlanApproval: Automatic
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+        name: file-integrity-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-cloud-ingress-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-file-integrity
+      roleRef:
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    - apiVersion: fileintegrity.openshift.io/v1alpha1
+      kind: FileIntegrity
+      metadata:
+        name: fileintegrity
+        namespace: openshift-file-integrity
+      spec:
+        config:
+          gracePeriod: 900
+        tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+    - deploymentMode: SelectorSyncSet
+      selectorSyncSet:
+        matchExpressions:
+        - key: api.openshift.com/environment
+          operator: In
+          values:
+          - staging
+        matchLabels:
+          api.openshift.com/legal-entity-id: ${{SREP_LEGAL_ENTITY_ID}}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-hsts-routes
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6395,6 +6395,97 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-file-integrity-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-file-integrity
+        labels:
+          openshift.io/cluster-monitoring: 'true'
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: file-integrity-operator
+        namespace: openshift-file-integrity
+      spec:
+        targetNamespaces:
+        - openshift-file-integrity
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: file-integrity-operator
+        namespace: openshift-file-integrity
+      spec:
+        channel: '4.6'
+        installPlanApproval: Automatic
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+        name: file-integrity-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-cloud-ingress-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-file-integrity
+      roleRef:
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    - apiVersion: fileintegrity.openshift.io/v1alpha1
+      kind: FileIntegrity
+      metadata:
+        name: fileintegrity
+        namespace: openshift-file-integrity
+      spec:
+        config:
+          gracePeriod: 900
+        tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+    - deploymentMode: SelectorSyncSet
+      selectorSyncSet:
+        matchExpressions:
+        - key: api.openshift.com/environment
+          operator: In
+          values:
+          - staging
+        matchLabels:
+          api.openshift.com/legal-entity-id: ${{SREP_LEGAL_ENTITY_ID}}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-hsts-routes
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6395,6 +6395,97 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-file-integrity-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-file-integrity
+        labels:
+          openshift.io/cluster-monitoring: 'true'
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: file-integrity-operator
+        namespace: openshift-file-integrity
+      spec:
+        targetNamespaces:
+        - openshift-file-integrity
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: file-integrity-operator
+        namespace: openshift-file-integrity
+      spec:
+        channel: '4.6'
+        installPlanApproval: Automatic
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+        name: file-integrity-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-cloud-ingress-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-k8s
+        namespace: openshift-file-integrity
+      roleRef:
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    - apiVersion: fileintegrity.openshift.io/v1alpha1
+      kind: FileIntegrity
+      metadata:
+        name: fileintegrity
+        namespace: openshift-file-integrity
+      spec:
+        config:
+          gracePeriod: 900
+        tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+    - deploymentMode: SelectorSyncSet
+      selectorSyncSet:
+        matchExpressions:
+        - key: api.openshift.com/environment
+          operator: In
+          values:
+          - staging
+        matchLabels:
+          api.openshift.com/legal-entity-id: ${{SREP_LEGAL_ENTITY_ID}}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-hsts-routes
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This commit adds the OpenShift file-integrity-operator to staging
clusters. Additionally adding:

  * Prometheus role and rolebindings for clustermonitoring
  * FileIntegrity object, to scan all nodes every 15 minutes for changes

This is preliminary to a full alerting deployment, so there are no
alerts or related notifications if a file integrity scan fails yet.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
