### PR TITLE
[OSD-8757] Update managed-resources script to generate OCP and addon's configmaps

### DIFF
--- a/deploy/osd-managed-resources/addons-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/addons-namespaces.ConfigMap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: addons-namespaces
+  namespace: openshift-monitoring
+data:
+  managed_namespaces.yaml: |
+    Resources:
+      Namespace:
+      - name: openshift-storage
+      - name: redhat-rhoami-operator
+      - name: codeready-workspaces-operator
+      - name: redhat-ods-operator
+      - name: codeready-workspaces-operator-qe
+      - name: redhat-rhmi-operator
+      - name: redhat-gpu-operator
+      - name: redhat-rhmi-operator
+      - name: redhat-managed-kafka-operator-qe
+      - name: redhat-rhoam-operator
+      - name: openshift-storage
+      - name: redhat-addon-operator
+      - name: redhat-managed-kafka-operator
+      - name: redhat-kas-fleetshard-operator-qe
+      - name: prow
+      - name: openshift-logging
+      - name: acm
+      - name: addon-dba-operator
+      - name: redhat-reference-addon
+      - name: redhat-ocm-addon-test-operator
+      - name: redhat-kas-fleetshard-operator
+

--- a/deploy/osd-managed-resources/addons-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/addons-namespaces.ConfigMap.yaml
@@ -7,25 +7,23 @@ data:
   managed_namespaces.yaml: |
     Resources:
       Namespace:
-      - name: openshift-storage
-      - name: redhat-rhoami-operator
-      - name: codeready-workspaces-operator
-      - name: redhat-ods-operator
-      - name: codeready-workspaces-operator-qe
-      - name: redhat-rhmi-operator
-      - name: redhat-gpu-operator
-      - name: redhat-rhmi-operator
-      - name: redhat-managed-kafka-operator-qe
-      - name: redhat-rhoam-operator
-      - name: openshift-storage
-      - name: redhat-addon-operator
-      - name: redhat-managed-kafka-operator
-      - name: redhat-kas-fleetshard-operator-qe
-      - name: prow
-      - name: openshift-logging
       - name: acm
       - name: addon-dba-operator
-      - name: redhat-reference-addon
-      - name: redhat-ocm-addon-test-operator
+      - name: codeready-workspaces-operator
+      - name: codeready-workspaces-operator-qe
+      - name: openshift-logging
+      - name: openshift-storage
+      - name: prow
+      - name: redhat-addon-operator
+      - name: redhat-gpu-operator
       - name: redhat-kas-fleetshard-operator
+      - name: redhat-kas-fleetshard-operator-qe
+      - name: redhat-managed-kafka-operator
+      - name: redhat-managed-kafka-operator-qe
+      - name: redhat-ocm-addon-test-operator
+      - name: redhat-ods-operator
+      - name: redhat-reference-addon
+      - name: redhat-rhmi-operator
+      - name: redhat-rhoam-operator
+      - name: redhat-rhoami-operator
 

--- a/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
@@ -17,7 +17,6 @@ data:
       - name: openshift-cloud-ingress-operator
       - name: openshift-codeready-workspaces
       - name: openshift-compliance
-      - name: openshift-container-security-operator
       - name: openshift-custom-domains-operator
       - name: openshift-customer-monitoring
       - name: openshift-logging
@@ -30,7 +29,6 @@ data:
       - name: openshift-security
       - name: openshift-splunk-forwarder-operator
       - name: openshift-sre-pruning
-      - name: openshift-sre-sshd
       - name: openshift-strimzi
       - name: openshift-validation-webhook
       - name: openshift-velero

