### PR TITLE
Allow SREP and dedicated-admins to view API server request counts

### DIFF
--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -131,4 +131,13 @@ rules:
   - customresourcedefinitions
   verbs:
   - delete
+# SRE can view api request counts
+- apiGroups:
+  - apiserver.openshift.io
+  resources:
+  - apirequestcounts
+  verbs:
+  - get
+  - list
+  - watch
 ### End

--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -306,3 +306,13 @@ rules:
   verbs:
   - "*"
 ### END
+### Start - Allow dedicated admins to view api request counts
+- apiGroups:
+  - apiserver.openshift.io
+  resources:
+  - apirequestcounts
+  verbs:
+  - get
+  - list
+  - watch
+### END

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2583,6 +2583,14 @@ objects:
         - customresourcedefinitions
         verbs:
         - delete
+      - apiGroups:
+        - apiserver.openshift.io
+        resources:
+        - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9059,6 +9067,14 @@ objects:
         - clusterresourcequotas
         verbs:
         - '*'
+      - apiGroups:
+        - apiserver.openshift.io
+        resources:
+        - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2583,6 +2583,14 @@ objects:
         - customresourcedefinitions
         verbs:
         - delete
+      - apiGroups:
+        - apiserver.openshift.io
+        resources:
+        - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9059,6 +9067,14 @@ objects:
         - clusterresourcequotas
         verbs:
         - '*'
+      - apiGroups:
+        - apiserver.openshift.io
+        resources:
+        - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2583,6 +2583,14 @@ objects:
         - customresourcedefinitions
         verbs:
         - delete
+      - apiGroups:
+        - apiserver.openshift.io
+        resources:
+        - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9059,6 +9067,14 @@ objects:
         - clusterresourcequotas
         verbs:
         - '*'
+      - apiGroups:
+        - apiserver.openshift.io
+        resources:
+        - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
The `apirequestcounts.apiserver.openshift.io` CRD was created in OpenShift 4.8 to allow cluster owners to identify which APIs are being used in the cluster. This is to help determine workloads that are using deprecated API endpoints.

This adds RBAC to allow SREP and dedicated-admins view rights to this new CRD.

ref:
https://github.com/openshift/enhancements/blob/master/enhancements/kube-apiserver/stability-api-removal-notifications.md
https://issues.redhat.com/browse/API-1009
https://bugzilla.redhat.com/show_bug.cgi?id=1949306