### PR TITLE
set sync failure alert to high

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -70,13 +70,15 @@ spec:
       annotations:
         summary: "Node drain failed in the given time period which is not caused by the PDB"
         description: "node drain takes too long and cannot be finished in the given time period during cluster upgrade"
-    - alert: UpgradeConfigSyncFailureOver2HrSRE
-      # Alert if MUO has been unable to successfully sync with its upgrade policy provider for a two-hour window
-      expr: avg_over_time(upgradeoperator_upgradeconfig_synced[2h]) == 1
-      for: 5m
+    - alert: UpgradeConfigSyncFailureOver4HrSRE
+      # Alert if MUO has been unable to successfully sync with its upgrade policy provider for a four-hour window
+      # It will also be used for detecting the connection/authentication between cluster and OCM
+      # Should be moved to OCM Agent service eventually
+      expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+      for: 2m
       labels:
-        severity: warning
+        severity: critical
         namespace: openshift-monitoring
       annotations:
-        summary: "UpgradeConfig has not successfully synced in 2 hours."
-        description: "This clusters UpgradeConfig has not been synced in 2 hours and may be out of date"
+        summary: "UpgradeConfig has not successfully synced in 4 hours."
+        description: "This clusters UpgradeConfig has not been synced in 4 hours and may be out of date"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11409,15 +11409,15 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
-          - alert: UpgradeConfigSyncFailureOver2HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[2h]) == 1
-            for: 5m
+          - alert: UpgradeConfigSyncFailureOver4HrSRE
+            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+            for: 2m
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
             annotations:
-              summary: UpgradeConfig has not successfully synced in 2 hours.
-              description: This clusters UpgradeConfig has not been synced in 2 hours
+              summary: UpgradeConfig has not successfully synced in 4 hours.
+              description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11409,15 +11409,15 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
-          - alert: UpgradeConfigSyncFailureOver2HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[2h]) == 1
-            for: 5m
+          - alert: UpgradeConfigSyncFailureOver4HrSRE
+            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+            for: 2m
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
             annotations:
-              summary: UpgradeConfig has not successfully synced in 2 hours.
-              description: This clusters UpgradeConfig has not been synced in 2 hours
+              summary: UpgradeConfig has not successfully synced in 4 hours.
+              description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11409,15 +11409,15 @@ objects:
                 by the PDB
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
-          - alert: UpgradeConfigSyncFailureOver2HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[2h]) == 1
-            for: 5m
+          - alert: UpgradeConfigSyncFailureOver4HrSRE
+            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+            for: 2m
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
             annotations:
-              summary: UpgradeConfig has not successfully synced in 2 hours.
-              description: This clusters UpgradeConfig has not been synced in 2 hours
+              summary: UpgradeConfig has not successfully synced in 4 hours.
+              description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
To catch the sync issue between cluster and OCM earlier due to the cluster owner is unavailable.