### PR TITLE
Add alert for when bz2068601 is effecting a cluster

### DIFF
--- a/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
+++ b/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: custom-etcd-prometheus-rules
+  namespace: openshift-etcd-operator
+spec:
+  groups:
+  - name: etcd
+    rules:
+    - alert: etcdDivergentRevisionsSRE
+      annotations:
+        description: etcd is reporting divergent member revisions,
+          with a standard deviation of {{ $value }}.  Members may be
+          stuck or, in extreme circumstances, split brained.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
+        summary: etcd is reporting divergent member revisions.
+      expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s]) > 0
+      for: 3m
+      labels:
+        severity: critical

--- a/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
+++ b/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
@@ -16,4 +16,4 @@ spec:
       for: 3m
       labels:
         severity: critical
-        namespace: openshift-monitoring
+        namespace: openshift-etcd

--- a/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
+++ b/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
@@ -7,12 +7,14 @@ spec:
   groups:
   - name: etcd
     rules:
+    - record: etcd_revision_stddev_sre
+      expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
     - alert: etcdDivergentRevisionsSRE
       annotations:
         message: etcd is reporting divergent member revisions,
           with a standard deviation of {{ $value }}.  Members may be
           stuck or, in extreme circumstances, split brained.
-      expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s]) > 0
+      expr: etcd_revision_stddev_sre > 0
       for: 3m
       labels:
         severity: critical

--- a/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
+++ b/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
@@ -16,4 +16,4 @@ spec:
       for: 3m
       labels:
         severity: critical
-        namespace: openshift-etcd
+        namespace: openshift-etcd-operator

--- a/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
+++ b/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
@@ -9,12 +9,11 @@ spec:
     rules:
     - alert: etcdDivergentRevisionsSRE
       annotations:
-        description: etcd is reporting divergent member revisions,
+        message: etcd is reporting divergent member revisions,
           with a standard deviation of {{ $value }}.  Members may be
           stuck or, in extreme circumstances, split brained.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
-        summary: etcd is reporting divergent member revisions.
       expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s]) > 0
       for: 3m
       labels:
         severity: critical
+        namespace: openshift-monitoring

--- a/deploy/bz2068601/OWNERS
+++ b/deploy/bz2068601/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+- jewzaam
+- csheremeta

