### PR TITLE
Ensure the openshift namespace is included in the managed-namespace configmaps

### DIFF
--- a/scripts/managed-resources/generate-managed-list.py
+++ b/scripts/managed-resources/generate-managed-list.py
@@ -23,6 +23,7 @@ data:
 # are still being managed by SRE-P.
 ADDITIONAL_MANAGED_NAMESPACES = [
     {"name": "openshift-monitoring"},
+    {"name": "openshift"}
 ]
 
 


### PR DESCRIPTION
The generated configmaps from https://github.com/openshift/managed-cluster-config/pull/1024 showed that there are instances where the namespace `openshift` might not be scraped from the output of `oc adm release extract` . This change just ensures that namespace will be included in every generated configmap.