### PR TITLE
Remove OBSERVATORIUM_LEGALENTITY_IDS

### DIFF
--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -14,8 +14,6 @@ parameters:
   required: true
 - name: DPTP_LEGAL_ENTITY_ID
   required: true
-- name: OBSERVATORIUM_LEGALENTITY_IDS
-  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS


### PR DESCRIPTION
This variable is no longer used as we are pushing the observatorium config everywhere