### PR TITLE
Add pruner for bz2008282

### DIFF
--- a/deploy/bz2008282-pruning/105-pruning.rbac.Role.yaml
+++ b/deploy/bz2008282-pruning/105-pruning.rbac.Role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: bz2008282-pruning-role
+  namespace: openshift
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - delete

--- a/deploy/bz2008282-pruning/105-pruning.rbac.RoleBinding.yaml
+++ b/deploy/bz2008282-pruning/105-pruning.rbac.RoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bz2008282-pruning-rolebinding
+  namespace: openshift
+roleRef:
+  kind: Role
+  name: bz2008282-pruning-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: bz2008282-pruning-sa
+  namespace: openshift

--- a/deploy/bz2008282-pruning/105-pruning.rbac.ServiceAccount.yaml
+++ b/deploy/bz2008282-pruning/105-pruning.rbac.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bz2008282-pruning-sa
+  namespace: openshift

--- a/deploy/bz2008282-pruning/115-pruning.secret.CronJob.yaml
+++ b/deploy/bz2008282-pruning/115-pruning.secret.CronJob.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: bz2008282-pruner
+  namespace: openshift
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/7 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: bz2008282-pruning-sa
+          restartPolicy: Never
+          containers:
+          - name: bz2008282-pruner
+            image: quay.io/openshift/origin-cli:4.8 ## needs to be this instead of the local CLI image so that this can run always
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - >-
+              oc delete secret/samples-registry-credentials
+              --namespace openshift
+              --ignore-not-found

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3311,6 +3311,87 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2008282-pruning
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: bz2008282-pruning-role
+        namespace: openshift
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: bz2008282-pruning-rolebinding
+        namespace: openshift
+      roleRef:
+        kind: Role
+        name: bz2008282-pruning-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: bz2008282-pruning-sa
+        namespace: openshift
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: bz2008282-pruning-sa
+        namespace: openshift
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: bz2008282-pruner
+        namespace: openshift
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: bz2008282-pruning-sa
+                restartPolicy: Never
+                containers:
+                - name: bz2008282-pruner
+                  image: quay.io/openshift/origin-cli:4.8
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete secret/samples-registry-credentials --namespace openshift
+                    --ignore-not-found
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3311,6 +3311,87 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2008282-pruning
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: bz2008282-pruning-role
+        namespace: openshift
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: bz2008282-pruning-rolebinding
+        namespace: openshift
+      roleRef:
+        kind: Role
+        name: bz2008282-pruning-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: bz2008282-pruning-sa
+        namespace: openshift
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: bz2008282-pruning-sa
+        namespace: openshift
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: bz2008282-pruner
+        namespace: openshift
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: bz2008282-pruning-sa
+                restartPolicy: Never
+                containers:
+                - name: bz2008282-pruner
+                  image: quay.io/openshift/origin-cli:4.8
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete secret/samples-registry-credentials --namespace openshift
+                    --ignore-not-found
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3311,6 +3311,87 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2008282-pruning
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: bz2008282-pruning-role
+        namespace: openshift
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: bz2008282-pruning-rolebinding
+        namespace: openshift
+      roleRef:
+        kind: Role
+        name: bz2008282-pruning-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: bz2008282-pruning-sa
+        namespace: openshift
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: bz2008282-pruning-sa
+        namespace: openshift
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: bz2008282-pruner
+        namespace: openshift
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: bz2008282-pruning-sa
+                restartPolicy: Never
+                containers:
+                - name: bz2008282-pruner
+                  image: quay.io/openshift/origin-cli:4.8
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete secret/samples-registry-credentials --namespace openshift
+                    --ignore-not-found
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This adds a pruner to delete the `samples-registry-credentials` secret in the `openshift` namespace.

Once this has been promoted and run, it can be removed. This removes this secret from older clusters, as per the BZ.

https://bugzilla.redhat.com/show_bug.cgi?id=2008282#c9