### PR TITLE
osd-cluster-ready++ to fix misleading pod healthcheck log message

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.59-35375ed"
+                managed.openshift.io/version: "v0.1.62-24d189f"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2"
+              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6657,11 +6657,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.59-35375ed
+              managed.openshift.io/version: v0.1.62-24d189f
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6657,11 +6657,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.59-35375ed
+              managed.openshift.io/version: v0.1.62-24d189f
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6657,11 +6657,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.59-35375ed
+              managed.openshift.io/version: v0.1.62-24d189f
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:d3849028442568c7012e59371ff63531cd229328ebcfb35ca1d60daeada93ce2
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
The previous update in https://github.com/openshift/managed-cluster-config/pull/1089 fixed the bug described in OSD-10367, but noticed a misleading log message when I was testing this change as it rolled out in stage. Pulling in fixes from https://github.com/openshift/osd-cluster-ready/pull/13