### PR TITLE
Add exec permissions to kafka pods

### DIFF
--- a/deploy/backplane/cssre/redhat-kas-fleetshard/10-mkrts-admins-project.ClusterRole.yml
+++ b/deploy/backplane/cssre/redhat-kas-fleetshard/10-mkrts-admins-project.ClusterRole.yml
@@ -43,3 +43,10 @@ rules:
   - pods/portforward
   verbs:
   - create
+# SRE can run commands in pods
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1596,6 +1596,12 @@ objects:
         - pods/portforward
         verbs:
         - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1661,6 +1667,12 @@ objects:
         - ''
         resources:
         - pods/portforward
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
         verbs:
         - create
     - apiVersion: managed.openshift.io/v1alpha1
@@ -1730,6 +1742,12 @@ objects:
         - pods/portforward
         verbs:
         - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1795,6 +1813,12 @@ objects:
         - ''
         resources:
         - pods/portforward
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
         verbs:
         - create
     - apiVersion: managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1596,6 +1596,12 @@ objects:
         - pods/portforward
         verbs:
         - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1661,6 +1667,12 @@ objects:
         - ''
         resources:
         - pods/portforward
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
         verbs:
         - create
     - apiVersion: managed.openshift.io/v1alpha1
@@ -1730,6 +1742,12 @@ objects:
         - pods/portforward
         verbs:
         - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1795,6 +1813,12 @@ objects:
         - ''
         resources:
         - pods/portforward
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
         verbs:
         - create
     - apiVersion: managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1596,6 +1596,12 @@ objects:
         - pods/portforward
         verbs:
         - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1661,6 +1667,12 @@ objects:
         - ''
         resources:
         - pods/portforward
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
         verbs:
         - create
     - apiVersion: managed.openshift.io/v1alpha1
@@ -1730,6 +1742,12 @@ objects:
         - pods/portforward
         verbs:
         - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1795,6 +1813,12 @@ objects:
         - ''
         resources:
         - pods/portforward
+        verbs:
+        - create
+      - apiGroups:
+        - ''
+        resources:
+        - pods/exec
         verbs:
         - create
     - apiVersion: managed.openshift.io/v1alpha1


### PR DESCRIPTION
Adds permission to `oc exec` into RHOSAK pods, as required by SOPs.

fixes [CSSRE-1854](https://issues.redhat.com/browse/CSSRE-1854)