### PR TITLE
[OSD-7444] add rebalancing infra nodes from int/stg env

### DIFF
--- a/deploy/osd-rebalance-infra-nodes/00-osd-rebalance-infra-nodes.ServiceAccount.yaml
+++ b/deploy/osd-rebalance-infra-nodes/00-osd-rebalance-infra-nodes.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring

--- a/deploy/osd-rebalance-infra-nodes/01-osd-rebalance-infra-nodes.ClusterRole.yaml
+++ b/deploy/osd-rebalance-infra-nodes/01-osd-rebalance-infra-nodes.ClusterRole.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-rebalance-infra-nodes
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list

--- a/deploy/osd-rebalance-infra-nodes/02-osd-rebalance-infra-nodes.ClusterRoleBinding.yaml
+++ b/deploy/osd-rebalance-infra-nodes/02-osd-rebalance-infra-nodes.ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes

--- a/deploy/osd-rebalance-infra-nodes/03-osd-rebalance-infra-nodes-openshift-monitoring.Role.yaml
+++ b/deploy/osd-rebalance-infra-nodes/03-osd-rebalance-infra-nodes-openshift-monitoring.Role.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-monitoring
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete

--- a/deploy/osd-rebalance-infra-nodes/04-osd-rebalance-infra-nodes-openshift-monitoring.RoleBinding.yaml
+++ b/deploy/osd-rebalance-infra-nodes/04-osd-rebalance-infra-nodes-openshift-monitoring.RoleBinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-monitoring
+  namespace: openshift-monitoring
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-rebalance-infra-nodes-openshift-monitoring
+  namespace: openshift-monitoring

--- a/deploy/osd-rebalance-infra-nodes/05-osd-rebalance-infra-nodes-openshift-security.Role.yaml
+++ b/deploy/osd-rebalance-infra-nodes/05-osd-rebalance-infra-nodes-openshift-security.Role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-security
+  namespace: openshift-security
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/osd-rebalance-infra-nodes/06-osd-rebalance-infra-nodes-openshift-security.RoleBinding.yaml
+++ b/deploy/osd-rebalance-infra-nodes/06-osd-rebalance-infra-nodes-openshift-security.RoleBinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-security
+  namespace: openshift-security
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-rebalance-infra-nodes-openshift-security
+  namespace: openshift-security

