### PR TITLE
OSD-9131 OSD-8791 cluster proxy alerting

### DIFF
--- a/deploy/sre-prometheus/100-cluster-proxy.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-cluster-proxy.PrometheusRule.yaml
@@ -1,0 +1,36 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-cluster-proxy-alerts
+    role: alert-rules
+  name: sre-cluster-proxy-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: sre-cluster-proxy-alerts
+      rules:
+        - alert: ClusterProxyCAExpiringSRE
+          expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time() < 86400 * 30
+          for: 10m
+          labels:
+            severity: warning
+            namespace: openshift-monitoring
+          annotations:
+            message: "Cluster proxy certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degredation and/or unavailability"
+        - alert: ClusterProxyCAExpiringSRE
+          expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time() < 86400 * 15
+          for: 10m
+          labels:
+            severity: critical
+            namespace: openshift-monitoring
+          annotations:
+            message: "Cluster proxy certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degredation and/or unavailability"
+        - alert: ClusterProxyCAInvalidSRE
+          expr: cluster_proxy_ca_valid{name="osd_exporter"} == 0
+          for: 15m
+          labels:
+            severity: warning
+            namespace: openshift-monitoring
+          annotations:
+            message: "Cluster proxy CA has failed validation. Ensure the CA is PEM-encoded X.509."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10882,6 +10882,49 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cluster-proxy-alerts
+          role: alert-rules
+        name: sre-cluster-proxy-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-proxy-alerts
+          rules:
+          - alert: ClusterProxyCAExpiringSRE
+            expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
+              < 86400 * 30
+            for: 10m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
+                }}. Ensure new certificate is provided prior to expiration to avoid
+                cluster degredation and/or unavailability
+          - alert: ClusterProxyCAExpiringSRE
+            expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
+              < 86400 * 15
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
+                }}. Ensure new certificate is provided prior to expiration to avoid
+                cluster degredation and/or unavailability
+          - alert: ClusterProxyCAInvalidSRE
+            expr: cluster_proxy_ca_valid{name="osd_exporter"} == 0
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy CA has failed validation. Ensure the CA is PEM-encoded
+                X.509.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-configure-alertmanager-operator-offline-alerts
           role: alert-rules
         name: sre-configure-alertmanager-operator-offline-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10882,6 +10882,49 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cluster-proxy-alerts
+          role: alert-rules
+        name: sre-cluster-proxy-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-proxy-alerts
+          rules:
+          - alert: ClusterProxyCAExpiringSRE
+            expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
+              < 86400 * 30
+            for: 10m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
+                }}. Ensure new certificate is provided prior to expiration to avoid
+                cluster degredation and/or unavailability
+          - alert: ClusterProxyCAExpiringSRE
+            expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
+              < 86400 * 15
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
+                }}. Ensure new certificate is provided prior to expiration to avoid
+                cluster degredation and/or unavailability
+          - alert: ClusterProxyCAInvalidSRE
+            expr: cluster_proxy_ca_valid{name="osd_exporter"} == 0
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy CA has failed validation. Ensure the CA is PEM-encoded
+                X.509.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-configure-alertmanager-operator-offline-alerts
           role: alert-rules
         name: sre-configure-alertmanager-operator-offline-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10882,6 +10882,49 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cluster-proxy-alerts
+          role: alert-rules
+        name: sre-cluster-proxy-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-proxy-alerts
+          rules:
+          - alert: ClusterProxyCAExpiringSRE
+            expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
+              < 86400 * 30
+            for: 10m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
+                }}. Ensure new certificate is provided prior to expiration to avoid
+                cluster degredation and/or unavailability
+          - alert: ClusterProxyCAExpiringSRE
+            expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
+              < 86400 * 15
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
+                }}. Ensure new certificate is provided prior to expiration to avoid
+                cluster degredation and/or unavailability
+          - alert: ClusterProxyCAInvalidSRE
+            expr: cluster_proxy_ca_valid{name="osd_exporter"} == 0
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Cluster proxy CA has failed validation. Ensure the CA is PEM-encoded
+                X.509.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-configure-alertmanager-operator-offline-alerts
           role: alert-rules
         name: sre-configure-alertmanager-operator-offline-alerts


### PR DESCRIPTION
This PR enables alerting for the conditions of:

- proxy CA expiring in less then 30 days - warning
- proxy CA expiring in less then 15 days - critical
- proxy CA failed validation - warning

These will need to hit the pager and be service logged manually until ocm-agent is ready. 

SOPS will be provided later as not a priority against change freeze deadline. 

This PR should not be merged until https://github.com/openshift/osd-metrics-exporter/pull/72 is in production. 