### PR TITLE
OSD-7774 Ignore PruningCronJobErrorSRE alert in upgrade health check

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -31,6 +31,7 @@ data:
       - MetricsClientSendFailingSRE
       - UpgradeNodeScalingFailedSRE
       - UpgradeClusterCheckFailedSRE
+      - PruningCronjobErrorSRE
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown

--- a/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
@@ -35,6 +35,7 @@ data:
       - MetricsClientSendFailingSRE
       - UpgradeNodeScalingFailedSRE
       - UpgradeClusterCheckFailedSRE
+      - PruningCronjobErrorSRE
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown

--- a/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
@@ -33,6 +33,7 @@ data:
       - MetricsClientSendFailingSRE
       - UpgradeNodeScalingFailedSRE
       - UpgradeClusterCheckFailedSRE
+      - PruningCronjobErrorSRE
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4489,9 +4489,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -4528,9 +4529,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
@@ -4568,9 +4570,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4489,9 +4489,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -4528,9 +4529,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
@@ -4568,9 +4570,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4489,9 +4489,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -4528,9 +4529,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
@@ -4568,9 +4570,10 @@ objects:
           scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\


### PR DESCRIPTION
This PR adds the `PruningCronjobErrorSRE` alert to the list which will be ignored by MUO for the purpose of upgrade commencement/completion.

Refs [OSD-7774](https://issues.redhat.com/browse/OSD-7774)