### PR TITLE
Clean up RHODS SRE Permissions

### DIFF
--- a/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
@@ -7,6 +7,6 @@ spec:
   permissions:
   - allowFirst: true
     clusterRoleName: admin
-    namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
+    namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2416,7 +2416,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2416,7 +2416,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2416,7 +2416,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^gpu-operator-resources$|^nfd-operator$|^openshift-operators$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
1. Remove namespaces related to GPU namespaces as they are outside scope
   of the current RHODS addon.
2. Add rhods-notebooks namespace to list of namespaces under RHODS SRE
   admin.

Signed-off-by: Anish Asthana <anishasthana1@gmail.com>