### PR TITLE
Fixup leftover CIO metrics service

### DIFF
--- a/deploy/sre-prometheus/aws/100-cloud-ingress-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/aws/100-cloud-ingress-operator.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-cloud-ingress-operator-offline-alerts
     rules:
     - alert: CloudIngressOperatorOfflineSRE
-      expr: absent(up{service="localmetrics-cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
+      expr: absent(up{service="cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
       for: 15m
       labels:
         severity: critical

--- a/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
@@ -40,3 +40,12 @@ rules:
   - builds
   verbs:
   - delete
+# services pruning
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - get
+  - delete

--- a/deploy/sre-pruning/115-pruning.services.CronJob.yaml
+++ b/deploy/sre-pruning/115-pruning.services.CronJob.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: services-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/7 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+          - name: services-pruner
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - >-
+              oc delete services/localmetrics-cloud-ingress-operator
+              --namespace openshift-cloud-ingress-operator
+              --ignore-not-found

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11482,7 +11482,7 @@ objects:
         - name: sre-cloud-ingress-operator-offline-alerts
           rules:
           - alert: CloudIngressOperatorOfflineSRE
-            expr: absent(up{service="localmetrics-cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
+            expr: absent(up{service="cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
             for: 15m
             labels:
               severity: critical
@@ -11605,6 +11605,14 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -11704,6 +11712,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/localmetrics-cloud-ingress-operator --namespace
+                    openshift-cloud-ingress-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11482,7 +11482,7 @@ objects:
         - name: sre-cloud-ingress-operator-offline-alerts
           rules:
           - alert: CloudIngressOperatorOfflineSRE
-            expr: absent(up{service="localmetrics-cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
+            expr: absent(up{service="cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
             for: 15m
             labels:
               severity: critical
@@ -11605,6 +11605,14 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -11704,6 +11712,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/localmetrics-cloud-ingress-operator --namespace
+                    openshift-cloud-ingress-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11482,7 +11482,7 @@ objects:
         - name: sre-cloud-ingress-operator-offline-alerts
           rules:
           - alert: CloudIngressOperatorOfflineSRE
-            expr: absent(up{service="localmetrics-cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
+            expr: absent(up{service="cloud-ingress-operator", namespace="openshift-cloud-ingress-operator"})
             for: 15m
             labels:
               severity: critical
@@ -11605,6 +11605,14 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -11704,6 +11712,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/localmetrics-cloud-ingress-operator --namespace
+                    openshift-cloud-ingress-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
In https://github.com/openshift/cloud-ingress-operator/pull/177, the metrics service for CIO was renamed. This created a duplicate leftover service in some clusters, and alerts that CIO was missing in others. This PR creates a CronJob to cleanup the leftover service, and ensure that the correct service is being observed for the CIO alerts.