### PR TITLE
allow dedicated-admins to delete pods in openshift-customer-monitoring

### DIFF
--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -15,6 +15,12 @@ rules:
   - get
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+- apiGroups:
   - operators.coreos.com
   resources:
   - subscriptions

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6416,6 +6416,12 @@ objects:
         - get
         - watch
       - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+      - apiGroups:
         - operators.coreos.com
         resources:
         - subscriptions

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6416,6 +6416,12 @@ objects:
         - get
         - watch
       - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+      - apiGroups:
         - operators.coreos.com
         resources:
         - subscriptions

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6416,6 +6416,12 @@ objects:
         - get
         - watch
       - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+      - apiGroups:
         - operators.coreos.com
         resources:
         - subscriptions


### PR DESCRIPTION
when growing storage for Prometheus operator, the storage is not getting automatically updated in the PVCs, perhaps due to https://github.com/prometheus-operator/prometheus-operator/issues/4079.

to overcome this, we need to manually edit PVCs (dedicated-admins have that power) and delete pods one by one. we do not have permissions to delete pods. instead, we currently delete the StatefulSet, which is re-created by the operator, thus getting new pods.

instead and to prevent downtime, it would be useful to have the permissions to delete pods in the openshift-customer-monitoring namespace.

thank you!