### PR TITLE
Removing MCC management of the openshift-sre-token-scraper namespace

### DIFF
--- a/deploy/osd-fedramp-token-scraper/00-scraper-namespace.yaml
+++ b/deploy/osd-fedramp-token-scraper/00-scraper-namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-sre-token-scraper

--- a/deploy/osd-fedramp-token-scraper/config.yaml
+++ b/deploy/osd-fedramp-token-scraper/config.yaml
@@ -1,7 +1,0 @@
-deploymentMode: SelectorSyncSet
-selectorSyncSet:
-  matchLabels:
-    api.openshift.com/fedramp: "true"
-    ext-managed.openshift.io/hive-shard: "true"
-  resourceApplyMode: "Sync"
-  matchLabelsApplyMode: "AND"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7960,26 +7960,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-fedramp-token-scraper
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/fedramp: 'true'
-        ext-managed.openshift.io/hive-shard: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-sre-token-scraper
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-gcp-ssd-storage
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7960,26 +7960,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-fedramp-token-scraper
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/fedramp: 'true'
-        ext-managed.openshift.io/hive-shard: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-sre-token-scraper
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-gcp-ssd-storage
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7960,26 +7960,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-fedramp-token-scraper
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-        api.openshift.com/fedramp: 'true'
-        ext-managed.openshift.io/hive-shard: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-sre-token-scraper
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-gcp-ssd-storage
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-10326 after discussion with AppSRE, since this is targeting hive clusters it should go in app-interface.