--- a/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocp-namespaces
+  namespace: openshift-monitoring
+data:
+  managed_namespaces.yaml: |
+    Resources:
+      Namespace:
+      - name: openshift-service-ca-operator
+      - name: openshift-marketplace
+      - name: openshift-operator-lifecycle-manager
+      - name: openshift-operators
+      - name: openshift-machine-config-operator
+      - name: openshift-openstack-infra
+      - name: openshift-kni-infra
+      - name: openshift-ovirt-infra
+      - name: openshift-vsphere-infra
+      - name: openshift-machine-api
+      - name: openshift-insights
+      - name: openshift-console
+      - name: openshift-console-operator
+      - name: openshift-console-user-settings
+      - name: openshift-cluster-csi-drivers
+      - name: openshift-cluster-storage-operator
+      - name: openshift-cluster-samples-operator
+      - name: openshift-controller-manager-operator
+      - name: openshift-apiserver-operator
+      - name: openshift-cluster-node-tuning-operator
+      - name: openshift-network-operator
+      - name: openshift-monitoring
+      - name: openshift-user-workload-monitoring
+      - name: openshift-cluster-machine-approver
+      - name: openshift-kube-storage-version-migrator-operator
+      - name: openshift-kube-scheduler-operator
+      - name: openshift-kube-controller-manager-operator
+      - name: openshift-kube-apiserver-operator
+      - name: openshift-ingress-operator
+      - name: openshift-image-registry
+      - name: openshift-etcd-operator
+      - name: openshift-dns-operator
+      - name: openshift-config-operator
+      - name: openshift-config
+      - name: openshift-config-managed
+      - name: openshift-cloud-controller-manager-operator
+      - name: openshift-cloud-controller-manager
+      - name: openshift-authentication-operator
+      - name: openshift-cloud-credential-operator
+

--- a/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
@@ -7,43 +7,43 @@ data:
   managed_namespaces.yaml: |
     Resources:
       Namespace:
-      - name: openshift-service-ca-operator
-      - name: openshift-marketplace
-      - name: openshift-operator-lifecycle-manager
-      - name: openshift-operators
-      - name: openshift-machine-config-operator
-      - name: openshift-openstack-infra
-      - name: openshift-kni-infra
-      - name: openshift-ovirt-infra
-      - name: openshift-vsphere-infra
-      - name: openshift-machine-api
-      - name: openshift-insights
+      - name: openshift-apiserver-operator
+      - name: openshift-authentication-operator
+      - name: openshift-cloud-controller-manager
+      - name: openshift-cloud-controller-manager-operator
+      - name: openshift-cloud-credential-operator
+      - name: openshift-cluster-csi-drivers
+      - name: openshift-cluster-machine-approver
+      - name: openshift-cluster-node-tuning-operator
+      - name: openshift-cluster-samples-operator
+      - name: openshift-cluster-storage-operator
+      - name: openshift-config
+      - name: openshift-config-managed
+      - name: openshift-config-operator
       - name: openshift-console
       - name: openshift-console-operator
       - name: openshift-console-user-settings
-      - name: openshift-cluster-csi-drivers
-      - name: openshift-cluster-storage-operator
-      - name: openshift-cluster-samples-operator
       - name: openshift-controller-manager-operator
-      - name: openshift-apiserver-operator
-      - name: openshift-cluster-node-tuning-operator
-      - name: openshift-network-operator
-      - name: openshift-monitoring
-      - name: openshift-user-workload-monitoring
-      - name: openshift-cluster-machine-approver
-      - name: openshift-kube-storage-version-migrator-operator
-      - name: openshift-kube-scheduler-operator
-      - name: openshift-kube-controller-manager-operator
-      - name: openshift-kube-apiserver-operator
-      - name: openshift-ingress-operator
-      - name: openshift-image-registry
-      - name: openshift-etcd-operator
       - name: openshift-dns-operator
