### PR TITLE
Remove suricata-secrets From Suricata Daemonset

### DIFF
--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -32,8 +32,6 @@ spec:
           privileged: true
           runAsUser: 0
         volumeMounts:
-        - mountPath: /secrets
-          name: suricata-secrets
         - mountPath: /host/
           name: host-filesystem
       dnsPolicy: ClusterFirst
@@ -44,9 +42,6 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
-      - name: suricata-secrets
-        secret:
-          secretName: suricata-secrets
       - hostPath:
           path: /
         name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10432,8 +10432,6 @@ objects:
                 privileged: true
                 runAsUser: 0
               volumeMounts:
-              - mountPath: /secrets
-                name: suricata-secrets
               - mountPath: /host/
                 name: host-filesystem
             dnsPolicy: ClusterFirst
@@ -10444,9 +10442,6 @@ objects:
             tolerations:
             - operator: Exists
             volumes:
-            - name: suricata-secrets
-              secret:
-                secretName: suricata-secrets
             - hostPath:
                 path: /
               name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10432,8 +10432,6 @@ objects:
                 privileged: true
                 runAsUser: 0
               volumeMounts:
-              - mountPath: /secrets
-                name: suricata-secrets
               - mountPath: /host/
                 name: host-filesystem
             dnsPolicy: ClusterFirst
@@ -10444,9 +10442,6 @@ objects:
             tolerations:
             - operator: Exists
             volumes:
-            - name: suricata-secrets
-              secret:
-                secretName: suricata-secrets
             - hostPath:
                 path: /
               name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10432,8 +10432,6 @@ objects:
                 privileged: true
                 runAsUser: 0
               volumeMounts:
-              - mountPath: /secrets
-                name: suricata-secrets
               - mountPath: /host/
                 name: host-filesystem
             dnsPolicy: ClusterFirst
@@ -10444,9 +10442,6 @@ objects:
             tolerations:
             - operator: Exists
             volumes:
-            - name: suricata-secrets
-              secret:
-                secretName: suricata-secrets
             - hostPath:
                 path: /
               name: host-filesystem


### PR DESCRIPTION
Secrets do not exist in vault and pods do not need the volume mount. Tested on a integration test cluster.

https://issues.redhat.com/browse/OSD-9676