### PR TITLE
OSD- 8643 : Revised expected upgrade control plane duration window for MUO 

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -10,7 +10,7 @@ data:
       ocmBaseUrl: ${OCM_BASE_URL}
       watchInterval: 60
     maintenance:
-      controlPlaneTime: 90
+      controlPlaneTime: 120
       ignoredAlerts:
         controlPlaneCriticals:
         # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4257,7 +4257,7 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 120\n  ignoredAlerts:\n\
           \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
           \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4257,7 +4257,7 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 120\n  ignoredAlerts:\n\
           \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
           \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4257,7 +4257,7 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 120\n  ignoredAlerts:\n\
           \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
           \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\


### PR DESCRIPTION
In the context of https://issues.redhat.com/browse/OSD-8643 , SREs are often alerted unnecessarily for false positive upgrade control plane timeouts which makes their shifts noisier.
Thus, The expected upgrade control plane duration window for MUO has been revised from 90 to 120. 
This change comes from inferences and conclusions made through the values based on data found via CCX. 