### PR TITLE
Fix deployment config for RMO

### DIFF
--- a/deploy/osd-route-monitor-operator/config.yaml
+++ b/deploy/osd-route-monitor-operator/config.yaml
@@ -1,3 +1,6 @@
-deploymentMode: "Direct"
-direct:
-  environments: ["integration", "stage", "production"]
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/environment
+    operator: NotIn
+    values: ["production"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7741,6 +7741,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: RouteMonitor
+      metadata:
+        name: console
+        namespace: openshift-route-monitor-operator
+      spec:
+        route:
+          name: console
+          namespace: openshift-console
+        slo:
+          targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-samesite-cookie
   spec:
     clusterDeploymentSelector:
@@ -11273,14 +11303,3 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
-- apiVersion: monitoring.openshift.io/v1alpha1
-  kind: RouteMonitor
-  metadata:
-    name: console
-    namespace: openshift-route-monitor-operator
-  spec:
-    route:
-      name: console
-      namespace: openshift-console
-    slo:
-      targetAvailabilityPercent: '99.5'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7741,6 +7741,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: RouteMonitor
+      metadata:
+        name: console
+        namespace: openshift-route-monitor-operator
+      spec:
+        route:
+          name: console
+          namespace: openshift-console
+        slo:
+          targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-samesite-cookie
   spec:
     clusterDeploymentSelector:
@@ -11273,14 +11303,3 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
-- apiVersion: monitoring.openshift.io/v1alpha1
-  kind: RouteMonitor
-  metadata:
-    name: console
-    namespace: openshift-route-monitor-operator
-  spec:
-    route:
-      name: console
-      namespace: openshift-console
-    slo:
-      targetAvailabilityPercent: '99.5'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7741,6 +7741,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: RouteMonitor
+      metadata:
+        name: console
+        namespace: openshift-route-monitor-operator
+      spec:
+        route:
+          name: console
+          namespace: openshift-console
+        slo:
+          targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-samesite-cookie
   spec:
     clusterDeploymentSelector:
@@ -11273,14 +11303,3 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
-- apiVersion: monitoring.openshift.io/v1alpha1
-  kind: RouteMonitor
-  metadata:
-    name: console
-    namespace: openshift-route-monitor-operator
-  spec:
-    route:
-      name: console
-      namespace: openshift-console
-    slo:
-      targetAvailabilityPercent: '99.5'


### PR DESCRIPTION
The deploymentMode here would have caused this to never be deployed. This changes it to be deployed to all non-production environments. This file can be removed completely to push this out to prod when ready.

FYI @NautiluX @georgettica @RiRa12621 