### PR TITLE
OHSS-11084 Fix clusters impacted by BZ2067978

### DIFF
--- a/deploy/bz2067978/00-osd-delete-noderesolver-daemonset.ServiceAccount.yaml
+++ b/deploy/bz2067978/00-osd-delete-noderesolver-daemonset.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns

--- a/deploy/bz2067978/01-osd-delete-dns-operator.Role.yaml
+++ b/deploy/bz2067978/01-osd-delete-dns-operator.Role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/bz2067978/01-osd-delete-noderesolver-daemonset.Role.yaml
+++ b/deploy/bz2067978/01-osd-delete-noderesolver-daemonset.Role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/bz2067978/02-osd-delete-dns-operator.RoleBinding.yaml
+++ b/deploy/bz2067978/02-osd-delete-dns-operator.RoleBinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns-operator

--- a/deploy/bz2067978/02-osd-delete-noderesolver-daemonset.RoleBinding.yaml
+++ b/deploy/bz2067978/02-osd-delete-noderesolver-daemonset.RoleBinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns
+subjects:
+- kind: ServiceAccount
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns

--- a/deploy/bz2067978/10-osd-delete-noderesolver-daemonsets.CronJob.yaml
+++ b/deploy/bz2067978/10-osd-delete-noderesolver-daemonsets.CronJob.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-delete-noderesolver-daemonset-bz2067978
+  namespace: openshift-dns
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "35 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 120
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: osd-delete-noderesolver-daemonset-bz2067978
+          restartPolicy: Never
+          containers:
+          - name: osd-delete-noderesolver-daemonset-bz2067978
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - |
+              if [[ -z "$(oc get daemonset -n openshift-dns --ignore-not-found node-resolver -o jsonpath='{.metadata.ownerReferences[0].name}')" ]]; then
+                oc delete daemonset --ignore-not-found -n openshift-dns node-resolver
+                oc delete pod --ignore-not-found -n openshift-dns-operator -l name=dns-operator
+              fi

--- a/deploy/bz2067978/OWNERS
+++ b/deploy/bz2067978/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+- cblecker
+- mrbarge

--- a/deploy/bz2067978/README.md
+++ b/deploy/bz2067978/README.md
@@ -1,0 +1,7 @@
+References:
+* [BZ 2062798](https://bugzilla.redhat.com/show_bug.cgi?id=2067978)
+* [Temporary fix for BZ 2067978](https://issues.redhat.com/browse/OHSS-11084)
+
+Clusters that upgraded from 4.7 to 4.8.fc(.<2) can result in a node-resolver daemonset with an ownerReference set. This can trigger a race condition that blocks upgrades from completing as they get stuck on the dns clusteroperator.
+
+A workaround solution is to delete the node-resolver daemonset and let it be recreated with the ownerReference.

--- a/deploy/bz2067978/config.yaml
+++ b/deploy/bz2067978/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.8","4.9","4.10"]
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3855,6 +3855,129 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2067978
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      rules:
+      - apiGroups:
+        - apps
+        resources:
+        - daemonsets
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 35 * * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 120
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-delete-noderesolver-daemonset-bz2067978
+                restartPolicy: Never
+                containers:
+                - name: osd-delete-noderesolver-daemonset-bz2067978
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "if [[ -z \"$(oc get daemonset -n openshift-dns --ignore-not-found\
+                    \ node-resolver -o jsonpath='{.metadata.ownerReferences[0].name}')\"\
+                    \ ]]; then\n  oc delete daemonset --ignore-not-found -n openshift-dns\
+                    \ node-resolver\n  oc delete pod --ignore-not-found -n openshift-dns-operator\
+                    \ -l name=dns-operator\nfi\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3855,6 +3855,129 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2067978
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      rules:
+      - apiGroups:
+        - apps
+        resources:
+        - daemonsets
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 35 * * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 120
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-delete-noderesolver-daemonset-bz2067978
+                restartPolicy: Never
+                containers:
+                - name: osd-delete-noderesolver-daemonset-bz2067978
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "if [[ -z \"$(oc get daemonset -n openshift-dns --ignore-not-found\
+                    \ node-resolver -o jsonpath='{.metadata.ownerReferences[0].name}')\"\
+                    \ ]]; then\n  oc delete daemonset --ignore-not-found -n openshift-dns\
+                    \ node-resolver\n  oc delete pod --ignore-not-found -n openshift-dns-operator\
+                    \ -l name=dns-operator\nfi\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3855,6 +3855,129 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2067978
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      rules:
+      - apiGroups:
+        - apps
+        resources:
+        - daemonsets
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns-operator
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-delete-noderesolver-daemonset-bz2067978
+        namespace: openshift-dns
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 35 * * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 120
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-delete-noderesolver-daemonset-bz2067978
+                restartPolicy: Never
+                containers:
+                - name: osd-delete-noderesolver-daemonset-bz2067978
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "if [[ -z \"$(oc get daemonset -n openshift-dns --ignore-not-found\
+                    \ node-resolver -o jsonpath='{.metadata.ownerReferences[0].name}')\"\
+                    \ ]]; then\n  oc delete daemonset --ignore-not-found -n openshift-dns\
+                    \ node-resolver\n  oc delete pod --ignore-not-found -n openshift-dns-operator\
+                    \ -l name=dns-operator\nfi\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This adds a temporary job to identify clusters that have a `node-resolver` daemonset with missing `ownerReference` indicating that it can be a risk factor to encounter [BZ2067978](https://bugzilla.redhat.com/show_bug.cgi?id=2067978).

A workaround is to delete the daemonset and let it be recreated. Deleting the `dns-operator` forces the recreation.