### PR TITLE
Update pending timer for etcdDivergentRevisionsSRE

### DIFF
--- a/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
+++ b/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
@@ -25,10 +25,9 @@ spec:
           {{ $value }} compacted revisions behind pod {{ $labels.max_pod }} on
           instance {{ $labels.max_instance }}. Members may be stuck or, in
           extreme circumstances, split brained.
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDivergentRevisions.md
         summary: etcd is reporting divergent member revisions.
       expr: etcd_revision_stddev_sre > 0
-      for: 10m
+      for: 120m
       labels:
         severity: critical
         namespace: openshift-etcd-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4200,10 +4200,9 @@ objects:
                 }} compacted revisions behind pod {{ $labels.max_pod }} on instance
                 {{ $labels.max_instance }}. Members may be stuck or, in extreme circumstances,
                 split brained.
-              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDivergentRevisions.md
               summary: etcd is reporting divergent member revisions.
             expr: etcd_revision_stddev_sre > 0
-            for: 10m
+            for: 120m
             labels:
               severity: critical
               namespace: openshift-etcd-operator

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4200,10 +4200,9 @@ objects:
                 }} compacted revisions behind pod {{ $labels.max_pod }} on instance
                 {{ $labels.max_instance }}. Members may be stuck or, in extreme circumstances,
                 split brained.
-              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDivergentRevisions.md
               summary: etcd is reporting divergent member revisions.
             expr: etcd_revision_stddev_sre > 0
-            for: 10m
+            for: 120m
             labels:
               severity: critical
               namespace: openshift-etcd-operator

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4200,10 +4200,9 @@ objects:
                 }} compacted revisions behind pod {{ $labels.max_pod }} on instance
                 {{ $labels.max_instance }}. Members may be stuck or, in extreme circumstances,
                 split brained.
-              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-etcd-operator/etcdDivergentRevisions.md
               summary: etcd is reporting divergent member revisions.
             expr: etcd_revision_stddev_sre > 0
-            for: 10m
+            for: 120m
             labels:
               severity: critical
               namespace: openshift-etcd-operator


### PR DESCRIPTION
Update timer for this alert for 10m to 120m, and remove runbook link so that we can create an ops-sop SOP for this.