### PR TITLE
adding missing /secrets volumeMount path to watcher

### DIFF
--- a/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
+++ b/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
@@ -51,7 +51,6 @@ spec:
       volumes:
       - name: logger-secrets
         secret:
-          defaultMode: 420
           secretName: logger-secrets
       - hostPath:
           path: /var/log/

--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -105,6 +105,8 @@ spec:
           privileged: true
           runAsUser: 0
         volumeMounts:
+        - mountPath: /secrets
+          name: clam-secrets
         - mountPath: /var/log/journal
           name: watcher-host-journal
         - mountPath: /host
@@ -190,7 +192,6 @@ spec:
       volumes:
       - name: clam-secrets
         secret:
-          defaultMode: 420
           secretName: clam-secrets
       - emptyDir: {}
         name: clam-files

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9767,7 +9767,6 @@ objects:
             volumes:
             - name: logger-secrets
               secret:
-                defaultMode: 420
                 secretName: logger-secrets
             - hostPath:
                 path: /var/log/
@@ -9895,6 +9894,8 @@ objects:
                 privileged: true
                 runAsUser: 0
               volumeMounts:
+              - mountPath: /secrets
+                name: clam-secrets
               - mountPath: /var/log/journal
                 name: watcher-host-journal
               - mountPath: /host
@@ -9980,7 +9981,6 @@ objects:
             volumes:
             - name: clam-secrets
               secret:
-                defaultMode: 420
                 secretName: clam-secrets
             - emptyDir: {}
               name: clam-files

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9767,7 +9767,6 @@ objects:
             volumes:
             - name: logger-secrets
               secret:
-                defaultMode: 420
                 secretName: logger-secrets
             - hostPath:
                 path: /var/log/
@@ -9895,6 +9894,8 @@ objects:
                 privileged: true
                 runAsUser: 0
               volumeMounts:
+              - mountPath: /secrets
+                name: clam-secrets
               - mountPath: /var/log/journal
                 name: watcher-host-journal
               - mountPath: /host
@@ -9980,7 +9981,6 @@ objects:
             volumes:
             - name: clam-secrets
               secret:
-                defaultMode: 420
                 secretName: clam-secrets
             - emptyDir: {}
               name: clam-files

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9767,7 +9767,6 @@ objects:
             volumes:
             - name: logger-secrets
               secret:
-                defaultMode: 420
                 secretName: logger-secrets
             - hostPath:
                 path: /var/log/
@@ -9895,6 +9894,8 @@ objects:
                 privileged: true
                 runAsUser: 0
               volumeMounts:
+              - mountPath: /secrets
+                name: clam-secrets
               - mountPath: /var/log/journal
                 name: watcher-host-journal
               - mountPath: /host
@@ -9980,7 +9981,6 @@ objects:
             volumes:
             - name: clam-secrets
               secret:
-                defaultMode: 420
                 secretName: clam-secrets
             - emptyDir: {}
               name: clam-files


### PR DESCRIPTION
Trying to run 'make' is still giving me errors, I'll see if that can be fixed in this PR.