### PR TITLE
Specify namespace of the default ingress controller

### DIFF
--- a/deploy/cloud-ingress-operator-configuration/routerreplicas-osd-8028/10-routerreplics.ingresscontroller.yaml
+++ b/deploy/cloud-ingress-operator-configuration/routerreplicas-osd-8028/10-routerreplics.ingresscontroller.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: IngressController
 name: default
+namespace: openshift-ingress-operator
 applyMode: AlwaysApply
 patch: '{"spec":{"replicas":3}}'
 patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3328,6 +3328,7 @@ objects:
     - apiVersion: v1
       kind: IngressController
       name: default
+      namespace: openshift-ingress-operator
       applyMode: AlwaysApply
       patch: '{"spec":{"replicas":3}}'
       patchType: merge

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3328,6 +3328,7 @@ objects:
     - apiVersion: v1
       kind: IngressController
       name: default
+      namespace: openshift-ingress-operator
       applyMode: AlwaysApply
       patch: '{"spec":{"replicas":3}}'
       patchType: merge

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3328,6 +3328,7 @@ objects:
     - apiVersion: v1
       kind: IngressController
       name: default
+      namespace: openshift-ingress-operator
       applyMode: AlwaysApply
       patch: '{"spec":{"replicas":3}}'
       patchType: merge


### PR DESCRIPTION
Turns out you also need to supply a namespace when working with Kubernetes objects. This PR specifies which namespace the ingresscontroller is in that should be patched.

It's definitely a Monday