### PR TITLE
MTSRE-470 | added additional permissions for sre-ing ocs consumer and provider addons

### DIFF
--- a/deploy/backplane/mtsre/ocs-consumer/01-mtsre-ocs-consumer-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/01-mtsre-ocs-consumer-cr-admins.ClusterRole.yml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-mtsre-ocs-consumer-cr-admins
+rules:
+  - apiGroups:
+    - "ocs.openshift.io"
+    resources:
+      - "storageclassclaims"
+      - "storageconsumers"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+    - "noobaa.io"
+    resources:
+      - "noobaaaccounts"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+    - "ceph.rook.io"
+    resources:
+      - "cephbucketnotifications"
+      - "cephbuckettopics"
+      - "cephfilesystemsubvolumegroups"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+    - "csiaddons.openshift.io"
+    resources:
+      - "csiaddonsnodes"
+      - "networkfences"
+      - "reclaimspacecronjobs"
+      - "reclaimspacejobs"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update

--- a/deploy/backplane/mtsre/ocs-consumer/01-mtsre-ocs-consumer-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/01-mtsre-ocs-consumer-cr-admins.ClusterRole.yml
@@ -4,6 +4,16 @@ metadata:
   name: backplane-mtsre-ocs-consumer-cr-admins
 rules:
   - apiGroups:
+      - "odf.openshift.io"
+    resources:
+      - "storagesystems"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
       - "ocs.openshift.io"
     resources:
       - "storageclassclaims"

--- a/deploy/backplane/mtsre/ocs-consumer/01-mtsre-ocs-consumer-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/01-mtsre-ocs-consumer-cr-admins.ClusterRole.yml
@@ -4,7 +4,7 @@ metadata:
   name: backplane-mtsre-ocs-consumer-cr-admins
 rules:
   - apiGroups:
-    - "ocs.openshift.io"
+      - "ocs.openshift.io"
     resources:
       - "storageclassclaims"
       - "storageconsumers"
@@ -15,7 +15,7 @@ rules:
       - patch
       - update
   - apiGroups:
-    - "noobaa.io"
+      - "noobaa.io"
     resources:
       - "noobaaaccounts"
     verbs:
@@ -25,7 +25,7 @@ rules:
       - patch
       - update
   - apiGroups:
-    - "ceph.rook.io"
+      - "ceph.rook.io"
     resources:
       - "cephbucketnotifications"
       - "cephbuckettopics"
@@ -37,7 +37,7 @@ rules:
       - patch
       - update
   - apiGroups:
-    - "csiaddons.openshift.io"
+      - "csiaddons.openshift.io"
     resources:
       - "csiaddonsnodes"
       - "networkfences"

--- a/deploy/backplane/mtsre/ocs-consumer/10-mtsre-ocs-consumer-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/10-mtsre-ocs-consumer-admins.SubjectPermission.yml
@@ -8,5 +8,8 @@ spec:
   - allowFirst: true
     clusterRoleName: admin
     namespacesAllowedRegex: (^openshift-storage$)
+  - allowFirst: true
+    clusterRoleName: backplane-mtsre-ocs-consumer-cr-admins
+    namespacesAllowedRegex: (^openshift-storage$)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/deploy/backplane/mtsre/ocs-provider/01-mtsre-ocs-provider-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-provider/01-mtsre-ocs-provider-cr-admins.ClusterRole.yml
@@ -4,7 +4,7 @@ metadata:
   name: backplane-mtsre-ocs-provider-cr-admins
 rules:
   - apiGroups:
-    - "ocs.openshift.io"
+      - "ocs.openshift.io"
     resources:
       - "storageclassclaims"
       - "storageconsumers"
@@ -15,7 +15,7 @@ rules:
       - patch
       - update
   - apiGroups:
-    - "noobaa.io"
+      - "noobaa.io"
     resources:
       - "noobaaaccounts"
     verbs:
@@ -25,7 +25,7 @@ rules:
       - patch
       - update
   - apiGroups:
-    - "ceph.rook.io"
+      - "ceph.rook.io"
     resources:
       - "cephbucketnotifications"
       - "cephbuckettopics"
@@ -37,7 +37,7 @@ rules:
       - patch
       - update
   - apiGroups:
