### PR TITLE
OSD-8443 default samples to managed

### DIFF
--- a/deploy/osd-samples-operator/config.yaml
+++ b/deploy/osd-samples-operator/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: NotIn
+    values: ["4.0","4.1","4.2","4.3","4.4","4.5"]

--- a/deploy/osd-samples-operator/osd-branding.console.Patch.yaml
+++ b/deploy/osd-samples-operator/osd-branding.console.Patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: samples.operator.openshift.io/v1
+applyMode: AlwaysApply
+kind: Config
+name: cluster
+patchType: merge
+patch: >-
+  {"spec":{"managementState":"Managed"}}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8572,6 +8572,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-samples-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: samples.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: Config
+      name: cluster
+      patchType: merge
+      patch: '{"spec":{"managementState":"Managed"}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-serviceaccounts
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8572,6 +8572,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-samples-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: samples.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: Config
+      name: cluster
+      patchType: merge
+      patch: '{"spec":{"managementState":"Managed"}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-serviceaccounts
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8572,6 +8572,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-samples-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: samples.operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: Config
+      name: cluster
+      patchType: merge
+      patch: '{"spec":{"managementState":"Managed"}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-serviceaccounts
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Setting samples-operator to managed ensures the default imagestreams/images are there for reference. This will ensure the sre-build-test can complete. https://github.com/openshift/cluster-samples-operator#configuration 