### PR TITLE
Collect namespaces listed as relatedObjects in clusteroperator

### DIFF
--- a/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
@@ -7,7 +7,10 @@ data:
   managed_namespaces.yaml: |
     Resources:
       Namespace:
+      - name: openshift
+      - name: openshift-apiserver
       - name: openshift-apiserver-operator
+      - name: openshift-authentication
       - name: openshift-authentication-operator
       - name: openshift-cloud-controller-manager
       - name: openshift-cloud-controller-manager-operator
@@ -23,26 +26,41 @@ data:
       - name: openshift-console
       - name: openshift-console-operator
       - name: openshift-console-user-settings
+      - name: openshift-controller-manager
       - name: openshift-controller-manager-operator
+      - name: openshift-dns
       - name: openshift-dns-operator
+      - name: openshift-etcd
       - name: openshift-etcd-operator
+      - name: openshift-host-network
       - name: openshift-image-registry
+      - name: openshift-ingress
+      - name: openshift-ingress-canary
       - name: openshift-ingress-operator
       - name: openshift-insights
       - name: openshift-kni-infra
+      - name: openshift-kube-apiserver
       - name: openshift-kube-apiserver-operator
+      - name: openshift-kube-controller-manager
       - name: openshift-kube-controller-manager-operator
+      - name: openshift-kube-scheduler
       - name: openshift-kube-scheduler-operator
+      - name: openshift-kube-storage-version-migrator
       - name: openshift-kube-storage-version-migrator-operator
       - name: openshift-machine-api
       - name: openshift-machine-config-operator
       - name: openshift-marketplace
       - name: openshift-monitoring
+      - name: openshift-multus
+      - name: openshift-network-diagnostics
       - name: openshift-network-operator
+      - name: openshift-oauth-apiserver
       - name: openshift-openstack-infra
       - name: openshift-operator-lifecycle-manager
       - name: openshift-operators
       - name: openshift-ovirt-infra
+      - name: openshift-sdn
+      - name: openshift-service-ca
       - name: openshift-service-ca-operator
       - name: openshift-user-workload-monitoring
       - name: openshift-vsphere-infra

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8113,26 +8113,33 @@ objects:
         name: ocp-namespaces
         namespace: openshift-monitoring
       data:
-        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver-operator\n\
-          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
-          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
-          \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
-          \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
-          \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\
-          \  - name: openshift-config-managed\n  - name: openshift-config-operator\n\
-          \  - name: openshift-console\n  - name: openshift-console-operator\n  -\
-          \ name: openshift-console-user-settings\n  - name: openshift-controller-manager-operator\n\
-          \  - name: openshift-dns-operator\n  - name: openshift-etcd-operator\n \
-          \ - name: openshift-image-registry\n  - name: openshift-ingress-operator\n\
-          \  - name: openshift-insights\n  - name: openshift-kni-infra\n  - name:\
-          \ openshift-kube-apiserver-operator\n  - name: openshift-kube-controller-manager-operator\n\
-          \  - name: openshift-kube-scheduler-operator\n  - name: openshift-kube-storage-version-migrator-operator\n\
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift\n\
+          \  - name: openshift-apiserver\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication\n  - name: openshift-authentication-operator\n\
+          \  - name: openshift-cloud-controller-manager\n  - name: openshift-cloud-controller-manager-operator\n\
+          \  - name: openshift-cloud-credential-operator\n  - name: openshift-cluster-csi-drivers\n\
+          \  - name: openshift-cluster-machine-approver\n  - name: openshift-cluster-node-tuning-operator\n\
+          \  - name: openshift-cluster-samples-operator\n  - name: openshift-cluster-storage-operator\n\
+          \  - name: openshift-config\n  - name: openshift-config-managed\n  - name:\
+          \ openshift-config-operator\n  - name: openshift-console\n  - name: openshift-console-operator\n\
+          \  - name: openshift-console-user-settings\n  - name: openshift-controller-manager\n\
+          \  - name: openshift-controller-manager-operator\n  - name: openshift-dns\n\
+          \  - name: openshift-dns-operator\n  - name: openshift-etcd\n  - name: openshift-etcd-operator\n\
+          \  - name: openshift-host-network\n  - name: openshift-image-registry\n\
+          \  - name: openshift-ingress\n  - name: openshift-ingress-canary\n  - name:\
+          \ openshift-ingress-operator\n  - name: openshift-insights\n  - name: openshift-kni-infra\n\
+          \  - name: openshift-kube-apiserver\n  - name: openshift-kube-apiserver-operator\n\
+          \  - name: openshift-kube-controller-manager\n  - name: openshift-kube-controller-manager-operator\n\
+          \  - name: openshift-kube-scheduler\n  - name: openshift-kube-scheduler-operator\n\
+          \  - name: openshift-kube-storage-version-migrator\n  - name: openshift-kube-storage-version-migrator-operator\n\
           \  - name: openshift-machine-api\n  - name: openshift-machine-config-operator\n\
           \  - name: openshift-marketplace\n  - name: openshift-monitoring\n  - name:\
