### PR TITLE
[OSD-10326] Initial FedRAMP token vaulter configuration

### DIFF
--- a/deploy/osd-fedramp-token-scraper/00-vaulter-clusterrole.yaml
+++ b/deploy/osd-fedramp-token-scraper/00-vaulter-clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-sre-token-vaulter
+rules:
+  - apiGroups:
+      - "hive.openshift.io"
+    resources:
+      - "clusterdeployments"
+    verbs:
+      - get
+      - list

--- a/deploy/osd-fedramp-token-scraper/10-vaulter-clusterrolebinding.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-vaulter-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-sre-token-vaulter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-sre-token-vaulter
+subjects:
+  - kind: ServiceAccount
+    name: openshift-sre-token-vaulter
+    namespace: openshift-sre-token-scraper

--- a/deploy/osd-fedramp-token-scraper/10-vaulter-role.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-vaulter-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-sre-token-vaulter
+  namespace: openshift-sre-token-scraper
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list

--- a/deploy/osd-fedramp-token-scraper/10-vaulter-rolebinding.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-vaulter-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-sre-token-vaulter
+  namespace: openshift-sre-token-scraper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-sre-token-vaulter
+subjects:
+  - kind: ServiceAccount
+    name: openshift-sre-token-vaulter
+    namespace: openshift-sre-token-scraper

--- a/deploy/osd-fedramp-token-scraper/10-vaulter-serviceaccount.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-vaulter-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-sre-token-vaulter
+  namespace: openshift-sre-token-scraper
+automountServiceAccountToken: false

