### PR TITLE
OSD-7566 sre source builds

### DIFF
--- a/deploy/sre-build-test/20-build-test-ClusterRole.yaml
+++ b/deploy/sre-build-test/20-build-test-ClusterRole.yaml
@@ -14,6 +14,7 @@ rules:
   - build.openshift.io
   resources:
   - buildconfigs
+  - buildconfigs/instantiatebinary
   - builds
   verbs:
   - create
@@ -24,3 +25,9 @@ rules:
   - imagestreams
   verbs:
   - create
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - images
+  verbs:
+  - delete

--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -50,7 +50,8 @@ spec:
 
               # cleanup traps on exiting, so these always run
               cleanup () {
-                echo "$(date): Done, deleting build NS=$NS"
+                echo "$(date): Done, deleting build images and build NS=$NS"
+                oc -n "${NS}" get build -o jsonpath='{.items[0].status.output.to.imageDigest}' --ignore-not-found | xargs oc -n "${NS}" delete images
                 oc delete ns "${NS}"
               }
               trap "cleanup" EXIT SIGINT
@@ -81,7 +82,18 @@ spec:
               oc create ns "${NS}"
 
               # run build
-              oc -n "${NS}" new-build nodejs~https://github.com/openshift/nodejs-ex --name="${JOB_PREFIX}"
+              oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --image-stream openshift/golang
+              cat <<EOF > /tmp/main.go
+              package main
+              import (
+                     "fmt"
+              )
+
+              func main() {
+                      fmt.Println("Hello Openshift SRE :)")
+              }
+              EOF
+              oc -n "${NS}" start-build "${JOB_PREFIX}" --from-file=/tmp/main.go
               echo "$(date): Waiting for build to complete."
               while :
               do

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9867,6 +9867,7 @@ objects:
         - build.openshift.io
         resources:
         - buildconfigs
+        - buildconfigs/instantiatebinary
         - builds
         verbs:
         - create
