### PR TITLE
OSD-10249 allow token-refresher to use additional CA bundle

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -32,6 +32,14 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/infra
           operator: Exists
+      volumes:
+      - configMap:
+          defaultMode: 420
+          items:
+            - key: ca-bundle.crt
+              path: ca-certificates.crt
+          name: token-refresher-trusted-ca-bundle
+        name: token-refresher-trusted-ca-bundle
       containers:
       - args:
         - --oidc.audience=observatorium-telemeter
@@ -62,3 +70,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        volumeMounts:
+        - mountPath: /etc/ssl/certs/
+          name: token-refresher-trusted-ca-bundle
+          readOnly: true

--- a/deploy/osd-token-refresher/04-token-refresher.ConfigMap.yaml
+++ b/deploy/osd-token-refresher/04-token-refresher.ConfigMap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-monitoring
+  name: token-refresher-trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10626,6 +10626,14 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
+            volumes:
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: ca-certificates.crt
+                name: token-refresher-trusted-ca-bundle
+              name: token-refresher-trusted-ca-bundle
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
@@ -10656,6 +10664,10 @@ objects:
               ports:
               - containerPort: 8080
                 name: http
+              volumeMounts:
+              - mountPath: /etc/ssl/certs/
+                name: token-refresher-trusted-ca-bundle
+                readOnly: true
     - apiVersion: v1
       kind: Service
       metadata:
@@ -10693,6 +10705,13 @@ objects:
           - podSelector:
               matchLabels:
                 prometheus: k8s
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: openshift-monitoring
+        name: token-refresher-trusted-ca-bundle
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10626,6 +10626,14 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
+            volumes:
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: ca-certificates.crt
+                name: token-refresher-trusted-ca-bundle
+              name: token-refresher-trusted-ca-bundle
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
@@ -10656,6 +10664,10 @@ objects:
               ports:
               - containerPort: 8080
                 name: http
+              volumeMounts:
+              - mountPath: /etc/ssl/certs/
+                name: token-refresher-trusted-ca-bundle
+                readOnly: true
     - apiVersion: v1
       kind: Service
       metadata:
@@ -10693,6 +10705,13 @@ objects:
           - podSelector:
               matchLabels:
                 prometheus: k8s
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: openshift-monitoring
+        name: token-refresher-trusted-ca-bundle
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10626,6 +10626,14 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
+            volumes:
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: ca-certificates.crt
+                name: token-refresher-trusted-ca-bundle
+              name: token-refresher-trusted-ca-bundle
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
@@ -10656,6 +10664,10 @@ objects:
               ports:
               - containerPort: 8080
                 name: http
+              volumeMounts:
+              - mountPath: /etc/ssl/certs/
+                name: token-refresher-trusted-ca-bundle
+                readOnly: true
     - apiVersion: v1
       kind: Service
       metadata:
@@ -10693,6 +10705,13 @@ objects:
           - podSelector:
               matchLabels:
                 prometheus: k8s
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: openshift-monitoring
+        name: token-refresher-trusted-ca-bundle
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
It was identified during testing of SDE-1471 that the `token-refresher` will need to trust the cluster owner's additional CA if they are deploying the cluster with a cluster-wide proxy.

This PR updates the deployment of the `token-refresher` to include a ConfigMap that will have the system+user CA bundles injected into it and subsequently mounted into the host.

As the `token-refresher` image is alpine based, the usual approach of deploying it to `/etc/pki/ca-trust/extracted/pem` does not work. Instead I've opted to overwrite the image's existing `/etc/ssl/certs/ca-certificate.crt` with the contents of the system+user CA bundle.

This has been tested on both a cluster with no proxy or custom CA configured, as well as on a cluster with a proxy configured. When a cluster does not have a proxy or custom CA configured, the system CA trust store is mounted through.