--- a/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
+++ b/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+data:
+  entrypoint: |-
+    #!/bin/bash
+
+    echo "INFO: Attempting infra node pod rebalancing..."
+
+    AZ_COUNT=$(oc get nodes -o yaml | grep -E "^\s+failure-domain.beta.kubernetes.io/zone" | sort | uniq | wc -l)
+
+    echo "INFO: Number of AZs ${AZ_COUNT}"
+
+    INFRA_NODE_COUNT=$(oc get nodes -l node-role.kubernetes.io=infra --no-headers | wc -l)
+
+    echo "INFO: Number of INFRA NODES ${INFRA_NODE_COUNT}"
+
+    REBALANCE_PROMETHEUS=false
+
+    rebalancePods() {
+        APP=$1
+        NS=$2
+        LABEL=$3
+        VOLUME_NAME=$4
+        ALL_POD_NODES=$(oc get pods -n $NS -l $LABEL=$APP -o wide --no-headers | awk '{print $7}' | sort | wc -l)
+        UNIQUE_POD_NODES=$(oc get pods -n $NS -l $LABEL=$APP -o wide --no-headers | awk '{print $7}' | sort | uniq | wc -l)
+        echo "INFO: $APP pods needing rebalance: $(( $UNIQUE_POD_NODES == $INFRA_NODE_COUNT ? 0 : ALL_POD_NODES - UNIQUE_POD_NODES ))"
+
+        LAST_POD_NODE_NAME=""
+        for POD in $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}' ) ; do
+            POD_NODE_NAME=$(oc get pod -n $NS $POD -o jsonpath='{.spec.nodeName}')
+            if [ $UNIQUE_POD_NODES -ne $INFRA_NODE_COUNT ] && [ "${POD_NODE_NAME}" == "${LAST_POD_NODE_NAME}" ]; then
+                if [ ${VOLUME_NAME} ] && [ "${AZ_COUNT}" != "1" ]; then
+                    PVC=$(oc get pod -n $NS $POD -o jsonpath='{.spec.volumes[?(@.name=="'$VOLUME_NAME'")].persistentVolumeClaim.claimName}')
+                    echo "INFO: Deleting PVC $PVC"
+                    oc delete pvc --wait=false -n $NS $PVC
+                fi
+                echo "INFO: Deleting pod $POD"
+                oc delete pod -n $NS $POD
+                REBALANCE_PROMETHEUS=true
+            fi
+            LAST_POD_NODE_NAME=$POD_NODE_NAME
+        done
+    }
+
+    checkPendingPods() {
+        APP=$1
+        NS=$2
+        LABEL=$3
+        for POD in $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}' ) ; do
+            POD_STATUS_PHASE=$(oc get pods -n $NS $POD -o jsonpath='{.status.phase}')
+            if [ "${POD_STATUS_PHASE}" == "Pending" ]; then
+                echo "INFO: Deleting pod $POD"
+                oc delete pod -n $NS $POD
+            fi
+        done
+    }
+
+    waitRunningPods() {
+        APP=$1
+        NS=$2
+        LABEL=$3
+        for POD in $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}' ) ; do
+            echo "INFO: Waiting for $POD to be Running..."
+            while [ "$(oc get pod -n $NS $POD -o jsonpath='{.status.phase}' 2>/dev/null)" != "Running" ];
+            do
+                sleep 1
+            done
+        done
+    }
+
+    echo "INFO: Rebalancing prometheus pods..."
+    rebalancePods prometheus openshift-monitoring app prometheus-data
+
+    echo "INFO: Rebalancing alertmanager pods..."
+    rebalancePods alertmanager openshift-monitoring app alertmanager-data
+
+    echo "INFO: Rebalancing splunk-heavy-forwarder pods..."
+    rebalancePods splunk-heavy-forwarder openshift-security name
+
+    if $REBALANCE_PROMETHEUS; then
+        echo "INFO: Restarting prometheus operator..."
+        OPERATOR_POD=$( oc get pod -n openshift-monitoring -l app.kubernetes.io/name=prometheus-operator -o jsonpath='{.items[*].metadata.name}' )
+        oc delete pod -n openshift-monitoring $OPERATOR_POD
+    fi
+
+    echo "INFO: Check pending prometheus pods..."
+    checkPendingPods prometheus openshift-monitoring app
+
+    echo "INFO: Check pending alertmanager pods..."
+    checkPendingPods alertmanager openshift-monitoring app
+
+    echo "INFO: Check pending splunk-heavy-forwarder pods..."
+    checkPendingPods splunk-heavy-forwarder openshift-security name
+
+    echo "INFO: Wait for running prometheus pods..."
+    waitRunningPods prometheus openshift-monitoring app
+
+    echo "INFO: Wait for running alertmanager pods..."
+    waitRunningPods alertmanager openshift-monitoring app
+
+    echo "INFO: Wait for running splunk-heavy-forwarder pods..."
+    waitRunningPods splunk-heavy-forwarder openshift-security name

--- a/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
+++ b/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: osd-rebalance-infra-nodes
+          restartPolicy: Never
+          containers:
+            - name: osd-rebalance-infra-nodes
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              command: [ "/bin/sh", "-c", "/etc/config/entrypoint" ]
+              volumeMounts:
+                - name: osd-rebalance-infra-nodes
+                  mountPath: /etc/config
+                  readOnly: true
+          volumes:
+            - name: osd-rebalance-infra-nodes
+              configMap:
+                name: osd-rebalance-infra-nodes
+                defaultMode: 0755

