### PR TITLE
Tweaks the DNS Alert

### DIFF
--- a/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
@@ -10,11 +10,12 @@ spec:
   groups:
   - name: sre-dns-alerts
     rules:
-    - alert: DNSErrors05MinSRE
-      expr: rate(dns_failure_failure_total[5m]) > 0
-      for: 5m
+    - alert: DNSErrors10MinSRE
+      # If the amount of DNS failures increases by 3 over the span of 10 minutes
+      expr: increase(dns_failure_failure_total[10m]) >= 3
+      for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring
       annotations:
-        message: DNS checks have been failing for the past 5 minutes on pod- {{ $labels.pod }}
+        message: At least 3 DNS checks have been failing for the past 10 minutes on pod- {{ $labels.pod }}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -12395,15 +12395,15 @@ objects:
         groups:
         - name: sre-dns-alerts
           rules:
-          - alert: DNSErrors05MinSRE
-            expr: rate(dns_failure_failure_total[5m]) > 0
-            for: 5m
+          - alert: DNSErrors10MinSRE
+            expr: increase(dns_failure_failure_total[10m]) >= 3
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: DNS checks have been failing for the past 5 minutes on pod-
-                {{ $labels.pod }}
+              message: At least 3 DNS checks have been failing for the past 10 minutes
+                on pod- {{ $labels.pod }}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -12395,15 +12395,15 @@ objects:
         groups:
         - name: sre-dns-alerts
           rules:
-          - alert: DNSErrors05MinSRE
-            expr: rate(dns_failure_failure_total[5m]) > 0
-            for: 5m
+          - alert: DNSErrors10MinSRE
+            expr: increase(dns_failure_failure_total[10m]) >= 3
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: DNS checks have been failing for the past 5 minutes on pod-
-                {{ $labels.pod }}
+              message: At least 3 DNS checks have been failing for the past 10 minutes
+                on pod- {{ $labels.pod }}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -12395,15 +12395,15 @@ objects:
         groups:
         - name: sre-dns-alerts
           rules:
-          - alert: DNSErrors05MinSRE
-            expr: rate(dns_failure_failure_total[5m]) > 0
-            for: 5m
+          - alert: DNSErrors10MinSRE
+            expr: increase(dns_failure_failure_total[10m]) >= 3
+            for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: DNS checks have been failing for the past 5 minutes on pod-
-                {{ $labels.pod }}
+              message: At least 3 DNS checks have been failing for the past 10 minutes
+                on pod- {{ $labels.pod }}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Tweaks the DNS Alert to only fire if more than 3 DNS checks have failed
over the course of 10m.

Satisfies https://issues.redhat.com/browse/OSD-10036