### PR TITLE
Fix formatting for NotIn operator in the osd-token-refresher config

### DIFF
--- a/deploy/osd-token-refresher/config.yaml
+++ b/deploy/osd-token-refresher/config.yaml
@@ -3,4 +3,4 @@ selectorSyncSet:
   matchExpressions:
     - key: api.openshift.com/fedramp
       operator: NotIn
-      value: 'true'
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10460,7 +10460,8 @@ objects:
       matchExpressions:
       - key: api.openshift.com/fedramp
         operator: NotIn
-        value: 'true'
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: apps/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10460,7 +10460,8 @@ objects:
       matchExpressions:
       - key: api.openshift.com/fedramp
         operator: NotIn
-        value: 'true'
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: apps/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10460,7 +10460,8 @@ objects:
       matchExpressions:
       - key: api.openshift.com/fedramp
         operator: NotIn
-        value: 'true'
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: apps/v1


### PR DESCRIPTION
Quick fix for issue where this config isn't being read correctly:

```
time="2022-02-20T11:17:00.754Z" level=warning msg="cannot parse ClusterDeployment selector" controller=clustersync error="values: Invalid value: []string(nil): for 'in', 'notin' operators, values set can't be empty" selectorSyncSet=osd-token-refresher 
```

