### PR TITLE
Fix versions of cluster-monitoring-operator config

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/config.yaml
@@ -3,8 +3,8 @@ selectorSyncSet:
   matchLabelsApplyMode: "OR"
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
-      operator: NotIn
-      values: ["4.6", "4.7", "4.8"]
+      operator: In
+      values: ["4.5"]
     - key: ext-managed.openshift.io/uwm-disabled
       operator: In
       values: ["true"]

--- a/deploy/cluster-monitoring-config/config.yaml
+++ b/deploy/cluster-monitoring-config/config.yaml
@@ -2,8 +2,8 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
-      operator: In
-      values: ["4.6", "4.7", "4.8"]
+      operator: NotIn
+      values: ["4.5"]
     - key: ext-managed.openshift.io/uwm-disabled
       operator: NotIn
       values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3284,11 +3284,9 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: In
+        operator: NotIn
         values:
-        - '4.6'
-        - '4.7'
-        - '4.8'
+        - '4.5'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -3349,11 +3347,9 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: NotIn
+        operator: In
         values:
-        - '4.6'
-        - '4.7'
-        - '4.8'
+        - '4.5'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3284,11 +3284,9 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: In
+        operator: NotIn
         values:
-        - '4.6'
-        - '4.7'
-        - '4.8'
+        - '4.5'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -3349,11 +3347,9 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: NotIn
+        operator: In
         values:
-        - '4.6'
-        - '4.7'
-        - '4.8'
+        - '4.5'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3284,11 +3284,9 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: In
+        operator: NotIn
         values:
-        - '4.6'
-        - '4.7'
-        - '4.8'
+        - '4.5'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -3349,11 +3347,9 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: NotIn
+        operator: In
         values:
-        - '4.6'
-        - '4.7'
-        - '4.8'
+        - '4.5'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
This swaps around the version selections statements for the cluster-monitoring-operator configuration, so that we can support 4.9+