### PR TITLE
Adding 'openshift-monitoring' to the managed namespaces list

### DIFF
--- a/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
@@ -34,4 +34,5 @@ data:
       - name: openshift-strimzi
       - name: openshift-validation-webhook
       - name: openshift-velero
+      - name: openshift-monitoring
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7575,7 +7575,8 @@ objects:
           \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
           \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-sre-sshd\n  - name:\
-          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n"
+          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n\
+          \  - name: openshift-monitoring\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7575,7 +7575,8 @@ objects:
           \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
           \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-sre-sshd\n  - name:\
-          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n"
+          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n\
+          \  - name: openshift-monitoring\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7575,7 +7575,8 @@ objects:
           \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
           \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-sre-sshd\n  - name:\
-          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n"
+          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n\
+          \  - name: openshift-monitoring\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -5,6 +5,8 @@ Resources:
   - namespace: openshift-monitoring
     name: cluster-monitoring-config
   - namespace: openshift-monitoring
+    name: managed-namespaces
+  - namespace: openshift-monitoring
     name: osd-rebalance-infra-nodes
   - namespace: openshift-monitoring
     name: sre-dns-latency-exporter-code
@@ -14,10 +16,6 @@ Resources:
     name: sre-stuck-ebs-vols-code
   - namespace: openshift-security
     name: osd-audit-policy
-  - namespace: openshift-sre-sshd
-    name: aos-osd-customer-support
-  - namespace: openshift-sre-sshd
-    name: aos-sre
   - namespace: openshift-validation-webhook
     name: webhook-cert
   Endpoints:
@@ -59,6 +57,7 @@ Resources:
   - name: openshift-strimzi
   - name: openshift-validation-webhook
   - name: openshift-velero
+  - name: openshift-monitoring
   ReplicationController:
   - namespace: openshift-monitoring
     name: sre-ebs-iops-reporter-1
@@ -136,13 +135,13 @@ Resources:
   - name: configure-alertmanager-operator-prom
   - name: dedicated-admins-cluster
   - name: dedicated-admins-registry-cas-cluster
+  - name: openshift-backplane-managed-scripts-reader
   - name: osd-cluster-ready
   - name: osd-delete-backplane-script-resources
   - name: osd-delete-ownerrefs-bz1906584
   - name: osd-delete-ownerrefs-serviceaccounts
   - name: osd-patch-subscription-source
   - name: osd-rebalance-infra-nodes
-  - name: pcap-collector
   - name: pcap-dedicated-admins
   - name: splunk-forwarder-operator
   - name: splunk-forwarder-operator-clusterrolebinding
@@ -166,6 +165,7 @@ Resources:
   - name: dedicated-admins-registry-cas-cluster
   - name: dedicated-readers
   - name: image-scanner
+  - name: openshift-backplane-managed-scripts-reader
   - name: openshift-splunk-forwarder-operator
   - name: osd-cluster-ready
   - name: osd-custom-domains-dedicated-admin-cluster
@@ -178,7 +178,6 @@ Resources:
   - name: osd-patch-subscription-source
   - name: osd-readers-aggregate
   - name: osd-rebalance-infra-nodes
-  - name: pcap-collector
   - name: pcap-dedicated-admins
   - name: splunk-forwarder-operator
   - name: sre-allow-read-machine-info
@@ -206,18 +205,14 @@ Resources:
     name: deployments-pruner
   - namespace: openshift-sre-pruning
     name: services-pruner
+  - namespace: openshift-sre-pruning
+    name: sre-idp-pruner
   Job:
   - namespace: openshift-monitoring
     name: osd-cluster-ready
   APIScheme:
   - namespace: openshift-cloud-ingress-operator
     name: rh-api
-  PublishingStrategy:
-  - namespace: openshift-cloud-ingress-operator
-    name: publishingstrategy
-  SSHD:
-  - namespace: openshift-sre-sshd
-    name: rh-ssh
   ScanSettingBinding:
   - namespace: openshift-compliance
     name: fedramp-moderate
@@ -231,9 +226,9 @@ Resources:
     name: srep-worker-healthcheck
   MachineSet:
   - namespace: openshift-machine-api
-    name: blrm-9-2-7kgj9-infra-us-east-1a
+    name: blrm-9-17-5qbgh-infra-us-east-1a
   - namespace: openshift-machine-api
