### PR TITLE
Give RHODS SREs admin permissions to nfd-operator namespace

### DIFF
--- a/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
@@ -7,6 +7,6 @@ spec:
   permissions:
   - allowFirst: true
     clusterRoleName: admin
-    namespacesAllowedRegex: (^gpu-operator-resources$|^openshift-operators$|^redhat-ods-.*)
+    namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2094,7 +2094,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^gpu-operator-resources$|^openshift-operators$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2094,7 +2094,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^gpu-operator-resources$|^openshift-operators$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2094,7 +2094,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^gpu-operator-resources$|^openshift-operators$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
As part of RHODS, we also have the node-feature-discovery operator installed and deployed. This operator (along with daemon-sets/ replica sets that are created by the NFD operator) reside in the `nfd-operator` namespace. You can find more information under the [triage guide](https://docs.google.com/document/d/1pcYStWmlGN8dtOePyZ5Zy6F07BcHZrraZDYAEx9w_ik/edit#heading=h.ud90q2tx5q4i)

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>