### PR TITLE
Add ability for SRE to delete CSRs

### DIFF
--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -141,7 +141,7 @@ rules:
   - list
   - watch
 ### End
-# SRE can view CSR objects
+# SRE can view/delete CSR objects
 - apiGroups:
   - certificates.k8s.io
   resources:
@@ -150,4 +150,5 @@ rules:
   - get
   - list
   - watch
+  - delete
 ### End

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3063,6 +3063,7 @@ objects:
         - get
         - list
         - watch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3063,6 +3063,7 @@ objects:
         - get
         - list
         - watch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3063,6 +3063,7 @@ objects:
         - get
         - list
         - watch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
There are cases where due to a bug (like https://bugzilla.redhat.com/show_bug.cgi?id=2025767) or otherwise, a SREP engineer may need to delete CSR object from the cluster to clean them up. These objects are create/recreated automatically by the cluster, so this is safe.