### PR TITLE
OSD-6945 Add InfraNodesNeedResizingSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -42,7 +42,8 @@ spec:
         record: sre:node_masters:need_resize
       # infra has less than 16GB RAM or less than 5 CPU, worker count > 25, and worker count <= 100
       # infra has less than 32GB RAM or less than 9 CPU, worker count > 100, and worker count <= 250
-      # infra has less than 128GB RAM or less than 129 CPU, worker count > 250
+      # infra has less than 128GB RAM or less than 17 CPU, worker count > 250
+      # infra has less than 128GB RAM or less than 33 CPU, worker count > 500
       - expr: (
                 (
                   avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 16*1024*1024*1024

--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -8,12 +8,16 @@ metadata:
   namespace: openshift-monitoring
 spec:
   # https://issues.redhat.com/browse/OSD-3215
+  # https://issues.redhat.com/browse/OSD-6945
   # https://docs.openshift.com/container-platform/4.3/scalability_and_performance/recommended-host-practices.html#master-node-sizing_
+  # https://docs.openshift.com/container-platform/4.8/scalability_and_performance/recommended-host-practices.html#infrastructure-node-sizing_
   groups:
   - name: sre-control-plane-resizing-recording.rules
     rules:
       - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)") * on(instance) group_left node_memory_MemTotal_bytes
         record: sre:node_roles:memory_total_bytes
+      - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)") * on(instance) group_left instance:node_num_cpu:sum
+        record: sre:node_roles:node_num_cpu
       - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
         record: sre:node_workers:count
       # master has less than 16GB RAM, worker count > 25, and worker count <= 100
@@ -36,6 +40,41 @@ spec:
                 AND sre:node_workers:count > 250
               )
         record: sre:node_masters:need_resize
+      # infra has less than 16GB RAM or less than 5 CPU, worker count > 25, and worker count <= 100
+      # infra has less than 32GB RAM or less than 9 CPU, worker count > 100, and worker count <= 250
+      # infra has less than 128GB RAM or less than 129 CPU, worker count > 250
+      - expr: (
+                (
+                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 16*1024*1024*1024
+                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 4 
+                )
+                AND sre:node_workers:count > 25 
+                AND sre:node_workers:count <= 100 
+              )
+              OR 
+              (
+                (
+                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 32*1024*1024*1024
+                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 8
+                )
+                AND sre:node_workers:count > 100
+                AND sre:node_workers:count <= 250 
+              )
+              OR 
+              (
+                (
+                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 128*1024*1024*1024
+                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 16
+                )
+                AND sre:node_workers:count > 250
+              )
+              OR 
+              (
+                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 128*1024*1024*1024
+                AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 32
+                AND sre:node_workers:count > 500
+              )
+        record: sre:node_infras:need_resize
   - name: sre-control-plane-resizing-alerts
     rules:
       - alert: MasterNodesNeedResizingSRE
@@ -54,3 +93,11 @@ spec:
           namespace: openshift-monitoring
         annotations:
           message: "The cluster's master instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."
+      - alert: InfraNodesNeedResizingSRE
+        expr: sre:node_infras:need_resize > 0
+        for: 2h
+        labels:
+          severity: warning
+          namespace: openshift-monitoring
+        annotations:
+          message: "The cluster's infra instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10541,6 +10541,9 @@ objects:
           - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
               * on(instance) group_left node_memory_MemTotal_bytes
             record: sre:node_roles:memory_total_bytes
+          - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
+              * on(instance) group_left instance:node_num_cpu:sum
+            record: sre:node_roles:node_num_cpu
           - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
             record: sre:node_workers:count
           - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
@@ -10550,6 +10553,18 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 64*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
+          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
+              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
+              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 32 AND sre:node_workers:count > 500 )
+            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -10570,6 +10585,16 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
+                and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10541,6 +10541,9 @@ objects:
           - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
               * on(instance) group_left node_memory_MemTotal_bytes
             record: sre:node_roles:memory_total_bytes
+          - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
+              * on(instance) group_left instance:node_num_cpu:sum
+            record: sre:node_roles:node_num_cpu
           - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
             record: sre:node_workers:count
           - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
@@ -10550,6 +10553,18 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 64*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
+          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
+              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
+              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 32 AND sre:node_workers:count > 500 )
+            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -10570,6 +10585,16 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
+                and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10541,6 +10541,9 @@ objects:
           - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
               * on(instance) group_left node_memory_MemTotal_bytes
             record: sre:node_roles:memory_total_bytes
+          - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
+              * on(instance) group_left instance:node_num_cpu:sum
+            record: sre:node_roles:node_num_cpu
           - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
             record: sre:node_workers:count
           - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
@@ -10550,6 +10553,18 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 64*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
+          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
+              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
+              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
+              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
+              <= 32 AND sre:node_workers:count > 500 )
+            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -10570,6 +10585,16 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
+                and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
This PR adds a new `InfraNodesNeedResizingSRE` alert which identifies when a cluster's infra nodes should be resized in accordance with the [OCP Infrastructure Node Sizing guidelines](https://docs.openshift.com/container-platform/4.8/scalability_and_performance/recommended-host-practices.html#infrastructure-node-sizing_).

The alert fires at the `warning` level after a sustained `2h` period.

An associated SOP PR has been created: https://github.com/openshift/ops-sop/pull/1531

Refs: [OSD-6945](https://issues.redhat.com/browse/OSD-6945)