-          \ openshift-network-operator\n  - name: openshift-openstack-infra\n  - name:\
-          \ openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
-          \  - name: openshift-ovirt-infra\n  - name: openshift-service-ca-operator\n\
-          \  - name: openshift-user-workload-monitoring\n  - name: openshift-vsphere-infra\n"
+          \ openshift-multus\n  - name: openshift-network-diagnostics\n  - name: openshift-network-operator\n\
+          \  - name: openshift-oauth-apiserver\n  - name: openshift-openstack-infra\n\
+          \  - name: openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
+          \  - name: openshift-ovirt-infra\n  - name: openshift-sdn\n  - name: openshift-service-ca\n\
+          \  - name: openshift-service-ca-operator\n  - name: openshift-user-workload-monitoring\n\
+          \  - name: openshift-vsphere-infra\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8113,26 +8113,33 @@ objects:
         name: ocp-namespaces
         namespace: openshift-monitoring
       data:
-        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver-operator\n\
-          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
-          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
-          \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
-          \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
-          \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\
-          \  - name: openshift-config-managed\n  - name: openshift-config-operator\n\
-          \  - name: openshift-console\n  - name: openshift-console-operator\n  -\
-          \ name: openshift-console-user-settings\n  - name: openshift-controller-manager-operator\n\
-          \  - name: openshift-dns-operator\n  - name: openshift-etcd-operator\n \
-          \ - name: openshift-image-registry\n  - name: openshift-ingress-operator\n\
-          \  - name: openshift-insights\n  - name: openshift-kni-infra\n  - name:\
-          \ openshift-kube-apiserver-operator\n  - name: openshift-kube-controller-manager-operator\n\
-          \  - name: openshift-kube-scheduler-operator\n  - name: openshift-kube-storage-version-migrator-operator\n\
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift\n\
+          \  - name: openshift-apiserver\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication\n  - name: openshift-authentication-operator\n\
+          \  - name: openshift-cloud-controller-manager\n  - name: openshift-cloud-controller-manager-operator\n\
+          \  - name: openshift-cloud-credential-operator\n  - name: openshift-cluster-csi-drivers\n\
+          \  - name: openshift-cluster-machine-approver\n  - name: openshift-cluster-node-tuning-operator\n\
+          \  - name: openshift-cluster-samples-operator\n  - name: openshift-cluster-storage-operator\n\
+          \  - name: openshift-config\n  - name: openshift-config-managed\n  - name:\
+          \ openshift-config-operator\n  - name: openshift-console\n  - name: openshift-console-operator\n\
+          \  - name: openshift-console-user-settings\n  - name: openshift-controller-manager\n\
+          \  - name: openshift-controller-manager-operator\n  - name: openshift-dns\n\
+          \  - name: openshift-dns-operator\n  - name: openshift-etcd\n  - name: openshift-etcd-operator\n\
+          \  - name: openshift-host-network\n  - name: openshift-image-registry\n\
+          \  - name: openshift-ingress\n  - name: openshift-ingress-canary\n  - name:\
+          \ openshift-ingress-operator\n  - name: openshift-insights\n  - name: openshift-kni-infra\n\
+          \  - name: openshift-kube-apiserver\n  - name: openshift-kube-apiserver-operator\n\
+          \  - name: openshift-kube-controller-manager\n  - name: openshift-kube-controller-manager-operator\n\
+          \  - name: openshift-kube-scheduler\n  - name: openshift-kube-scheduler-operator\n\
+          \  - name: openshift-kube-storage-version-migrator\n  - name: openshift-kube-storage-version-migrator-operator\n\
           \  - name: openshift-machine-api\n  - name: openshift-machine-config-operator\n\
           \  - name: openshift-marketplace\n  - name: openshift-monitoring\n  - name:\
