### PR TITLE
Add visualization  job builds SLI in Grafana [OSD 9951]

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    enableUserWorkload: true 
+    enableUserWorkload: true
     prometheusK8s:
     # If the location of this config changes,
     # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total)'
+            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/deploy/sre-prometheus/100-sre-build-test-job.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-build-test-job.PrometheusRule.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus:
+    role: recording-rules
+  name: sre-build-test-job
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-build-test-job
+    rules:
+    - record: sre_kube_build_test_job_complete_total
+      expr:  kube_job_complete{namespace="openshift-build-test"}
+
+    - record: sre_kube_build_test_job_succes_total
+      expr:  kube_job_status_succeeded{namespace="openshift-build-test"}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4450,12 +4450,12 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n# If the location\
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
           \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13529,6 +13529,22 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: null
+          role: recording-rules
+        name: sre-build-test-job
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-build-test-job
+          rules:
+          - record: sre_kube_build_test_job_complete_total
+            expr: kube_job_complete{namespace="openshift-build-test"}
+          - record: sre_kube_build_test_job_succes_total
+            expr: kube_job_status_succeeded{namespace="openshift-build-test"}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4450,12 +4450,12 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n# If the location\
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
           \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13529,6 +13529,22 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: null
+          role: recording-rules
+        name: sre-build-test-job
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-build-test-job
+          rules:
+          - record: sre_kube_build_test_job_complete_total
+            expr: kube_job_complete{namespace="openshift-build-test"}
+          - record: sre_kube_build_test_job_succes_total
+            expr: kube_job_status_succeeded{namespace="openshift-build-test"}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4450,12 +4450,12 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true \nprometheusK8s:\n# If the location\
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
           \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|sre_kube_build_test_job_complete_total|sre_kube_build_test_job_succes_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13529,6 +13529,22 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: null
+          role: recording-rules
+        name: sre-build-test-job
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-build-test-job
+          rules:
+          - record: sre_kube_build_test_job_complete_total
+            expr: kube_job_complete{namespace="openshift-build-test"}
+          - record: sre_kube_build_test_job_succes_total
+            expr: kube_job_status_succeeded{namespace="openshift-build-test"}
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
This will resolve OSD-9951, It was reverted twice, were getting alert `PrometheusRemoteStorageFailures WARNING (1)`. I have tested this on 4 stage clusters, slack thread for same https://coreos.slack.com/archives/CFJD1NZFT/p1648774196129329.

For this we have added one Promrule and regex for getting 2 metrics for creating SLI for Kube Job Builds for namespace openshit-build-test