-      - name: openshift-config-operator
-      - name: openshift-config
-      - name: openshift-config-managed
-      - name: openshift-cloud-controller-manager-operator
-      - name: openshift-cloud-controller-manager
-      - name: openshift-authentication-operator
-      - name: openshift-cloud-credential-operator
+      - name: openshift-etcd-operator
+      - name: openshift-image-registry
+      - name: openshift-ingress-operator
+      - name: openshift-insights
+      - name: openshift-kni-infra
+      - name: openshift-kube-apiserver-operator
+      - name: openshift-kube-controller-manager-operator
+      - name: openshift-kube-scheduler-operator
+      - name: openshift-kube-storage-version-migrator-operator
+      - name: openshift-machine-api
+      - name: openshift-machine-config-operator
+      - name: openshift-marketplace
+      - name: openshift-monitoring
+      - name: openshift-network-operator
+      - name: openshift-openstack-infra
+      - name: openshift-operator-lifecycle-manager
+      - name: openshift-operators
+      - name: openshift-ovirt-infra
+      - name: openshift-service-ca-operator
+      - name: openshift-user-workload-monitoring
+      - name: openshift-vsphere-infra
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7869,6 +7869,21 @@ objects:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
+        name: addons-namespaces
+        namespace: openshift-monitoring
+      data:
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: acm\n  - name:\
+          \ addon-dba-operator\n  - name: codeready-workspaces-operator\n  - name:\
+          \ codeready-workspaces-operator-qe\n  - name: openshift-logging\n  - name:\
+          \ openshift-storage\n  - name: prow\n  - name: redhat-addon-operator\n \
+          \ - name: redhat-gpu-operator\n  - name: redhat-kas-fleetshard-operator\n\
+          \  - name: redhat-kas-fleetshard-operator-qe\n  - name: redhat-managed-kafka-operator\n\
+          \  - name: redhat-managed-kafka-operator-qe\n  - name: redhat-ocm-addon-test-operator\n\
+          \  - name: redhat-ods-operator\n  - name: redhat-reference-addon\n  - name:\
+          \ redhat-rhmi-operator\n  - name: redhat-rhoam-operator\n  - name: redhat-rhoami-operator\n"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
         name: managed-namespaces
         namespace: openshift-monitoring
       data:
@@ -7877,15 +7892,40 @@ objects:
           \  - name: openshift-backplane-managed-scripts\n  - name: openshift-backplane-srep\n\
           \  - name: openshift-build-test\n  - name: openshift-cloud-ingress-operator\n\
           \  - name: openshift-codeready-workspaces\n  - name: openshift-compliance\n\
-          \  - name: openshift-container-security-operator\n  - name: openshift-custom-domains-operator\n\
-          \  - name: openshift-customer-monitoring\n  - name: openshift-logging\n\
-          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
-          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
-          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
-          \  - name: openshift-sre-pruning\n  - name: openshift-sre-sshd\n  - name:\
-          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n\
-          \  - name: openshift-monitoring\n"
+          \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
+          \  - name: openshift-must-gather-operator\n  - name: openshift-operators-redhat\n\
+          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
+          \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
+          \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
+          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
+          \ - name: openshift-velero\n  - name: openshift-monitoring\n"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ocp-namespaces
+        namespace: openshift-monitoring
+      data:
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
+          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
+          \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
+          \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
+          \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\
+          \  - name: openshift-config-managed\n  - name: openshift-config-operator\n\
+          \  - name: openshift-console\n  - name: openshift-console-operator\n  -\
+          \ name: openshift-console-user-settings\n  - name: openshift-controller-manager-operator\n\
+          \  - name: openshift-dns-operator\n  - name: openshift-etcd-operator\n \
+          \ - name: openshift-image-registry\n  - name: openshift-ingress-operator\n\
+          \  - name: openshift-insights\n  - name: openshift-kni-infra\n  - name:\
+          \ openshift-kube-apiserver-operator\n  - name: openshift-kube-controller-manager-operator\n\
+          \  - name: openshift-kube-scheduler-operator\n  - name: openshift-kube-storage-version-migrator-operator\n\
+          \  - name: openshift-machine-api\n  - name: openshift-machine-config-operator\n\
+          \  - name: openshift-marketplace\n  - name: openshift-monitoring\n  - name:\
+          \ openshift-network-operator\n  - name: openshift-openstack-infra\n  - name:\
+          \ openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
+          \  - name: openshift-ovirt-infra\n  - name: openshift-service-ca-operator\n\
+          \  - name: openshift-user-workload-monitoring\n  - name: openshift-vsphere-infra\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7869,6 +7869,21 @@ objects:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
+        name: addons-namespaces
+        namespace: openshift-monitoring
+      data:
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: acm\n  - name:\
+          \ addon-dba-operator\n  - name: codeready-workspaces-operator\n  - name:\
+          \ codeready-workspaces-operator-qe\n  - name: openshift-logging\n  - name:\
+          \ openshift-storage\n  - name: prow\n  - name: redhat-addon-operator\n \
+          \ - name: redhat-gpu-operator\n  - name: redhat-kas-fleetshard-operator\n\
+          \  - name: redhat-kas-fleetshard-operator-qe\n  - name: redhat-managed-kafka-operator\n\
+          \  - name: redhat-managed-kafka-operator-qe\n  - name: redhat-ocm-addon-test-operator\n\
+          \  - name: redhat-ods-operator\n  - name: redhat-reference-addon\n  - name:\
+          \ redhat-rhmi-operator\n  - name: redhat-rhoam-operator\n  - name: redhat-rhoami-operator\n"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
         name: managed-namespaces
         namespace: openshift-monitoring
       data:
