### PR TITLE
workaround for BZ1997062 - deploy daemonset to clean /run fs

### DIFF
--- a/deploy/bz1997062/00-execpid-cleaner.cronjob.yaml
+++ b/deploy/bz1997062/00-execpid-cleaner.cronjob.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: execpid-cleaner
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: execpid-cleaner
+  template:
+    metadata:
+      labels:
+        name: execpid-cleaner
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: execpid-cleaner
+        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        command:
+        - sh
+        - -c
+        - |
+          set -euo pipefail
+          while true; do
+              printf "%s Running cleanup:\n" "$(date)"
+              set -x
+              find /run/crio/exec-pid-dir -type f -mmin +15 -exec rm -f {} \;
+              sleep 15m
+              set +x
+          done
+        securityContext:
+          privileged: true
+        resources:
+          limits:
+            memory: 64Mi
+          requests:
+            memory: 64Mi
+        volumeMounts:
+        - name: exec-pid-dir
+          mountPath: /run/crio/exec-pid-dir
+      volumes:
+      - name: exec-pid-dir
+        hostPath:
+          path: /run/crio/exec-pid-dir
+

--- a/deploy/bz1997062/config.yaml
+++ b/deploy/bz1997062/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "Direct"
+direct:
+    environments: ["production", "stage", "integration"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11725,6 +11725,48 @@ objects:
           - events
           snapshotVolumes: false
           ttl: 0h25m0s
+- apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    name: execpid-cleaner
+    namespace: kube-system
+  spec:
+    selector:
+      matchLabels:
+        name: execpid-cleaner
+    template:
+      metadata:
+        labels:
+          name: execpid-cleaner
+      spec:
+        tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        terminationGracePeriodSeconds: 5
+        containers:
+        - name: execpid-cleaner
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          command:
+          - sh
+          - -c
+          - "set -euo pipefail\nwhile true; do\n    printf \"%s Running cleanup:\\\
+            n\" \"$(date)\"\n    set -x\n    find /run/crio/exec-pid-dir -type f -mmin\
+            \ +15 -exec rm -f {} \\;\n    sleep 15m\n    set +x\ndone\n"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              memory: 64Mi
+            requests:
+              memory: 64Mi
+          volumeMounts:
+          - name: exec-pid-dir
+            mountPath: /run/crio/exec-pid-dir
+        volumes:
+        - name: exec-pid-dir
+          hostPath:
+            path: /run/crio/exec-pid-dir
 - apiVersion: v1
   data:
     environment: integration

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11725,6 +11725,48 @@ objects:
           - events
           snapshotVolumes: false
           ttl: 0h25m0s
+- apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    name: execpid-cleaner
+    namespace: kube-system
+  spec:
+    selector:
+      matchLabels:
+        name: execpid-cleaner
+    template:
+      metadata:
+        labels:
+          name: execpid-cleaner
+      spec:
+        tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        terminationGracePeriodSeconds: 5
+        containers:
+        - name: execpid-cleaner
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          command:
+          - sh
+          - -c
+          - "set -euo pipefail\nwhile true; do\n    printf \"%s Running cleanup:\\\
+            n\" \"$(date)\"\n    set -x\n    find /run/crio/exec-pid-dir -type f -mmin\
+            \ +15 -exec rm -f {} \\;\n    sleep 15m\n    set +x\ndone\n"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              memory: 64Mi
+            requests:
+              memory: 64Mi
+          volumeMounts:
+          - name: exec-pid-dir
+            mountPath: /run/crio/exec-pid-dir
+        volumes:
+        - name: exec-pid-dir
+          hostPath:
+            path: /run/crio/exec-pid-dir
 - apiVersion: v1
   data:
     environment: production

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11725,6 +11725,48 @@ objects:
           - events
           snapshotVolumes: false
           ttl: 0h25m0s
+- apiVersion: apps/v1
+  kind: DaemonSet
+  metadata:
+    name: execpid-cleaner
+    namespace: kube-system
+  spec:
+    selector:
+      matchLabels:
+        name: execpid-cleaner
+    template:
+      metadata:
+        labels:
+          name: execpid-cleaner
+      spec:
+        tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+        terminationGracePeriodSeconds: 5
+        containers:
+        - name: execpid-cleaner
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          command:
+          - sh
+          - -c
+          - "set -euo pipefail\nwhile true; do\n    printf \"%s Running cleanup:\\\
+            n\" \"$(date)\"\n    set -x\n    find /run/crio/exec-pid-dir -type f -mmin\
+            \ +15 -exec rm -f {} \\;\n    sleep 15m\n    set +x\ndone\n"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              memory: 64Mi
+            requests:
+              memory: 64Mi
+          volumeMounts:
+          - name: exec-pid-dir
+            mountPath: /run/crio/exec-pid-dir
+        volumes:
+        - name: exec-pid-dir
+          hostPath:
+            path: /run/crio/exec-pid-dir
 - apiVersion: v1
   data:
     environment: stage


### PR DESCRIPTION
push out the workaround from https://access.redhat.com/solutions/6304881 to all clusters to stop the shift primary from having to do it manually after an alert