### PR TITLE
Update admin-acks configmap to create if doesn't exist

### DIFF
--- a/deploy/osd-cluster-acks/ocp/4.9/admin-gates.yaml
+++ b/deploy/osd-cluster-acks/ocp/4.9/admin-gates.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
+data:
+  ack-4.8-kube-1.22-api-removals-in-4.9: "true"
 kind: ConfigMap
-name: admin-acks
-namespace: openshift-config
-applyMode: AlwaysApply
-patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
-patchType: merge
+metadata:
+  name: admin-acks
+  namespace: openshift-config

--- a/deploy/osd-cluster-acks/ocp/4.9/config.yaml
+++ b/deploy/osd-cluster-acks/ocp/4.9/config.yaml
@@ -1,9 +1,10 @@
-deploymentMode: "SelectorSyncSet" 
+deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
+  resourceApplyMode: Upsert
   matchExpressions:
-  - key: hive.openshift.io/version-major-minor 
+  - key: hive.openshift.io/version-major-minor
     operator: In
     values: ["4.8"]
   - key: api.openshift.com/gate-ocp
-    operator: In 
+    operator: In
     values: ["4.9"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6390,15 +6390,15 @@ objects:
         operator: In
         values:
         - '4.9'
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    resources:
     - apiVersion: v1
+      data:
+        ack-4.8-kube-1.22-api-removals-in-4.9: 'true'
       kind: ConfigMap
-      name: admin-acks
-      namespace: openshift-config
-      applyMode: AlwaysApply
-      patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
-      patchType: merge
+      metadata:
+        name: admin-acks
+        namespace: openshift-config
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6390,15 +6390,15 @@ objects:
         operator: In
         values:
         - '4.9'
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    resources:
     - apiVersion: v1
+      data:
+        ack-4.8-kube-1.22-api-removals-in-4.9: 'true'
       kind: ConfigMap
-      name: admin-acks
-      namespace: openshift-config
-      applyMode: AlwaysApply
-      patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
-      patchType: merge
+      metadata:
+        name: admin-acks
+        namespace: openshift-config
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6390,15 +6390,15 @@ objects:
         operator: In
         values:
         - '4.9'
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    resources:
     - apiVersion: v1
+      data:
+        ack-4.8-kube-1.22-api-removals-in-4.9: 'true'
       kind: ConfigMap
-      name: admin-acks
-      namespace: openshift-config
-      applyMode: AlwaysApply
-      patch: '{"data":{"ack-4.8-kube-1.22-api-removals-in-4.9":"true"}}'
-      patchType: merge
+      metadata:
+        name: admin-acks
+        namespace: openshift-config
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
If the admin-acks configmap doesn't exist, we should create it. We can manage the full set of data in the configmap, as it's data is only valuable to a specific version.