### PR TITLE
add rebalancing infra nodes in prod env

### DIFF
--- a/deploy/osd-rebalance-infra-nodes/config.yaml
+++ b/deploy/osd-rebalance-infra-nodes/config.yaml
@@ -4,4 +4,4 @@ selectorSyncSet:
   matchExpressions:
   - key: api.openshift.com/environment
     operator: In
-    values: ["integration","staging"]
+    values: ["integration", "staging", "production"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7611,6 +7611,7 @@ objects:
         values:
         - integration
         - staging
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7611,6 +7611,7 @@ objects:
         values:
         - integration
         - staging
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7611,6 +7611,7 @@ objects:
         values:
         - integration
         - staging
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
I have been testing the cronjob on staging clusters for weeks. It works as expected. This PR is to deploy the cronjob in prod env.

Signed-off-by: Jing Zhang <jingzhan@redhat.com>