### PR TITLE
OSD-7916 cronjob to clean backplane script resources

### DIFF
--- a/deploy/osd-delete-backplane-script-resources/00-delete-backplane-script-resources.namespace.yml
+++ b/deploy/osd-delete-backplane-script-resources/00-delete-backplane-script-resources.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane-managed-scripts

--- a/deploy/osd-delete-backplane-script-resources/10-delete-backplane-script-resources.rbac.yaml
+++ b/deploy/osd-delete-backplane-script-resources/10-delete-backplane-script-resources.rbac.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-backplane
+  namespace: openshift-backplane-managed-scripts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-delete-backplane-script-resources
+  namespace: openshift-backplane-managed-scripts
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osd-delete-backplane-script-resources
+  namespace: openshift-backplane-managed-scripts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-delete-backplane-script-resources
+subjects:
+- kind: ServiceAccount
+  name: osd-backplane
+  namespace: openshift-backplane-managed-scripts
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-delete-backplane-script-resources
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: osd-delete-backplane-script-resources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-delete-backplane-script-resources
+subjects:
+- kind: ServiceAccount
+  name: osd-backplane
+  namespace: openshift-backplane-managed-scripts

--- a/deploy/osd-delete-backplane-script-resources/20-delete-backplane-script-resources.CronJob.yaml
+++ b/deploy/osd-delete-backplane-script-resources/20-delete-backplane-script-resources.CronJob.yaml
@@ -1,0 +1,125 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: osd-delete-backplane-script-resources
+  namespace: openshift-backplane-managed-scripts
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "42 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          restartPolicy: Never
+          serviceAccountName: osd-backplane
+          containers:
+            - name:  osd-delete-backplane-script-resources
+              imagePullPolicy: Always
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              args:
+                - /bin/bash
+                - -c
+                - |
+                  set -euxo pipefail
+
+                  # Namespace which pods run in
+                  NS="openshift-backplane-managed-scripts"
+                  # Label which all backplane script resources should have
+                  LABEL="managed.openshift.io/backplane-job-uuid"
+                  # Only delete resources created before this time, in unix epoch seconds.
+                  DEL_ONLY_BEFORE=$(($(date +%s) - 3600*24))
+
+                  ### Gather data
+                  # Format: pod_name pod_status creation_timestamp
+                  PODS=$(oc get pod -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,CT:.metadata.creationTimestamp --no-headers)
+
+                  # Format: sa_name
+                  SAS=$(oc get serviceaccount -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name --no-headers)
+
+                  # Format: role_name role_ns
+                  ROLES=$(oc get role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace --no-headers) 
+
+                  # Format: rolebinding_name rolebinding_ns
+                  ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace --no-headers)
+
+                  # Format: clusterrole_name
+                  CROLES=$(oc get clusterrole --selector $LABEL -o custom-columns=NAME:.metadata.name --no-headers)
+
+                  # Format: clusterrolebinding_name
+                  CROLEBINDINGS=$(oc get clusterrolebinding --selector $LABEL -o custom-columns=NAME:.metadata.name --no-headers)
+
+                  # Pick up those resources we don't want to delete.
+                  # - Current running pods and related resources.
+                  # - pods created within THRESHOLD_PERIOD and related resouces.
+                  PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \
+                    '{
+                    if($2 ~ /Running/){print $1} 
+                    else{cmd = sprintf("date +\"%%s\" --date=%s", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0 > before+0){print $1}}
+                    }' \
+                    <<< "$PODS")
+
+                  PODS_TO_DEL=$(awk '{print $1}' <<< "$PODS")
+
+                  for pod in $PODS_TO_KEEP
+                  do
+                    PODS_TO_DEL=$({ grep -v "$pod" || test $? = 1; } <<< "$PODS_TO_DEL")
+                    SAS=$({ grep -v "$pod" || test $? = 1; } <<< "$SAS")
+                    ROLES=$({ grep -v "$pod" || test $? = 1; } <<< "$ROLES")
+                    ROLEBINDINGS=$({ grep -v "$pod" || test $? = 1; } <<< "$ROLEBINDINGS")
+                    CROLES=$({ grep -v "$pod" || test $? = 1; } <<< "$CROLES")
+                    CROLEBINDINGS=$({ grep -v "$pod" || test $? = 1; } <<< "$CROLEBINDINGS")
+                  done
+
+                  ## Delete non-running pods
+                  for pod in $PODS_TO_DEL
+                  do
+                    oc delete pod -n $NS $pod
+                  done
+
+                  ## Delete Rolebindings
+                  [[ -z "$ROLEBINDINGS" ]] || while read line
+                  do
+                    rb_name=$(echo $line | awk '{print $1}')
+                    rb_namespace=$(echo $line | awk '{print $2}')
+                    oc delete rolebindings -n $rb_namespace $rb_name
+                  done <<< "$ROLEBINDINGS"
+
+                  ## Delete ClusterRolebindings
+                  for clb in $CROLEBINDINGS
+                  do
+                    oc delete clusterrolebinding $clb
+                  done
+
+                  ## Delete Roles
+                  [[ -z "$ROLES" ]] || while read line
+                  do
+                    role_name=$(echo $line | awk '{print $1}')
+                    role_namespace=$(echo $line | awk '{print $2}')
+                    oc delete role -n $role_namespace $role_name
+                  done <<< "$ROLES"
+
+                  ## Delete Clusterroles
+                  for crole in $CROLES
+                  do
+                    oc delete clusterrole $crole
+                  done
+
+                  ## Delete SAs
+                  for sa in $SAS
+                  do
+                    oc delete serviceaccount -n $NS $sa
+                  done

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6100,6 +6100,165 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-script-resources
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-managed-scripts
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - serviceaccounts
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-backplane-script-resources
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-backplane-script-resources
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-script-resources
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-script-resources
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 42 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-backplane
+                containers:
+                - name: osd-delete-backplane-script-resources
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "set -euxo pipefail\n\n# Namespace which pods run in\nNS=\"openshift-backplane-managed-scripts\"\
+                    \n# Label which all backplane script resources should have\nLABEL=\"\
+                    managed.openshift.io/backplane-job-uuid\"\n# Only delete resources\
+                    \ created before this time, in unix epoch seconds.\nDEL_ONLY_BEFORE=$(($(date\
+                    \ +%s) - 3600*24))\n\n### Gather data\n# Format: pod_name pod_status\
+                    \ creation_timestamp\nPODS=$(oc get pod -n $NS --selector $LABEL\
+                    \ -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,CT:.metadata.creationTimestamp\
+                    \ --no-headers)\n\n# Format: sa_name\nSAS=$(oc get serviceaccount\
+                    \ -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Format: role_name role_ns\nROLES=$(oc get\
+                    \ role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
+                    \ --no-headers) \n\n# Format: rolebinding_name rolebinding_ns\n\
+                    ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
+                    \ --no-headers)\n\n# Format: clusterrole_name\nCROLES=$(oc get\
+                    \ clusterrole --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Format: clusterrolebinding_name\nCROLEBINDINGS=$(oc\
+                    \ get clusterrolebinding --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Pick up those resources we don't want to\
+                    \ delete.\n# - Current running pods and related resources.\n#\
+                    \ - pods created within THRESHOLD_PERIOD and related resouces.\n\
+                    PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \\\n  '{\n  if($2\
+                    \ ~ /Running/){print $1} \n  else{cmd = sprintf(\"date +\\\"%%s\\\
+                    \" --date=%s\", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0\
+                    \ > before+0){print $1}}\n  }' \\\n  <<< \"$PODS\")\n\nPODS_TO_DEL=$(awk\
+                    \ '{print $1}' <<< \"$PODS\")\n\nfor pod in $PODS_TO_KEEP\ndo\n\
+                    \  PODS_TO_DEL=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$PODS_TO_DEL\"\
+                    )\n  SAS=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$SAS\")\n\
+                    \  ROLES=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$ROLES\"\
+                    )\n  ROLEBINDINGS=$({ grep -v \"$pod\" || test $? = 1; } <<< \"\
+                    $ROLEBINDINGS\")\n  CROLES=$({ grep -v \"$pod\" || test $? = 1;\
+                    \ } <<< \"$CROLES\")\n  CROLEBINDINGS=$({ grep -v \"$pod\" ||\
+                    \ test $? = 1; } <<< \"$CROLEBINDINGS\")\ndone\n\n## Delete non-running\
+                    \ pods\nfor pod in $PODS_TO_DEL\ndo\n  oc delete pod -n $NS $pod\n\
+                    done\n\n## Delete Rolebindings\n[[ -z \"$ROLEBINDINGS\" ]] ||\
+                    \ while read line\ndo\n  rb_name=$(echo $line | awk '{print $1}')\n\
+                    \  rb_namespace=$(echo $line | awk '{print $2}')\n  oc delete\
+                    \ rolebindings -n $rb_namespace $rb_name\ndone <<< \"$ROLEBINDINGS\"\
+                    \n\n## Delete ClusterRolebindings\nfor clb in $CROLEBINDINGS\n\
+                    do\n  oc delete clusterrolebinding $clb\ndone\n\n## Delete Roles\n\
+                    [[ -z \"$ROLES\" ]] || while read line\ndo\n  role_name=$(echo\
+                    \ $line | awk '{print $1}')\n  role_namespace=$(echo $line | awk\
+                    \ '{print $2}')\n  oc delete role -n $role_namespace $role_name\n\
+                    done <<< \"$ROLES\"\n\n## Delete Clusterroles\nfor crole in $CROLES\n\
+                    do\n  oc delete clusterrole $crole\ndone\n\n## Delete SAs\nfor\
+                    \ sa in $SAS\ndo\n  oc delete serviceaccount -n $NS $sa\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-delete-backplane-serviceaccounts
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6100,6 +6100,165 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-script-resources
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-managed-scripts
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - serviceaccounts
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-backplane-script-resources
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-backplane-script-resources
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-script-resources
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-script-resources
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 42 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-backplane
+                containers:
+                - name: osd-delete-backplane-script-resources
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "set -euxo pipefail\n\n# Namespace which pods run in\nNS=\"openshift-backplane-managed-scripts\"\
+                    \n# Label which all backplane script resources should have\nLABEL=\"\
+                    managed.openshift.io/backplane-job-uuid\"\n# Only delete resources\
+                    \ created before this time, in unix epoch seconds.\nDEL_ONLY_BEFORE=$(($(date\
+                    \ +%s) - 3600*24))\n\n### Gather data\n# Format: pod_name pod_status\
+                    \ creation_timestamp\nPODS=$(oc get pod -n $NS --selector $LABEL\
+                    \ -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,CT:.metadata.creationTimestamp\
+                    \ --no-headers)\n\n# Format: sa_name\nSAS=$(oc get serviceaccount\
+                    \ -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Format: role_name role_ns\nROLES=$(oc get\
+                    \ role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
+                    \ --no-headers) \n\n# Format: rolebinding_name rolebinding_ns\n\
+                    ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
+                    \ --no-headers)\n\n# Format: clusterrole_name\nCROLES=$(oc get\
+                    \ clusterrole --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Format: clusterrolebinding_name\nCROLEBINDINGS=$(oc\
+                    \ get clusterrolebinding --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Pick up those resources we don't want to\
+                    \ delete.\n# - Current running pods and related resources.\n#\
+                    \ - pods created within THRESHOLD_PERIOD and related resouces.\n\
+                    PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \\\n  '{\n  if($2\
+                    \ ~ /Running/){print $1} \n  else{cmd = sprintf(\"date +\\\"%%s\\\
+                    \" --date=%s\", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0\
+                    \ > before+0){print $1}}\n  }' \\\n  <<< \"$PODS\")\n\nPODS_TO_DEL=$(awk\
+                    \ '{print $1}' <<< \"$PODS\")\n\nfor pod in $PODS_TO_KEEP\ndo\n\
+                    \  PODS_TO_DEL=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$PODS_TO_DEL\"\
+                    )\n  SAS=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$SAS\")\n\
+                    \  ROLES=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$ROLES\"\
+                    )\n  ROLEBINDINGS=$({ grep -v \"$pod\" || test $? = 1; } <<< \"\
+                    $ROLEBINDINGS\")\n  CROLES=$({ grep -v \"$pod\" || test $? = 1;\
+                    \ } <<< \"$CROLES\")\n  CROLEBINDINGS=$({ grep -v \"$pod\" ||\
+                    \ test $? = 1; } <<< \"$CROLEBINDINGS\")\ndone\n\n## Delete non-running\
+                    \ pods\nfor pod in $PODS_TO_DEL\ndo\n  oc delete pod -n $NS $pod\n\
+                    done\n\n## Delete Rolebindings\n[[ -z \"$ROLEBINDINGS\" ]] ||\
+                    \ while read line\ndo\n  rb_name=$(echo $line | awk '{print $1}')\n\
+                    \  rb_namespace=$(echo $line | awk '{print $2}')\n  oc delete\
+                    \ rolebindings -n $rb_namespace $rb_name\ndone <<< \"$ROLEBINDINGS\"\
+                    \n\n## Delete ClusterRolebindings\nfor clb in $CROLEBINDINGS\n\
+                    do\n  oc delete clusterrolebinding $clb\ndone\n\n## Delete Roles\n\
+                    [[ -z \"$ROLES\" ]] || while read line\ndo\n  role_name=$(echo\
+                    \ $line | awk '{print $1}')\n  role_namespace=$(echo $line | awk\
+                    \ '{print $2}')\n  oc delete role -n $role_namespace $role_name\n\
+                    done <<< \"$ROLES\"\n\n## Delete Clusterroles\nfor crole in $CROLES\n\
+                    do\n  oc delete clusterrole $crole\ndone\n\n## Delete SAs\nfor\
+                    \ sa in $SAS\ndo\n  oc delete serviceaccount -n $NS $sa\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-delete-backplane-serviceaccounts
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6100,6 +6100,165 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-script-resources
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-managed-scripts
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - serviceaccounts
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-backplane-script-resources
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-backplane-script-resources
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-script-resources
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-script-resources
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: openshift-backplane-managed-scripts
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-script-resources
+        namespace: openshift-backplane-managed-scripts
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 42 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-backplane
+                containers:
+                - name: osd-delete-backplane-script-resources
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "set -euxo pipefail\n\n# Namespace which pods run in\nNS=\"openshift-backplane-managed-scripts\"\
+                    \n# Label which all backplane script resources should have\nLABEL=\"\
+                    managed.openshift.io/backplane-job-uuid\"\n# Only delete resources\
+                    \ created before this time, in unix epoch seconds.\nDEL_ONLY_BEFORE=$(($(date\
+                    \ +%s) - 3600*24))\n\n### Gather data\n# Format: pod_name pod_status\
+                    \ creation_timestamp\nPODS=$(oc get pod -n $NS --selector $LABEL\
+                    \ -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,CT:.metadata.creationTimestamp\
+                    \ --no-headers)\n\n# Format: sa_name\nSAS=$(oc get serviceaccount\
+                    \ -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Format: role_name role_ns\nROLES=$(oc get\
+                    \ role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
+                    \ --no-headers) \n\n# Format: rolebinding_name rolebinding_ns\n\
+                    ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
+                    \ --no-headers)\n\n# Format: clusterrole_name\nCROLES=$(oc get\
+                    \ clusterrole --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Format: clusterrolebinding_name\nCROLEBINDINGS=$(oc\
+                    \ get clusterrolebinding --selector $LABEL -o custom-columns=NAME:.metadata.name\
+                    \ --no-headers)\n\n# Pick up those resources we don't want to\
+                    \ delete.\n# - Current running pods and related resources.\n#\
+                    \ - pods created within THRESHOLD_PERIOD and related resouces.\n\
+                    PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \\\n  '{\n  if($2\
+                    \ ~ /Running/){print $1} \n  else{cmd = sprintf(\"date +\\\"%%s\\\
+                    \" --date=%s\", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0\
+                    \ > before+0){print $1}}\n  }' \\\n  <<< \"$PODS\")\n\nPODS_TO_DEL=$(awk\
+                    \ '{print $1}' <<< \"$PODS\")\n\nfor pod in $PODS_TO_KEEP\ndo\n\
+                    \  PODS_TO_DEL=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$PODS_TO_DEL\"\
+                    )\n  SAS=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$SAS\")\n\
+                    \  ROLES=$({ grep -v \"$pod\" || test $? = 1; } <<< \"$ROLES\"\
+                    )\n  ROLEBINDINGS=$({ grep -v \"$pod\" || test $? = 1; } <<< \"\
+                    $ROLEBINDINGS\")\n  CROLES=$({ grep -v \"$pod\" || test $? = 1;\
+                    \ } <<< \"$CROLES\")\n  CROLEBINDINGS=$({ grep -v \"$pod\" ||\
+                    \ test $? = 1; } <<< \"$CROLEBINDINGS\")\ndone\n\n## Delete non-running\
+                    \ pods\nfor pod in $PODS_TO_DEL\ndo\n  oc delete pod -n $NS $pod\n\
+                    done\n\n## Delete Rolebindings\n[[ -z \"$ROLEBINDINGS\" ]] ||\
+                    \ while read line\ndo\n  rb_name=$(echo $line | awk '{print $1}')\n\
+                    \  rb_namespace=$(echo $line | awk '{print $2}')\n  oc delete\
+                    \ rolebindings -n $rb_namespace $rb_name\ndone <<< \"$ROLEBINDINGS\"\
+                    \n\n## Delete ClusterRolebindings\nfor clb in $CROLEBINDINGS\n\
+                    do\n  oc delete clusterrolebinding $clb\ndone\n\n## Delete Roles\n\
+                    [[ -z \"$ROLES\" ]] || while read line\ndo\n  role_name=$(echo\
+                    \ $line | awk '{print $1}')\n  role_namespace=$(echo $line | awk\
+                    \ '{print $2}')\n  oc delete role -n $role_namespace $role_name\n\
+                    done <<< \"$ROLES\"\n\n## Delete Clusterroles\nfor crole in $CROLES\n\
+                    do\n  oc delete clusterrole $crole\ndone\n\n## Delete SAs\nfor\
+                    \ sa in $SAS\ndo\n  oc delete serviceaccount -n $NS $sa\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-delete-backplane-serviceaccounts
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
For [OSD-7916](https://issues.redhat.com/browse/OSD-7916). Place a cronjob in OSD clusters to clean up backplane script related resources.

Assumptions:
- pod/sa/role/rolebinding/clusterrole/clusterrolebinding share the same name, like `openshift-job-czxtr`.
  - Deleting the resource using label-selector needs 2 requests: 1 GET request to get the name and namespace and 1 DELETE request to delete the resource.
  - It will find all the resources using label-seletor in one-go.
  - It will delete the resource using the name directly, then it can save 1 request per resource.
- Some pod/sa/role/rolebinding/.. can be missing.
  - If a node got drain, the pod in that node will be deleted automatically.
  - User might delete some of the resources.

Potential issues:
- The cronjob run every 24hrs. If the bp script finishes shortly before the cronjob, the user might not have enough time to retrieve the corresponding logs.
  - Possible solution is to add an annotation like `delete-not-before:time`.
- The cronjob will clean-up all resources which the corresponding pod is not in Running state. It also delete Pending pods because Pending usually indicate there are some problems. If the cronjob runs right after the user run a backplane script, the Pending pod will be deleted unexpectedly.
  -  Possible solution is to add a threshold of the pod age.

