### PR TITLE
OSD-8028: Patch IngressController.spec.replicas to 3 for specific clusters

### DIFF
--- a/deploy/cloud-ingress-operator-configuration/routerreplicas-OSD-8028/10-routerreplics.ingresscontroller.yaml
+++ b/deploy/cloud-ingress-operator-configuration/routerreplicas-OSD-8028/10-routerreplics.ingresscontroller.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: IngressController
+name: default
+applyMode: AlwaysApply
+patch: '{"spec":{"replicas":3}}'
+patchType: merge

--- a/deploy/cloud-ingress-operator-configuration/routerreplicas-OSD-8028/config.yaml
+++ b/deploy/cloud-ingress-operator-configuration/routerreplicas-OSD-8028/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/id
+      operator: In
+      values: "${{ROUTER_REPLICA_CLUSTER_IDS}}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -38,6 +38,8 @@ parameters:
   required: true
 - name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
+- name: ROUTER_REPLICA_CLUSTER_IDS
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -3305,6 +3307,30 @@ objects:
           enabled: ${{ENABLE_MANAGEMENT_API_SERVER_INGRESS}}
           dnsName: rh-api
           allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator-configuration-routerreplicas-OSD-8028
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values: ${{ROUTER_REPLICA_CLUSTER_IDS}}
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -38,6 +38,8 @@ parameters:
   required: true
 - name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
+- name: ROUTER_REPLICA_CLUSTER_IDS
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -3305,6 +3307,30 @@ objects:
           enabled: ${{ENABLE_MANAGEMENT_API_SERVER_INGRESS}}
           dnsName: rh-api
           allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator-configuration-routerreplicas-OSD-8028
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values: ${{ROUTER_REPLICA_CLUSTER_IDS}}
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -38,6 +38,8 @@ parameters:
   required: true
 - name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
+- name: ROUTER_REPLICA_CLUSTER_IDS
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:
@@ -3305,6 +3307,30 @@ objects:
           enabled: ${{ENABLE_MANAGEMENT_API_SERVER_INGRESS}}
           dnsName: rh-api
           allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator-configuration-routerreplicas-OSD-8028
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values: ${{ROUTER_REPLICA_CLUSTER_IDS}}
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -38,6 +38,8 @@ parameters:
   required: true
 - name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
+- name: ROUTER_REPLICA_CLUSTER_IDS
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:


### PR DESCRIPTION
As a solution of [OSD-8028](https://issues.redhat.com/browse/OSD-8028), this PR applies a replica count of 3 to cluster IDs specified by `ROUTER_REPLICA_CLUSTER_IDS`