### PR TITLE
[OSD-9948] push oauth server sli to observatorium-mst

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable)'
+            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_health_checks)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_health_checks)'
+            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/deploy/sre-prometheus/100-oauth-server.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-oauth-server.PrometheusRule.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-oauth-server
+    role: recording-rules
+  name: sre-oauth-server
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-oauth-server
+    rules:
+      # aggregate the metrics under a new name to make sending these via remoteWrite easier
+    - record: oauth_server_health_checks
+      expr: apiserver_request_total{container="oauth-openshift"}

--- a/deploy/sre-prometheus/100-oauth-server.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-oauth-server.PrometheusRule.yaml
@@ -11,5 +11,5 @@ spec:
   - name: sre-oauth-server
     rules:
       # aggregate the metrics under a new name to make sending these via remoteWrite easier
-    - record: oauth_server_health_checks
+    - record: oauth_server_requests_total
       expr: apiserver_request_total{container="oauth-openshift"}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4085,7 +4085,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13001,6 +13001,20 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-oauth-server
+          role: recording-rules
+        name: sre-oauth-server
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-oauth-server
+          rules:
+          - record: oauth_server_requests_total
+            expr: apiserver_request_total{container="oauth-openshift"}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4085,7 +4085,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13001,6 +13001,20 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-oauth-server
+          role: recording-rules
+        name: sre-oauth-server
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-oauth-server
+          rules:
+          - record: oauth_server_requests_total
+            expr: apiserver_request_total{container="oauth-openshift"}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4085,7 +4085,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13001,6 +13001,20 @@ objects:
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-oauth-server
+          role: recording-rules
+        name: sre-oauth-server
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-oauth-server
+          rules:
+          - record: oauth_server_requests_total
+            expr: apiserver_request_total{container="oauth-openshift"}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
This PR implements part of [OSD-9948](https://issues.redhat.com/browse/OSD-9948).

It makes sure, that oauth-server's availability is pushed to observatorium for validating our SLOs. A new recording rule was created to create a simpler alias for pushing only the desired metrics to observatorium.

If that is not desired, it's also possible to use a much more complicated relabel config to select only `apiserver_request_total{container="oauth-openshift"}` for pushing ( see linked ticket for more information ).

This PR must only be merged, after [gitlab/lifecycler#3](https://gitlab.cee.redhat.com/service/lifecycler/-/merge_requests/3) has also been merged.

@dofinn