### PR TITLE
Adds label selector for OSD Logging support

### DIFF
--- a/deploy/osd-logging/supported/config.yaml
+++ b/deploy/osd-logging/supported/config.yaml
@@ -1,14 +1,8 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchExpressions:
-  # Ensure SRE does not get alerts for in-cluster logging on ROSA clusters
-  # https://issues.redhat.com/browse/OSD-6322
-  - key: api.openshift.com/product
-    operator: NotIn
-    values: ["rosa"]
-
-  # Disable routing in-cluster logging alerts to SRE PD for OCP 4.7+
-  # https://issues.redhat.com/browse/OSD-6324
-  - key: hive.openshift.io/version-major-minor
+  # Enable in-cluster logging alerts for those clusters that already have logging installed
+  # https://issues.redhat.com/browse/OSD-7564
+  - key: ext-managed.openshift.io/extended-logging-support
     operator: In
-    values: ["4.4","4.5","4.6"]
+    values: ["true"]

--- a/deploy/osd-logging/unsupported/config.yaml
+++ b/deploy/osd-logging/unsupported/config.yaml
@@ -11,8 +11,10 @@ selectorSyncSet:
     operator: In
     values: ["rosa"]
 
-  # Disable routing in-cluster logging alerts to SRE PD for OCP 4.7+
-  # https://issues.redhat.com/browse/OSD-6324
-  - key: hive.openshift.io/version-major-minor
+  # Disable in-cluster logging alerts for those clusters that do not already have logging installed
+  # We removed the version check because that would conflict with this check here for clusters that
+  # are granted the support exception and do upgrade their cluster.
+  # https://issues.redhat.com/browse/OSD-7564
+  - key: ext-managed.openshift.io/extended-logging-support
     operator: NotIn
-    values: ["4.4","4.5","4.6"]
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7542,16 +7542,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/product
-        operator: NotIn
-        values:
-        - rosa
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: In
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -7674,16 +7668,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/product
-        operator: NotIn
-        values:
-        - rosa
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: In
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -7945,18 +7933,16 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-logging-unsupported-version-major-minor
+    name: osd-logging-unsupported-extended-logging-support
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: NotIn
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7542,16 +7542,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/product
-        operator: NotIn
-        values:
-        - rosa
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: In
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -7674,16 +7668,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/product
-        operator: NotIn
-        values:
-        - rosa
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: In
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -7945,18 +7933,16 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-logging-unsupported-version-major-minor
+    name: osd-logging-unsupported-extended-logging-support
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: NotIn
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7542,16 +7542,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/product
-        operator: NotIn
-        values:
-        - rosa
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: In
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -7674,16 +7668,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/product
-        operator: NotIn
-        values:
-        - rosa
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: In
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -7945,18 +7933,16 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-logging-unsupported-version-major-minor
+    name: osd-logging-unsupported-extended-logging-support
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor
+      - key: ext-managed.openshift.io/extended-logging-support
         operator: NotIn
         values:
-        - '4.4'
-        - '4.5'
-        - '4.6'
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1


### PR DESCRIPTION
Satisfies [OSD-7564](https://issues.redhat.com/browse/OSD-7564)

Converts from version selector to label selector for extended logging support, enabling those clusters who do have logging to upgrade and continue to receive support.

This label has already been added to the necessary clusters.