### PR TITLE
Add RBAC to allow dedicated-admins to patch kube-apiserver-to-kubelet-signer on 4.5/4.6

### DIFF
--- a/deploy/rbac-rotate-certs/15-dedicated-admins-cert-secret.Role.yaml
+++ b/deploy/rbac-rotate-certs/15-dedicated-admins-cert-secret.Role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-cert-secret
+  namespace: openshift-kube-apiserver-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - patch
+  resourceNames:
+  - kube-apiserver-to-kubelet-signer

--- a/deploy/rbac-rotate-certs/25-dedicated-admins-cert-secret.RoleBinding.yaml
+++ b/deploy/rbac-rotate-certs/25-dedicated-admins-cert-secret.RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-cert-secret
+  namespace: openshift-kube-apiserver-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-cert-secret

--- a/deploy/rbac-rotate-certs/OWNERS
+++ b/deploy/rbac-rotate-certs/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- cblecker
+- iamkirkbater
+- mrbarge

--- a/deploy/rbac-rotate-certs/config.yaml
+++ b/deploy/rbac-rotate-certs/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: hive.openshift.io/version-major-minor
+      operator: In
+      values: ["4.5", "4.6"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9428,6 +9428,56 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rbac-rotate-certs
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+        - '4.6'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-cert-secret
+        namespace: openshift-kube-apiserver-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - patch
+        resourceNames:
+        - kube-apiserver-to-kubelet-signer
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-cert-secret
+        namespace: openshift-kube-apiserver-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-cert-secret
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9428,6 +9428,56 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rbac-rotate-certs
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+        - '4.6'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-cert-secret
+        namespace: openshift-kube-apiserver-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - patch
+        resourceNames:
+        - kube-apiserver-to-kubelet-signer
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-cert-secret
+        namespace: openshift-kube-apiserver-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-cert-secret
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9428,6 +9428,56 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rbac-rotate-certs
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+        - '4.6'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-cert-secret
+        namespace: openshift-kube-apiserver-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - patch
+        resourceNames:
+        - kube-apiserver-to-kubelet-signer
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-cert-secret
+        namespace: openshift-kube-apiserver-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-cert-secret
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
fixes [OSD-8153](https://issues.redhat.com/browse/OSD-8153)

There is a use case for a customer to be able to self-serve patch the secret object `kube-apiserver-to-kubelet-signer` located in the `openshift-kube-apiserver-operator` namespace.

Allowing this would permit a dedicated-admin to run the following command, and rotate the certificates early:
```
oc annotate -n openshift-kube-apiserver-operator secret/kube-apiserver-to-kubelet-signer auth.openshift.io/certificate-not-after-
```

This is only required on 4.5 and 4.6, as starting in 4.7, the certificate rotation doesn't impact the cluster's nodes ([RFE-1212](https://issues.redhat.com/browse/RFE-1212)).

References:
- https://access.redhat.com/solutions/5319661