### PR TITLE
Don't back up oauth token objects

### DIFF
--- a/deploy/velero-configuration/110-velero.Schedules.yaml
+++ b/deploy/velero-configuration/110-velero.Schedules.yaml
@@ -11,6 +11,8 @@ spec:
     excludedResources:
     - imagetags.image.openshift.io
     - images.image.openshift.io
+    - oauthaccesstokens.oauth.openshift.io
+    - oauthauthorizetokens.oauth.openshift.io
     - templateinstances.template.openshift.io
     - clusterserviceversions.operators.coreos.com
     - packagemanifests.packages.operators.coreos.com
@@ -38,6 +40,8 @@ spec:
     excludedResources:
     - imagetags.image.openshift.io
     - images.image.openshift.io
+    - oauthaccesstokens.oauth.openshift.io
+    - oauthauthorizetokens.oauth.openshift.io
     - templateinstances.template.openshift.io
     - clusterserviceversions.operators.coreos.com
     - packagemanifests.packages.operators.coreos.com
@@ -66,6 +70,8 @@ spec:
     excludedResources:
     - imagetags.image.openshift.io
     - images.image.openshift.io
+    - oauthaccesstokens.oauth.openshift.io
+    - oauthauthorizetokens.oauth.openshift.io
     - templateinstances.template.openshift.io
     - clusterserviceversions.operators.coreos.com
     - packagemanifests.packages.operators.coreos.com

--- a/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
+++ b/deploy/velero-configuration/hive-specific/111-velero.Schedules.yaml
@@ -11,6 +11,8 @@ spec:
     excludedResources:
     - imagetags.image.openshift.io
     - images.image.openshift.io
+    - oauthaccesstokens.oauth.openshift.io
+    - oauthauthorizetokens.oauth.openshift.io
     - templateinstances.template.openshift.io
     - clusterserviceversions.operators.coreos.com
     - packagemanifests.packages.operators.coreos.com

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11087,6 +11087,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11113,6 +11115,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11140,6 +11144,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11195,6 +11201,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11087,6 +11087,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11113,6 +11115,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11140,6 +11144,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11195,6 +11201,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11087,6 +11087,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11113,6 +11115,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11140,6 +11144,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com
@@ -11195,6 +11201,8 @@ objects:
           excludedResources:
           - imagetags.image.openshift.io
           - images.image.openshift.io
+          - oauthaccesstokens.oauth.openshift.io
+          - oauthauthorizetokens.oauth.openshift.io
           - templateinstances.template.openshift.io
           - clusterserviceversions.operators.coreos.com
           - packagemanifests.packages.operators.coreos.com


### PR DESCRIPTION
These objects are temporary, and are not required for a restore. They can also be numerous, so this reduces backup size and improves speed.