--- a/deploy/osd-rebalance-infra-nodes/README.md
+++ b/deploy/osd-rebalance-infra-nodes/README.md
@@ -1,0 +1,3 @@
+# Rebalancing Infra Nodes on cluster
+
+This is used to evenly distribute SRE workloads on infra nodes, so that infra nodes aren't starved of resources and necessary SRE workloads aren't degraded.

--- a/deploy/osd-rebalance-infra-nodes/config.yaml
+++ b/deploy/osd-rebalance-infra-nodes/config.yaml
@@ -1,0 +1,7 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/environment
+    operator: In
+    values: ["integration","staging"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8602,6 +8602,217 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-rebalance-infra-nodes
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+        - staging
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-rebalance-infra-nodes
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - persistentvolumeclaims
+        verbs:
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      data:
+        entrypoint: "#!/bin/bash\n\necho \"INFO: Attempting infra node pod rebalancing...\"\
+          \n\nAZ_COUNT=$(oc get nodes -o yaml | grep -E \"^\\s+failure-domain.beta.kubernetes.io/zone\"\
+          \ | sort | uniq | wc -l)\n\necho \"INFO: Number of AZs ${AZ_COUNT}\"\n\n\
+          INFRA_NODE_COUNT=$(oc get nodes -l node-role.kubernetes.io=infra --no-headers\
+          \ | wc -l)\n\necho \"INFO: Number of INFRA NODES ${INFRA_NODE_COUNT}\"\n\
+          \nREBALANCE_PROMETHEUS=false\n\nrebalancePods() {\n    APP=$1\n    NS=$2\n\
+          \    LABEL=$3\n    VOLUME_NAME=$4\n    ALL_POD_NODES=$(oc get pods -n $NS\
+          \ -l $LABEL=$APP -o wide --no-headers | awk '{print $7}' | sort | wc -l)\n\
+          \    UNIQUE_POD_NODES=$(oc get pods -n $NS -l $LABEL=$APP -o wide --no-headers\
+          \ | awk '{print $7}' | sort | uniq | wc -l)\n    echo \"INFO: $APP pods\
+          \ needing rebalance: $(( $UNIQUE_POD_NODES == $INFRA_NODE_COUNT ? 0 : ALL_POD_NODES\
+          \ - UNIQUE_POD_NODES ))\"\n\n    LAST_POD_NODE_NAME=\"\"\n    for POD in\
+          \ $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}'\
+          \ ) ; do\n        POD_NODE_NAME=$(oc get pod -n $NS $POD -o jsonpath='{.spec.nodeName}')\n\
+          \        if [ $UNIQUE_POD_NODES -ne $INFRA_NODE_COUNT ] && [ \"${POD_NODE_NAME}\"\
+          \ == \"${LAST_POD_NODE_NAME}\" ]; then\n            if [ ${VOLUME_NAME}\
+          \ ] && [ \"${AZ_COUNT}\" != \"1\" ]; then\n                PVC=$(oc get\
+          \ pod -n $NS $POD -o jsonpath='{.spec.volumes[?(@.name==\"'$VOLUME_NAME'\"\
+          )].persistentVolumeClaim.claimName}')\n                echo \"INFO: Deleting\
+          \ PVC $PVC\"\n                oc delete pvc --wait=false -n $NS $PVC\n \
+          \           fi\n            echo \"INFO: Deleting pod $POD\"\n         \
+          \   oc delete pod -n $NS $POD\n            REBALANCE_PROMETHEUS=true\n \
+          \       fi\n        LAST_POD_NODE_NAME=$POD_NODE_NAME\n    done\n}\n\ncheckPendingPods()\
+          \ {\n    APP=$1\n    NS=$2\n    LABEL=$3\n    for POD in $( oc get pods\
+          \ -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}' ) ; do\n\
+          \        POD_STATUS_PHASE=$(oc get pods -n $NS $POD -o jsonpath='{.status.phase}')\n\
+          \        if [ \"${POD_STATUS_PHASE}\" == \"Pending\" ]; then\n         \
+          \   echo \"INFO: Deleting pod $POD\"\n            oc delete pod -n $NS $POD\n\
+          \        fi\n    done\n}\n\nwaitRunningPods() {\n    APP=$1\n    NS=$2\n\
+          \    LABEL=$3\n    for POD in $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}'\
+          \ ) ; do\n        echo \"INFO: Waiting for $POD to be Running...\"\n   \
+          \     while [ \"$(oc get pod -n $NS $POD -o jsonpath='{.status.phase}' 2>/dev/null)\"\
+          \ != \"Running\" ];\n        do\n            sleep 1\n        done\n   \
+          \ done\n}\n\necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods\
+          \ prometheus openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing\
+          \ alertmanager pods...\"\nrebalancePods alertmanager openshift-monitoring\
+          \ app alertmanager-data\n\necho \"INFO: Rebalancing splunk-heavy-forwarder\
+          \ pods...\"\nrebalancePods splunk-heavy-forwarder openshift-security name\n\
+          \nif $REBALANCE_PROMETHEUS; then\n    echo \"INFO: Restarting prometheus\
+          \ operator...\"\n    OPERATOR_POD=$( oc get pod -n openshift-monitoring\
+          \ -l app.kubernetes.io/name=prometheus-operator -o jsonpath='{.items[*].metadata.name}'\
+          \ )\n    oc delete pod -n openshift-monitoring $OPERATOR_POD\nfi\n\necho\
+          \ \"INFO: Check pending prometheus pods...\"\ncheckPendingPods prometheus\
+          \ openshift-monitoring app\n\necho \"INFO: Check pending alertmanager pods...\"\
+          \ncheckPendingPods alertmanager openshift-monitoring app\n\necho \"INFO:\
+          \ Check pending splunk-heavy-forwarder pods...\"\ncheckPendingPods splunk-heavy-forwarder\
+          \ openshift-security name\n\necho \"INFO: Wait for running prometheus pods...\"\
+          \nwaitRunningPods prometheus openshift-monitoring app\n\necho \"INFO: Wait\
+          \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
+          \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
+          waitRunningPods splunk-heavy-forwarder openshift-security name"
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-rebalance-infra-nodes
+                restartPolicy: Never
+                containers:
+                - name: osd-rebalance-infra-nodes
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  command:
+                  - /bin/sh
+                  - -c
+                  - /etc/config/entrypoint
+                  volumeMounts:
+                  - name: osd-rebalance-infra-nodes
+                    mountPath: /etc/config
+                    readOnly: true
+                volumes:
+                - name: osd-rebalance-infra-nodes
+                  configMap:
+                    name: osd-rebalance-infra-nodes
+                    defaultMode: 493
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-registry
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8602,6 +8602,217 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-rebalance-infra-nodes
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+        - staging
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-rebalance-infra-nodes
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - persistentvolumeclaims
+        verbs:
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      data:
+        entrypoint: "#!/bin/bash\n\necho \"INFO: Attempting infra node pod rebalancing...\"\
+          \n\nAZ_COUNT=$(oc get nodes -o yaml | grep -E \"^\\s+failure-domain.beta.kubernetes.io/zone\"\
+          \ | sort | uniq | wc -l)\n\necho \"INFO: Number of AZs ${AZ_COUNT}\"\n\n\
+          INFRA_NODE_COUNT=$(oc get nodes -l node-role.kubernetes.io=infra --no-headers\
+          \ | wc -l)\n\necho \"INFO: Number of INFRA NODES ${INFRA_NODE_COUNT}\"\n\
+          \nREBALANCE_PROMETHEUS=false\n\nrebalancePods() {\n    APP=$1\n    NS=$2\n\
+          \    LABEL=$3\n    VOLUME_NAME=$4\n    ALL_POD_NODES=$(oc get pods -n $NS\
+          \ -l $LABEL=$APP -o wide --no-headers | awk '{print $7}' | sort | wc -l)\n\
+          \    UNIQUE_POD_NODES=$(oc get pods -n $NS -l $LABEL=$APP -o wide --no-headers\
+          \ | awk '{print $7}' | sort | uniq | wc -l)\n    echo \"INFO: $APP pods\
+          \ needing rebalance: $(( $UNIQUE_POD_NODES == $INFRA_NODE_COUNT ? 0 : ALL_POD_NODES\
+          \ - UNIQUE_POD_NODES ))\"\n\n    LAST_POD_NODE_NAME=\"\"\n    for POD in\
+          \ $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}'\
+          \ ) ; do\n        POD_NODE_NAME=$(oc get pod -n $NS $POD -o jsonpath='{.spec.nodeName}')\n\
+          \        if [ $UNIQUE_POD_NODES -ne $INFRA_NODE_COUNT ] && [ \"${POD_NODE_NAME}\"\
+          \ == \"${LAST_POD_NODE_NAME}\" ]; then\n            if [ ${VOLUME_NAME}\
+          \ ] && [ \"${AZ_COUNT}\" != \"1\" ]; then\n                PVC=$(oc get\
+          \ pod -n $NS $POD -o jsonpath='{.spec.volumes[?(@.name==\"'$VOLUME_NAME'\"\
+          )].persistentVolumeClaim.claimName}')\n                echo \"INFO: Deleting\
+          \ PVC $PVC\"\n                oc delete pvc --wait=false -n $NS $PVC\n \
+          \           fi\n            echo \"INFO: Deleting pod $POD\"\n         \
+          \   oc delete pod -n $NS $POD\n            REBALANCE_PROMETHEUS=true\n \
+          \       fi\n        LAST_POD_NODE_NAME=$POD_NODE_NAME\n    done\n}\n\ncheckPendingPods()\
+          \ {\n    APP=$1\n    NS=$2\n    LABEL=$3\n    for POD in $( oc get pods\
+          \ -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}' ) ; do\n\
+          \        POD_STATUS_PHASE=$(oc get pods -n $NS $POD -o jsonpath='{.status.phase}')\n\
+          \        if [ \"${POD_STATUS_PHASE}\" == \"Pending\" ]; then\n         \
+          \   echo \"INFO: Deleting pod $POD\"\n            oc delete pod -n $NS $POD\n\
+          \        fi\n    done\n}\n\nwaitRunningPods() {\n    APP=$1\n    NS=$2\n\
+          \    LABEL=$3\n    for POD in $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}'\
+          \ ) ; do\n        echo \"INFO: Waiting for $POD to be Running...\"\n   \
+          \     while [ \"$(oc get pod -n $NS $POD -o jsonpath='{.status.phase}' 2>/dev/null)\"\
+          \ != \"Running\" ];\n        do\n            sleep 1\n        done\n   \
+          \ done\n}\n\necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods\
+          \ prometheus openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing\
+          \ alertmanager pods...\"\nrebalancePods alertmanager openshift-monitoring\
+          \ app alertmanager-data\n\necho \"INFO: Rebalancing splunk-heavy-forwarder\
+          \ pods...\"\nrebalancePods splunk-heavy-forwarder openshift-security name\n\
+          \nif $REBALANCE_PROMETHEUS; then\n    echo \"INFO: Restarting prometheus\
+          \ operator...\"\n    OPERATOR_POD=$( oc get pod -n openshift-monitoring\
+          \ -l app.kubernetes.io/name=prometheus-operator -o jsonpath='{.items[*].metadata.name}'\
+          \ )\n    oc delete pod -n openshift-monitoring $OPERATOR_POD\nfi\n\necho\
+          \ \"INFO: Check pending prometheus pods...\"\ncheckPendingPods prometheus\
+          \ openshift-monitoring app\n\necho \"INFO: Check pending alertmanager pods...\"\
+          \ncheckPendingPods alertmanager openshift-monitoring app\n\necho \"INFO:\
+          \ Check pending splunk-heavy-forwarder pods...\"\ncheckPendingPods splunk-heavy-forwarder\
+          \ openshift-security name\n\necho \"INFO: Wait for running prometheus pods...\"\
+          \nwaitRunningPods prometheus openshift-monitoring app\n\necho \"INFO: Wait\
+          \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
+          \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
+          waitRunningPods splunk-heavy-forwarder openshift-security name"
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-rebalance-infra-nodes
+                restartPolicy: Never
+                containers:
+                - name: osd-rebalance-infra-nodes
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  command:
+                  - /bin/sh
+                  - -c
+                  - /etc/config/entrypoint
+                  volumeMounts:
+                  - name: osd-rebalance-infra-nodes
+                    mountPath: /etc/config
+                    readOnly: true
+                volumes:
+                - name: osd-rebalance-infra-nodes
+                  configMap:
+                    name: osd-rebalance-infra-nodes
+                    defaultMode: 493
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-registry
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8602,6 +8602,217 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-rebalance-infra-nodes
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+        - staging
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-rebalance-infra-nodes
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - persistentvolumeclaims
+        verbs:
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-rebalance-infra-nodes-openshift-monitoring
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-rebalance-infra-nodes-openshift-security
+        namespace: openshift-security
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      data:
+        entrypoint: "#!/bin/bash\n\necho \"INFO: Attempting infra node pod rebalancing...\"\
+          \n\nAZ_COUNT=$(oc get nodes -o yaml | grep -E \"^\\s+failure-domain.beta.kubernetes.io/zone\"\
+          \ | sort | uniq | wc -l)\n\necho \"INFO: Number of AZs ${AZ_COUNT}\"\n\n\
+          INFRA_NODE_COUNT=$(oc get nodes -l node-role.kubernetes.io=infra --no-headers\
+          \ | wc -l)\n\necho \"INFO: Number of INFRA NODES ${INFRA_NODE_COUNT}\"\n\
+          \nREBALANCE_PROMETHEUS=false\n\nrebalancePods() {\n    APP=$1\n    NS=$2\n\
+          \    LABEL=$3\n    VOLUME_NAME=$4\n    ALL_POD_NODES=$(oc get pods -n $NS\
+          \ -l $LABEL=$APP -o wide --no-headers | awk '{print $7}' | sort | wc -l)\n\
+          \    UNIQUE_POD_NODES=$(oc get pods -n $NS -l $LABEL=$APP -o wide --no-headers\
+          \ | awk '{print $7}' | sort | uniq | wc -l)\n    echo \"INFO: $APP pods\
+          \ needing rebalance: $(( $UNIQUE_POD_NODES == $INFRA_NODE_COUNT ? 0 : ALL_POD_NODES\
+          \ - UNIQUE_POD_NODES ))\"\n\n    LAST_POD_NODE_NAME=\"\"\n    for POD in\
+          \ $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}'\
+          \ ) ; do\n        POD_NODE_NAME=$(oc get pod -n $NS $POD -o jsonpath='{.spec.nodeName}')\n\
+          \        if [ $UNIQUE_POD_NODES -ne $INFRA_NODE_COUNT ] && [ \"${POD_NODE_NAME}\"\
+          \ == \"${LAST_POD_NODE_NAME}\" ]; then\n            if [ ${VOLUME_NAME}\
+          \ ] && [ \"${AZ_COUNT}\" != \"1\" ]; then\n                PVC=$(oc get\
+          \ pod -n $NS $POD -o jsonpath='{.spec.volumes[?(@.name==\"'$VOLUME_NAME'\"\
+          )].persistentVolumeClaim.claimName}')\n                echo \"INFO: Deleting\
+          \ PVC $PVC\"\n                oc delete pvc --wait=false -n $NS $PVC\n \
+          \           fi\n            echo \"INFO: Deleting pod $POD\"\n         \
+          \   oc delete pod -n $NS $POD\n            REBALANCE_PROMETHEUS=true\n \
+          \       fi\n        LAST_POD_NODE_NAME=$POD_NODE_NAME\n    done\n}\n\ncheckPendingPods()\
+          \ {\n    APP=$1\n    NS=$2\n    LABEL=$3\n    for POD in $( oc get pods\
+          \ -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}' ) ; do\n\
+          \        POD_STATUS_PHASE=$(oc get pods -n $NS $POD -o jsonpath='{.status.phase}')\n\
+          \        if [ \"${POD_STATUS_PHASE}\" == \"Pending\" ]; then\n         \
+          \   echo \"INFO: Deleting pod $POD\"\n            oc delete pod -n $NS $POD\n\
+          \        fi\n    done\n}\n\nwaitRunningPods() {\n    APP=$1\n    NS=$2\n\
+          \    LABEL=$3\n    for POD in $( oc get pods -n $NS -l $LABEL=$APP -o jsonpath='{.items[*].metadata.name}'\
+          \ ) ; do\n        echo \"INFO: Waiting for $POD to be Running...\"\n   \
+          \     while [ \"$(oc get pod -n $NS $POD -o jsonpath='{.status.phase}' 2>/dev/null)\"\
+          \ != \"Running\" ];\n        do\n            sleep 1\n        done\n   \
+          \ done\n}\n\necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods\
+          \ prometheus openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing\
+          \ alertmanager pods...\"\nrebalancePods alertmanager openshift-monitoring\
+          \ app alertmanager-data\n\necho \"INFO: Rebalancing splunk-heavy-forwarder\
+          \ pods...\"\nrebalancePods splunk-heavy-forwarder openshift-security name\n\
+          \nif $REBALANCE_PROMETHEUS; then\n    echo \"INFO: Restarting prometheus\
+          \ operator...\"\n    OPERATOR_POD=$( oc get pod -n openshift-monitoring\
+          \ -l app.kubernetes.io/name=prometheus-operator -o jsonpath='{.items[*].metadata.name}'\
+          \ )\n    oc delete pod -n openshift-monitoring $OPERATOR_POD\nfi\n\necho\
+          \ \"INFO: Check pending prometheus pods...\"\ncheckPendingPods prometheus\
+          \ openshift-monitoring app\n\necho \"INFO: Check pending alertmanager pods...\"\
+          \ncheckPendingPods alertmanager openshift-monitoring app\n\necho \"INFO:\
+          \ Check pending splunk-heavy-forwarder pods...\"\ncheckPendingPods splunk-heavy-forwarder\
+          \ openshift-security name\n\necho \"INFO: Wait for running prometheus pods...\"\
+          \nwaitRunningPods prometheus openshift-monitoring app\n\necho \"INFO: Wait\
+          \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
+          \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
+          waitRunningPods splunk-heavy-forwarder openshift-security name"
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-rebalance-infra-nodes
+                restartPolicy: Never
+                containers:
+                - name: osd-rebalance-infra-nodes
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  command:
+                  - /bin/sh
+                  - -c
+                  - /etc/config/entrypoint
+                  volumeMounts:
+                  - name: osd-rebalance-infra-nodes
+                    mountPath: /etc/config
+                    readOnly: true
+                volumes:
+                - name: osd-rebalance-infra-nodes
+                  configMap:
+                    name: osd-rebalance-infra-nodes
+                    defaultMode: 493
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-registry
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This includes a `cronjob` to execute a script every one hour to balance the  infra nodes from **integration/staging** environment, and `service account`, `clusterrole`, `clusterrolebinding`, `role`, `rolebinding` with the permissions for the script.

The script is based on [infra-pod-rebalance](https://github.com/openshift/ops-sop/blob/master/v4/utils/infra-pod-rebalance), and extended to all the rebalancing infra workloads:
```
Kind                NAMESPACE                  NAME
StatefulSet   openshift-monitoring    alertmanager-main
StatefulSet   openshift-monitoring    prometheus-k8s
ReplicaSet    openshift-monitoring    prometheus-adapter
ReplicaSet    openshift-security      splunkforwarder-deployment
```