@@ -7877,15 +7892,40 @@ objects:
           \  - name: openshift-backplane-managed-scripts\n  - name: openshift-backplane-srep\n\
           \  - name: openshift-build-test\n  - name: openshift-cloud-ingress-operator\n\
           \  - name: openshift-codeready-workspaces\n  - name: openshift-compliance\n\
-          \  - name: openshift-container-security-operator\n  - name: openshift-custom-domains-operator\n\
-          \  - name: openshift-customer-monitoring\n  - name: openshift-logging\n\
-          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
-          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
-          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
-          \  - name: openshift-sre-pruning\n  - name: openshift-sre-sshd\n  - name:\
-          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n\
-          \  - name: openshift-monitoring\n"
+          \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
+          \  - name: openshift-must-gather-operator\n  - name: openshift-operators-redhat\n\
+          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
+          \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
+          \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
+          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
+          \ - name: openshift-velero\n  - name: openshift-monitoring\n"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ocp-namespaces
+        namespace: openshift-monitoring
+      data:
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
+          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
+          \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
+          \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
+          \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\
+          \  - name: openshift-config-managed\n  - name: openshift-config-operator\n\
+          \  - name: openshift-console\n  - name: openshift-console-operator\n  -\
+          \ name: openshift-console-user-settings\n  - name: openshift-controller-manager-operator\n\
+          \  - name: openshift-dns-operator\n  - name: openshift-etcd-operator\n \
+          \ - name: openshift-image-registry\n  - name: openshift-ingress-operator\n\
+          \  - name: openshift-insights\n  - name: openshift-kni-infra\n  - name:\
+          \ openshift-kube-apiserver-operator\n  - name: openshift-kube-controller-manager-operator\n\
+          \  - name: openshift-kube-scheduler-operator\n  - name: openshift-kube-storage-version-migrator-operator\n\
+          \  - name: openshift-machine-api\n  - name: openshift-machine-config-operator\n\
+          \  - name: openshift-marketplace\n  - name: openshift-monitoring\n  - name:\
+          \ openshift-network-operator\n  - name: openshift-openstack-infra\n  - name:\
+          \ openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
+          \  - name: openshift-ovirt-infra\n  - name: openshift-service-ca-operator\n\
+          \  - name: openshift-user-workload-monitoring\n  - name: openshift-vsphere-infra\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7869,6 +7869,21 @@ objects:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
+        name: addons-namespaces
+        namespace: openshift-monitoring
+      data:
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: acm\n  - name:\
+          \ addon-dba-operator\n  - name: codeready-workspaces-operator\n  - name:\
+          \ codeready-workspaces-operator-qe\n  - name: openshift-logging\n  - name:\
+          \ openshift-storage\n  - name: prow\n  - name: redhat-addon-operator\n \
+          \ - name: redhat-gpu-operator\n  - name: redhat-kas-fleetshard-operator\n\
+          \  - name: redhat-kas-fleetshard-operator-qe\n  - name: redhat-managed-kafka-operator\n\
+          \  - name: redhat-managed-kafka-operator-qe\n  - name: redhat-ocm-addon-test-operator\n\
+          \  - name: redhat-ods-operator\n  - name: redhat-reference-addon\n  - name:\
+          \ redhat-rhmi-operator\n  - name: redhat-rhoam-operator\n  - name: redhat-rhoami-operator\n"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
         name: managed-namespaces
         namespace: openshift-monitoring
       data:
@@ -7877,15 +7892,40 @@ objects:
           \  - name: openshift-backplane-managed-scripts\n  - name: openshift-backplane-srep\n\
           \  - name: openshift-build-test\n  - name: openshift-cloud-ingress-operator\n\
           \  - name: openshift-codeready-workspaces\n  - name: openshift-compliance\n\
