### PR TITLE
 [ ODD - 9141 ] MUO's cluster-config role/binding as a workaround for CSV permissions issue

### DIFF
--- a/deploy/managed-upgrade-operator-rbac/110-monitoring_reader_role.yaml
+++ b/deploy/managed-upgrade-operator-rbac/110-monitoring_reader_role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: muo-monitoring-reader
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps  
+  - serviceaccounts
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/managed-upgrade-operator-rbac/110-pullsecret_reader_role.yaml
+++ b/deploy/managed-upgrade-operator-rbac/110-pullsecret_reader_role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: muo-pullsecret-reader
+  namespace: openshift-config
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/managed-upgrade-operator-rbac/117-monitoring_reader_rolebinding.yaml
+++ b/deploy/managed-upgrade-operator-rbac/117-monitoring_reader_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: muo-monitoring-reader
+  namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: muo-monitoring-reader
+subjects:
+- kind: ServiceAccount
+  name: managed-upgrade-operator
+  namespace: openshift-managed-upgrade-operator

--- a/deploy/managed-upgrade-operator-rbac/117-pullsecret_reader_rolebinding.yaml
+++ b/deploy/managed-upgrade-operator-rbac/117-pullsecret_reader_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: muo-pullsecret-reader
+  namespace: openshift-config
+roleRef:
+  kind: Role
+  name: muo-pullsecret-reader
+subjects:
+- kind: ServiceAccount
+  name: managed-upgrade-operator
+  namespace: openshift-managed-upgrade-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4409,6 +4409,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: managed-upgrade-operator-rbac
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: muo-monitoring-reader
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        - serviceaccounts
+        - secrets
+        - services
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: muo-pullsecret-reader
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: muo-monitoring-reader
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: muo-monitoring-reader
+      subjects:
+      - kind: ServiceAccount
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: muo-pullsecret-reader
+        namespace: openshift-config
+      roleRef:
+        kind: Role
+        name: muo-pullsecret-reader
+      subjects:
+      - kind: ServiceAccount
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: managed-velero-operator-rolebinding
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4409,6 +4409,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: managed-upgrade-operator-rbac
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: muo-monitoring-reader
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        - serviceaccounts
+        - secrets
+        - services
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: muo-pullsecret-reader
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: muo-monitoring-reader
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: muo-monitoring-reader
+      subjects:
+      - kind: ServiceAccount
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: muo-pullsecret-reader
+        namespace: openshift-config
+      roleRef:
+        kind: Role
+        name: muo-pullsecret-reader
+      subjects:
+      - kind: ServiceAccount
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: managed-velero-operator-rolebinding
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4409,6 +4409,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: managed-upgrade-operator-rbac
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: muo-monitoring-reader
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        - serviceaccounts
+        - secrets
+        - services
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: muo-pullsecret-reader
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: muo-monitoring-reader
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: muo-monitoring-reader
+      subjects:
+      - kind: ServiceAccount
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: muo-pullsecret-reader
+        namespace: openshift-config
+      roleRef:
+        kind: Role
+        name: muo-pullsecret-reader
+      subjects:
+      - kind: ServiceAccount
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: managed-velero-operator-rolebinding
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-9141
As a workaround, this selectorsyncset will create that role and rolebinding.