### PR TITLE
OSD-8643 : readme update for timeout window upgrade process

### DIFF
--- a/deploy/managed-upgrade-operator-config/README.md
+++ b/deploy/managed-upgrade-operator-config/README.md
@@ -26,3 +26,12 @@ Following is the reference for alert silence in different OCP versions:
     * ClusterOperatorDegraded alert silence maintained for 4.5, 4.6, 4.7
     * KubeDeploymentReplicasMismatch alert silence removed
     * MachineWithNoRunningPhase alert silence removed
+
+## TIMEOUT WINDOW UPGRADE PROCESS
+### In reference to OSD-8643, the expected upgrade control plane duration window for MUO was changed from 90 to 120 minutes.
+For SREs to re-evaluate the window timings in future, the following steps can be taken:
+ * Reach out to **CCX** team, clearly mentioning the requirements.
+ * The **CCX** team will auccordingly guide about accessing the data depending on the team's current status of providing data access to   someone out of CCX team.
+ * The data provided by **CCX** (mostly the Jupyter notebook) will help in analysis of potential and suitable window timings for the upgrade timeout.
+ * Once the timing has been finalised, upgrade the same on https://github.com/openshift/managed-cluster-config/blob/master/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+ * After successful upgradation and verification in staging environment, follow the steps on https://github.com/openshift/ops-sop/blob/master/v4/howto/push_operators_to_production.md to finally push the change to production environment.

--- a/deploy/managed-upgrade-operator-config/README.md
+++ b/deploy/managed-upgrade-operator-config/README.md
@@ -30,8 +30,8 @@ Following is the reference for alert silence in different OCP versions:
 ## TIMEOUT WINDOW UPGRADE PROCESS
 ### In reference to OSD-8643, the expected upgrade control plane duration window for MUO was changed from 90 to 120 minutes.
 For SREs to re-evaluate the window timings in future, the following steps can be taken:
- * Reach out to **CCX** team, clearly mentioning the requirements.
- * The **CCX** team will auccordingly guide about accessing the data depending on the team's current status of providing data access to   someone out of CCX team.
+ * Reach out to **CCX** team via the ccx slack channel, clearly mentioning the requirements.
+ * The **CCX** team will accordingly guide about accessing the data depending on the team's status and procedure of providing data access to a non-member of CCX team at that time.
  * The data provided by **CCX** (mostly the Jupyter notebook) will help in analysis of potential and suitable window timings for the upgrade timeout.
  * Once the timing has been finalised, upgrade the same on https://github.com/openshift/managed-cluster-config/blob/master/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
  * After successful upgradation and verification in staging environment, follow the steps on https://github.com/openshift/ops-sop/blob/master/v4/howto/push_operators_to_production.md to finally push the change to production environment.

--- a/deploy/managed-upgrade-operator-config/README.md
+++ b/deploy/managed-upgrade-operator-config/README.md
@@ -30,7 +30,7 @@ Following is the reference for alert silence in different OCP versions:
 ## TIMEOUT WINDOW UPGRADE PROCESS
 ### In reference to OSD-8643, the expected upgrade control plane duration window for MUO was changed from 90 to 120 minutes.
 For SREs to re-evaluate the window timings in future, the following steps can be taken:
- * Reach out to **CCX** team via the ccx slack channel, clearly mentioning the requirements.
+ * Reach out to **CCX** team via the ccx slack channel (@ccx in slack channel #ccx (CoreOS Workspace),clearly mentioning the requirements.
  * The **CCX** team will accordingly guide about accessing the data depending on the team's status and procedure of providing data access to a non-member of CCX team at that time.
  * The data provided by **CCX** (mostly the Jupyter notebook) will help in analysis of potential and suitable window timings for the upgrade timeout.
  * Once the timing has been finalised, upgrade the same on https://github.com/openshift/managed-cluster-config/blob/master/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml


### PR DESCRIPTION
In reference to : [**[OSD-8643](https://issues.redhat.com/browse/OSD-8643)** ](https://issues.redhat.com/browse/OSD-8643) , the expected upgrade control plane duration window for MUO was successfully upgraded from 90 minutes to 120 minutes.

The findings and conclusions for the same can be found in : https://docs.google.com/document/d/1qvpaOoPyNTXXoqRP-nY8mT7c0T74bCMSr2y48y_5X9E/edit?usp=sharing

The PR is about the readme update for the process for re-evaluating the window timings in future.