### PR TITLE
Reduce prometheus retention

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -31,7 +31,7 @@ data:
         - effect: NoSchedule
           key: node-role.kubernetes.io/infra
           operator: Exists
-      retention: 15d
+      retention: 11d
       volumeClaimTemplate:
         metadata:
           name: prometheus-data

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2981,7 +2981,7 @@ objects:
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
+          \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \
           \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2981,7 +2981,7 @@ objects:
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
+          \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \
           \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2981,7 +2981,7 @@ objects:
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 15d\n  volumeClaimTemplate:\n    metadata:\n    \
+          \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \
           \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
           \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\


### PR DESCRIPTION
Currently we deploy OSD with 100GB volumes for prometheueses. This is regardless of the clusters size and workload activity. 

We are now starting to receive alerts for `KubePersistentVolumeFillingUp` where the short term solution is editing this CM to reduce the retention and have prom truncate some data to reclaim space. 

If the prom disks fill up, some awful things can happen -> https://issues.redhat.com/browse/OHSS-4541 

Given that these metrics are utilized (underutilized?) by SRE, We should reduce retention to 11 days until we have a more resilient provisioning policy in place that takes into consideration potential cluster characteristics. https://issues.redhat.com/browse/OSD-7629 

I did not update this in user-workload-monitoring as SRE is not utilizing those metrics. We in future should test what happens when UWM is bombed by metrics to assure that openshift-monitoring stays available and consumable.