### PR TITLE
[OSD-7437] Create alert for image-pruner to trigger if it has failed more than two times

### DIFF
--- a/deploy/sre-prometheus/100-sre-image-pruner.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-image-pruner.PrometheusRule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-image-pruning
+    role: alert-rules
+  name: sre-image-pruning
+  namespace: openshift-image-registry
+spec:
+  groups:
+  - name: sre-image-pruning
+    rules:
+    - alert: ImagePruningCronjobFailed
+      expr: count(kube_job_failed{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}  > 0) > 1
+      for: 30m
+      labels:
+        severity: warning
+        namespace: openshift-image-registry
+      annotations:
+        message: Image Pruning Job failed more than 1 time {{ $labels.namespace }}/{{ $labels.cronjob }}.
+        link: "https://github.com/openshift/ops-sop/tree/master/v4/alerts/KubeJobFailed.md"


### PR DESCRIPTION
In my PR on [configure-alertmanager-operator](https://github.com/openshift/configure-alertmanager-operator/pull/173), I disabled the upstream KubeJobFailed alert for image-pruner because a single-failed job causes noise and it isn't an indication of an issue with the setup. Consequently, after looking at clusters with such image-pruner jobs, I introduce a custom KubeJobFailed alert for image-pruner that counts the number of failed jobs, and if we have more than 2 failed jobs for 30m we trigger the alert. Note: The image-pruner job runs every hour.

PTAL

See: https://issues.redhat.com/browse/OSD-7437