### PR TITLE
Provide dedicated-admins storageclass permissions

### DIFF
--- a/deploy/osd-gcp-ssd-storage/provisioner-fix/105-ssd-provisioner.rbac.ClusterRole.yaml
+++ b/deploy/osd-gcp-ssd-storage/provisioner-fix/105-ssd-provisioner.rbac.ClusterRole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: openshift-ssd-provisioner
+  labels:
+    managed.openshift.io/aggregate-to-dedicated-admins: "cluster"
 rules:
 - apiGroups:
   - storage.k8s.io


### PR DESCRIPTION
Added label `managed.openshift.io/aggregate-to-dedicated-admins: "cluster"` to which allows dedicated-admins to modify storageclasses in order to create encrypted PVs for https://issues.redhat.com/browse/OSD-7216