### PR TITLE
removed quay from healthcheck

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -46,5 +46,4 @@ data:
       http:
         timeout: 10
         urls:
-          - https://quay.io/health
           - ${OCM_BASE_URL}

--- a/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
@@ -50,7 +50,6 @@ data:
       http:
         timeout: 10
         urls:
-          - https://quay.io/health
           - ${OCM_BASE_URL}
     verification:
       ignoredNamespaces:

--- a/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
@@ -48,7 +48,6 @@ data:
       http:
         timeout: 10
         urls:
-          - https://quay.io/health
           - ${OCM_BASE_URL}
     verification:
       ignoredNamespaces:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4440,8 +4440,7 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4480,9 +4479,9 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4520,9 +4519,9 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4440,8 +4440,7 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4480,9 +4479,9 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4520,9 +4519,9 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4440,8 +4440,7 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4480,9 +4479,9 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -4520,9 +4519,9 @@ objects:
           \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - https://quay.io/health\n \
-          \     - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  namespacePrefixesToCheck:\n  - openshift\n  - kube\n  - default\n"
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
MUO/Upgrades should not fail due to quay production unavailability. Given the configuration of imagecontentsourcepolicies, the fallback mirrors will be used when quay.io is unavailable. See https://issues.redhat.com/browse/OSD-7573 as spike from removing quay.io.