--- a/deploy/osd-fedramp-token-scraper/20-vaulter-cronjob.yaml
+++ b/deploy/osd-fedramp-token-scraper/20-vaulter-cronjob.yaml
@@ -1,0 +1,56 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: openshift-sre-token-vaulter
+  namespace: openshift-sre-token-scraper
+spec:
+  schedule: "*/30 * * * *"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          automountServiceAccountToken: true
+          serviceAccountName: openshift-sre-token-vaulter
+          containers:
+            - name: vaulter
+              image: "quay.io/mshen/openshift-sre-token-vaulter@sha256:db7807beeb4ead02f7b1575899472efb5040d35c7c9f218b9b73948cda6134ec"
+              env:
+                - name: VAULT_APPROLE_ROLE_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: sre-token-scraper-vault-approle-secret
+                      key: "role_id"
+                      optional: false
+                - name: VAULT_APPROLE_SECRET_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: sre-token-scraper-vault-approle-secret
+                      key: "secret_id"
+                      optional: false
+                - name: VAULT_ADDR
+                  value: "https://vault.fedramp.devshift.net"
+              command:
+                - 'bash'
+                - '-c'
+              args:
+                - |
+                  export VAULT_TOKEN="$(vault write auth/approle/login role_id=${VAULT_APPROLE_ROLE_ID} secret_id=${VAULT_APPROLE_SECRET_ID} -format=json | jq -r '.auth.client_token')";
+                  readarray -t tokens < <(oc get secrets -n openshift-sre-token-scraper -l app=openshift-sre-token-scraper -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
+                  for token in "${tokens[@]}"; do
+                    readarray -t components < <(echo "${token}" | sed 's/-sre-/\n/g');
+                    CLUSTER="${components[0]}";
+                    SRE="${components[1]}";
+                    API="$(oc get cd -n ${components[0]} -ojson | jq -r '.items[0].status.apiURL')";
+                    SECRET="$(oc get secret -n openshift-sre-token-scraper ${token} -ojson | jq -r '.data.token' | base64 -d)";
+                    vault kv put "osd-fedramp/srep-sa-tokens/${CLUSTER}/${SRE}" api="${API}" token="${SECRET}";
+                    # Spread out calls to Vault
+                    sleep 3;
+                  done;
+          dnsConfig:
+            nameservers:
+              - "10.125.32.103"
+            searches:
+              - "vault.fedramp.devshift.net"
+          dnsPolicy: None
+          restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7947,6 +7947,18 @@ objects:
       metadata:
         name: openshift-sre-token-scraper
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: openshift-sre-token-vaulter
+      rules:
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
         name: openshift-sre-token-replacer
@@ -7989,6 +8001,50 @@ objects:
       kind: ServiceAccount
       metadata:
         name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      automountServiceAccountToken: false
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: openshift-sre-token-vaulter
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: openshift-sre-token-vaulter
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: openshift-sre-token-vaulter
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: openshift-sre-token-vaulter
         namespace: openshift-sre-token-scraper
       automountServiceAccountToken: false
     - apiVersion: batch/v1
@@ -8036,6 +8092,62 @@ objects:
                     \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
                     \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
                     done;\n"
+                restartPolicy: OnFailure
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      spec:
+        schedule: '*/30 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                automountServiceAccountToken: true
+                serviceAccountName: openshift-sre-token-vaulter
+                containers:
+                - name: vaulter
+                  image: quay.io/mshen/openshift-sre-token-vaulter@sha256:db7807beeb4ead02f7b1575899472efb5040d35c7c9f218b9b73948cda6134ec
+                  env:
+                  - name: VAULT_APPROLE_ROLE_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: sre-token-scraper-vault-approle-secret
+                        key: role_id
+                        optional: false
+                  - name: VAULT_APPROLE_SECRET_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: sre-token-scraper-vault-approle-secret
+                        key: secret_id
+                        optional: false
+                  - name: VAULT_ADDR
+                    value: https://vault.fedramp.devshift.net
+                  command:
+                  - bash
+                  - -c
+                  args:
+                  - "export VAULT_TOKEN=\"$(vault write auth/approle/login role_id=${VAULT_APPROLE_ROLE_ID}\
+                    \ secret_id=${VAULT_APPROLE_SECRET_ID} -format=json | jq -r '.auth.client_token')\"\
+                    ;\nreadarray -t tokens < <(oc get secrets -n openshift-sre-token-scraper\
+                    \ -l app=openshift-sre-token-scraper -o go-template='{{range .items}}{{.metadata.name}}{{\"\
+                    \\n\"}}{{end}}');\nfor token in \"${tokens[@]}\"; do\n  readarray\
+                    \ -t components < <(echo \"${token}\" | sed 's/-sre-/\\n/g');\n\
+                    \  CLUSTER=\"${components[0]}\";\n  SRE=\"${components[1]}\";\n\
+                    \  API=\"$(oc get cd -n ${components[0]} -ojson | jq -r '.items[0].status.apiURL')\"\
+                    ;\n  SECRET=\"$(oc get secret -n openshift-sre-token-scraper ${token}\
+                    \ -ojson | jq -r '.data.token' | base64 -d)\";\n  vault kv put\
+                    \ \"osd-fedramp/srep-sa-tokens/${CLUSTER}/${SRE}\" api=\"${API}\"\
+                    \ token=\"${SECRET}\";\n  # Spread out calls to Vault\n  sleep\
+                    \ 3;\ndone;\n"
+                dnsConfig:
+                  nameservers:
+                  - 10.125.32.103
+                  searches:
+                  - vault.fedramp.devshift.net
+                dnsPolicy: None
                 restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7947,6 +7947,18 @@ objects:
       metadata:
         name: openshift-sre-token-scraper
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: openshift-sre-token-vaulter
+      rules:
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
         name: openshift-sre-token-replacer
@@ -7989,6 +8001,50 @@ objects:
       kind: ServiceAccount
       metadata:
         name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      automountServiceAccountToken: false
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: openshift-sre-token-vaulter
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: openshift-sre-token-vaulter
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: openshift-sre-token-vaulter
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: openshift-sre-token-vaulter
         namespace: openshift-sre-token-scraper
       automountServiceAccountToken: false
     - apiVersion: batch/v1
@@ -8036,6 +8092,62 @@ objects:
                     \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
                     \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
                     done;\n"
+                restartPolicy: OnFailure
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      spec:
+        schedule: '*/30 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                automountServiceAccountToken: true
+                serviceAccountName: openshift-sre-token-vaulter
+                containers:
+                - name: vaulter
+                  image: quay.io/mshen/openshift-sre-token-vaulter@sha256:db7807beeb4ead02f7b1575899472efb5040d35c7c9f218b9b73948cda6134ec
+                  env:
+                  - name: VAULT_APPROLE_ROLE_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: sre-token-scraper-vault-approle-secret
+                        key: role_id
+                        optional: false
+                  - name: VAULT_APPROLE_SECRET_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: sre-token-scraper-vault-approle-secret
+                        key: secret_id
+                        optional: false
+                  - name: VAULT_ADDR
+                    value: https://vault.fedramp.devshift.net
+                  command:
+                  - bash
+                  - -c
+                  args:
+                  - "export VAULT_TOKEN=\"$(vault write auth/approle/login role_id=${VAULT_APPROLE_ROLE_ID}\
+                    \ secret_id=${VAULT_APPROLE_SECRET_ID} -format=json | jq -r '.auth.client_token')\"\
+                    ;\nreadarray -t tokens < <(oc get secrets -n openshift-sre-token-scraper\
+                    \ -l app=openshift-sre-token-scraper -o go-template='{{range .items}}{{.metadata.name}}{{\"\
+                    \\n\"}}{{end}}');\nfor token in \"${tokens[@]}\"; do\n  readarray\
+                    \ -t components < <(echo \"${token}\" | sed 's/-sre-/\\n/g');\n\
+                    \  CLUSTER=\"${components[0]}\";\n  SRE=\"${components[1]}\";\n\
+                    \  API=\"$(oc get cd -n ${components[0]} -ojson | jq -r '.items[0].status.apiURL')\"\
+                    ;\n  SECRET=\"$(oc get secret -n openshift-sre-token-scraper ${token}\
+                    \ -ojson | jq -r '.data.token' | base64 -d)\";\n  vault kv put\
+                    \ \"osd-fedramp/srep-sa-tokens/${CLUSTER}/${SRE}\" api=\"${API}\"\
+                    \ token=\"${SECRET}\";\n  # Spread out calls to Vault\n  sleep\
+                    \ 3;\ndone;\n"
+                dnsConfig:
+                  nameservers:
+                  - 10.125.32.103
+                  searches:
+                  - vault.fedramp.devshift.net
+                dnsPolicy: None
                 restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7947,6 +7947,18 @@ objects:
       metadata:
         name: openshift-sre-token-scraper
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: openshift-sre-token-vaulter
+      rules:
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
         name: openshift-sre-token-replacer
@@ -7989,6 +8001,50 @@ objects:
       kind: ServiceAccount
       metadata:
         name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      automountServiceAccountToken: false
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: openshift-sre-token-vaulter
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: openshift-sre-token-vaulter
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: openshift-sre-token-vaulter
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: openshift-sre-token-vaulter
         namespace: openshift-sre-token-scraper
       automountServiceAccountToken: false
     - apiVersion: batch/v1
@@ -8036,6 +8092,62 @@ objects:
                     \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
                     \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
                     done;\n"
+                restartPolicy: OnFailure
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: openshift-sre-token-vaulter
+        namespace: openshift-sre-token-scraper
+      spec:
+        schedule: '*/30 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                automountServiceAccountToken: true
+                serviceAccountName: openshift-sre-token-vaulter
+                containers:
+                - name: vaulter
+                  image: quay.io/mshen/openshift-sre-token-vaulter@sha256:db7807beeb4ead02f7b1575899472efb5040d35c7c9f218b9b73948cda6134ec
+                  env:
+                  - name: VAULT_APPROLE_ROLE_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: sre-token-scraper-vault-approle-secret
+                        key: role_id
+                        optional: false
+                  - name: VAULT_APPROLE_SECRET_ID
+                    valueFrom:
+                      secretKeyRef:
+                        name: sre-token-scraper-vault-approle-secret
+                        key: secret_id
+                        optional: false
+                  - name: VAULT_ADDR
+                    value: https://vault.fedramp.devshift.net
+                  command:
+                  - bash
+                  - -c
+                  args:
+                  - "export VAULT_TOKEN=\"$(vault write auth/approle/login role_id=${VAULT_APPROLE_ROLE_ID}\
+                    \ secret_id=${VAULT_APPROLE_SECRET_ID} -format=json | jq -r '.auth.client_token')\"\
+                    ;\nreadarray -t tokens < <(oc get secrets -n openshift-sre-token-scraper\
+                    \ -l app=openshift-sre-token-scraper -o go-template='{{range .items}}{{.metadata.name}}{{\"\
+                    \\n\"}}{{end}}');\nfor token in \"${tokens[@]}\"; do\n  readarray\
+                    \ -t components < <(echo \"${token}\" | sed 's/-sre-/\\n/g');\n\
+                    \  CLUSTER=\"${components[0]}\";\n  SRE=\"${components[1]}\";\n\
+                    \  API=\"$(oc get cd -n ${components[0]} -ojson | jq -r '.items[0].status.apiURL')\"\
+                    ;\n  SECRET=\"$(oc get secret -n openshift-sre-token-scraper ${token}\
+                    \ -ojson | jq -r '.data.token' | base64 -d)\";\n  vault kv put\
+                    \ \"osd-fedramp/srep-sa-tokens/${CLUSTER}/${SRE}\" api=\"${API}\"\
+                    \ token=\"${SECRET}\";\n  # Spread out calls to Vault\n  sleep\
+                    \ 3;\ndone;\n"
+                dnsConfig:
+                  nameservers:
+                  - 10.125.32.103
+                  searches:
+                  - vault.fedramp.devshift.net
+                dnsPolicy: None
                 restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
Stores the apiserver URL (ClusterRole to get/list ClusterDeployments) and token (Role to get/list secrets in the openshift-sre-token-scraper namespace) which will be needed when running `oc login`

I was able to use Pod dnsConfig/dnsPolicies to get DNS resolution to FR Vault

```yaml
dnsConfig:
   nameservers:
     - "10.125.32.103"
   searches:
     - "vault.fedramp.devshift.net"
dnsPolicy: None
```

Verified this works in integration hive and it's sharing the MCC "config.yaml" with the token scraper so it'll be targeted to run on all FR Hives