--- a/deploy/bz2068601/README.md
+++ b/deploy/bz2068601/README.md
@@ -1,0 +1,4 @@
+References:
+* [BZ 2068601](https://bugzilla.redhat.com/show_bug.cgi?id=2068601)
+* [KCS](https://access.redhat.com/solutions/6849521)
+

--- a/deploy/bz2068601/config.yaml
+++ b/deploy/bz2068601/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.9","4.10"]
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4180,7 +4180,7 @@ objects:
             for: 3m
             labels:
               severity: critical
-              namespace: openshift-etcd
+              namespace: openshift-etcd-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4170,13 +4170,14 @@ objects:
         groups:
         - name: etcd
           rules:
+          - record: etcd_revision_stddev_sre
+            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
           - alert: etcdDivergentRevisionsSRE
             annotations:
               message: etcd is reporting divergent member revisions, with a standard
                 deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
                 split brained.
-            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
-              > 0
+            expr: etcd_revision_stddev_sre > 0
             for: 3m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4148,6 +4148,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2068601
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.9'
+        - '4.10'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: custom-etcd-prometheus-rules
+        namespace: openshift-etcd-operator
+      spec:
+        groups:
+        - name: etcd
+          rules:
+          - alert: etcdDivergentRevisionsSRE
+            annotations:
+              description: etcd is reporting divergent member revisions, with a standard
+                deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
+                split brained.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
+              summary: etcd is reporting divergent member revisions.
+            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
+              > 0
+            for: 3m
+            labels:
+              severity: critical
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4180,7 +4180,7 @@ objects:
             for: 3m
             labels:
               severity: critical
-              namespace: openshift-monitoring
+              namespace: openshift-etcd
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4172,16 +4172,15 @@ objects:
           rules:
           - alert: etcdDivergentRevisionsSRE
             annotations:
-              description: etcd is reporting divergent member revisions, with a standard
+              message: etcd is reporting divergent member revisions, with a standard
                 deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
                 split brained.
-              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
-              summary: etcd is reporting divergent member revisions.
             expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
               > 0
             for: 3m
             labels:
               severity: critical
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4180,7 +4180,7 @@ objects:
             for: 3m
             labels:
               severity: critical
-              namespace: openshift-etcd
+              namespace: openshift-etcd-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4170,13 +4170,14 @@ objects:
         groups:
         - name: etcd
           rules:
+          - record: etcd_revision_stddev_sre
+            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
           - alert: etcdDivergentRevisionsSRE
             annotations:
               message: etcd is reporting divergent member revisions, with a standard
                 deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
                 split brained.
-            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
-              > 0
+            expr: etcd_revision_stddev_sre > 0
             for: 3m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4148,6 +4148,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2068601
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.9'
+        - '4.10'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: custom-etcd-prometheus-rules
+        namespace: openshift-etcd-operator
+      spec:
+        groups:
+        - name: etcd
+          rules:
+          - alert: etcdDivergentRevisionsSRE
+            annotations:
+              description: etcd is reporting divergent member revisions, with a standard
+                deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
+                split brained.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
+              summary: etcd is reporting divergent member revisions.
+            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
+              > 0
+            for: 3m
+            labels:
+              severity: critical
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4180,7 +4180,7 @@ objects:
             for: 3m
             labels:
               severity: critical
-              namespace: openshift-monitoring
+              namespace: openshift-etcd
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4172,16 +4172,15 @@ objects:
           rules:
           - alert: etcdDivergentRevisionsSRE
             annotations:
-              description: etcd is reporting divergent member revisions, with a standard
+              message: etcd is reporting divergent member revisions, with a standard
                 deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
                 split brained.
-              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
-              summary: etcd is reporting divergent member revisions.
             expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
               > 0
             for: 3m
             labels:
               severity: critical
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4180,7 +4180,7 @@ objects:
             for: 3m
             labels:
               severity: critical
-              namespace: openshift-etcd
+              namespace: openshift-etcd-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4170,13 +4170,14 @@ objects:
         groups:
         - name: etcd
           rules:
+          - record: etcd_revision_stddev_sre
+            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
           - alert: etcdDivergentRevisionsSRE
             annotations:
               message: etcd is reporting divergent member revisions, with a standard
                 deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
                 split brained.
-            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
-              > 0
+            expr: etcd_revision_stddev_sre > 0
             for: 3m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4148,6 +4148,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz2068601
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.9'
+        - '4.10'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: custom-etcd-prometheus-rules
+        namespace: openshift-etcd-operator
+      spec:
+        groups:
+        - name: etcd
+          rules:
+          - alert: etcdDivergentRevisionsSRE
+            annotations:
+              description: etcd is reporting divergent member revisions, with a standard
+                deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
+                split brained.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
+              summary: etcd is reporting divergent member revisions.
+            expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
+              > 0
+            for: 3m
+            labels:
+              severity: critical
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ccs-dedicated-admins
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4180,7 +4180,7 @@ objects:
             for: 3m
             labels:
               severity: critical
-              namespace: openshift-monitoring
+              namespace: openshift-etcd
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4172,16 +4172,15 @@ objects:
           rules:
           - alert: etcdDivergentRevisionsSRE
             annotations:
-              description: etcd is reporting divergent member revisions, with a standard
+              message: etcd is reporting divergent member revisions, with a standard
                 deviation of {{ $value }}.  Members may be stuck or, in extreme circumstances,
                 split brained.
-              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/FIXME
-              summary: etcd is reporting divergent member revisions.
             expr: min_over_time(stddev(max by (pod) (etcd_debugging_mvcc_compact_revision{namespace="openshift-etcd"}))[5m:15s])
               > 0
             for: 3m
             labels:
               severity: critical
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
upstream: https://github.com/openshift/cluster-etcd-operator/pull/774

goal: get in prod for ROSA/OSD reasonably fast, test/bake in stage first