### PR TITLE
OSD-9184 Pending csr indicate orphaned VM creation

### DIFF
--- a/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
@@ -20,4 +20,3 @@ spec:
             namespace: openshift-monitoring
           annotations:
             message: "MAPI CSR requests have been pending for more then 15 minutes. This can indicate that orphaned VMs are being created and requires immeditate remediation."
-            link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md

--- a/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-pending-csr-alert
+    role: alert-rules
+  name: sre-pending-csr-alert
+  namespace: openshift-monitoring
+spec:
+  groups:
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2025767
+    # MAPI currently has a bug that leaves orphaned-vms. Pending CSRs are indications of this occurring
+    - name: sre-pending-csr-alert
+      rules:
+        - alert: CSRPendingLongDurationSRE
+          expr: sum(mapi_current_pending_csr) > 0
+          for: 15m
+          labels:
+            severity: critical
+            namespace: openshift-monitoring
+          annotations:
+            message: "MAPI CSR requests have been pending for more then 15 minutes. This can indicate that orphaned VMs are being created and requires immeditate remediation."
+            link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11350,6 +11350,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-pending-csr-alert
+          role: alert-rules
+        name: sre-pending-csr-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-pending-csr-alert
+          rules:
+          - alert: CSRPendingLongDurationSRE
+            expr: sum(mapi_current_pending_csr) > 0
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: MAPI CSR requests have been pending for more then 15 minutes.
+                This can indicate that orphaned VMs are being created and requires
+                immeditate remediation.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: rhmi-sre-cluster-admins
           role: alert-rules
         name: rhmi-sre-cluster-admins

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11368,7 +11368,6 @@ objects:
               message: MAPI CSR requests have been pending for more then 15 minutes.
                 This can indicate that orphaned VMs are being created and requires
                 immeditate remediation.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11350,6 +11350,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-pending-csr-alert
+          role: alert-rules
+        name: sre-pending-csr-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-pending-csr-alert
+          rules:
+          - alert: CSRPendingLongDurationSRE
+            expr: sum(mapi_current_pending_csr) > 0
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: MAPI CSR requests have been pending for more then 15 minutes.
+                This can indicate that orphaned VMs are being created and requires
+                immeditate remediation.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: rhmi-sre-cluster-admins
           role: alert-rules
         name: rhmi-sre-cluster-admins

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11368,7 +11368,6 @@ objects:
               message: MAPI CSR requests have been pending for more then 15 minutes.
                 This can indicate that orphaned VMs are being created and requires
                 immeditate remediation.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11350,6 +11350,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-pending-csr-alert
+          role: alert-rules
+        name: sre-pending-csr-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-pending-csr-alert
+          rules:
+          - alert: CSRPendingLongDurationSRE
+            expr: sum(mapi_current_pending_csr) > 0
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: MAPI CSR requests have been pending for more then 15 minutes.
+                This can indicate that orphaned VMs are being created and requires
+                immeditate remediation.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: rhmi-sre-cluster-admins
           role: alert-rules
         name: rhmi-sre-cluster-admins

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11368,7 +11368,6 @@ objects:
               message: MAPI CSR requests have been pending for more then 15 minutes.
                 This can indicate that orphaned VMs are being created and requires
                 immeditate remediation.
-              link: https://github.com/openshift/ops-sop/blob/master/v4/howto/remove-orphaned-machines.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Rather then splunk, this promql allows us to have clusters generate their own alerts on the pending CSR conditions that have been evident in impacted clusters. Examples can be found below

![cluster3](https://user-images.githubusercontent.com/21171128/144172763-e3102621-3086-4584-8406-aedaec6334dd.png)
![cluster2](https://user-images.githubusercontent.com/21171128/144172768-5a903e0f-228a-46d7-b08f-967ce04eb066.png)
![cluster1](https://user-images.githubusercontent.com/21171128/144172769-95b0b74d-6f3a-413d-a758-ea32c1c0f2c5.png)

Hibernation was also tested. I have a staging cluster that has been hibernated/resumed twice and it did not meet these conditions to alert. 

cc @mrbarge @cblecker 