### PR TITLE
osd-8641:upgrading avg_over_time to 10 mins to prevent flappy MUO alerts

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -11,9 +11,9 @@ spec:
   - name: sre-managed-upgrade-operator-alerts
     rules:
     - alert: UpgradeConfigValidationFailedSRE
-      # Alert if the UpgradeConfig validation check metric has been set for a five-minute average window
-      expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[5m]) == 1
-      for: 5m
+      # Alert if the UpgradeConfig validation check metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m]) == 1
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring
@@ -21,9 +21,9 @@ spec:
         summary: "Upgrade config validation failed"
         description: "Upgrade config validation failed"
     - alert: UpgradeClusterCheckFailedSRE
-      # Alert if the cluster has set its pre/post-upgrade health check failure metric for a five-minute average window
-      expr: avg_over_time(upgradeoperator_cluster_check_failed[5m]) == 1
-      for: 5m
+      # Alert if the cluster has set its pre/post-upgrade health check failure metric for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_cluster_check_failed[10m]) == 1
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring
@@ -31,9 +31,9 @@ spec:
         summary: "cluster check failed"
         description: "basic cluster checks failed on either before the upgrade or after the upgrade"
     - alert: UpgradeNodeScalingFailedSRE
-      # Alert if the cluster has set its compute capacity scaling failure metric for a five-minute average window
-      expr: avg_over_time(upgradeoperator_scaling_failed[5m]) == 1
-      for: 5m
+      # Alert if the cluster has set its compute capacity scaling failure metric for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring
@@ -41,9 +41,9 @@ spec:
         summary: "node scaling failed"
         description: "The extra machine/node was not ready before the upgrade started"
     - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-      # Alert if the control plane timeout metric has been set for a five-minute average window
-      expr: avg_over_time(upgradeoperator_controlplane_timeout[5m]) == 1
-      for: 5m
+      # Alert if the control plane timeout metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring
@@ -51,9 +51,9 @@ spec:
         summary: "Controlplane upgrade timeout for {{ $labels.version }}"
         description: "controlplane upgrade for {{ $labels.version }} cannot be finished in the given time period"
     - alert: UpgradeNodeUpgradeTimeoutSRE
-      # Alert if the worker node upgrade timeout metric has been set for a five-minute average window
-      expr: avg_over_time(upgradeoperator_worker_timeout[5m]) == 1
-      for: 5m
+      # Alert if the worker node upgrade timeout metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring
@@ -61,9 +61,9 @@ spec:
         summary: "Nodes upgrade timeout for {{ $labels.version }}"
         description: "nodes upgrade for {{ $labels.version }} cannot be finished after the silence expired"
     - alert: UpgradeNodeDrainFailedSRE
-      # Alert if the node drain failure metric has been set for a five-minute average window
-      expr: avg_over_time(upgradeoperator_node_drain_timeout[5m]) == 1
-      for: 5m
+      # Alert if the node drain failure metric has been set for a ten-minute average window
+      expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11853,9 +11853,9 @@ objects:
         - name: sre-managed-upgrade-operator-alerts
           rules:
           - alert: UpgradeConfigValidationFailedSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[5m])
+            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m])
               == 1
-            for: 5m
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11863,8 +11863,8 @@ objects:
               summary: Upgrade config validation failed
               description: Upgrade config validation failed
           - alert: UpgradeClusterCheckFailedSRE
-            expr: avg_over_time(upgradeoperator_cluster_check_failed[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_cluster_check_failed[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11873,8 +11873,8 @@ objects:
               description: basic cluster checks failed on either before the upgrade
                 or after the upgrade
           - alert: UpgradeNodeScalingFailedSRE
-            expr: avg_over_time(upgradeoperator_scaling_failed[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11883,8 +11883,8 @@ objects:
               description: The extra machine/node was not ready before the upgrade
                 started
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11893,8 +11893,8 @@ objects:
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
           - alert: UpgradeNodeUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_worker_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11903,8 +11903,8 @@ objects:
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
           - alert: UpgradeNodeDrainFailedSRE
-            expr: avg_over_time(upgradeoperator_node_drain_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11853,9 +11853,9 @@ objects:
         - name: sre-managed-upgrade-operator-alerts
           rules:
           - alert: UpgradeConfigValidationFailedSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[5m])
+            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m])
               == 1
-            for: 5m
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11863,8 +11863,8 @@ objects:
               summary: Upgrade config validation failed
               description: Upgrade config validation failed
           - alert: UpgradeClusterCheckFailedSRE
-            expr: avg_over_time(upgradeoperator_cluster_check_failed[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_cluster_check_failed[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11873,8 +11873,8 @@ objects:
               description: basic cluster checks failed on either before the upgrade
                 or after the upgrade
           - alert: UpgradeNodeScalingFailedSRE
-            expr: avg_over_time(upgradeoperator_scaling_failed[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11883,8 +11883,8 @@ objects:
               description: The extra machine/node was not ready before the upgrade
                 started
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11893,8 +11893,8 @@ objects:
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
           - alert: UpgradeNodeUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_worker_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11903,8 +11903,8 @@ objects:
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
           - alert: UpgradeNodeDrainFailedSRE
-            expr: avg_over_time(upgradeoperator_node_drain_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11853,9 +11853,9 @@ objects:
         - name: sre-managed-upgrade-operator-alerts
           rules:
           - alert: UpgradeConfigValidationFailedSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[5m])
+            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m])
               == 1
-            for: 5m
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11863,8 +11863,8 @@ objects:
               summary: Upgrade config validation failed
               description: Upgrade config validation failed
           - alert: UpgradeClusterCheckFailedSRE
-            expr: avg_over_time(upgradeoperator_cluster_check_failed[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_cluster_check_failed[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11873,8 +11873,8 @@ objects:
               description: basic cluster checks failed on either before the upgrade
                 or after the upgrade
           - alert: UpgradeNodeScalingFailedSRE
-            expr: avg_over_time(upgradeoperator_scaling_failed[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11883,8 +11883,8 @@ objects:
               description: The extra machine/node was not ready before the upgrade
                 started
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11893,8 +11893,8 @@ objects:
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
           - alert: UpgradeNodeUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_worker_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
@@ -11903,8 +11903,8 @@ objects:
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
           - alert: UpgradeNodeDrainFailedSRE
-            expr: avg_over_time(upgradeoperator_node_drain_timeout[5m]) == 1
-            for: 5m
+            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
[OSD-8641](https://issues.redhat.com/browse/OSD-8641)
In reference to https://github.com/openshift/managed-cluster-config/pull/966 created by @mrbarge to prevent flappy MUO alerts during upgrades, **the avg_over_time [which was earlier set 5 mins]** has been upgraded to **10 mins** so as to lower the number of flappy alerts that are fired during MUO upgrades.
