### PR TITLE
OSD-9760 Add ocm-agent-operator pre-reqs to MCC

### DIFF
--- a/deploy/osd-serviceaccounts/cronjob/10-osd-delete-ownerrefs.CronJob.yaml
+++ b/deploy/osd-serviceaccounts/cronjob/10-osd-delete-ownerrefs.CronJob.yaml
@@ -35,7 +35,7 @@ spec:
             - /bin/bash
             - -c
             - |
-              for NS in openshift-cloud-ingress-operator openshift-custom-domains-operator openshift-managed-upgrade-operator openshift-monitoring openshift-rbac-permissions openshift-splunk-forwarder-operator openshift-velero;
+              for NS in openshift-cloud-ingress-operator openshift-custom-domains-operator openshift-managed-upgrade-operator openshift-monitoring openshift-rbac-permissions openshift-splunk-forwarder-operator openshift-velero openshift-ocm-agent-operator;
               do
                 for SA in $(oc -n $NS get serviceaccount --ignore-not-found -o jsonpath='{.items[?(@.metadata.ownerReferences[0].kind=="ClusterServiceVersion")].metadata.name}');
                 do

--- a/deploy/osd-serviceaccounts/oao/00-ocm-agent-operator.ServiceAccount.yaml
+++ b/deploy/osd-serviceaccounts/oao/00-ocm-agent-operator.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocm-agent-operator 
+  namespace: openshift-ocm-agent-operator

--- a/deploy/osd-serviceaccounts/oao/README.md
+++ b/deploy/osd-serviceaccounts/oao/README.md
@@ -1,0 +1,7 @@
+Whilst the openshift-ocm-agent-operator is in development, this location shall house MCC configuration intended only for staging and integration clusters.
+
+Once the operator is ready for Production release, the changes listed below will be migrated to their more universal location.
+
+### 00-ocm-agent-operator.ServiceAccount.yaml
+
+Migrate to `../00-serviceaccounts.yaml`

--- a/deploy/osd-serviceaccounts/oao/config.yaml
+++ b/deploy/osd-serviceaccounts/oao/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"                                                                                                                                                                          
+selectorSyncSet:
+  resourceApplyMode: Upsert
+  matchExpressions:
+  - key: environment
+    operator: In
+    values: ["staging", "integration"]

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
@@ -52,6 +52,7 @@ aggregationRule:
       - openshift-splunk-forwarder-operator
       - openshift-managed-upgrade-operator
       - openshift-velero
+      - openshift-ocm-agent-operator
       # MTSRE AddonOperator namespace
       - openshift-addon-operator
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
@@ -36,6 +36,7 @@ aggregationRule:
       - openshift-splunk-forwarder-operator
       - openshift-velero
       - openshift-managed-upgrade-operator
+      - openshift-ocm-agent-operator
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9673,13 +9673,38 @@ objects:
                   - -c
                   - "for NS in openshift-cloud-ingress-operator openshift-custom-domains-operator\
                     \ openshift-managed-upgrade-operator openshift-monitoring openshift-rbac-permissions\
-                    \ openshift-splunk-forwarder-operator openshift-velero;\ndo\n\
-                    \  for SA in $(oc -n $NS get serviceaccount --ignore-not-found\
+                    \ openshift-splunk-forwarder-operator openshift-velero openshift-ocm-agent-operator;\n\
+                    do\n  for SA in $(oc -n $NS get serviceaccount --ignore-not-found\
                     \ -o jsonpath='{.items[?(@.metadata.ownerReferences[0].kind==\"\
                     ClusterServiceVersion\")].metadata.name}');\n  do\n    echo \"\
                     Removing owner ref from SA '$SA' in NS '$NS'\"\n    oc -n $NS\
                     \ patch serviceaccount $SA --type=json -p '[{\"op\":\"remove\"\
                     ,\"path\":\"/metadata/ownerReferences\"}]'\n  done\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-oao
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - staging
+        - integration
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocm-agent-operator
+        namespace: openshift-ocm-agent-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10058,6 +10083,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-managed-upgrade-operator
             - openshift-velero
+            - openshift-ocm-agent-operator
             - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
@@ -10098,6 +10124,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-velero
             - openshift-managed-upgrade-operator
+            - openshift-ocm-agent-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9673,13 +9673,38 @@ objects:
                   - -c
                   - "for NS in openshift-cloud-ingress-operator openshift-custom-domains-operator\
                     \ openshift-managed-upgrade-operator openshift-monitoring openshift-rbac-permissions\
-                    \ openshift-splunk-forwarder-operator openshift-velero;\ndo\n\
-                    \  for SA in $(oc -n $NS get serviceaccount --ignore-not-found\
+                    \ openshift-splunk-forwarder-operator openshift-velero openshift-ocm-agent-operator;\n\
+                    do\n  for SA in $(oc -n $NS get serviceaccount --ignore-not-found\
                     \ -o jsonpath='{.items[?(@.metadata.ownerReferences[0].kind==\"\
                     ClusterServiceVersion\")].metadata.name}');\n  do\n    echo \"\
                     Removing owner ref from SA '$SA' in NS '$NS'\"\n    oc -n $NS\
                     \ patch serviceaccount $SA --type=json -p '[{\"op\":\"remove\"\
                     ,\"path\":\"/metadata/ownerReferences\"}]'\n  done\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-oao
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - staging
+        - integration
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocm-agent-operator
+        namespace: openshift-ocm-agent-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10058,6 +10083,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-managed-upgrade-operator
             - openshift-velero
