### PR TITLE
tune condition for pending csr alert

### DIFF
--- a/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
@@ -13,7 +13,7 @@ spec:
     - name: sre-pending-csr-alert
       rules:
         - alert: CSRPendingLongDurationSRE
-          expr: sum(mapi_current_pending_csr) > 0
+          expr: sum(mapi_current_pending_csr) > 1
           for: 15m
           labels:
             severity: critical

--- a/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
@@ -13,6 +13,7 @@ spec:
     - name: sre-pending-csr-alert
       rules:
         - alert: CSRPendingLongDurationSRE
+          # set to 1 as per https://access.redhat.com/solutions/6411541
           expr: sum(mapi_current_pending_csr) > 1
           for: 15m
           labels:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11359,7 +11359,7 @@ objects:
         - name: sre-pending-csr-alert
           rules:
           - alert: CSRPendingLongDurationSRE
-            expr: sum(mapi_current_pending_csr) > 0
+            expr: sum(mapi_current_pending_csr) > 1
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11359,7 +11359,7 @@ objects:
         - name: sre-pending-csr-alert
           rules:
           - alert: CSRPendingLongDurationSRE
-            expr: sum(mapi_current_pending_csr) > 0
+            expr: sum(mapi_current_pending_csr) > 1
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11359,7 +11359,7 @@ objects:
         - name: sre-pending-csr-alert
           rules:
           - alert: CSRPendingLongDurationSRE
-            expr: sum(mapi_current_pending_csr) > 0
+            expr: sum(mapi_current_pending_csr) > 1
             for: 15m
             labels:
               severity: critical


### PR DESCRIPTION
Following up on https://github.com/openshift/managed-cluster-config/pull/993 

This was reviewed in pagerduty for staging/integration and was firing. Upon investigation, it appears the metric being used (mapi_current_pending_csr) was by default being set to `1` in versions prior to 4.9.8:

* https://access.redhat.com/solutions/6411541
* https://bugzilla.redhat.com/show_bug.cgi?id=2019754

This PR changes the condition to account for this bug that is still evident within the fleet. 