### PR TITLE
Place definition of cloud-ingress-operator in MCC so deployment is owned

### DIFF
--- a/deploy/cloud-ingress-operator-configuration/clusterrole/10-cloud-ingress-operator-clusterrole.yaml
+++ b/deploy/cloud-ingress-operator-configuration/clusterrole/10-cloud-ingress-operator-clusterrole.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ClusterRole
+metadata:
+  name: cloud-ingress-operator

--- a/deploy/cloud-ingress-operator-configuration/clusterrole/config.yaml
+++ b/deploy/cloud-ingress-operator-configuration/clusterrole/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  # Upsert prevents this configuration from being accidentily removed. If removed,
+  # rh-api reachability may be impacted.
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: api.openshift.com/sts
+    operator: NotIn
+    values: ["true"]
+  - key: api.openshift.com/private-link
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3750,6 +3750,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator-configuration-clusterrole
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ClusterRole
+      metadata:
+        name: cloud-ingress-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: cloud-ingress-operator-configuration-routerreplicas-osd-8028
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3750,6 +3750,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator-configuration-clusterrole
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ClusterRole
+      metadata:
+        name: cloud-ingress-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: cloud-ingress-operator-configuration-routerreplicas-osd-8028
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3750,6 +3750,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cloud-ingress-operator-configuration-clusterrole
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ClusterRole
+      metadata:
+        name: cloud-ingress-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: cloud-ingress-operator-configuration-routerreplicas-osd-8028
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
tl;dr this PR ensures that MCC owns the cloud-ingress-operator clusterrole for future removal.

When cloud-ingress-operator is deployed, OLM deploys a clusterrole called `cloud-ingress-operator.v1.<CSV Version>`. For example `cloud-ingress-operator.v0.1.485-c329c1d-5679d97985`.  Previously, the cloud-ingress-operator deployment also included a definition of a clusterrole called `cloud-ingress-operator`, deployed by a syncset. As a result, both clusterroles were present with exactly the same permission set. The selectorsyncset of the `cloud-ingress-opreator`clusterrole has been removed, so on new clusters there will only be the OLM-deployed version with the CSV name appended. However, when the `cloud-ingress-operator` clusterrole was removed from the syncset, the sync mode was Upsert, so existing clusterroles on clusters were not removed. This PR serves as a way to regain control of the deployment of those clusterroles so they can removed via MCC in the future. 