### PR TITLE
Remove unneeded variables from MCC config

### DIFF
--- a/deploy/cloud-ingress-operator-configuration/apischeme/10-rh-api.apischeme.yaml
+++ b/deploy/cloud-ingress-operator-configuration/apischeme/10-rh-api.apischeme.yaml
@@ -7,6 +7,6 @@ metadata:
     allowedCIDRBlocks: ${ALLOWED_CIDR_BLOCKS}
 spec:
   managementAPIServerIngress:
-    enabled: ${{ENABLE_MANAGEMENT_API_SERVER_INGRESS}}
+    enabled: true
     dnsName: rh-api
     allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6,24 +6,6 @@ parameters:
 - name: REPO_NAME
   value: managed-cluster-config
   required: true
-- name: IDENTITY_ATTR_EMAIL
-  required: true
-- name: IDENTITY_ATTR_ID
-  required: true
-- name: IDENTITY_ATTR_NAME
-  required: true
-- name: IDENTITY_ATTR_PREFERRED_USERNAME
-  required: true
-- name: IDENTITY_BIND_DN
-  required: true
-- name: IDENTITY_URL
-  required: true
-- name: IDENTITY_SRE_GOOGLE_CLIENTID
-  required: true
-- name: IDENTITY_NAME
-  required: true
-- name: IDENTITY_MAPPING_METHOD
-  required: true
 - name: TELEMETER_SERVER_URL
   required: true
 - name: OCM_BASE_URL
@@ -35,8 +17,6 @@ parameters:
 - name: OBSERVATORIUM_LEGALENTITY_IDS
   required: true
 - name: ALLOWED_CIDR_BLOCKS
-  required: true
-- name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
@@ -3573,7 +3553,7 @@ objects:
           allowedCIDRBlocks: ${ALLOWED_CIDR_BLOCKS}
       spec:
         managementAPIServerIngress:
-          enabled: ${{ENABLE_MANAGEMENT_API_SERVER_INGRESS}}
+          enabled: true
           dnsName: rh-api
           allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6,24 +6,6 @@ parameters:
 - name: REPO_NAME
   value: managed-cluster-config
   required: true
-- name: IDENTITY_ATTR_EMAIL
-  required: true
-- name: IDENTITY_ATTR_ID
-  required: true
-- name: IDENTITY_ATTR_NAME
-  required: true
-- name: IDENTITY_ATTR_PREFERRED_USERNAME
-  required: true
-- name: IDENTITY_BIND_DN
-  required: true
-- name: IDENTITY_URL
-  required: true
-- name: IDENTITY_SRE_GOOGLE_CLIENTID
-  required: true
-- name: IDENTITY_NAME
-  required: true
-- name: IDENTITY_MAPPING_METHOD
-  required: true
 - name: TELEMETER_SERVER_URL
   required: true
 - name: OCM_BASE_URL
@@ -35,8 +17,6 @@ parameters:
 - name: OBSERVATORIUM_LEGALENTITY_IDS
   required: true
 - name: ALLOWED_CIDR_BLOCKS
-  required: true
-- name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
@@ -3573,7 +3553,7 @@ objects:
           allowedCIDRBlocks: ${ALLOWED_CIDR_BLOCKS}
       spec:
         managementAPIServerIngress:
-          enabled: ${{ENABLE_MANAGEMENT_API_SERVER_INGRESS}}
+          enabled: true
           dnsName: rh-api
           allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6,24 +6,6 @@ parameters:
 - name: REPO_NAME
   value: managed-cluster-config
   required: true
-- name: IDENTITY_ATTR_EMAIL
-  required: true
-- name: IDENTITY_ATTR_ID
-  required: true
-- name: IDENTITY_ATTR_NAME
-  required: true
-- name: IDENTITY_ATTR_PREFERRED_USERNAME
-  required: true
-- name: IDENTITY_BIND_DN
-  required: true
-- name: IDENTITY_URL
-  required: true
-- name: IDENTITY_SRE_GOOGLE_CLIENTID
-  required: true
-- name: IDENTITY_NAME
-  required: true
-- name: IDENTITY_MAPPING_METHOD
-  required: true
 - name: TELEMETER_SERVER_URL
   required: true
 - name: OCM_BASE_URL
@@ -35,8 +17,6 @@ parameters:
 - name: OBSERVATORIUM_LEGALENTITY_IDS
   required: true
 - name: ALLOWED_CIDR_BLOCKS
-  required: true
-- name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
@@ -3573,7 +3553,7 @@ objects:
           allowedCIDRBlocks: ${ALLOWED_CIDR_BLOCKS}
       spec:
         managementAPIServerIngress:
-          enabled: ${{ENABLE_MANAGEMENT_API_SERVER_INGRESS}}
+          enabled: true
           dnsName: rh-api
           allowedCIDRBlocks: ${{ALLOWED_CIDR_BLOCKS}}
 - apiVersion: hive.openshift.io/v1

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -6,24 +6,6 @@ parameters:
 - name: REPO_NAME
   value: REPLACED_BY_SCRIPT
   required: true
-- name: IDENTITY_ATTR_EMAIL
-  required: true
-- name: IDENTITY_ATTR_ID
-  required: true
-- name: IDENTITY_ATTR_NAME
-  required: true
-- name: IDENTITY_ATTR_PREFERRED_USERNAME
-  required: true
-- name: IDENTITY_BIND_DN
-  required: true
-- name: IDENTITY_URL
-  required: true
-- name: IDENTITY_SRE_GOOGLE_CLIENTID
-  required: true
-- name: IDENTITY_NAME
-  required: true
-- name: IDENTITY_MAPPING_METHOD
-  required: true
 - name: TELEMETER_SERVER_URL
   required: true
 - name: OCM_BASE_URL
@@ -35,8 +17,6 @@ parameters:
 - name: OBSERVATORIUM_LEGALENTITY_IDS
   required: true
 - name: ALLOWED_CIDR_BLOCKS
-  required: true
-- name: ENABLE_MANAGEMENT_API_SERVER_INGRESS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true


### PR DESCRIPTION
The `IDENTITY_*` variables are no longer needed as the legacy OpenShift_SRE IdP has been removed.

The `ENABLE_MANAGEMENT_API_SERVER_INGRESS` is no longer needed as we only have v4 shards left, so this should be `true` for everyone.