-          \ openshift-network-operator\n  - name: openshift-openstack-infra\n  - name:\
-          \ openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
-          \  - name: openshift-ovirt-infra\n  - name: openshift-service-ca-operator\n\
-          \  - name: openshift-user-workload-monitoring\n  - name: openshift-vsphere-infra\n"
+          \ openshift-multus\n  - name: openshift-network-diagnostics\n  - name: openshift-network-operator\n\
+          \  - name: openshift-oauth-apiserver\n  - name: openshift-openstack-infra\n\
+          \  - name: openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
+          \  - name: openshift-ovirt-infra\n  - name: openshift-sdn\n  - name: openshift-service-ca\n\
+          \  - name: openshift-service-ca-operator\n  - name: openshift-user-workload-monitoring\n\
+          \  - name: openshift-vsphere-infra\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8113,26 +8113,33 @@ objects:
         name: ocp-namespaces
         namespace: openshift-monitoring
       data:
-        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver-operator\n\
-          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
-          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
-          \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
-          \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
-          \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\
-          \  - name: openshift-config-managed\n  - name: openshift-config-operator\n\
-          \  - name: openshift-console\n  - name: openshift-console-operator\n  -\
-          \ name: openshift-console-user-settings\n  - name: openshift-controller-manager-operator\n\
-          \  - name: openshift-dns-operator\n  - name: openshift-etcd-operator\n \
-          \ - name: openshift-image-registry\n  - name: openshift-ingress-operator\n\
-          \  - name: openshift-insights\n  - name: openshift-kni-infra\n  - name:\
-          \ openshift-kube-apiserver-operator\n  - name: openshift-kube-controller-manager-operator\n\
-          \  - name: openshift-kube-scheduler-operator\n  - name: openshift-kube-storage-version-migrator-operator\n\
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift\n\
+          \  - name: openshift-apiserver\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication\n  - name: openshift-authentication-operator\n\
+          \  - name: openshift-cloud-controller-manager\n  - name: openshift-cloud-controller-manager-operator\n\
+          \  - name: openshift-cloud-credential-operator\n  - name: openshift-cluster-csi-drivers\n\
+          \  - name: openshift-cluster-machine-approver\n  - name: openshift-cluster-node-tuning-operator\n\
+          \  - name: openshift-cluster-samples-operator\n  - name: openshift-cluster-storage-operator\n\
+          \  - name: openshift-config\n  - name: openshift-config-managed\n  - name:\
+          \ openshift-config-operator\n  - name: openshift-console\n  - name: openshift-console-operator\n\
+          \  - name: openshift-console-user-settings\n  - name: openshift-controller-manager\n\
+          \  - name: openshift-controller-manager-operator\n  - name: openshift-dns\n\
+          \  - name: openshift-dns-operator\n  - name: openshift-etcd\n  - name: openshift-etcd-operator\n\
+          \  - name: openshift-host-network\n  - name: openshift-image-registry\n\
+          \  - name: openshift-ingress\n  - name: openshift-ingress-canary\n  - name:\
+          \ openshift-ingress-operator\n  - name: openshift-insights\n  - name: openshift-kni-infra\n\
+          \  - name: openshift-kube-apiserver\n  - name: openshift-kube-apiserver-operator\n\
+          \  - name: openshift-kube-controller-manager\n  - name: openshift-kube-controller-manager-operator\n\
+          \  - name: openshift-kube-scheduler\n  - name: openshift-kube-scheduler-operator\n\
+          \  - name: openshift-kube-storage-version-migrator\n  - name: openshift-kube-storage-version-migrator-operator\n\
           \  - name: openshift-machine-api\n  - name: openshift-machine-config-operator\n\
           \  - name: openshift-marketplace\n  - name: openshift-monitoring\n  - name:\
-          \ openshift-network-operator\n  - name: openshift-openstack-infra\n  - name:\
-          \ openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
-          \  - name: openshift-ovirt-infra\n  - name: openshift-service-ca-operator\n\
-          \  - name: openshift-user-workload-monitoring\n  - name: openshift-vsphere-infra\n"
+          \ openshift-multus\n  - name: openshift-network-diagnostics\n  - name: openshift-network-operator\n\
+          \  - name: openshift-oauth-apiserver\n  - name: openshift-openstack-infra\n\
+          \  - name: openshift-operator-lifecycle-manager\n  - name: openshift-operators\n\
+          \  - name: openshift-ovirt-infra\n  - name: openshift-sdn\n  - name: openshift-service-ca\n\
+          \  - name: openshift-service-ca-operator\n  - name: openshift-user-workload-monitoring\n\
+          \  - name: openshift-vsphere-infra\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
The managed namespace script currently looks for OCP managed namespaces by collecting Namespace manifests in the `oc adm release extract` output. However, there are other namespaces associated with clusteroperators that aren't represented in the release manifests. This updates the managed-namespaces script to also include any namespaces referenced as `relatedObjects` in all clusteroperator resources. 