### PR TITLE
OSD-8015 Revise KubeNodeUnschedulableSRE timeout to 80m

### DIFF
--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: KubeNodeUnschedulableSRE
       expr: kube_node_spec_unschedulable > 0
-      for: 1h
+      for: 80m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11339,7 +11339,7 @@ objects:
           rules:
           - alert: KubeNodeUnschedulableSRE
             expr: kube_node_spec_unschedulable > 0
-            for: 1h
+            for: 80m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11339,7 +11339,7 @@ objects:
           rules:
           - alert: KubeNodeUnschedulableSRE
             expr: kube_node_spec_unschedulable > 0
-            for: 1h
+            for: 80m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11339,7 +11339,7 @@ objects:
           rules:
           - alert: KubeNodeUnschedulableSRE
             expr: kube_node_spec_unschedulable > 0
-            for: 1h
+            for: 80m
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
This PR bumps the alert threshold for `KubeNodeUnschedulableSRE` from 60 minutes to 80 minutes.

This is a short-term solution being done to reduce noise to SRE Primary.

This alert often fires during cluster upgrades and requires no action from SRE. The reason is because clusters running workloads with blocking PDBs will have nodes left in an unschedulable state whilst MUO waits until its PDB Node Drain timeout threshold is reached. Coincidentally, the default PDB Node Drain timeout is also 60 minutes. This means that for the vast majority of clusters using a default PDB Node Drain timeout on their upgrades, the following situation occurs:

- A node is drained to be upgraded
- A workload blocks the drain
- MUO waits 60 minutes for that situation to resolve itself
- After 60 minutes, `KubeNodeUnschedulableSRE` fires and notifies Primary.
- Shortly thereafter, MUO addresses the problem to let the drain continue.
- The alert self-resolves.

A long-term fix for this would be for MUO to silence `KubeNodeUnschedulableSRE` for the specific node being drained for an upgrade, whilst it is being upgraded. This is tracked by [OSD-8342](https://issues.redhat.com/browse/OSD-8342) to be addressed in the next maintenance sprint. 

A bump of +20 minutes should be enough to reduce the noise for Primary without being a major inhibitor of SRE's overall responsiveness to a genuine cluster issue. 

After [OSD-8342](https://issues.redhat.com/browse/OSD-8342) is completed, this can be dropped back to 60m. (If merged, that will be added as an acceptance criteria to the ticket).