### PR TITLE
allow CONTAINER_ENGINE var to be overriden from the outside

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifndef GEN_TEMPLATE
 $(error GEN_TEMPLATE is not set; check project.mk file)
 endif
 
-CONTAINER_ENGINE=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
+CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
 
 ifeq ($(CONTAINER_ENGINE),)
 # Running already in a container


### PR DESCRIPTION
use-case: I have docker and podman on my machine but want to use podman.
example: `make CONTAINER_ENGINE=podman` uses podman over docker
