### PR TITLE
Add MUO UpgradeConfig CR renaming job

### DIFF
--- a/deploy/sre-pruning/115-pruning-rename-MUO-CR.CronJob.yaml
+++ b/deploy/sre-pruning/115-pruning-rename-MUO-CR.CronJob.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-muo-cr-rename-sa
+  namespace: openshift-managed-upgrade-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-muo-cr-rename-role
+  namespace: openshift-managed-upgrade-operator
+rules:
+  - apiGroups:
+      - upgrade.managed.openshift.io
+    resources:
+      - upgradeconfigs
+    verbs:
+      - get
+      - list
+      - delete
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osd-muo-cr-rename-rb
+  namespace: openshift-managed-upgrade-operator
+roleRef:
+  kind: Role
+  name: osd-muo-cr-rename-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: osd-muo-cr-rename-sa
+  namespace: openshift-managed-upgrade-operator
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: osd-muo-cr-rename
+  namespace: openshift-managed-upgrade-operator
+spec:
+  failedJobsHistoryLimit: 1
+  ttlSecondsAfterFinished: 100
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: osd-muo-cr-rename-sa
+          containers:
+            - name: osd-muo-cr-rename
+              imagePullPolicy: Always
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              args:
+                - /bin/bash
+                - -euo pipefail -c
+                - |
+                  for uc in $(oc get upgradeconfig -n openshift-managed-upgrade-operator osd-upgrade-config -o name --ignore-not-found); do
+                     oc delete upgradeconfig -n openshift-managed-upgrade-operator --ignore-not-found=true managed-upgrade-config 
+                     oc get upgradeconfig -n openshift-managed-upgrade-operator osd-upgrade-config -o json | sed -e 's#osd-upgrade-config#managed-upgrade-config#' | oc apply -f - && oc delete upgradeconfig -n openshift-managed-upgrade-operator osd-upgrade-config
+                  done

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11702,6 +11702,71 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-muo-cr-rename-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-muo-cr-rename-role
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - upgrade.managed.openshift.io
+        resources:
+        - upgradeconfigs
+        verbs:
+        - get
+        - list
+        - delete
+        - create
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-muo-cr-rename-rb
+        namespace: openshift-managed-upgrade-operator
+      roleRef:
+        kind: Role
+        name: osd-muo-cr-rename-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: osd-muo-cr-rename-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-muo-cr-rename
+        namespace: openshift-managed-upgrade-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        ttlSecondsAfterFinished: 100
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                serviceAccountName: osd-muo-cr-rename-sa
+                containers:
+                - name: osd-muo-cr-rename
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -euo pipefail -c
+                  - "for uc in $(oc get upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config -o name --ignore-not-found); do\n   oc delete\
+                    \ upgradeconfig -n openshift-managed-upgrade-operator --ignore-not-found=true\
+                    \ managed-upgrade-config \n   oc get upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config -o json | sed -e 's#osd-upgrade-config#managed-upgrade-config#'\
+                    \ | oc apply -f - && oc delete upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config\ndone\n"
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11702,6 +11702,71 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-muo-cr-rename-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-muo-cr-rename-role
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - upgrade.managed.openshift.io
+        resources:
+        - upgradeconfigs
+        verbs:
+        - get
+        - list
+        - delete
+        - create
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-muo-cr-rename-rb
+        namespace: openshift-managed-upgrade-operator
+      roleRef:
+        kind: Role
+        name: osd-muo-cr-rename-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: osd-muo-cr-rename-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-muo-cr-rename
+        namespace: openshift-managed-upgrade-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        ttlSecondsAfterFinished: 100
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                serviceAccountName: osd-muo-cr-rename-sa
+                containers:
+                - name: osd-muo-cr-rename
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -euo pipefail -c
+                  - "for uc in $(oc get upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config -o name --ignore-not-found); do\n   oc delete\
+                    \ upgradeconfig -n openshift-managed-upgrade-operator --ignore-not-found=true\
+                    \ managed-upgrade-config \n   oc get upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config -o json | sed -e 's#osd-upgrade-config#managed-upgrade-config#'\
+                    \ | oc apply -f - && oc delete upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config\ndone\n"
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11702,6 +11702,71 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-muo-cr-rename-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-muo-cr-rename-role
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - upgrade.managed.openshift.io
+        resources:
+        - upgradeconfigs
+        verbs:
+        - get
+        - list
+        - delete
+        - create
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-muo-cr-rename-rb
+        namespace: openshift-managed-upgrade-operator
+      roleRef:
+        kind: Role
+        name: osd-muo-cr-rename-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: osd-muo-cr-rename-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-muo-cr-rename
+        namespace: openshift-managed-upgrade-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        ttlSecondsAfterFinished: 100
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                restartPolicy: Never
+                serviceAccountName: osd-muo-cr-rename-sa
+                containers:
+                - name: osd-muo-cr-rename
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -euo pipefail -c
+                  - "for uc in $(oc get upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config -o name --ignore-not-found); do\n   oc delete\
+                    \ upgradeconfig -n openshift-managed-upgrade-operator --ignore-not-found=true\
+                    \ managed-upgrade-config \n   oc get upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config -o json | sed -e 's#osd-upgrade-config#managed-upgrade-config#'\
+                    \ | oc apply -f - && oc delete upgradeconfig -n openshift-managed-upgrade-operator\
+                    \ osd-upgrade-config\ndone\n"
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:


### PR DESCRIPTION
This is a short-lived job intended to be coupled with [OSD-6918](https://issues.redhat.com/browse/OSD-6918) and the promotion of its [associated MUO PR](https://github.com/openshift/managed-upgrade-operator/pull/224) which involves renaming of the managed-upgrade-operator CR from `osd-upgrade-config` to `managed-upgrade-config`.

This job will recreate the existing `osd-upgrade-config` CR as `managed-upgrade-config` if it exists, and then delete the `osd-upgrade-config` CR. It will only perform this action on clusters where an `osd-upgrade-config` CR already exists.

This will fix the following potential issues which can stem from renaming the managed CR:
- Clusters which are mid-upgrading would not report a completed upgrade to OCM.
- Clusters which are not mid-upgrade but had an existing `osd-upgrade-config` present due to an automatic upgrade policy would have that resource orphaned.