@@ -9877,6 +9878,12 @@ objects:
         - imagestreams
         verbs:
         - create
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -9961,13 +9968,15 @@ objects:
                   - "# ensure we fail if something exits non-zero\nset -o errexit\n\
                     set -o nounset\nset -o pipefail\n\n# cleanup traps on exiting,\
                     \ so these always run\ncleanup () {\n  echo \"$(date): Done, deleting\
-                    \ build NS=$NS\"\n  oc delete ns \"${NS}\"\n}\ntrap \"cleanup\"\
-                    \ EXIT SIGINT\n\n# set NS to include job name, to ease linking\
-                    \ namespace to a specific job\nJOB_PREFIX=sre-build-test\nNS=\"\
-                    ${POD_NS}-${POD_NAME##${JOB_PREFIX}-}\"\nJOB_NAME=$(echo \"${POD_NAME}\"\
-                    \ | rev | cut -d- -f2- | rev)\n\nGET_FAILED_JOBS=$(cat <<END\n\
-                    import json,sys\nr = json.load(sys.stdin)\n# create a list of\
-                    \ jobs\njobs = [ job['metadata']['name'] for job in r['items']\
+                    \ build images and build NS=$NS\"\n  oc -n \"${NS}\" get build\
+                    \ -o jsonpath='{.items[0].status.output.to.imageDigest}' --ignore-not-found\
+                    \ | xargs oc -n \"${NS}\" delete images\n  oc delete ns \"${NS}\"\
+                    \n}\ntrap \"cleanup\" EXIT SIGINT\n\n# set NS to include job name,\
+                    \ to ease linking namespace to a specific job\nJOB_PREFIX=sre-build-test\n\
+                    NS=\"${POD_NS}-${POD_NAME##${JOB_PREFIX}-}\"\nJOB_NAME=$(echo\
+                    \ \"${POD_NAME}\" | rev | cut -d- -f2- | rev)\n\nGET_FAILED_JOBS=$(cat\
+                    \ <<END\nimport json,sys\nr = json.load(sys.stdin)\n# create a\
+                    \ list of jobs\njobs = [ job['metadata']['name'] for job in r['items']\
                     \ if\n  # no jobs are currently running \n  ( not 'active' in\
                     \ job['status']) and\n  # if '.status.failed' exists on job\n\
                     \  'failed' in job['status'] and\n  # if job failed count is bigger\
@@ -9976,24 +9985,28 @@ objects:
                     \  # if this changes we should consider using an easier implementation\n\
                     \  job['spec']['backoffLimit'] - 1 <= job['status']['failed']]\n\
                     print(\" \".join(jobs))\nEND\n)\noc create ns \"${NS}\"\n\n# run\
-                    \ build\noc -n \"${NS}\" new-build nodejs~https://github.com/openshift/nodejs-ex\
-                    \ --name=\"${JOB_PREFIX}\"\necho \"$(date): Waiting for build\
-                    \ to complete.\"\nwhile :\ndo\n  ST=$(oc -n \"${NS}\" get build\
-                    \ -o custom-columns=STATUS:.status.phase --no-headers)\n  case\
-                    \ ${ST} in\n    \"\")\n      # if build status is blank, assume\
-                    \ we are still starting the build\n      ST=\"Starting\"\n   \
-                    \   ;;\n    Failed)\n      echo \"$(date): Build Failed\" >&2\n\
-                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
-                    \ Build was Cancelled\" >&2\n      exit 1\n      ;;\n    Complete)\n\
-                    \      echo \"$(date): Build Complete\"\n      # Get all job names\
-                    \ that have exceeded failed retries\n      JOBS=$(oc -n \"${POD_NS}\"\
-                    \ get job -o json)\n      JOBS_TO_DELETE=$(echo \"${JOBS}\" |\
-                    \ python -c \"$GET_FAILED_JOBS\")\n\n      if [[ -n \"${JOBS_TO_DELETE}\"\
-                    \ ]] ; then\n        echo \"$(date): Selected jobs for deletion:\
-                    \ ${JOBS_TO_DELETE}\"\n        echo \"${JOBS_TO_DELETE}\" | xargs\
-                    \ oc -n \"${POD_NS}\" delete job\n      fi\n      break\n    \
-                    \  ;;\n  esac\n  echo \"$(date): Build is ${ST}; checking build\
-                    \ again in 15 seconds, NS=${NS}\"\n  sleep 15\ndone\nexit 0\n"
+                    \ build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\" --binary\
+                    \ --strategy source --image-stream openshift/golang\ncat <<EOF\
+                    \ > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\n)\n\n\
+                    func main() {\n        fmt.Println(\"Hello Openshift SRE :)\"\
+                    )\n}\nEOF\noc -n \"${NS}\" start-build \"${JOB_PREFIX}\" --from-file=/tmp/main.go\n\
+                    echo \"$(date): Waiting for build to complete.\"\nwhile :\ndo\n\
+                    \  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
+                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
+                    \ status is blank, assume we are still starting the build\n  \
+                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ Build Failed\" >&2\n      exit 1\n      ;;\n    Cancelled)\n\
+                    \      echo \"$(date): Build was Cancelled\" >&2\n      exit 1\n\
+                    \      ;;\n    Complete)\n      echo \"$(date): Build Complete\"\
+                    \n      # Get all job names that have exceeded failed retries\n\
+                    \      JOBS=$(oc -n \"${POD_NS}\" get job -o json)\n      JOBS_TO_DELETE=$(echo\
+                    \ \"${JOBS}\" | python -c \"$GET_FAILED_JOBS\")\n\n      if [[\
+                    \ -n \"${JOBS_TO_DELETE}\" ]] ; then\n        echo \"$(date):\
+                    \ Selected jobs for deletion: ${JOBS_TO_DELETE}\"\n        echo\
+                    \ \"${JOBS_TO_DELETE}\" | xargs oc -n \"${POD_NS}\" delete job\n\
+                    \      fi\n      break\n      ;;\n  esac\n  echo \"$(date): Build\
+                    \ is ${ST}; checking build again in 15 seconds, NS=${NS}\"\n \
+                    \ sleep 15\ndone\nexit 0\n"
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9867,6 +9867,7 @@ objects:
         - build.openshift.io
         resources:
         - buildconfigs
+        - buildconfigs/instantiatebinary
         - builds
         verbs:
         - create
@@ -9877,6 +9878,12 @@ objects:
         - imagestreams
         verbs:
         - create
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -9961,13 +9968,15 @@ objects:
                   - "# ensure we fail if something exits non-zero\nset -o errexit\n\
                     set -o nounset\nset -o pipefail\n\n# cleanup traps on exiting,\
                     \ so these always run\ncleanup () {\n  echo \"$(date): Done, deleting\
-                    \ build NS=$NS\"\n  oc delete ns \"${NS}\"\n}\ntrap \"cleanup\"\
-                    \ EXIT SIGINT\n\n# set NS to include job name, to ease linking\
-                    \ namespace to a specific job\nJOB_PREFIX=sre-build-test\nNS=\"\
-                    ${POD_NS}-${POD_NAME##${JOB_PREFIX}-}\"\nJOB_NAME=$(echo \"${POD_NAME}\"\
-                    \ | rev | cut -d- -f2- | rev)\n\nGET_FAILED_JOBS=$(cat <<END\n\
-                    import json,sys\nr = json.load(sys.stdin)\n# create a list of\
-                    \ jobs\njobs = [ job['metadata']['name'] for job in r['items']\
+                    \ build images and build NS=$NS\"\n  oc -n \"${NS}\" get build\
+                    \ -o jsonpath='{.items[0].status.output.to.imageDigest}' --ignore-not-found\
+                    \ | xargs oc -n \"${NS}\" delete images\n  oc delete ns \"${NS}\"\
+                    \n}\ntrap \"cleanup\" EXIT SIGINT\n\n# set NS to include job name,\
+                    \ to ease linking namespace to a specific job\nJOB_PREFIX=sre-build-test\n\
+                    NS=\"${POD_NS}-${POD_NAME##${JOB_PREFIX}-}\"\nJOB_NAME=$(echo\
+                    \ \"${POD_NAME}\" | rev | cut -d- -f2- | rev)\n\nGET_FAILED_JOBS=$(cat\
+                    \ <<END\nimport json,sys\nr = json.load(sys.stdin)\n# create a\
+                    \ list of jobs\njobs = [ job['metadata']['name'] for job in r['items']\
                     \ if\n  # no jobs are currently running \n  ( not 'active' in\
                     \ job['status']) and\n  # if '.status.failed' exists on job\n\
                     \  'failed' in job['status'] and\n  # if job failed count is bigger\
@@ -9976,24 +9985,28 @@ objects:
                     \  # if this changes we should consider using an easier implementation\n\
                     \  job['spec']['backoffLimit'] - 1 <= job['status']['failed']]\n\
                     print(\" \".join(jobs))\nEND\n)\noc create ns \"${NS}\"\n\n# run\
-                    \ build\noc -n \"${NS}\" new-build nodejs~https://github.com/openshift/nodejs-ex\
-                    \ --name=\"${JOB_PREFIX}\"\necho \"$(date): Waiting for build\
-                    \ to complete.\"\nwhile :\ndo\n  ST=$(oc -n \"${NS}\" get build\
-                    \ -o custom-columns=STATUS:.status.phase --no-headers)\n  case\
-                    \ ${ST} in\n    \"\")\n      # if build status is blank, assume\
-                    \ we are still starting the build\n      ST=\"Starting\"\n   \
-                    \   ;;\n    Failed)\n      echo \"$(date): Build Failed\" >&2\n\
-                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
-                    \ Build was Cancelled\" >&2\n      exit 1\n      ;;\n    Complete)\n\
-                    \      echo \"$(date): Build Complete\"\n      # Get all job names\
-                    \ that have exceeded failed retries\n      JOBS=$(oc -n \"${POD_NS}\"\
-                    \ get job -o json)\n      JOBS_TO_DELETE=$(echo \"${JOBS}\" |\
-                    \ python -c \"$GET_FAILED_JOBS\")\n\n      if [[ -n \"${JOBS_TO_DELETE}\"\
-                    \ ]] ; then\n        echo \"$(date): Selected jobs for deletion:\
-                    \ ${JOBS_TO_DELETE}\"\n        echo \"${JOBS_TO_DELETE}\" | xargs\
-                    \ oc -n \"${POD_NS}\" delete job\n      fi\n      break\n    \
-                    \  ;;\n  esac\n  echo \"$(date): Build is ${ST}; checking build\
-                    \ again in 15 seconds, NS=${NS}\"\n  sleep 15\ndone\nexit 0\n"
+                    \ build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\" --binary\
+                    \ --strategy source --image-stream openshift/golang\ncat <<EOF\
+                    \ > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\n)\n\n\
+                    func main() {\n        fmt.Println(\"Hello Openshift SRE :)\"\
+                    )\n}\nEOF\noc -n \"${NS}\" start-build \"${JOB_PREFIX}\" --from-file=/tmp/main.go\n\
+                    echo \"$(date): Waiting for build to complete.\"\nwhile :\ndo\n\
+                    \  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
+                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
+                    \ status is blank, assume we are still starting the build\n  \
+                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ Build Failed\" >&2\n      exit 1\n      ;;\n    Cancelled)\n\
+                    \      echo \"$(date): Build was Cancelled\" >&2\n      exit 1\n\
+                    \      ;;\n    Complete)\n      echo \"$(date): Build Complete\"\
+                    \n      # Get all job names that have exceeded failed retries\n\
+                    \      JOBS=$(oc -n \"${POD_NS}\" get job -o json)\n      JOBS_TO_DELETE=$(echo\
+                    \ \"${JOBS}\" | python -c \"$GET_FAILED_JOBS\")\n\n      if [[\
+                    \ -n \"${JOBS_TO_DELETE}\" ]] ; then\n        echo \"$(date):\
+                    \ Selected jobs for deletion: ${JOBS_TO_DELETE}\"\n        echo\
+                    \ \"${JOBS_TO_DELETE}\" | xargs oc -n \"${POD_NS}\" delete job\n\
+                    \      fi\n      break\n      ;;\n  esac\n  echo \"$(date): Build\
+                    \ is ${ST}; checking build again in 15 seconds, NS=${NS}\"\n \
+                    \ sleep 15\ndone\nexit 0\n"
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9867,6 +9867,7 @@ objects:
         - build.openshift.io
         resources:
         - buildconfigs
+        - buildconfigs/instantiatebinary
         - builds
         verbs:
         - create
@@ -9877,6 +9878,12 @@ objects:
         - imagestreams
         verbs:
         - create
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        verbs:
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -9961,13 +9968,15 @@ objects:
                   - "# ensure we fail if something exits non-zero\nset -o errexit\n\
                     set -o nounset\nset -o pipefail\n\n# cleanup traps on exiting,\
                     \ so these always run\ncleanup () {\n  echo \"$(date): Done, deleting\
-                    \ build NS=$NS\"\n  oc delete ns \"${NS}\"\n}\ntrap \"cleanup\"\
-                    \ EXIT SIGINT\n\n# set NS to include job name, to ease linking\
-                    \ namespace to a specific job\nJOB_PREFIX=sre-build-test\nNS=\"\
-                    ${POD_NS}-${POD_NAME##${JOB_PREFIX}-}\"\nJOB_NAME=$(echo \"${POD_NAME}\"\
-                    \ | rev | cut -d- -f2- | rev)\n\nGET_FAILED_JOBS=$(cat <<END\n\
-                    import json,sys\nr = json.load(sys.stdin)\n# create a list of\
-                    \ jobs\njobs = [ job['metadata']['name'] for job in r['items']\
+                    \ build images and build NS=$NS\"\n  oc -n \"${NS}\" get build\
+                    \ -o jsonpath='{.items[0].status.output.to.imageDigest}' --ignore-not-found\
+                    \ | xargs oc -n \"${NS}\" delete images\n  oc delete ns \"${NS}\"\
+                    \n}\ntrap \"cleanup\" EXIT SIGINT\n\n# set NS to include job name,\
+                    \ to ease linking namespace to a specific job\nJOB_PREFIX=sre-build-test\n\
+                    NS=\"${POD_NS}-${POD_NAME##${JOB_PREFIX}-}\"\nJOB_NAME=$(echo\
+                    \ \"${POD_NAME}\" | rev | cut -d- -f2- | rev)\n\nGET_FAILED_JOBS=$(cat\
+                    \ <<END\nimport json,sys\nr = json.load(sys.stdin)\n# create a\
+                    \ list of jobs\njobs = [ job['metadata']['name'] for job in r['items']\
                     \ if\n  # no jobs are currently running \n  ( not 'active' in\
                     \ job['status']) and\n  # if '.status.failed' exists on job\n\
                     \  'failed' in job['status'] and\n  # if job failed count is bigger\
@@ -9976,24 +9985,28 @@ objects:
                     \  # if this changes we should consider using an easier implementation\n\
                     \  job['spec']['backoffLimit'] - 1 <= job['status']['failed']]\n\
                     print(\" \".join(jobs))\nEND\n)\noc create ns \"${NS}\"\n\n# run\
-                    \ build\noc -n \"${NS}\" new-build nodejs~https://github.com/openshift/nodejs-ex\
-                    \ --name=\"${JOB_PREFIX}\"\necho \"$(date): Waiting for build\
-                    \ to complete.\"\nwhile :\ndo\n  ST=$(oc -n \"${NS}\" get build\
-                    \ -o custom-columns=STATUS:.status.phase --no-headers)\n  case\
-                    \ ${ST} in\n    \"\")\n      # if build status is blank, assume\
-                    \ we are still starting the build\n      ST=\"Starting\"\n   \
-                    \   ;;\n    Failed)\n      echo \"$(date): Build Failed\" >&2\n\
-                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
-                    \ Build was Cancelled\" >&2\n      exit 1\n      ;;\n    Complete)\n\
-                    \      echo \"$(date): Build Complete\"\n      # Get all job names\
-                    \ that have exceeded failed retries\n      JOBS=$(oc -n \"${POD_NS}\"\
-                    \ get job -o json)\n      JOBS_TO_DELETE=$(echo \"${JOBS}\" |\
-                    \ python -c \"$GET_FAILED_JOBS\")\n\n      if [[ -n \"${JOBS_TO_DELETE}\"\
-                    \ ]] ; then\n        echo \"$(date): Selected jobs for deletion:\
-                    \ ${JOBS_TO_DELETE}\"\n        echo \"${JOBS_TO_DELETE}\" | xargs\
-                    \ oc -n \"${POD_NS}\" delete job\n      fi\n      break\n    \
-                    \  ;;\n  esac\n  echo \"$(date): Build is ${ST}; checking build\
-                    \ again in 15 seconds, NS=${NS}\"\n  sleep 15\ndone\nexit 0\n"
+                    \ build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\" --binary\
+                    \ --strategy source --image-stream openshift/golang\ncat <<EOF\
+                    \ > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\n)\n\n\
+                    func main() {\n        fmt.Println(\"Hello Openshift SRE :)\"\
+                    )\n}\nEOF\noc -n \"${NS}\" start-build \"${JOB_PREFIX}\" --from-file=/tmp/main.go\n\
+                    echo \"$(date): Waiting for build to complete.\"\nwhile :\ndo\n\
+                    \  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
+                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
+                    \ status is blank, assume we are still starting the build\n  \
+                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ Build Failed\" >&2\n      exit 1\n      ;;\n    Cancelled)\n\
+                    \      echo \"$(date): Build was Cancelled\" >&2\n      exit 1\n\
+                    \      ;;\n    Complete)\n      echo \"$(date): Build Complete\"\
+                    \n      # Get all job names that have exceeded failed retries\n\
+                    \      JOBS=$(oc -n \"${POD_NS}\" get job -o json)\n      JOBS_TO_DELETE=$(echo\
+                    \ \"${JOBS}\" | python -c \"$GET_FAILED_JOBS\")\n\n      if [[\
+                    \ -n \"${JOBS_TO_DELETE}\" ]] ; then\n        echo \"$(date):\
+                    \ Selected jobs for deletion: ${JOBS_TO_DELETE}\"\n        echo\
+                    \ \"${JOBS_TO_DELETE}\" | xargs oc -n \"${POD_NS}\" delete job\n\
+                    \      fi\n      break\n      ;;\n  esac\n  echo \"$(date): Build\
+                    \ is ${ST}; checking build again in 15 seconds, NS=${NS}\"\n \
+                    \ sleep 15\ndone\nexit 0\n"
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Locked egress evironments prevent the current sre-build-test from completing due to requiring pull data from github/registry.npmjs.org.

This build is performed locally form filesystem using `--binary` and passing the source into the builds rather then retrieving it remotely. To complete the build, a new image is now pushed to the internal registry of which extra garbage collection has been added to remove created images to prevent polluting the registry for customers.