### PR TITLE
OSD-10187-Exclude FedRAMP for SelectorSyncSets

### DIFF
--- a/deploy/backplane/srep/hive/config.yaml
+++ b/deploy/backplane/srep/hive/config.yaml
@@ -4,3 +4,7 @@ selectorSyncSet:
   - key: ext-managed.openshift.io/hive-shard
     operator: In
     values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/deploy/cloud-ingress-operator-configuration/apischeme/config.yaml
+++ b/deploy/cloud-ingress-operator-configuration/apischeme/config.yaml
@@ -10,3 +10,7 @@ selectorSyncSet:
   - key: api.openshift.com/private-link
     operator: NotIn
     values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/deploy/cloud-ingress-operator-configuration/sshd/config.yaml
+++ b/deploy/cloud-ingress-operator-configuration/sshd/config.yaml
@@ -4,3 +4,7 @@ selectorSyncSet:
   - key: ext-managed.openshift.io/hive-shard
     operator: In
     values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/deploy/velero-configuration/config.yaml
+++ b/deploy/velero-configuration/config.yaml
@@ -4,3 +4,7 @@ selectorSyncSet:
   - key: api.openshift.com/sts
     operator: NotIn
     values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3488,6 +3488,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -3912,6 +3916,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: cloudingress.managed.openshift.io/v1alpha1
@@ -3966,6 +3974,10 @@ objects:
       matchExpressions:
       - key: ext-managed.openshift.io/hive-shard
         operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
         values:
         - 'true'
     resourceApplyMode: Sync
@@ -13737,6 +13749,10 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
         operator: NotIn
         values:
         - 'true'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3488,6 +3488,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -3912,6 +3916,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: cloudingress.managed.openshift.io/v1alpha1
@@ -3966,6 +3974,10 @@ objects:
       matchExpressions:
       - key: ext-managed.openshift.io/hive-shard
         operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
         values:
         - 'true'
     resourceApplyMode: Sync
@@ -13737,6 +13749,10 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
         operator: NotIn
         values:
         - 'true'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3488,6 +3488,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -3912,6 +3916,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: cloudingress.managed.openshift.io/v1alpha1
@@ -3966,6 +3974,10 @@ objects:
       matchExpressions:
       - key: ext-managed.openshift.io/hive-shard
         operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
         values:
         - 'true'
     resourceApplyMode: Sync
@@ -13737,6 +13749,10 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
         operator: NotIn
         values:
         - 'true'


### PR DESCRIPTION
[OSD-10187](https://issues.redhat.com/browse/OSD-10187)
Excluding FedRAMP from SelectorSyncSets backplane-srep-hive, cloud-ingress-operator-configuration-sshd, osd-serviceaccounts, velero-configuration, velero-configuration-hive-specific