### PR TITLE
OSD-8714 - Add location for STS differences

### DIFF
--- a/resources/sts-diff/sts_diff_4.9.txt
+++ b/resources/sts-diff/sts_diff_4.9.txt
@@ -1,0 +1,6 @@
+diff /tmp/crs-4.8.13/0000_30_machine-api-operator_00_credentials-request.yaml /tmp/crs-4.9.0/0000_30_machine-api-operator_00_credentials-request.yaml
+22a23
+>       - ec2:DescribeInternetGateways
+29a31
+>       - elasticloadbalancing:DescribeTargetHealth
+


### PR DESCRIPTION
As part of card for automating STS diff in osdctl, we need to add location for STS difference in MCC repo.
Resolves: https://issues.redhat.com/browse/OSD-8714