### PR TITLE
MTSRE-237 | Update: Managed ODH's backplane RBAC for MT-SRE to make it more compliant with the current conventions and PoLP

### DIFF
--- a/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
@@ -1,12 +1,12 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-admins
+  name: backplane-mtsre-managed-odh-admins
   namespace: openshift-rbac-permissions
 spec:
   permissions:
   - allowFirst: true
     clusterRoleName: admin
-    namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
+    namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2517,13 +2517,13 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-admins
+        name: backplane-mtsre-managed-odh-admins
         namespace: openshift-rbac-permissions
       spec:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2517,13 +2517,13 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-admins
+        name: backplane-mtsre-managed-odh-admins
         namespace: openshift-rbac-permissions
       spec:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2517,13 +2517,13 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-admins
+        name: backplane-mtsre-managed-odh-admins
         namespace: openshift-rbac-permissions
       spec:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-.*)
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

- Regarding the change of `metadata.name`. That's to make it compliant with the [current convention](https://github.com/openshift/managed-cluster-config/blob/ba5ac3ef87b276502c85e450c32283134659a1b5/deploy/backplane/mtsre/reference-addon/10-mtsre-reference-addon-admins.SubjectPermission.yml#L4) of `backplane-mtsre-<addon name>-admins`
- Regarding the change in `spec.permissions[0].namespacesAllowedRegex`: It is just to ensure that upon backplane-accessing a cluster, the MTSRE folks (inheriting `system:serviceaccounts:openshift-backplane-mtsre`) don't end up having an unintended access to the user's personal namespaces prefixed with `redhat-ods` such as `redhat-ods-foobar`. I can understand that this sounds a bit stretched and it would be pretty rare for someone to create a personal namespace prefixed with `redhat-ods` but this small change in the PR is more compliant with RHODS from the standpoint of PoLP (Principal of Least Privilege), and from an MT-SRE's standpoint, ideally, it should be an unrecognizable change as their access was and will be meant to be bound to the namespaces: `rhods-notebooks, redhat-ods-applications, redhat-ods-monitoring, redhat-ods-operator`