### PR TITLE
OSD-9760 Fix SSS config for OAO ServiceAccount deployment

### DIFF
--- a/deploy/osd-serviceaccounts/oao/config.yaml
+++ b/deploy/osd-serviceaccounts/oao/config.yaml
@@ -2,6 +2,6 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: Upsert
   matchExpressions:
-  - key: environment
+  - key: api.openshift.com/environment
     operator: In
     values: ["staging", "integration"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10185,7 +10185,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: environment
+      - key: api.openshift.com/environment
         operator: In
         values:
         - staging

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10185,7 +10185,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: environment
+      - key: api.openshift.com/environment
         operator: In
         values:
         - staging

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10185,7 +10185,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: environment
+      - key: api.openshift.com/environment
         operator: In
         values:
         - staging


### PR DESCRIPTION
This PR fixes a small mistake in the deployment of the `ocm-agent-operator` ServiceAccount to staging/integration clusters; the wrong key was used when selecting the deployment environment. (`environment` instead of `api.openshift.com/environment`)

Refs [OSD-9760](https://issues.redhat.com/browse/OSD-9760)