### PR TITLE
fix(sts-ack): fix typo [OSD-8884]

### DIFF
--- a/deploy/osd-cluster-acks/sts/4.9/osd-sts-ack_4.9_CloudCredential.yaml
+++ b/deploy/osd-cluster-acks/sts/4.9/osd-sts-ack_4.9_CloudCredential.yaml
@@ -2,5 +2,5 @@ apiVersion: operator.openshift.io/v1
 kind: CloudCredential
 name: cluster
 applyMode: AlwaysApply
-patch: '{"metadata":{"annotations"{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
+patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
 patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5717,7 +5717,7 @@ objects:
       kind: CloudCredential
       name: cluster
       applyMode: AlwaysApply
-      patch: '{"metadata":{"annotations"{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5717,7 +5717,7 @@ objects:
       kind: CloudCredential
       name: cluster
       applyMode: AlwaysApply
-      patch: '{"metadata":{"annotations"{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5717,7 +5717,7 @@ objects:
       kind: CloudCredential
       name: cluster
       applyMode: AlwaysApply
-      patch: '{"metadata":{"annotations"{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.9"}}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
without it the resource fails to be patched

to test locally I:
```
$ oc patch ${TYPE}/${NAME} -p ${PATCH_JSON} --type merge --dry-run
${TYPE}/${NAME}  patched
```

related to #978