### PR TITLE
[OSD-10448] updated api URL to use livez

### DIFF
--- a/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
+++ b/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   prefix: https://api.
   port: "6443"
-  suffix: /healthz
+  suffix: /livez
   slo:
     targetAvailabilityPercent: "99.0"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9489,7 +9489,7 @@ objects:
       spec:
         prefix: https://api.
         port: '6443'
-        suffix: /healthz
+        suffix: /livez
         slo:
           targetAvailabilityPercent: '99.0'
     - apiVersion: monitoring.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9489,7 +9489,7 @@ objects:
       spec:
         prefix: https://api.
         port: '6443'
-        suffix: /healthz
+        suffix: /livez
         slo:
           targetAvailabilityPercent: '99.0'
     - apiVersion: monitoring.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9489,7 +9489,7 @@ objects:
       spec:
         prefix: https://api.
         port: '6443'
-        suffix: /healthz
+        suffix: /livez
         slo:
           targetAvailabilityPercent: '99.0'
     - apiVersion: monitoring.openshift.io/v1alpha1


### PR DESCRIPTION
As per https://kubernetes.io/docs/reference/using-api/health-checks/ the /healthz endpoint is being depreciated in favour of the more explicit /livez and /readyz. 

With the consideration of SLOs being generated by RMO and this endpoint, the /livez endpoint appears to be more applicable as its used to catch container failures and triggers container restarts as per https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ 