### PR TITLE
Update apiVersion for the rebalance-infra-nodes CronJob to batch/v1beta1

### DIFF
--- a/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
+++ b/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: osd-rebalance-infra-nodes

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8117,7 +8117,7 @@ objects:
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
           waitRunningPods splunk-heavy-forwarder openshift-security name"
-    - apiVersion: batch/v1
+    - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:
         name: osd-rebalance-infra-nodes

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8117,7 +8117,7 @@ objects:
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
           waitRunningPods splunk-heavy-forwarder openshift-security name"
-    - apiVersion: batch/v1
+    - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:
         name: osd-rebalance-infra-nodes

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8117,7 +8117,7 @@ objects:
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
           waitRunningPods splunk-heavy-forwarder openshift-security name"
-    - apiVersion: batch/v1
+    - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:
         name: osd-rebalance-infra-nodes


### PR DESCRIPTION
This is a small change to update the apiVersion for the infra node rebalance cronjob from `v1` to `v1beta1`.