### PR TITLE
Add ec2:GetConsoleOutput permission for STS to enable the verifier

### DIFF
--- a/resources/sts/4.7/sts_installer_permission_policy.json
+++ b/resources/sts/4.7/sts_installer_permission_policy.json
@@ -62,6 +62,7 @@
                 "ec2:DescribeVpcs",
                 "ec2:DetachInternetGateway",
                 "ec2:DisassociateRouteTable",
+                "ec2:GetConsoleOutput",
                 "ec2:GetEbsDefaultKmsKeyId",
                 "ec2:ModifyNetworkInterfaceAttribute",
                 "ec2:ModifyVpcAttribute",

--- a/resources/sts/4.7/sts_support_permission_policy.json
+++ b/resources/sts/4.7/sts_support_permission_policy.json
@@ -95,6 +95,7 @@
                 "ec2:DescribeVpnConnections",
                 "ec2:DescribeVpnGateways",
                 "ec2:GetAssociatedIpv6PoolCidrs",
+                "ec2:GetConsoleOutput",
                 "ec2:GetTransitGatewayAttachmentPropagations",
                 "ec2:GetTransitGatewayMulticastDomainAssociations",
                 "ec2:GetTransitGatewayPrefixListReferences",

--- a/resources/sts/4.8/sts_installer_permission_policy.json
+++ b/resources/sts/4.8/sts_installer_permission_policy.json
@@ -62,6 +62,7 @@
                 "ec2:DescribeVpcs",
                 "ec2:DetachInternetGateway",
                 "ec2:DisassociateRouteTable",
+                "ec2:GetConsoleOutput",
                 "ec2:GetEbsDefaultKmsKeyId",
                 "ec2:ModifyNetworkInterfaceAttribute",
                 "ec2:ModifyVpcAttribute",

--- a/resources/sts/4.8/sts_support_permission_policy.json
+++ b/resources/sts/4.8/sts_support_permission_policy.json
@@ -95,6 +95,7 @@
                 "ec2:DescribeVpnConnections",
                 "ec2:DescribeVpnGateways",
                 "ec2:GetAssociatedIpv6PoolCidrs",
+                "ec2:GetConsoleOutput",
                 "ec2:GetTransitGatewayAttachmentPropagations",
                 "ec2:GetTransitGatewayMulticastDomainAssociations",
                 "ec2:GetTransitGatewayPrefixListReferences",

--- a/resources/sts/4.9/sts_installer_permission_policy.json
+++ b/resources/sts/4.9/sts_installer_permission_policy.json
@@ -63,6 +63,7 @@
                 "ec2:DetachInternetGateway",
                 "ec2:DisassociateRouteTable",
                 "ec2:GetEbsDefaultKmsKeyId",
+                "ec2:GetConsoleOutput"
                 "ec2:ModifyNetworkInterfaceAttribute",
                 "ec2:ModifyVpcAttribute",
                 "ec2:ReleaseAddress",

--- a/resources/sts/4.9/sts_support_permission_policy.json
+++ b/resources/sts/4.9/sts_support_permission_policy.json
@@ -95,6 +95,7 @@
                 "ec2:DescribeVpnConnections",
                 "ec2:DescribeVpnGateways",
                 "ec2:GetAssociatedIpv6PoolCidrs",
+                "ec2:GetConsoleOutput",
                 "ec2:GetTransitGatewayAttachmentPropagations",
                 "ec2:GetTransitGatewayMulticastDomainAssociations",
                 "ec2:GetTransitGatewayPrefixListReferences",


### PR DESCRIPTION
The osd-network-verifier requires GetConsoleOutput. This PR adds that permission to the installer and the SRE Support STS roles to enable automatic and manual runs of the verifier. 