### PR TITLE
OSD-9006 silence CODown during upgrades

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -13,6 +13,8 @@ data:
       controlPlaneTime: 90
       ignoredAlerts:
         controlPlaneCriticals:
+        # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300
+        - ClusterOperatorDown
     scale:
       timeOut: 30
     upgradeWindow:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4231,7 +4231,8 @@ objects:
       data:
         config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
           \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4231,7 +4231,8 @@ objects:
       data:
         config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
           \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4231,7 +4231,8 @@ objects:
       data:
         config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
           \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\


### PR DESCRIPTION
This PR silences the `ClusterOperatorDown` alert during upgrades.

We currently have this alert silenced during upgrades for all non-4.8 clusters. We unsilenced it for 4.8+ clusters as part of OSD-7890. However, there is still the real possibility that the `machine-api` operator can report `ClusterOperatorDown` during upgrades in 4.8+, as tracked by [BZ1955300](https://bugzilla.redhat.com/show_bug.cgi?id=1955300).

Therefore, we shall silence it again in 4.8+ until that bug is resolved.

Refs [OSD-9006](https://issues.redhat.com/browse/OSD-9006)