+            - openshift-ocm-agent-operator
             - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
@@ -10098,6 +10124,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-velero
             - openshift-managed-upgrade-operator
+            - openshift-ocm-agent-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9673,13 +9673,38 @@ objects:
                   - -c
                   - "for NS in openshift-cloud-ingress-operator openshift-custom-domains-operator\
                     \ openshift-managed-upgrade-operator openshift-monitoring openshift-rbac-permissions\
-                    \ openshift-splunk-forwarder-operator openshift-velero;\ndo\n\
-                    \  for SA in $(oc -n $NS get serviceaccount --ignore-not-found\
+                    \ openshift-splunk-forwarder-operator openshift-velero openshift-ocm-agent-operator;\n\
+                    do\n  for SA in $(oc -n $NS get serviceaccount --ignore-not-found\
                     \ -o jsonpath='{.items[?(@.metadata.ownerReferences[0].kind==\"\
                     ClusterServiceVersion\")].metadata.name}');\n  do\n    echo \"\
                     Removing owner ref from SA '$SA' in NS '$NS'\"\n    oc -n $NS\
                     \ patch serviceaccount $SA --type=json -p '[{\"op\":\"remove\"\
                     ,\"path\":\"/metadata/ownerReferences\"}]'\n  done\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-oao
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - staging
+        - integration
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocm-agent-operator
+        namespace: openshift-ocm-agent-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10058,6 +10083,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-managed-upgrade-operator
             - openshift-velero
+            - openshift-ocm-agent-operator
             - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
@@ -10098,6 +10124,7 @@ objects:
             - openshift-splunk-forwarder-operator
             - openshift-velero
             - openshift-managed-upgrade-operator
+            - openshift-ocm-agent-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -46,6 +46,7 @@ Resources:
   - name: openshift-logging
   - name: openshift-managed-upgrade-operator
   - name: openshift-must-gather-operator
+  - name: openshift-ocm-agent-operator
   - name: openshift-operators-redhat
   - name: openshift-osd-metrics
   - name: openshift-rbac-permissions
@@ -274,6 +275,8 @@ Resources:
     name: configure-alertmanager-operator-registry
   - namespace: openshift-must-gather-operator
     name: must-gather-operator-registry
+  - namespace: openshift-ocm-agent-operator
+    name: ocm-agent-operator-registry
   - namespace: openshift-osd-metrics
     name: osd-metrics-exporter-registry
   - namespace: openshift-rbac-permissions
@@ -305,6 +308,8 @@ Resources:
     name: managed-upgrade-operator-og
   - namespace: openshift-must-gather-operator
     name: must-gather-operator
+  - namespace: openshift-ocm-agent-operator
+    name: ocm-agent-operator
   - namespace: openshift-osd-metrics
     name: osd-metrics-exporter
   - namespace: openshift-rbac-permissions
@@ -332,6 +337,8 @@ Resources:
     name: configure-alertmanager-operator
   - namespace: openshift-must-gather-operator
     name: must-gather-operator
+  - namespace: openshift-ocm-agent-operator
+    name: ocm-agent-operator
   - namespace: openshift-osd-metrics
     name: osd-metrics-exporter
   - namespace: openshift-rbac-permissions
@@ -357,6 +364,8 @@ Resources:
     name: route-monitor-operator
   - namespace: openshift-managed-upgrade-operator
     name: managed-upgrade-operator
+  - namespace: openshift-ocm-agent-operator
+    name: ocm-agent-operator
   - namespace: openshift-velero
     name: managed-velero-operator
   - namespace: openshift-custom-domains-operator
@@ -384,6 +393,7 @@ Resources:
   - name: openshift-logging
   - name: openshift-managed-upgrade-operator
   - name: openshift-must-gather-operator
+  - name: openshift-ocm-agent-operator
   - name: openshift-operators-redhat
   - name: openshift-osd-metrics
   - name: openshift-rbac-permissions


### PR DESCRIPTION
This PR adds some pre-requisites for the `ocm-agent-operator` to MCC:

- Adding related OAO resources to the `all-osd-resources.yaml` file.
- Adding the OAO namespace `openshift-ocm-agent-operator` to relevant `rbac-permissions-operator` rules.
- Creation of the `ocm-agent-operator` ServiceAccount, but only in staging/integration environments initially, as this would otherwise cause SelectorSyncSet application failures in production where the operator/namespace is not installed.