### PR TITLE
Add SLO targetAvailabilityPercent to enable alerting on API BudgetBurn

### DIFF
--- a/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
+++ b/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
@@ -7,3 +7,5 @@ spec:
   prefix: https://api.
   port: "6443"
   suffix: /healthz
+  slo:
+    targetAvailabilityPercent: "99.0"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8702,6 +8702,8 @@ objects:
         prefix: https://api.
         port: '6443'
         suffix: /healthz
+        slo:
+          targetAvailabilityPercent: '99.0'
     - apiVersion: monitoring.openshift.io/v1alpha1
       kind: RouteMonitor
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8702,6 +8702,8 @@ objects:
         prefix: https://api.
         port: '6443'
         suffix: /healthz
+        slo:
+          targetAvailabilityPercent: '99.0'
     - apiVersion: monitoring.openshift.io/v1alpha1
       kind: RouteMonitor
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8702,6 +8702,8 @@ objects:
         prefix: https://api.
         port: '6443'
         suffix: /healthz
+        slo:
+          targetAvailabilityPercent: '99.0'
     - apiVersion: monitoring.openshift.io/v1alpha1
       kind: RouteMonitor
       metadata:


### PR DESCRIPTION
Adding "slo - targetAvailabilityPercent" configuration to enable alerting on api-ErrorBudgetBurn if the target SLO breaks (99.0%). (OSD-6296)