### PR TITLE
Do not allow customers to administer AddonOperator Custom Resources

### DIFF
--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
@@ -37,6 +37,8 @@ aggregationRule:
       - addon-rhmi-og
       - addon-rhmi-internal-og
       - rhmi-registry-og
+      # MTSRE AddonOperator operator group
+      - addon-operator-og
     # exclude specific namespaces too, just in case
     - key: olm.owner.namespace
       operator: NotIn
@@ -50,6 +52,8 @@ aggregationRule:
       - openshift-splunk-forwarder-operator
       - openshift-managed-upgrade-operator
       - openshift-velero
+      # MTSRE AddonOperator namespace
+      - openshift-addon-operator
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9463,6 +9463,7 @@ objects:
             - addon-rhmi-og
             - addon-rhmi-internal-og
             - rhmi-registry-og
+            - addon-operator-og
           - key: olm.owner.namespace
             operator: NotIn
             values:
@@ -9473,6 +9474,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-managed-upgrade-operator
             - openshift-velero
+            - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9463,6 +9463,7 @@ objects:
             - addon-rhmi-og
             - addon-rhmi-internal-og
             - rhmi-registry-og
+            - addon-operator-og
           - key: olm.owner.namespace
             operator: NotIn
             values:
@@ -9473,6 +9474,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-managed-upgrade-operator
             - openshift-velero
+            - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9463,6 +9463,7 @@ objects:
             - addon-rhmi-og
             - addon-rhmi-internal-og
             - rhmi-registry-og
+            - addon-operator-og
           - key: olm.owner.namespace
             operator: NotIn
             values:
@@ -9473,6 +9474,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-managed-upgrade-operator
             - openshift-velero
+            - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
This PR revokes write operations on AddonOperator CRs for dedicated-admins

Ref:

https://issues.redhat.com/browse/MTSRE-332
https://issues.redhat.com/browse/OSD-9420

Signed-off-by: Mayank Shah <m.shah@redhat.com>