-    - "csiaddons.openshift.io"
+      - "csiaddons.openshift.io"
     resources:
       - "csiaddonsnodes"
       - "networkfences"

--- a/deploy/backplane/mtsre/ocs-provider/01-mtsre-ocs-provider-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-provider/01-mtsre-ocs-provider-cr-admins.ClusterRole.yml
@@ -4,6 +4,16 @@ metadata:
   name: backplane-mtsre-ocs-provider-cr-admins
 rules:
   - apiGroups:
+      - "odf.openshift.io"
+    resources:
+      - "storagesystems"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
       - "ocs.openshift.io"
     resources:
       - "storageclassclaims"

--- a/deploy/backplane/mtsre/ocs-provider/01-mtsre-ocs-provider-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-provider/01-mtsre-ocs-provider-cr-admins.ClusterRole.yml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-mtsre-ocs-provider-cr-admins
+rules:
+  - apiGroups:
+    - "ocs.openshift.io"
+    resources:
+      - "storageclassclaims"
+      - "storageconsumers"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+    - "noobaa.io"
+    resources:
+      - "noobaaaccounts"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+    - "ceph.rook.io"
+    resources:
+      - "cephbucketnotifications"
+      - "cephbuckettopics"
+      - "cephfilesystemsubvolumegroups"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+    - "csiaddons.openshift.io"
+    resources:
+      - "csiaddonsnodes"
+      - "networkfences"
+      - "reclaimspacecronjobs"
+      - "reclaimspacejobs"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update

--- a/deploy/backplane/mtsre/ocs-provider/10-mtsre-ocs-provider-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/ocs-provider/10-mtsre-ocs-provider-admins.SubjectPermission.yml
@@ -8,5 +8,8 @@ spec:
   - allowFirst: true
     clusterRoleName: admin
     namespacesAllowedRegex: (^openshift-storage$)
+  - allowFirst: true
+    clusterRoleName: backplane-mtsre-ocs-provider-cr-admins
+    namespacesAllowedRegex: (^openshift-storage$)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3342,6 +3342,16 @@ objects:
         name: backplane-mtsre-ocs-consumer-cr-admins
       rules:
       - apiGroups:
+        - odf.openshift.io
+        resources:
+        - storagesystems
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
         - ocs.openshift.io
         resources:
         - storageclassclaims
@@ -3449,6 +3459,16 @@ objects:
       metadata:
         name: backplane-mtsre-ocs-provider-cr-admins
       rules:
+      - apiGroups:
+        - odf.openshift.io
+        resources:
+        - storagesystems
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
       - apiGroups:
         - ocs.openshift.io
         resources:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3336,6 +3336,57 @@ objects:
         api.openshift.com/addon-ocs-consumer: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mtsre-ocs-consumer-cr-admins
