### PR TITLE
MTSRE-467 | provide MTSRE the backplane access to credentialsrequests CR

### DIFF
--- a/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
@@ -8,5 +8,8 @@ spec:
   - allowFirst: true
     clusterRoleName: admin
     namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
+  - allowFirst: true
+    clusterRoleName: system:openshift:cloud-credential-operator:cluster-reader
+    namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3042,6 +3042,9 @@ objects:
         - allowFirst: true
           clusterRoleName: admin
           namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
+        - allowFirst: true
+          clusterRoleName: system:openshift:cloud-credential-operator:cluster-reader
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3042,6 +3042,9 @@ objects:
         - allowFirst: true
           clusterRoleName: admin
           namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
+        - allowFirst: true
+          clusterRoleName: system:openshift:cloud-credential-operator:cluster-reader
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3042,6 +3042,9 @@ objects:
         - allowFirst: true
           clusterRoleName: admin
           namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
+        - allowFirst: true
+          clusterRoleName: system:openshift:cloud-credential-operator:cluster-reader
+          namespacesAllowedRegex: (^rhods-notebooks$|^redhat-ods-applications$|^redhat-ods-monitoring$|^redhat-ods-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

For the addons relying on CRO, we (MTSRE) would require access to reading the `CredentialsRequest` CR to debug problems in case of incidents associated with CRO's failures with provisioning RDS instances.