### PR TITLE
OSD-7065: Pull osd-cluster-ready by digest

### DIFF
--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -11,14 +11,14 @@ spec:
     template:
         metadata:
             name: osd-cluster-ready
-            annotations:
+            labels:
                 # Keep this in sync with image
-                managed.openshift.io/imageTag: v0.1.45-c9f1f45
+                managed.openshift.io/version: v0.1.45-c9f1f45
         spec:
             containers:
             - name: osd-cluster-ready
-              # Keep the `managed.openshift.io/imageTag` annotation in
-              # sync with this
+              # Keep the `managed.openshift.io/version` label in sync
+              # with this
               image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
               command: ["/root/main"]
             restartPolicy: OnFailure

--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -11,10 +11,15 @@ spec:
     template:
         metadata:
             name: osd-cluster-ready
+            annotations:
+                # Keep this in sync with image
+                managed.openshift.io/imageTag: v0.1.45-c9f1f45
         spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
+              # Keep the `managed.openshift.io/imageTag` annotation in
+              # sync with this
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5196,10 +5196,12 @@ objects:
         template:
           metadata:
             name: osd-cluster-ready
+            labels:
+              managed.openshift.io/version: v0.1.45-c9f1f45
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5196,10 +5196,12 @@ objects:
         template:
           metadata:
             name: osd-cluster-ready
+            labels:
+              managed.openshift.io/version: v0.1.45-c9f1f45
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5196,10 +5196,12 @@ objects:
         template:
           metadata:
             name: osd-cluster-ready
+            labels:
+              managed.openshift.io/version: v0.1.45-c9f1f45
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready:v0.1.45-c9f1f45
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
NOTE: Until https://issues.redhat.com/browse/OSD-6276 is resolved, we're still building and pushing osd-cluster-ready container images manually, so we should solve the "disappearing digest" problem via "option 2" -- create a tag corresponding to the digest to make sure that digest persists. To go with this PR, I created [quay.io/openshift-sre/osd-cluster-ready:freeze-digest-eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2](https://quay.io/repository/openshift-sre/osd-cluster-ready?tag=freeze-digest-eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2&tab=tags)

[OSD-7065](https://issues.redhat.com/browse/OSD-7065)