+      rules:
+      - apiGroups:
+        - ocs.openshift.io
+        resources:
+        - storageclassclaims
+        - storageconsumers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - noobaaaccounts
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - ceph.rook.io
+        resources:
+        - cephbucketnotifications
+        - cephbuckettopics
+        - cephfilesystemsubvolumegroups
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - csiaddons.openshift.io
+        resources:
+        - csiaddonsnodes
+        - networkfences
+        - reclaimspacecronjobs
+        - reclaimspacejobs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3345,6 +3396,9 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-storage$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-ocs-consumer-cr-admins
           namespacesAllowedRegex: (^openshift-storage$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3390,6 +3444,57 @@ objects:
         api.openshift.com/addon-ocs-provider: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mtsre-ocs-provider-cr-admins
+      rules:
+      - apiGroups:
+        - ocs.openshift.io
+        resources:
+        - storageclassclaims
+        - storageconsumers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - noobaaaccounts
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - ceph.rook.io
+        resources:
+        - cephbucketnotifications
+        - cephbuckettopics
+        - cephfilesystemsubvolumegroups
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - csiaddons.openshift.io
+        resources:
+        - csiaddonsnodes
+        - networkfences
+        - reclaimspacecronjobs
+        - reclaimspacejobs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3399,6 +3504,9 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-storage$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-ocs-provider-cr-admins
           namespacesAllowedRegex: (^openshift-storage$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3342,6 +3342,16 @@ objects:
         name: backplane-mtsre-ocs-consumer-cr-admins
       rules:
       - apiGroups:
+        - odf.openshift.io
+        resources:
+        - storagesystems
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
         - ocs.openshift.io
         resources:
         - storageclassclaims
@@ -3449,6 +3459,16 @@ objects:
       metadata:
         name: backplane-mtsre-ocs-provider-cr-admins
       rules:
+      - apiGroups:
+        - odf.openshift.io
+        resources:
+        - storagesystems
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
       - apiGroups:
         - ocs.openshift.io
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3336,6 +3336,57 @@ objects:
         api.openshift.com/addon-ocs-consumer: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mtsre-ocs-consumer-cr-admins
+      rules:
+      - apiGroups:
+        - ocs.openshift.io
+        resources:
+        - storageclassclaims
+        - storageconsumers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - noobaaaccounts
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - ceph.rook.io
+        resources:
+        - cephbucketnotifications
+        - cephbuckettopics
+        - cephfilesystemsubvolumegroups
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - csiaddons.openshift.io
+        resources:
+        - csiaddonsnodes
+        - networkfences
+        - reclaimspacecronjobs
+        - reclaimspacejobs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3345,6 +3396,9 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-storage$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-ocs-consumer-cr-admins
           namespacesAllowedRegex: (^openshift-storage$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3390,6 +3444,57 @@ objects:
         api.openshift.com/addon-ocs-provider: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mtsre-ocs-provider-cr-admins
+      rules:
+      - apiGroups:
+        - ocs.openshift.io
+        resources:
+        - storageclassclaims
+        - storageconsumers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - noobaaaccounts
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - ceph.rook.io
+        resources:
+        - cephbucketnotifications
+        - cephbuckettopics
+        - cephfilesystemsubvolumegroups
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - csiaddons.openshift.io
+        resources:
+        - csiaddonsnodes
+        - networkfences
+        - reclaimspacecronjobs
+        - reclaimspacejobs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3399,6 +3504,9 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-storage$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-ocs-provider-cr-admins
           namespacesAllowedRegex: (^openshift-storage$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3342,6 +3342,16 @@ objects:
         name: backplane-mtsre-ocs-consumer-cr-admins
       rules:
       - apiGroups:
+        - odf.openshift.io
+        resources:
+        - storagesystems
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
         - ocs.openshift.io
         resources:
         - storageclassclaims
@@ -3449,6 +3459,16 @@ objects:
       metadata:
         name: backplane-mtsre-ocs-provider-cr-admins
       rules:
+      - apiGroups:
+        - odf.openshift.io
+        resources:
+        - storagesystems
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
       - apiGroups:
         - ocs.openshift.io
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3336,6 +3336,57 @@ objects:
         api.openshift.com/addon-ocs-consumer: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mtsre-ocs-consumer-cr-admins
+      rules:
+      - apiGroups:
+        - ocs.openshift.io
+        resources:
+        - storageclassclaims
+        - storageconsumers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - noobaaaccounts
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - ceph.rook.io
+        resources:
+        - cephbucketnotifications
+        - cephbuckettopics
+        - cephfilesystemsubvolumegroups
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - csiaddons.openshift.io
+        resources:
+        - csiaddonsnodes
+        - networkfences
+        - reclaimspacecronjobs
+        - reclaimspacejobs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3345,6 +3396,9 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-storage$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-ocs-consumer-cr-admins
           namespacesAllowedRegex: (^openshift-storage$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3390,6 +3444,57 @@ objects:
         api.openshift.com/addon-ocs-provider: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mtsre-ocs-provider-cr-admins
+      rules:
+      - apiGroups:
+        - ocs.openshift.io
+        resources:
+        - storageclassclaims
+        - storageconsumers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - noobaaaccounts
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - ceph.rook.io
+        resources:
+        - cephbucketnotifications
+        - cephbuckettopics
+        - cephfilesystemsubvolumegroups
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - csiaddons.openshift.io
+        resources:
+        - csiaddonsnodes
+        - networkfences
+        - reclaimspacecronjobs
+        - reclaimspacejobs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3399,6 +3504,9 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-storage$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-ocs-provider-cr-admins
           namespacesAllowedRegex: (^openshift-storage$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

There are a bunch of CRs which don't get covered under the scope of the `admin` clusterrole, therefore, raising this PR to setup dedicated clusterrole providing access to deal with those PRs.