### PR TITLE
Remove oauth token configuration

### DIFF
--- a/deploy/osd-oauth-tokens/config.yaml
+++ b/deploy/osd-oauth-tokens/config.yaml
@@ -1,6 +1,0 @@
-deploymentMode: "SelectorSyncSet"
-selectorSyncSet:
-  matchExpressions:
-  - key: api.openshift.com/environment
-    operator: NotIn
-    values: ["production","staging"]

--- a/deploy/osd-oauth-tokens/osd-oauth-tokens.patch.yaml
+++ b/deploy/osd-oauth-tokens/osd-oauth-tokens.patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: config.openshift.io/v1
-applyMode: AlwaysApply
-kind: OAuth
-name: cluster
-# accessTokenInactivityTimeout is the replacement for the deprecated accessTokenInactivityTimeoutSeconds
-patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":86400,
-  "accessTokenInactivityTimeoutSeconds":21600,"accessTokenInactivityTimeout":"6h"}}}'
-patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7805,32 +7805,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-oauth-tokens
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/environment
-        operator: NotIn
-        values:
-        - production
-        - staging
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: OAuth
-      name: cluster
-      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":86400, "accessTokenInactivityTimeoutSeconds":21600,"accessTokenInactivityTimeout":"6h"}}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-openshift-operators-redhat
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7805,32 +7805,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-oauth-tokens
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/environment
-        operator: NotIn
-        values:
-        - production
-        - staging
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: OAuth
-      name: cluster
-      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":86400, "accessTokenInactivityTimeoutSeconds":21600,"accessTokenInactivityTimeout":"6h"}}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-openshift-operators-redhat
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7805,32 +7805,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-oauth-tokens
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/environment
-        operator: NotIn
-        values:
-        - production
-        - staging
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: OAuth
-      name: cluster
-      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":86400, "accessTokenInactivityTimeoutSeconds":21600,"accessTokenInactivityTimeout":"6h"}}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-openshift-operators-redhat
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This configuration was never deployed to prod, and as it stands, will be a breaking change for customers. Default token length is 24 hours, and is configurable by the customer.