### PR TITLE
OSD-8656 explicitly schedule uwm components to workers

### DIFF
--- a/deploy/osd-user-workload-monitoring/cluster-monitoring-config.yaml
+++ b/deploy/osd-user-workload-monitoring/cluster-monitoring-config.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheusOperator:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+    prometheus:
+      retention: 24h
+      resources:
+        requests:
+          cpu: 200m
+          memory: 2Gi
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
+    thanosRuler:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""

--- a/deploy/osd-user-workload-monitoring/config.yaml
+++ b/deploy/osd-user-workload-monitoring/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: hive.openshift.io/version-major-minor
+      operator: NotIn
+      values: ["4.5"]
+    - key: ext-managed.openshift.io/uwm-disabled
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9327,6 +9327,15 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -9371,6 +9380,17 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-user-workload-monitoring-create-cm
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: user-workload-monitoring-config
+        namespace: openshift-user-workload-monitoring
+      data:
+        config.yaml: "prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\nprometheus:\n  retention: 24h\n  resources:\n    requests:\n   \
+          \   cpu: 200m\n      memory: 2Gi\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\nthanosRuler:\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9327,6 +9327,15 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -9371,6 +9380,17 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-user-workload-monitoring-create-cm
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: user-workload-monitoring-config
+        namespace: openshift-user-workload-monitoring
+      data:
+        config.yaml: "prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\nprometheus:\n  retention: 24h\n  resources:\n    requests:\n   \
+          \   cpu: 200m\n      memory: 2Gi\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\nthanosRuler:\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9327,6 +9327,15 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -9371,6 +9380,17 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-user-workload-monitoring-create-cm
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: user-workload-monitoring-config
+        namespace: openshift-user-workload-monitoring
+      data:
+        config.yaml: "prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\nprometheus:\n  retention: 24h\n  resources:\n    requests:\n   \
+          \   cpu: 200m\n      memory: 2Gi\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\nthanosRuler:\n  nodeSelector:\n    node-role.kubernetes.io/worker:\
+          \ \"\"\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Currently the UWM config is not set enabling defaults to be deployed by the openshift-user-workload-monitoring/prometheus-operator. This is undesirable as the operator schedules itself to master nodes. 

```
[~ {production} (osd-v4prod-aws:default)]$ oc -n openshift-user-workload-monitoring get pods prometheus-operator-68fd48b89d-6tp7s -o json | jq '.spec.tolerations[]'
{
  "effect": "NoSchedule",
  "key": "node-role.kubernetes.io/master",
  "operator": "Exists"
}
{
  "effect": "NoExecute",
  "key": "node.kubernetes.io/not-ready",
  "operator": "Exists",
  "tolerationSeconds": 300
}
{
  "effect": "NoExecute",
  "key": "node.kubernetes.io/unreachable",
  "operator": "Exists",
  "tolerationSeconds": 300
}
{
  "effect": "NoSchedule",
  "key": "node.kubernetes.io/memory-pressure",
  "operator": "Exists"
}
```

Thus, this PR explicity schedules UWM components onto workers inclusive of the default prometheus configuration as seen below. 

```
[~ {production} (osd-v4prod-aws:default)]$ oc -n openshift-user-workload-monitoring get cm user-workload-monitoring-config -o yaml
apiVersion: v1
data:
  config.yaml: |
    prometheus:
      retention: 24h
      resources:
        requests:
          cpu: 200m
          memory: 2Gi
```

Open question: should the openshift-user-workload-monitoring/prometheus-operator itself be seen as an infra component? Its not obvious: https://docs.openshift.com/dedicated/osd_policy/policy-responsibility-matrix.html#policy-customer-responsibility_policy-responsibility-matrix 