### PR TITLE
docs(readme): make disclaimer on deploy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ You must specify a `deploymentMode` property in `config.yaml`.
 * `deploymentMode` (optional, default = `"SelectorSyncSet"`) - either "Direct" or "SelectorSyncSet".
 
 ## Direct Deployment
+> :warning: **In most of the cases, use a SelectorSyncSet Deployment**: Be very careful here!
 
 You must specify the `environments` where the resource is deployed.  There is no default set of environments.  It is a child of the top level `direct` property.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You must specify a `deploymentMode` property in `config.yaml`.
 * `deploymentMode` (optional, default = `"SelectorSyncSet"`) - either "Direct" or "SelectorSyncSet".
 
 ## Direct Deployment
-> :warning: **In most of the cases, use a SelectorSyncSet Deployment**: Be very careful here!
+> :warning: **Most cases don't require Direct Deployment** : use SelectorSyncSet instead
 
 You must specify the `environments` where the resource is deployed.  There is no default set of environments.  It is a child of the top level `direct` property.
 


### PR DESCRIPTION
I accidently used the `direct` as I didn't read the README to throughly, and this caused RMO not to be deployed correctly.

I hope we can discuss in this change how to make this onboarding less voodoo

cc @cblecker, as you helped me fix the issue and might have some insight on it

regarding #787 