### PR TITLE
Updated image for osd-cluster-ready

### DIFF
--- a/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/60-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: v0.1.45-c9f1f45
+                managed.openshift.io/version: v0.1.50-f6d6cb2
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:7583974bcac9e17e8ff6416b77cf406bd6e8b84393775c11c183efd53fc2a67d
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5531,11 +5531,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.45-c9f1f45
+              managed.openshift.io/version: v0.1.50-f6d6cb2
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:7583974bcac9e17e8ff6416b77cf406bd6e8b84393775c11c183efd53fc2a67d
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5531,11 +5531,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.45-c9f1f45
+              managed.openshift.io/version: v0.1.50-f6d6cb2
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:7583974bcac9e17e8ff6416b77cf406bd6e8b84393775c11c183efd53fc2a67d
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5531,11 +5531,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.45-c9f1f45
+              managed.openshift.io/version: v0.1.50-f6d6cb2
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:eb600ec385f76bd1cb746287dafc512ffcdaf09fd7aa7c7d78ac7aed30f665d2
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:7583974bcac9e17e8ff6416b77cf406bd6e8b84393775c11c183efd53fc2a67d
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
This PR updates the image for osd-cluster-ready to be up to date

This is blocking e2e testing for 4.9 

related conversation https://coreos.slack.com/archives/C029LD3DZ5J/p1632252999029500?thread_ts=1632225377.014500&cid=C029LD3DZ5J