### PR TITLE
Use direct image pull for build-test

### DIFF
--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -95,7 +95,7 @@ spec:
               done
 
               # run build
-              oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --image-stream openshift/golang
+              oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:latest
               cat <<EOF > /tmp/main.go
               package main
               import (

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10443,20 +10443,21 @@ objects:
                     \ sa default >/dev/null; do\n  echo \"$(date): Waiting for service\
                     \ account to be created\"\n  sleep 5\ndone\n\n# run build\noc\
                     \ -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\" --binary --strategy\
-                    \ source --image-stream openshift/golang\ncat <<EOF > /tmp/main.go\n\
-                    package main\nimport (\n       \"fmt\"\n)\n\nfunc main() {\n \
-                    \       fmt.Println(\"Hello Openshift SRE :)\")\n}\nEOF\noc -n\
-                    \ \"${NS}\" start-build \"${JOB_PREFIX}\" --from-file=/tmp/main.go\n\
-                    echo \"$(date): Waiting for build to complete.\"\nwhile :\ndo\n\
-                    \  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
-                    \ status is blank, assume we are still starting the build\n  \
-                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
-                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
-                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
-                    \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
-                    \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
-                    \     echo \"$(date): Build Complete\"\n      # Get all job names\
+                    \ source --docker-image registry.redhat.io/ubi8/go-toolset:latest\n\
+                    cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
+                    \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
+                    \ :)\")\n}\nEOF\noc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\
+                    \ --from-file=/tmp/main.go\necho \"$(date): Waiting for build\
+                    \ to complete.\"\nwhile :\ndo\n  ST=$(oc -n \"${NS}\" get build\
+                    \ -o custom-columns=STATUS:.status.phase --no-headers)\n  case\
+                    \ ${ST} in\n    \"\")\n      # if build status is blank, assume\
+                    \ we are still starting the build\n      ST=\"Starting\"\n   \
+                    \   ;;\n    Failed)\n      echo \"$(date): Build Failed\" >&2\n\
+                    \      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n     \
+                    \ exit 1\n      ;;\n    Cancelled)\n      echo \"$(date): Build\
+                    \ was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build \"\
+                    ${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n     \
+                    \ echo \"$(date): Build Complete\"\n      # Get all job names\
                     \ that have exceeded failed retries\n      JOBS=$(oc -n \"${POD_NS}\"\
                     \ get job -o json)\n      JOBS_TO_DELETE=$(echo \"${JOBS}\" |\
                     \ python -c \"$GET_FAILED_JOBS\")\n\n      if [[ -n \"${JOBS_TO_DELETE}\"\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10443,20 +10443,21 @@ objects:
                     \ sa default >/dev/null; do\n  echo \"$(date): Waiting for service\
                     \ account to be created\"\n  sleep 5\ndone\n\n# run build\noc\
                     \ -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\" --binary --strategy\
-                    \ source --image-stream openshift/golang\ncat <<EOF > /tmp/main.go\n\
-                    package main\nimport (\n       \"fmt\"\n)\n\nfunc main() {\n \
-                    \       fmt.Println(\"Hello Openshift SRE :)\")\n}\nEOF\noc -n\
-                    \ \"${NS}\" start-build \"${JOB_PREFIX}\" --from-file=/tmp/main.go\n\
-                    echo \"$(date): Waiting for build to complete.\"\nwhile :\ndo\n\
-                    \  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
-                    \ status is blank, assume we are still starting the build\n  \
-                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
-                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
-                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
-                    \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
-                    \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
-                    \     echo \"$(date): Build Complete\"\n      # Get all job names\
+                    \ source --docker-image registry.redhat.io/ubi8/go-toolset:latest\n\
+                    cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
+                    \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
+                    \ :)\")\n}\nEOF\noc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\
+                    \ --from-file=/tmp/main.go\necho \"$(date): Waiting for build\
+                    \ to complete.\"\nwhile :\ndo\n  ST=$(oc -n \"${NS}\" get build\
+                    \ -o custom-columns=STATUS:.status.phase --no-headers)\n  case\
+                    \ ${ST} in\n    \"\")\n      # if build status is blank, assume\
+                    \ we are still starting the build\n      ST=\"Starting\"\n   \
+                    \   ;;\n    Failed)\n      echo \"$(date): Build Failed\" >&2\n\
+                    \      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n     \
+                    \ exit 1\n      ;;\n    Cancelled)\n      echo \"$(date): Build\
+                    \ was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build \"\
+                    ${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n     \
+                    \ echo \"$(date): Build Complete\"\n      # Get all job names\
                     \ that have exceeded failed retries\n      JOBS=$(oc -n \"${POD_NS}\"\
                     \ get job -o json)\n      JOBS_TO_DELETE=$(echo \"${JOBS}\" |\
                     \ python -c \"$GET_FAILED_JOBS\")\n\n      if [[ -n \"${JOBS_TO_DELETE}\"\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10443,20 +10443,21 @@ objects:
                     \ sa default >/dev/null; do\n  echo \"$(date): Waiting for service\
                     \ account to be created\"\n  sleep 5\ndone\n\n# run build\noc\
                     \ -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\" --binary --strategy\
-                    \ source --image-stream openshift/golang\ncat <<EOF > /tmp/main.go\n\
-                    package main\nimport (\n       \"fmt\"\n)\n\nfunc main() {\n \
-                    \       fmt.Println(\"Hello Openshift SRE :)\")\n}\nEOF\noc -n\
-                    \ \"${NS}\" start-build \"${JOB_PREFIX}\" --from-file=/tmp/main.go\n\
-                    echo \"$(date): Waiting for build to complete.\"\nwhile :\ndo\n\
-                    \  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
-                    \ status is blank, assume we are still starting the build\n  \
-                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
-                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
-                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
-                    \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
-                    \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
-                    \     echo \"$(date): Build Complete\"\n      # Get all job names\
+                    \ source --docker-image registry.redhat.io/ubi8/go-toolset:latest\n\
+                    cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
+                    \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
+                    \ :)\")\n}\nEOF\noc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\
+                    \ --from-file=/tmp/main.go\necho \"$(date): Waiting for build\
+                    \ to complete.\"\nwhile :\ndo\n  ST=$(oc -n \"${NS}\" get build\
+                    \ -o custom-columns=STATUS:.status.phase --no-headers)\n  case\
+                    \ ${ST} in\n    \"\")\n      # if build status is blank, assume\
+                    \ we are still starting the build\n      ST=\"Starting\"\n   \
+                    \   ;;\n    Failed)\n      echo \"$(date): Build Failed\" >&2\n\
+                    \      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n     \
+                    \ exit 1\n      ;;\n    Cancelled)\n      echo \"$(date): Build\
+                    \ was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build \"\
+                    ${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n     \
+                    \ echo \"$(date): Build Complete\"\n      # Get all job names\
                     \ that have exceeded failed retries\n      JOBS=$(oc -n \"${POD_NS}\"\
                     \ get job -o json)\n      JOBS_TO_DELETE=$(echo \"${JOBS}\" |\
                     \ python -c \"$GET_FAILED_JOBS\")\n\n      if [[ -n \"${JOBS_TO_DELETE}\"\


### PR DESCRIPTION
Some customers may decide to remove the system default imagestreams. This swaps the build-test job to use an upstream image pull rather than the on-cluster imagestream

ref [OSD-8443](https://issues.redhat.com/browse/OSD-8443)