### PR TITLE
OSD-7983 Change MUO configmap to use upsert

### DIFF
--- a/deploy/managed-upgrade-operator-config/4.5/config.yaml
+++ b/deploy/managed-upgrade-operator-config/4.5/config.yaml
@@ -4,3 +4,4 @@ selectorSyncSet:
   - key: hive.openshift.io/version-major-minor
     operator: In
     values: ["4.5"]
+  resourceApplyMode: Upsert

--- a/deploy/managed-upgrade-operator-config/4.6/config.yaml
+++ b/deploy/managed-upgrade-operator-config/4.6/config.yaml
@@ -4,3 +4,4 @@ selectorSyncSet:
   - key: hive.openshift.io/version-major-minor
     operator: In
     values: ["4.6"]
+  resourceApplyMode: Upsert

--- a/deploy/managed-upgrade-operator-config/config.yaml
+++ b/deploy/managed-upgrade-operator-config/config.yaml
@@ -4,3 +4,4 @@ selectorSyncSet:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
       values: ["4.5", "4.6"]
+  resourceApplyMode: Upsert

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3615,7 +3615,7 @@ objects:
         values:
         - '4.5'
         - '4.6'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -3653,7 +3653,7 @@ objects:
         operator: In
         values:
         - '4.5'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -3695,7 +3695,7 @@ objects:
         operator: In
         values:
         - '4.6'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3615,7 +3615,7 @@ objects:
         values:
         - '4.5'
         - '4.6'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -3653,7 +3653,7 @@ objects:
         operator: In
         values:
         - '4.5'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -3695,7 +3695,7 @@ objects:
         operator: In
         values:
         - '4.6'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3615,7 +3615,7 @@ objects:
         values:
         - '4.5'
         - '4.6'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -3653,7 +3653,7 @@ objects:
         operator: In
         values:
         - '4.5'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap
@@ -3695,7 +3695,7 @@ objects:
         operator: In
         values:
         - '4.6'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: ConfigMap


### PR DESCRIPTION
In [OSD-7983](https://issues.redhat.com/browse/OSD-7983) we identified that using `Sync` for the `managed-upgrade-operator` configmap is causing removal of the configmap when 4.5/4.6 clusters upgrade to 4.7, which confuses `managed-upgrade-operator` for a little while until Hive sorts it out.

We can use `upsert` instead, which prevents this from happening.

Successfully tested in Hive integration.