### PR TITLE
OSD-10734 Add pruning for duplicate OAO servicemonitor

### DIFF
--- a/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
@@ -40,3 +40,20 @@ rules:
   - builds
   verbs:
   - delete
+# service and servicemonitor pruning
+- apiGroups:           
+  - ""                           
+  resources:                                                                                                            
+  - services                                                                                                            
+  verbs:                   
+  - list                           
+  - get                                               
+  - delete                                                                                                                                                                                                                                        
+- apiGroups:                                                                                                                                                                                                                                      
+  - monitoring.coreos.com                                 
+  resources:                                                                                                            
+  - servicemonitors                                                                                                                                                                                                                               
+  verbs:                      
+  - list                                   
+  - get                                                                                                                 
+  - delete

--- a/deploy/sre-pruning/115-pruning-servicemonitors.CronJob.yaml
+++ b/deploy/sre-pruning/115-pruning-servicemonitors.CronJob.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1beta1
+kind: CronJob                                                                                                           
+metadata:   
+  name: services-pruner
+  namespace: openshift-sre-pruning
+spec:        
+  namespace: openshift-sre-pruning
+spec:                                                                                                                   
+  failedJobsHistoryLimit: 5                                                                                                                                                                                                                       
+  successfulJobsHistoryLimit: 3                                                                                                                                                                                                                   
+  concurrencyPolicy: Replace                                                                                            
+  schedule: "*/7 * * * *"                                                                                                                                                                                                                         
+  jobTemplate:                                                                                                          
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+          - name: services-pruner
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - >-
+              oc delete services/ocm-agent-operator-metrics servicemonitors/ocm-agent-operator-metrics
+              --namespace openshift-ocm-agent-operator --ignore-not-found

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13977,6 +13977,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -14076,6 +14092,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/ocm-agent-operator-metrics servicemonitors/ocm-agent-operator-metrics
+                    --namespace openshift-ocm-agent-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13977,6 +13977,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -14076,6 +14092,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/ocm-agent-operator-metrics servicemonitors/ocm-agent-operator-metrics
+                    --namespace openshift-ocm-agent-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13977,6 +13977,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -14076,6 +14092,43 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete services/ocm-agent-operator-metrics servicemonitors/ocm-agent-operator-metrics
+                    --namespace openshift-ocm-agent-operator --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
In [OSD-9942](https://issues.redhat.com/browse/OSD-9942) we added metrics to the `ocm-agent-operator`, but a consequence of this was that we needed to change the name of OAO's `service` and `servicemonitor` to not be `ocm-agent-operator-metrics`. This change, when promoted, will leave an orphaned service and servicemonitor with those name on Production clusters.

This MCC PR is a reinstatement of a similar pruning cronjob (commit 8a4fee6c), modified to clean up these orphaned resources and prevent them from causing `TargetDown` alerts.

It will be removed upon successful execution.

refs [OSD-10734](https://issues.redhat.com/browse/OSD-10734)