### PR TITLE
Fully qualify all velero resource exclusions

### DIFF
--- a/deploy/velero-configuration/110-velero.Schedules.yaml
+++ b/deploy/velero-configuration/110-velero.Schedules.yaml
@@ -9,18 +9,19 @@ spec:
     includedNamespaces:
     - '*'
     excludedResources:
-    - imagetags
-    - images
-    - templateinstances
-    - clusterserviceversions
-    - packagemanifests
-    - subscriptions
-    - servicebrokers
-    - servicebindings
-    - serviceclasses
-    - serviceinstances
-    - serviceplans
-    - operatorgroups
+    - imagetags.image.openshift.io
+    - images.image.openshift.io
+    - templateinstances.template.openshift.io
+    - clusterserviceversions.operators.coreos.com
+    - packagemanifests.packages.operators.coreos.com
+    - operatorgroups.operators.coreos.com
+    - subscriptions.operators.coreos.com
+    - servicebrokers.servicecatalog.k8s.io
+    - servicebindings.servicecatalog.k8s.io
+    - serviceclasses.servicecatalog.k8s.io
+    - serviceinstances.servicecatalog.k8s.io
+    - serviceplans.servicecatalog.k8s.io
+    - events.events.k8s.io
     - events
     ttl: 168h0m0s
 ---
@@ -35,18 +36,19 @@ spec:
     includedNamespaces:
     - '*'
     excludedResources:
-    - imagetags
-    - images
-    - templateinstances
-    - clusterserviceversions
-    - packagemanifests
-    - subscriptions
-    - servicebrokers
-    - servicebindings
-    - serviceclasses
-    - serviceinstances
-    - serviceplans
-    - operatorgroups
+    - imagetags.image.openshift.io
+    - images.image.openshift.io
+    - templateinstances.template.openshift.io
+    - clusterserviceversions.operators.coreos.com
+    - packagemanifests.packages.operators.coreos.com
+    - operatorgroups.operators.coreos.com
+    - subscriptions.operators.coreos.com
+    - servicebrokers.servicecatalog.k8s.io
+    - servicebindings.servicecatalog.k8s.io
+    - serviceclasses.servicecatalog.k8s.io
+    - serviceinstances.servicecatalog.k8s.io
+    - serviceplans.servicecatalog.k8s.io
+    - events.events.k8s.io
     - events
     snapshotVolumes: false
     ttl: 24h0m0s
@@ -62,17 +64,18 @@ spec:
     includedNamespaces:
     - '*'
     excludedResources:
-    - imagetags
-    - images
-    - templateinstances
-    - clusterserviceversions
-    - packagemanifests
-    - subscriptions
-    - servicebrokers
-    - servicebindings
-    - serviceclasses
-    - serviceinstances
-    - serviceplans
-    - operatorgroups
+    - imagetags.image.openshift.io
+    - images.image.openshift.io
+    - templateinstances.template.openshift.io
+    - clusterserviceversions.operators.coreos.com
+    - packagemanifests.packages.operators.coreos.com
+    - operatorgroups.operators.coreos.com
+    - subscriptions.operators.coreos.com
+    - servicebrokers.servicecatalog.k8s.io
+    - servicebindings.servicecatalog.k8s.io
+    - serviceclasses.servicecatalog.k8s.io
+    - serviceinstances.servicecatalog.k8s.io
+    - serviceplans.servicecatalog.k8s.io
+    - events.events.k8s.io
     - events
     ttl: 720h0m0s

--- a/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
+++ b/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
@@ -9,18 +9,19 @@ spec:
     includedNamespaces:
     - '*'
     excludedResources:
-    - imagetags
-    - images
-    - templateinstances
-    - clusterserviceversions
-    - packagemanifests
-    - subscriptions
-    - servicebrokers
-    - servicebindings
-    - serviceclasses
-    - serviceinstances
-    - serviceplans
-    - operatorgroups
+    - imagetags.image.openshift.io
+    - images.image.openshift.io
+    - templateinstances.template.openshift.io
+    - clusterserviceversions.operators.coreos.com
+    - packagemanifests.packages.operators.coreos.com
+    - operatorgroups.operators.coreos.com
+    - subscriptions.operators.coreos.com
+    - servicebrokers.servicecatalog.k8s.io
+    - servicebindings.servicecatalog.k8s.io
+    - serviceclasses.servicecatalog.k8s.io
+    - serviceinstances.servicecatalog.k8s.io
+    - serviceplans.servicecatalog.k8s.io
+    - events.events.k8s.io
     - events
     snapshotVolumes: false
     ttl: 0h25m0s

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11014,18 +11014,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
@@ -11039,18 +11040,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           snapshotVolumes: false
           ttl: 24h0m0s
@@ -11065,18 +11067,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           ttl: 720h0m0s
 - apiVersion: hive.openshift.io/v1
@@ -11119,18 +11122,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           snapshotVolumes: false
           ttl: 0h25m0s

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11014,18 +11014,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
@@ -11039,18 +11040,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           snapshotVolumes: false
           ttl: 24h0m0s
@@ -11065,18 +11067,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           ttl: 720h0m0s
 - apiVersion: hive.openshift.io/v1
@@ -11119,18 +11122,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           snapshotVolumes: false
           ttl: 0h25m0s

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11014,18 +11014,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           ttl: 168h0m0s
     - apiVersion: velero.io/v1
@@ -11039,18 +11040,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           snapshotVolumes: false
           ttl: 24h0m0s
@@ -11065,18 +11067,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           ttl: 720h0m0s
 - apiVersion: hive.openshift.io/v1
@@ -11119,18 +11122,19 @@ objects:
           includedNamespaces:
           - '*'
           excludedResources:
-          - imagetags
-          - images
-          - templateinstances
-          - clusterserviceversions
-          - packagemanifests
-          - subscriptions
-          - servicebrokers
-          - servicebindings
-          - serviceclasses
-          - serviceinstances
-          - serviceplans
-          - operatorgroups
+          - imagetags.image.openshift.io
+          - images.image.openshift.io
+          - templateinstances.template.openshift.io
+          - clusterserviceversions.operators.coreos.com
+          - packagemanifests.packages.operators.coreos.com
+          - operatorgroups.operators.coreos.com
+          - subscriptions.operators.coreos.com
+          - servicebrokers.servicecatalog.k8s.io
+          - servicebindings.servicecatalog.k8s.io
+          - serviceclasses.servicecatalog.k8s.io
+          - serviceinstances.servicecatalog.k8s.io
+          - serviceplans.servicecatalog.k8s.io
+          - events.events.k8s.io
           - events
           snapshotVolumes: false
           ttl: 0h25m0s


### PR DESCRIPTION
This ensures that the correct type of resource is excluded, as well as both API endpoints for the events objects.