### PR TITLE
Add storageclass read perms to osd-reader

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -277,6 +277,7 @@ rules:
 - apiGroups:
   - storage.k8s.io
   resources:
+  - storageclasses
   - volumeattachments
   - csinodes
   - csidrivers

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9812,6 +9812,7 @@ objects:
       - apiGroups:
         - storage.k8s.io
         resources:
+        - storageclasses
         - volumeattachments
         - csinodes
         - csidrivers

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9812,6 +9812,7 @@ objects:
       - apiGroups:
         - storage.k8s.io
         resources:
+        - storageclasses
         - volumeattachments
         - csinodes
         - csidrivers

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9812,6 +9812,7 @@ objects:
       - apiGroups:
         - storage.k8s.io
         resources:
+        - storageclasses
         - volumeattachments
         - csinodes
         - csidrivers


### PR DESCRIPTION
This adds storageclass read perms to osd-reader,so we can get/list/watch storageclass. adding this because we see a lot errors when lunch console locally.

```tq33/apis/storage.k8s.io/v1/storageclasses?watch=true&resourceVersion=6461485'
2021/05/14 06:56:44 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://api-backplane.apps.jroche-1.3e6y.s1.devshift.org/backplane/cluster/1kh2pk0uhb8kt35vu3s58tdhu0gbtq33/apis/storage.k8s.io/v1/storageclasses?watch=true&resourceVersion=6462130'
2021/05/14 06:57:01 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://api-backplane.apps.jroche-1.3e6y.s1.devshift.org/backplane/cluster/1kh2pk0uhb8kt35vu3s58tdhu0gbtq33/apis/storage.k8s.io/v1/storageclasses?watch=true&resourceVersion=6462740'
2021/05/14 06:57:17 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://api-backplane.apps.jroche-1.3e6y.s1.devshift.org/backplane/cluster/1kh2pk0uhb8kt35vu3s58tdhu0gbtq33/apis/storage.k8s.io/v1/storageclasses?watch=true&resourceVersion=6463259'
2021/05/14 06:57:34 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://api-backplane.apps.jroche-1.3e6y.s1.devshift.org/backplane/cluster/1kh2pk0uhb8kt35vu3s58tdhu0gbtq33/apis/storage.k8s.io/v1/storageclasses?watch=true&resourceVersion=6463922'
2021/05/14 06:57:50 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://api-backplane.apps.jroche-1.3e6y.s1.devshift.org/backplane/cluster/1kh2pk0uhb8kt35vu3s58tdhu0gbtq33/apis/storage.k8s.io/v1/storageclasses?watch=true&resourceVersion=6464549'
```