-          \  - name: openshift-container-security-operator\n  - name: openshift-custom-domains-operator\n\
-          \  - name: openshift-customer-monitoring\n  - name: openshift-logging\n\
-          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
-          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
-          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
-          \  - name: openshift-sre-pruning\n  - name: openshift-sre-sshd\n  - name:\
-          \ openshift-strimzi\n  - name: openshift-validation-webhook\n  - name: openshift-velero\n\
-          \  - name: openshift-monitoring\n"
+          \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
+          \  - name: openshift-must-gather-operator\n  - name: openshift-operators-redhat\n\
+          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
+          \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
+          \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
+          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
+          \ - name: openshift-velero\n  - name: openshift-monitoring\n"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ocp-namespaces
+        namespace: openshift-monitoring
+      data:
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
+          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
+          \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
+          \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
+          \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\
+          \  - name: openshift-config-managed\n  - name: openshift-config-operator\n\
+          \  - name: openshift-console\n  - name: openshift-console-operator\n  -\
+          \ name: openshift-console-user-settings\n  - name: openshift-controller-manager-operator\n\
+          \  - name: openshift-dns-operator\n  - name: openshift-etcd-operator\n \
+          \ - name: openshift-image-registry\n  - name: openshift-ingress-operator\n\
+          \  - name: openshift-insights\n  - name: openshift-kni-infra\n  - name:\
+          \ openshift-kube-apiserver-operator\n  - name: openshift-kube-controller-manager-operator\n\
+          \  - name: openshift-kube-scheduler-operator\n  - name: openshift-kube-storage-version-migrator-operator\n\
+          \  - name: openshift-machine-api\n  - name: openshift-machine-config-operator\n\
+          \  - name: openshift-marketplace\n  - name: openshift-monitoring\n  - name:\
+          \ openshift-network-operator\n  - name: openshift-openstack-infra\n  - name:\
+          \ openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
+          \  - name: openshift-ovirt-infra\n  - name: openshift-service-ca-operator\n\
+          \  - name: openshift-user-workload-monitoring\n  - name: openshift-vsphere-infra\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/managed-resources/generate-managed-list.py
+++ b/scripts/managed-resources/generate-managed-list.py
@@ -64,6 +64,7 @@ def collect_ocp_release_namespaces():
                         ocp_namespaces.append(manifest["metadata"]["name"])
     resources = dict()
     resources["Resources"] = {}
+    ocp_namespaces.sort()
     resources["Resources"]["Namespace"] = [{"name": ns} for ns in ocp_namespaces]
     return resources
 
@@ -77,11 +78,11 @@ def collect_addon_namespaces(
     addons_dict = {}
     with open(addons_filepath, "r") as f:
         addons_dict = yaml.safe_load(f)
+    # Some addons use the same namespace, so remove duplicates and sort
+    addon_ns_list = sorted(list(set(addons_dict["addon-namespaces"].values())))
     resources = dict()
     resources["Resources"] = {}
-    resources["Resources"]["Namespace"] = [
-        {"name": ns} for ns in addons_dict["addon-namespaces"].values()
-    ]
+    resources["Resources"]["Namespace"] = [{"name": ns} for ns in addon_ns_list]
     return resources
 
 

--- a/scripts/managed-resources/make-all-managed-lists.sh
+++ b/scripts/managed-resources/make-all-managed-lists.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
-./generate-managed-list.py --output yaml --all --path ../../resources/managed/all-osd-resources.yaml
-./generate-managed-list.py --output configmap --path ../../deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+./generate-managed-list.py --output yaml -s osd-all --path ../../resources/managed/all-osd-resources.yaml
+./generate-managed-list.py --output configmap -s osd-namespaces --path ../../deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+./generate-managed-list.py --output configmap -s ocp-namespaces --name ocp-namespaces --path ../../deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
+./generate-managed-list.py --output configmap -s addons-namespaces --name addons-namespaces --path ../../deploy/osd-managed-resources/addons-namespaces.ConfigMap.yaml


### PR DESCRIPTION
This updates the managed-resources script to generate namespace lists for OCP and available addons. 

The OCP namespaces are collected by running `oc adm release extract` and pulling out any namespaces being created.
The addons namespaces are being collected by reading in the [list](https://github.com/openshift/managed-cluster-config/blob/master/resources/addons-namespaces/main.yaml) produced by the addon namespaces script.