### PR TITLE
Add pruning for duplicate CIO servicemonitor

### DIFF
--- a/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
@@ -40,3 +40,20 @@ rules:
   - builds
   verbs:
   - delete
+# servicemonitor pruning
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - list
+  - get
+  - delete

--- a/deploy/sre-pruning/115-pruning.servicemonitorss.CronJob.yaml
+++ b/deploy/sre-pruning/115-pruning.servicemonitorss.CronJob.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: services-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/7 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+          - name: services-pruner
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - >-
+              oc delete services/localmetrics-cloud-ingress-operator servicemonitors/localmetrics-cloud-ingress-operator
+              --namespace openshift-cloud-ingress-operator
+              --ignore-not-found

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11555,6 +11555,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -11654,6 +11670,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/localmetrics-cloud-ingress-operator servicemonitors/localmetrics-cloud-ingress-operator
+                    --namespace openshift-cloud-ingress-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11555,6 +11555,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -11654,6 +11670,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/localmetrics-cloud-ingress-operator servicemonitors/localmetrics-cloud-ingress-operator
+                    --namespace openshift-cloud-ingress-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11555,6 +11555,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -11654,6 +11670,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/localmetrics-cloud-ingress-operator servicemonitors/localmetrics-cloud-ingress-operator
+                    --namespace openshift-cloud-ingress-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Follow up to #824 and https://github.com/openshift/cloud-ingress-operator/pull/177 to remove the matching service monitor