### PR TITLE
Add port forwarding to managed kafka permissions

### DIFF
--- a/deploy/backplane/cssre/redhat-kas-fleetshard/10-mkrts-admins-project.ClusterRole.yml
+++ b/deploy/backplane/cssre/redhat-kas-fleetshard/10-mkrts-admins-project.ClusterRole.yml
@@ -36,3 +36,10 @@ rules:
   verbs:
   - delete
   - deletecollection
+# SRE can use oc port-forward
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1590,6 +1590,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1651,6 +1657,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1712,6 +1724,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1773,6 +1791,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1590,6 +1590,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1651,6 +1657,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1712,6 +1724,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1773,6 +1791,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1590,6 +1590,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1651,6 +1657,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1712,6 +1724,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1773,6 +1791,12 @@ objects:
         verbs:
         - delete
         - deletecollection
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:


### PR DESCRIPTION
This is necessary for CSSRE to be able to port forward into namespaces that they manage for managed kafka. This will primarily allow the monitoring stack to be accessed.