### PR TITLE
Use a merge patch to remove Config.spec.nodeSelector

### DIFF
--- a/deploy/osd-registry/cluster.Config.removeNodeSelector.patch.yaml
+++ b/deploy/osd-registry/cluster.Config.removeNodeSelector.patch.yaml
@@ -4,5 +4,5 @@ kind: Config
 name: cluster
 # patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
 # patch registry to expose default route: https://docs.openshift.com/container-platform/4.1/registry/configuring-registry-operator.html#registry-operator-default-crd_configuring-registry-operator
-patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
-patchType: json
+patch: '{"spec":{"nodeSelector": null}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9139,8 +9139,8 @@ objects:
       applyMode: AlwaysApply
       kind: Config
       name: cluster
-      patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
-      patchType: json
+      patch: '{"spec":{"nodeSelector": null}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9139,8 +9139,8 @@ objects:
       applyMode: AlwaysApply
       kind: Config
       name: cluster
-      patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
-      patchType: json
+      patch: '{"spec":{"nodeSelector": null}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9139,8 +9139,8 @@ objects:
       applyMode: AlwaysApply
       kind: Config
       name: cluster
-      patch: '[{"op":"remove","path":"/spec/nodeSelector"}]'
-      patchType: json
+      patch: '{"spec":{"nodeSelector": null}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
The osd-registry SelectorSyncSet has been failing to apply with a status message like:

`failed to apply patch 1: the server rejected our request due to an error in our request`

We think this is due to the fact that a JSON patch asking to `remove` a field will fail if that field is already absent.

Change to a `merge` patch setting the field to `null` instead, which has the same effect, but idempotently.

[OSD-7926](https://issues.redhat.com/browse/OSD-7926)