### PR TITLE
[OSD-8801] adding ids-tester weekly CronJob for suricata

### DIFF
--- a/deploy/osd-ids-tester/100-ids-tester.Namespace.yaml
+++ b/deploy/osd-ids-tester/100-ids-tester.Namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-suricata

--- a/deploy/osd-ids-tester/105-ids-tester.rbac.ServiceAccount.yaml
+++ b/deploy/osd-ids-tester/105-ids-tester.rbac.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ids-test
+  namespace: openshift-suricata

--- a/deploy/osd-ids-tester/110-ids-tester-CronJob.yaml
+++ b/deploy/osd-ids-tester/110-ids-tester-CronJob.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ids-tester
+  namespace: openshift-suricata
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "05 05 * * 3"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                    - us-gov-west-1
+                    - us-gov-east-1
+                weight: 1
+          serviceAccountName: ids-test-sa
+          restartPolicy: Never
+          containers:
+          - name: ids-tester
+            image: quay.io/dedgar/ids-tester:v0.0.4
+            imagePullPolicy: Always
+            command: ["/usr/local/bin/start.sh"]

--- a/deploy/osd-ids-tester/OWNERS
+++ b/deploy/osd-ids-tester/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- rhdedgar 

--- a/deploy/osd-ids-tester/README.md
+++ b/deploy/osd-ids-tester/README.md
@@ -1,0 +1,5 @@
+# IDS tester 
+This project runs basic IDS tests by mimicking suspicious network traffic. Intended for use with openshift-suricata rules as it should log the connection attempts made by this project.
+
+### Permissions 
+This project runs as CronJob in the openshift-suricata namespace, and requires no elevated permissions.

--- a/deploy/osd-ids-tester/config.yaml
+++ b/deploy/osd-ids-tester/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+    - key: hive.openshift.io/cluster-region
+      operator: In
+      values: ["us-gov-west-1", "us-gov-east-1"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7816,6 +7816,68 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-ids-tester
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/cluster-region
+        operator: In
+        values:
+        - us-gov-west-1
+        - us-gov-east-1
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-suricata
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ids-test
+        namespace: openshift-suricata
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ids-tester
+        namespace: openshift-suricata
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 05 05 * * 3
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: topology.kubernetes.io/region
+                          operator: In
+                          values:
+                          - us-gov-west-1
+                          - us-gov-east-1
+                      weight: 1
+                serviceAccountName: ids-test-sa
+                restartPolicy: Never
+                containers:
+                - name: ids-tester
+                  image: quay.io/dedgar/ids-tester:v0.0.4
+                  imagePullPolicy: Always
+                  command:
+                  - /usr/local/bin/start.sh
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-ingress
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7816,6 +7816,68 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-ids-tester
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/cluster-region
+        operator: In
+        values:
+        - us-gov-west-1
+        - us-gov-east-1
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-suricata
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ids-test
+        namespace: openshift-suricata
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ids-tester
+        namespace: openshift-suricata
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 05 05 * * 3
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: topology.kubernetes.io/region
+                          operator: In
+                          values:
+                          - us-gov-west-1
+                          - us-gov-east-1
+                      weight: 1
+                serviceAccountName: ids-test-sa
+                restartPolicy: Never
+                containers:
+                - name: ids-tester
+                  image: quay.io/dedgar/ids-tester:v0.0.4
+                  imagePullPolicy: Always
+                  command:
+                  - /usr/local/bin/start.sh
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-ingress
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7816,6 +7816,68 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-ids-tester
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/cluster-region
+        operator: In
+        values:
+        - us-gov-west-1
+        - us-gov-east-1
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-suricata
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ids-test
+        namespace: openshift-suricata
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ids-tester
+        namespace: openshift-suricata
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 05 05 * * 3
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: topology.kubernetes.io/region
+                          operator: In
+                          values:
+                          - us-gov-west-1
+                          - us-gov-east-1
+                      weight: 1
+                serviceAccountName: ids-test-sa
+                restartPolicy: Never
+                containers:
+                - name: ids-tester
+                  image: quay.io/dedgar/ids-tester:v0.0.4
+                  imagePullPolicy: Always
+                  command:
+                  - /usr/local/bin/start.sh
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-ingress
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Basic test coverage deployed via CronJob for selected AWS regions only. This should not affect general OpenShift clusters in regions currently used by OSD/ROSA customers.