### PR TITLE
OSD-10019 Add metrics for router SLI

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'
+            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total|sre_router_default_available)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/deploy/sre-prometheus/100-sre-router-available.yaml
+++ b/deploy/sre-prometheus/100-sre-router-available.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus:
+    role: recording-rules
+  name: sre-router-available
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-router-available
+    rules:
+    - record: sre_router_default_available
+      expr: kube_deployment_status_replicas_available{namespace="openshift-ingress",deployment="router-default"} > bool 0

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4431,7 +4431,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total|sre_router_default_available)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13660,6 +13660,21 @@ objects:
                 by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
                 }} is expected to fill up within four days. Currently {{ printf "%0.2f"
                 $value }}% is available.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: null
+          role: recording-rules
+        name: sre-router-available
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-router-available
+          rules:
+          - record: sre_router_default_available
+            expr: kube_deployment_status_replicas_available{namespace="openshift-ingress",deployment="router-default"}
+              > bool 0
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4431,7 +4431,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total|sre_router_default_available)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13660,6 +13660,21 @@ objects:
                 by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
                 }} is expected to fill up within four days. Currently {{ printf "%0.2f"
                 $value }}% is available.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: null
+          role: recording-rules
+        name: sre-router-available
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-router-available
+          rules:
+          - record: sre_router_default_available
+            expr: kube_deployment_status_replicas_available{namespace="openshift-ingress",deployment="router-default"}
+              > bool 0
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4431,7 +4431,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total|sre_router_default_available)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13660,6 +13660,21 @@ objects:
                 by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
                 }} is expected to fill up within four days. Currently {{ printf "%0.2f"
                 $value }}% is available.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: null
+          role: recording-rules
+        name: sre-router-available
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-router-available
+          rules:
+          - record: sre_router_default_available
+            expr: kube_deployment_status_replicas_available{namespace="openshift-ingress",deployment="router-default"}
+              > bool 0
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
Adding a prometheus record `sre_router_default_available`.  This records if the number of running router pod >= 1. If there's a least 1 pod running, it will have value 1, otherwise the value is 0.

To calculate the router availability, we can use:
```
avg_over_time(sre_router_default_available[24h])
```