### PR TITLE
Use the correct apiVersion for the CIO ClusterRole

### DIFF
--- a/deploy/cloud-ingress-operator-configuration/clusterrole/10-cloud-ingress-operator-clusterrole.yaml
+++ b/deploy/cloud-ingress-operator-configuration/clusterrole/10-cloud-ingress-operator-clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cloud-ingress-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3766,7 +3766,7 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: v1
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: cloud-ingress-operator

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3766,7 +3766,7 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: v1
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: cloud-ingress-operator

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3766,7 +3766,7 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: v1
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: cloud-ingress-operator


### PR DESCRIPTION
The apiVersion for ClusterRole is actually `rbac.authorization.k8s.io/v1`, not `v1`. 