### PR TITLE
OSD-8883: added cvo gates for cluster updates

### DIFF
--- a/deploy/osd-cluster-acks/4.9/admin-gates.yaml
+++ b/deploy/osd-cluster-acks/4.9/admin-gates.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+name: admin-acks
+namespace: openshift-config
+applyMode: AlwaysApply
+patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
+patchType: merge

--- a/deploy/osd-cluster-acks/4.9/config.yaml
+++ b/deploy/osd-cluster-acks/4.9/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor 
+    operator: In
+    values: ["4.8"]
+  - key: api.openshift.com/ocp-admin-ack
+    operator: In 
+    values: ["v4.9"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5693,6 +5693,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-4.9
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+      - key: api.openshift.com/ocp-admin-ack
+        operator: In
+        values:
+        - v4.9
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: admin-acks
+      namespace: openshift-config
+      applyMode: AlwaysApply
+      patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-sts-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5693,6 +5693,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-4.9
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+      - key: api.openshift.com/ocp-admin-ack
+        operator: In
+        values:
+        - v4.9
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: admin-acks
+      namespace: openshift-config
+      applyMode: AlwaysApply
+      patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-sts-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5693,6 +5693,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-4.9
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+      - key: api.openshift.com/ocp-admin-ack
+        operator: In
+        values:
+        - v4.9
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: ConfigMap
+      name: admin-acks
+      namespace: openshift-config
+      applyMode: AlwaysApply
+      patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-sts-4.9
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
syncing admin-acks to osd clusters for the case it is specified in the ClusterDeployment annotation