### PR TITLE
Add cronjob to delete leftoever cdo metrics service

### DIFF
--- a/deploy/osd-delete-custom-domains-operator-metrics-service/00-delete-custom-domains-operator-metrics-service.namespace.yml
+++ b/deploy/osd-delete-custom-domains-operator-metrics-service/00-delete-custom-domains-operator-metrics-service.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-custom-domains-operator

--- a/deploy/osd-delete-custom-domains-operator-metrics-service/10-delete-custom-domains-operator-metrics-service.rbac.yaml
+++ b/deploy/osd-delete-custom-domains-operator-metrics-service/10-delete-custom-domains-operator-metrics-service.rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-delete-custom-domains-operator-metrics-service
+  namespace: openshift-custom-domains-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-delete-custom-domains-operator-metrics-service
+  namespace: openshift-custom-domains-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osd-delete-custom-domains-operator-metrics-service
+  namespace: openshift-custom-domains-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-delete-custom-domains-operator-metrics-service
+subjects:
+- kind: ServiceAccount
+  name: osd-delete-custom-domains-operator-metrics-service
+  namespace: openshift-custom-domains-operator

--- a/deploy/osd-delete-custom-domains-operator-metrics-service/20-delete-custom-domains-operator-metrics-service.CronJob.yaml
+++ b/deploy/osd-delete-custom-domains-operator-metrics-service/20-delete-custom-domains-operator-metrics-service.CronJob.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: osd-delete-custom-domains-operator-metrics-service
+  namespace: openshift-custom-domains-operator
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          restartPolicy: Never
+          serviceAccountName: osd-delete-custom-domains-operator-metrics-service
+          containers:
+            - name: osd-delete-custom-domains-operator-metrics-service
+              imagePullPolicy: Always
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              args:
+                - /bin/bash
+                - -c
+                - oc delete svc custom-domains-operator-metrics || true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6256,6 +6256,92 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-custom-domains-operator-metrics-service
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-custom-domains-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-custom-domains-operator-metrics-service
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-delete-custom-domains-operator-metrics-service
+                containers:
+                - name: osd-delete-custom-domains-operator-metrics-service
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete svc custom-domains-operator-metrics || true
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-devaccess
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6256,6 +6256,92 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-custom-domains-operator-metrics-service
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-custom-domains-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-custom-domains-operator-metrics-service
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-delete-custom-domains-operator-metrics-service
+                containers:
+                - name: osd-delete-custom-domains-operator-metrics-service
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete svc custom-domains-operator-metrics || true
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-devaccess
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6256,6 +6256,92 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-custom-domains-operator-metrics-service
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-custom-domains-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-custom-domains-operator-metrics-service
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-custom-domains-operator-metrics-service
+        namespace: openshift-custom-domains-operator
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-delete-custom-domains-operator-metrics-service
+                containers:
+                - name: osd-delete-custom-domains-operator-metrics-service
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete svc custom-domains-operator-metrics || true
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-devaccess
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This removes the leftover service for prom metrics from CDO since operator deployments can't delete resources.