-    name: blrm-9-2-7kgj9-worker-us-east-1a
+    name: blrm-9-17-5qbgh-worker-us-east-1a
   KubeletConfig:
   - name: custom-kubelet
   SubjectPermission:
@@ -345,28 +340,28 @@ Resources:
   - namespace: openshift-velero
     name: managed-velero-operator
   PackageManifest:
-  - namespace: openshift-managed-upgrade-operator
-    name: managed-upgrade-operator
-  - namespace: openshift-cloud-ingress-operator
-    name: cloud-ingress-operator
-  - namespace: openshift-osd-metrics
-    name: osd-metrics-exporter
-  - namespace: openshift-velero
-    name: managed-velero-operator
   - namespace: openshift-monitoring
     name: configure-alertmanager-operator
-  - namespace: openshift-custom-domains-operator
-    name: custom-domains-operator
   - namespace: openshift-splunk-forwarder-operator
     name: splunk-forwarder-operator
-  - namespace: openshift-route-monitor-operator
-    name: route-monitor-operator
-  - namespace: openshift-rbac-permissions
-    name: rbac-permissions-operator
-  - namespace: openshift-must-gather-operator
-    name: must-gather-operator
+  - namespace: openshift-osd-metrics
+    name: osd-metrics-exporter
   - namespace: openshift-compliance
     name: compliance-operator
+  - namespace: openshift-must-gather-operator
+    name: must-gather-operator
+  - namespace: openshift-rbac-permissions
+    name: rbac-permissions-operator
+  - namespace: openshift-route-monitor-operator
+    name: route-monitor-operator
+  - namespace: openshift-managed-upgrade-operator
+    name: managed-upgrade-operator
+  - namespace: openshift-velero
+    name: managed-velero-operator
+  - namespace: openshift-custom-domains-operator
+    name: custom-domains-operator
+  - namespace: openshift-cloud-ingress-operator
+    name: cloud-ingress-operator
   Status:
   - {}
   Project:
@@ -401,7 +396,6 @@ Resources:
   - name: loadbalancer-quota
   - name: persistent-volume-quota
   SecurityContextConstraints:
-  - name: pcap-collector
   - name: pcap-dedicated-admins
   - name: splunkforwarder
   SplunkForwarder:
@@ -409,6 +403,5 @@ Resources:
     name: splunkforwarder
   Group:
   - name: dedicated-admins
-  - name: osd-sre-admins
   User:
   - name: backplane-cluster-admin

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -213,6 +213,9 @@ Resources:
   APIScheme:
   - namespace: openshift-cloud-ingress-operator
     name: rh-api
+  PublishingStrategy:
+  - namespace: openshift-cloud-ingress-operator
+    name: publishingstrategy
   ScanSettingBinding:
   - namespace: openshift-compliance
     name: fedramp-moderate
@@ -340,8 +343,6 @@ Resources:
   - namespace: openshift-velero
     name: managed-velero-operator
   PackageManifest:
-  - namespace: openshift-monitoring
-    name: configure-alertmanager-operator
   - namespace: openshift-splunk-forwarder-operator
     name: splunk-forwarder-operator
   - namespace: openshift-osd-metrics
@@ -362,6 +363,8 @@ Resources:
     name: custom-domains-operator
   - namespace: openshift-cloud-ingress-operator
     name: cloud-ingress-operator
+  - namespace: openshift-monitoring
+    name: configure-alertmanager-operator
   Status:
   - {}
   Project:

--- a/scripts/managed-resources/generate-managed-list.py
+++ b/scripts/managed-resources/generate-managed-list.py
@@ -17,6 +17,12 @@ data:
 {}
 """
 
+# This is a list of namespaces that do not have the "hive.openshift.io/managed=true" label but
+# are still being managed by SRE-P.
+ADDITIONAL_MANAGED_NAMESPACES = [
+    {"name": "openshift-monitoring"},
+]
+
 
 def get_api_resource_kinds():
     """
@@ -71,6 +77,7 @@ def collect_managed_resources(kinds):
             ]
             resources["Resources"][kind_name] = filtered_kind_list
     resources = remove_backplane_service_account(resources)
+    resources["Resources"]["Namespace"] += ADDITIONAL_MANAGED_NAMESPACES
     return resources
 
 


### PR DESCRIPTION
The `openshift-monitoring` namespace doesn't have the "hive.openshift.io/managed=true" label but it is a namespace that SRE manages. This adds the `openshift-monitoring` namespace to both of the generated managed resource files in MCC.