### PR TITLE
Allow MHCs to run on all worker nodes

### DIFF
--- a/deploy/osd-machine-api/010-machine-api.srep-infra-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/010-machine-api.srep-infra-healthcheck.MachineHealthCheck.yaml
@@ -5,8 +5,13 @@ metadata:
   namespace: openshift-machine-api
 spec:
   selector:
-    matchLabels:
-      machine.openshift.io/cluster-api-machine-role: infra
+    matchExpressions:
+    - key: machine.openshift.io/cluster-api-machine-role
+      operator: In
+      values:
+      - "infra"
+    - key: machine.openshift.io/cluster-api-machineset
+      operator: Exists
   unhealthyConditions:
   - type:    "Ready"
     timeout: "480s"

--- a/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -5,8 +5,14 @@ metadata:
   namespace: openshift-machine-api
 spec:
   selector:
-    matchLabels:
-      machine.openshift.io/cluster-api-machine-role: worker
+    matchExpressions:
+    - key: machine.openshift.io/cluster-api-machine-role
+      operator: NotIn
+      values:
+      - "infra"
+      - "master"
+    - key: machine.openshift.io/cluster-api-machineset
+      operator: Exists
   unhealthyConditions:
   - type:    "Ready"
     timeout: "480s"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9056,8 +9056,13 @@ objects:
         namespace: openshift-machine-api
       spec:
         selector:
-          matchLabels:
-            machine.openshift.io/cluster-api-machine-role: infra
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: In
+            values:
+            - infra
+          - key: machine.openshift.io/cluster-api-machineset
+            operator: Exists
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -9073,8 +9078,14 @@ objects:
         namespace: openshift-machine-api
       spec:
         selector:
-          matchLabels:
-            machine.openshift.io/cluster-api-machine-role: worker
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: NotIn
+            values:
+            - infra
+            - master
+          - key: machine.openshift.io/cluster-api-machineset
+            operator: Exists
         unhealthyConditions:
         - type: Ready
           timeout: 480s

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9056,8 +9056,13 @@ objects:
         namespace: openshift-machine-api
       spec:
         selector:
-          matchLabels:
-            machine.openshift.io/cluster-api-machine-role: infra
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: In
+            values:
+            - infra
+          - key: machine.openshift.io/cluster-api-machineset
+            operator: Exists
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -9073,8 +9078,14 @@ objects:
         namespace: openshift-machine-api
       spec:
         selector:
-          matchLabels:
-            machine.openshift.io/cluster-api-machine-role: worker
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: NotIn
+            values:
+            - infra
+            - master
+          - key: machine.openshift.io/cluster-api-machineset
+            operator: Exists
         unhealthyConditions:
         - type: Ready
           timeout: 480s

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9056,8 +9056,13 @@ objects:
         namespace: openshift-machine-api
       spec:
         selector:
-          matchLabels:
-            machine.openshift.io/cluster-api-machine-role: infra
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: In
+            values:
+            - infra
+          - key: machine.openshift.io/cluster-api-machineset
+            operator: Exists
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -9073,8 +9078,14 @@ objects:
         namespace: openshift-machine-api
       spec:
         selector:
-          matchLabels:
-            machine.openshift.io/cluster-api-machine-role: worker
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: NotIn
+            values:
+            - infra
+            - master
+          - key: machine.openshift.io/cluster-api-machineset
+            operator: Exists
         unhealthyConditions:
         - type: Ready
           timeout: 480s


### PR DESCRIPTION
Use `matchExpressions` on the `MachineHealthCheck` objects in order to have them apply to non-default worker pools, as well as the default one.

fixes [OSD-8885](https://issues.redhat.com/browse/OSD-8885)