### PR TITLE
updated OWNER_ALIASES to reflect state of roles

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,28 +5,26 @@ aliases:
     - dustman9000
     - fahlmant
     - jaybeeunix
-    - jharrington22
     - mrbarge
-    - NautiluX
     - rafael-azevedo
-    - rogbas
     - wanghaoran1988
     - blrm
+	- iamkirkbater
   srep-team-leads:
     - cblecker
     - dofinn
     - jharrington22
     - mwoodson
+    - NautiluX
+    - rogbas
   sre-alert-sme:
     - ravitri
     - jeremyeder
     - wanghaoran1988
-    - RiRa12621
     - boranx
     - dofinn
     - rogbas
   sre-mst-observatorium:
     - jeremyeder
-    - RiRa12621
     - jharrington22
     - dofinn

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,7 +9,7 @@ aliases:
     - rafael-azevedo
     - wanghaoran1988
     - blrm
-	- iamkirkbater
+    - iamkirkbater
   srep-team-leads:
     - cblecker
     - dofinn

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@ aliases:
   srep-functional-leads:
     - dustman9000
     - fahlmant
-    - jaybeeunix
     - mrbarge
     - rafael-azevedo
     - wanghaoran1988


### PR DESCRIPTION
This PR updates OWNER_ALIASES to reflect true state of roles within teams. Engineers whom have left team/RH have also been removed. 