### PR TITLE
[OSD-10367] osd-cluster-ready++

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: v0.1.53-77031d8
+                managed.openshift.io/version: "v0.1.59-35375ed"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:ce351a409991ba6ed3c37379026b426ce5c54bdb260bae41ae051bd87d5abf51
+              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6657,11 +6657,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.53-77031d8
+              managed.openshift.io/version: v0.1.59-35375ed
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:ce351a409991ba6ed3c37379026b426ce5c54bdb260bae41ae051bd87d5abf51
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6657,11 +6657,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.53-77031d8
+              managed.openshift.io/version: v0.1.59-35375ed
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:ce351a409991ba6ed3c37379026b426ce5c54bdb260bae41ae051bd87d5abf51
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6657,11 +6657,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.53-77031d8
+              managed.openshift.io/version: v0.1.59-35375ed
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:ce351a409991ba6ed3c37379026b426ce5c54bdb260bae41ae051bd87d5abf51
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
Pulls in updates to the osd-cluster-ready container to:
* Switch to ubi8-micro from fedora and not download oc as it's no longer needed (https://github.com/openshift/osd-cluster-ready/pull/12)
* Pull in upstream osde2e bug fixes around controller and pod healthcheck fixes (https://github.com/openshift/osde2e/pull/1069)