### PR TITLE
[OSD-7830] ignore openshift-cnv namespace for healthcheck

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -40,6 +40,7 @@ data:
       - openshift-redhat-marketplace
       - openshift-operators
       - openshift-customer-monitoring
+      - openshift-cnv
       - openshift-route-monitoring-operator
       - openshift-user-workload-monitoring
       - openshift-pipelines

--- a/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
@@ -44,6 +44,7 @@ data:
       - openshift-redhat-marketplace
       - openshift-operators
       - openshift-customer-monitoring
+      - openshift-cnv
       - openshift-route-monitoring-operator
       - openshift-user-workload-monitoring
       - openshift-pipelines

--- a/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
@@ -42,6 +42,7 @@ data:
       - openshift-redhat-marketplace
       - openshift-operators
       - openshift-customer-monitoring
+      - openshift-cnv
       - openshift-route-monitoring-operator
       - openshift-user-workload-monitoring
       - openshift-pipelines

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4492,7 +4492,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -4532,7 +4532,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
@@ -4573,7 +4573,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4492,7 +4492,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -4532,7 +4532,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
@@ -4573,7 +4573,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4492,7 +4492,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -4532,7 +4532,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
@@ -4573,7 +4573,7 @@ objects:
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
           \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
           \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\


### PR DESCRIPTION
This PR adds the `openshift-cnv` namespace to the managed-upgrade-operator's cluster health check ignore list.

Ref: [OSD-7830](https://issues.redhat.com/browse/OSD-7830)