### PR TITLE
Allow Dedicated Admins To Annotate NetNamespaces

### DIFF
--- a/deploy/osd-netnamespaces/01-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/osd-netnamespaces/01-dedicated-admins-cluster.ClusterRole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    managed.openshift.io/aggregate-to-dedicated-admins: "cluster"
+  name: osd-netnamespaces-dedicated-admin-cluster
+rules:
+- apiGroups:
+  - network.openshift.io
+  resources:
+  - netnamespaces
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8060,6 +8060,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-netnamespaces
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: cluster
+        name: osd-netnamespaces-dedicated-admin-cluster
+      rules:
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+        - watch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-oauth-templates
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8060,6 +8060,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-netnamespaces
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: cluster
+        name: osd-netnamespaces-dedicated-admin-cluster
+      rules:
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+        - watch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-oauth-templates
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8060,6 +8060,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-netnamespaces
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        labels:
+          managed.openshift.io/aggregate-to-dedicated-admins: cluster
+        name: osd-netnamespaces-dedicated-admin-cluster
+      rules:
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+        - watch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-oauth-templates
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This will allow dedicated admins to annotate netnamespaces resources.

Example for enabling multicast:
```
oc annotate netnamespace my-ns netnamespace.network.openshift.io/multicast-enabled=true
```

Depends on https://github.com/openshift/managed-cluster-validating-webhooks/pull/159 so that dedicated-admins cannot modify protected namespaces.

JIRA: https://issues.redhat.com/browse/OSD-7367