### PR TITLE
OSD-8160 Ignore MUO alerts re BZ1986981

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -35,6 +35,20 @@ data:
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1986981
+      - PrometheusRemoteWriteBehind
+      - KubePersistentVolumeErrors
+      - PrometheusBadConfig
+      - PrometheusRemoteStorageFailures
+      - AlertmanagerMembersInconsistent
+      - AlertmanagerClusterFailedToSendAlerts
+      - AlertmanagerConfigInconsistent
+      - AlertmanagerClusterDown
+      - KubeStateMetricsListErrors
+      - KubeStateMetricsWatchErrors
+      - ThanosRuleSenderIsFailingAlerts
+      - ThanosRuleHighRuleEvaluationFailures
+      - ThanosNoRuleEvaluations
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3631,11 +3631,17 @@ objects:
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
+          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
+          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
+          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
+          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
+          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3631,11 +3631,17 @@ objects:
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
+          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
+          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
+          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
+          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
+          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3631,11 +3631,17 @@ objects:
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
+          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
+          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
+          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
+          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
+          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Bug [BZ1986981](https://bugzilla.redhat.com/show_bug.cgi?id=1986981) highlights several alerts which are critical but should be warning/info.

Some of these alerts are currently impacting the ability of upgrades to successfully trigger because they're firing on-cluster.

Ignore these alerts for the MUO health-check until we're on v4.9.

