### PR TITLE
Add 4.6.43 to list of impacted versions for BZ1997062

### DIFF
--- a/deploy/bz1997062-crio-pid-leak/config.yaml
+++ b/deploy/bz1997062-crio-pid-leak/config.yaml
@@ -3,4 +3,4 @@ selectorSyncSet:
   matchExpressions:
   - key: hive.openshift.io/version-major-minor-patch
     operator: In
-    values: ["4.7.24", "4.7.25", "4.7.26", "4.7.27", "4.7.28", "4.8.5", "4.8.6", "4.8.7", "4.8.8", "4.8.9"]
+    values: ["4.6.43", "4.7.24", "4.7.25", "4.7.26", "4.7.27", "4.7.28", "4.8.5", "4.8.6", "4.8.7", "4.8.8", "4.8.9"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3242,6 +3242,7 @@ objects:
       - key: hive.openshift.io/version-major-minor-patch
         operator: In
         values:
+        - 4.6.43
         - 4.7.24
         - 4.7.25
         - 4.7.26

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3242,6 +3242,7 @@ objects:
       - key: hive.openshift.io/version-major-minor-patch
         operator: In
         values:
+        - 4.6.43
         - 4.7.24
         - 4.7.25
         - 4.7.26

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3242,6 +3242,7 @@ objects:
       - key: hive.openshift.io/version-major-minor-patch
         operator: In
         values:
+        - 4.6.43
         - 4.7.24
         - 4.7.25
         - 4.7.26


### PR DESCRIPTION
Based on https://bugzilla.redhat.com/show_bug.cgi?id=1997062#c35, extending the workaround to this impacted version