### PR TITLE
Reinstall route-monitor-operator

### DIFF
--- a/deploy/sre-pruning/115-pruning-RMO-CSVs.Cronjob.yaml
+++ b/deploy/sre-pruning/115-pruning-RMO-CSVs.Cronjob.yaml
@@ -94,7 +94,7 @@ spec:
               COUNT_CSV=$(oc -n "$NAMESPACE" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator= -o name | wc -l) || true
               if [[ $COUNT_CSV -ge 2 ]]; then
                 oc -n "$NAMESPACE" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=
-                oc -n "$NAMESPACE" get installplan -o name | xargs oc delete
+                oc -n "$NAMESPACE" delete installplan --all --ignore-not-found
                 touch /tmp/sub.yaml
                 oc -n "$NAMESPACE" get subscription route-monitor-operator -o yaml > /tmp/sub.yaml
                 oc -n "$NAMESPACE" delete -f /tmp/sub.yaml

--- a/deploy/sre-pruning/115-pruning-RMO-CSVs.Cronjob.yaml
+++ b/deploy/sre-pruning/115-pruning-RMO-CSVs.Cronjob.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-route-monitor-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-route-monitor-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-route-monitor-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-route-monitor-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-route-monitor-operator
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-route-monitor-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/3 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-route-monitor-operator
+              COUNT_CSV=$(oc -n "$NAMESPACE" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator= -o name | wc -l) || true
+              if [[ $COUNT_CSV -ge 2 ]]; then
+                oc -n "$NAMESPACE" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=
+                oc -n "$NAMESPACE" get installplan -o name | xargs oc delete
+                touch /tmp/sub.yaml
+                oc -n "$NAMESPACE" get subscription route-monitor-operator -o yaml > /tmp/sub.yaml
+                oc -n "$NAMESPACE" delete -f /tmp/sub.yaml
+                oc -n "$NAMESPACE" apply -f /tmp/sub.yaml
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10942,6 +10942,104 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-route-monitor-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-route-monitor-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-route-monitor-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/3 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
+                    COUNT_CSV=$(oc -n \"$NAMESPACE\" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\
+                    \ -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
+                    \  oc -n \"$NAMESPACE\" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\n\
+                    \  oc -n \"$NAMESPACE\" get installplan -o name | xargs oc delete\n\
+                    \  touch /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" get subscription\
+                    \ route-monitor-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11031,7 +11031,7 @@ objects:
                     COUNT_CSV=$(oc -n \"$NAMESPACE\" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\
                     \ -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
                     \  oc -n \"$NAMESPACE\" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\n\
-                    \  oc -n \"$NAMESPACE\" get installplan -o name | xargs oc delete\n\
+                    \  oc -n \"$NAMESPACE\" delete installplan --all --ignore-not-found\n\
                     \  touch /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" get subscription\
                     \ route-monitor-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
                     \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10942,6 +10942,104 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-route-monitor-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-route-monitor-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-route-monitor-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/3 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
+                    COUNT_CSV=$(oc -n \"$NAMESPACE\" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\
+                    \ -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
+                    \  oc -n \"$NAMESPACE\" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\n\
+                    \  oc -n \"$NAMESPACE\" get installplan -o name | xargs oc delete\n\
+                    \  touch /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" get subscription\
+                    \ route-monitor-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11031,7 +11031,7 @@ objects:
                     COUNT_CSV=$(oc -n \"$NAMESPACE\" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\
                     \ -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
                     \  oc -n \"$NAMESPACE\" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\n\
-                    \  oc -n \"$NAMESPACE\" get installplan -o name | xargs oc delete\n\
+                    \  oc -n \"$NAMESPACE\" delete installplan --all --ignore-not-found\n\
                     \  touch /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" get subscription\
                     \ route-monitor-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
                     \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10942,6 +10942,104 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-route-monitor-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-route-monitor-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-route-monitor-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/3 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
+                    COUNT_CSV=$(oc -n \"$NAMESPACE\" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\
+                    \ -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
+                    \  oc -n \"$NAMESPACE\" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\n\
+                    \  oc -n \"$NAMESPACE\" get installplan -o name | xargs oc delete\n\
+                    \  touch /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" get subscription\
+                    \ route-monitor-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11031,7 +11031,7 @@ objects:
                     COUNT_CSV=$(oc -n \"$NAMESPACE\" get csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\
                     \ -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
                     \  oc -n \"$NAMESPACE\" delete csv -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\n\
-                    \  oc -n \"$NAMESPACE\" get installplan -o name | xargs oc delete\n\
+                    \  oc -n \"$NAMESPACE\" delete installplan --all --ignore-not-found\n\
                     \  touch /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" get subscription\
                     \ route-monitor-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
                     \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\


### PR DESCRIPTION
CSVs are getting wedged due to a [bad build](https://gitlab.cee.redhat.com/service/saas-route-monitor-operator-bundle/-/blob/staging/route-monitor-operator/0.1.276-8560aa0/route-monitor-operator.clusterserviceversion.yaml#L176).

Some seem to be recovering on their own, but not all.

This CronJob was created following https://github.com/openshift/ops-sop/blob/master/v4/knowledge_base/reinstall-operator.md
I tested it on a happy cluster (it correctly shorts out) and a sad one (it resolves the problem).

It *only* needs to go to staging.