### PR TITLE
Add control plane leader election alert

### DIFF
--- a/deploy/sre-prometheus/100-control-plan-leader-election-status.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plan-leader-election-status.PrometheusRule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-leader-election-master-status-alerts
+    role: alert-rules
+  name: sre-leader-election-master-status-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-leader-election-master-status-alerts
+    rules:
+    - alert: ControlPlaneLeaderElectionFailingSRE
+      expr: sum(leader_election_master_status{container=~"kube-scheduler|provisioner-kube-rbac-proxy|kube-controller-manager" }) by (container) < 1
+      for: 10m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+      annotations:
+        message: "Control plane has failing leader election for 10 minutes and should be scaled to support cluster."
+        link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ControlPlaneLeaderElectionFailingSRE.md

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13054,6 +13054,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-leader-election-master-status-alerts
+          role: alert-rules
+        name: sre-leader-election-master-status-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-leader-election-master-status-alerts
+          rules:
+          - alert: ControlPlaneLeaderElectionFailingSRE
+            expr: sum(leader_election_master_status{container=~"kube-scheduler|provisioner-kube-rbac-proxy|kube-controller-manager"
+              }) by (container) < 1
+            for: 10m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Control plane has failing leader election for 10 minutes and
+                should be scaled to support cluster.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ControlPlaneLeaderElectionFailingSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-control-plane-resizing-alerts
           role: alert-rules
         name: sre-control-plane-resizing-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13054,6 +13054,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-leader-election-master-status-alerts
+          role: alert-rules
+        name: sre-leader-election-master-status-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-leader-election-master-status-alerts
+          rules:
+          - alert: ControlPlaneLeaderElectionFailingSRE
+            expr: sum(leader_election_master_status{container=~"kube-scheduler|provisioner-kube-rbac-proxy|kube-controller-manager"
+              }) by (container) < 1
+            for: 10m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Control plane has failing leader election for 10 minutes and
+                should be scaled to support cluster.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ControlPlaneLeaderElectionFailingSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-control-plane-resizing-alerts
           role: alert-rules
         name: sre-control-plane-resizing-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13054,6 +13054,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-leader-election-master-status-alerts
+          role: alert-rules
+        name: sre-leader-election-master-status-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-leader-election-master-status-alerts
+          rules:
+          - alert: ControlPlaneLeaderElectionFailingSRE
+            expr: sum(leader_election_master_status{container=~"kube-scheduler|provisioner-kube-rbac-proxy|kube-controller-manager"
+              }) by (container) < 1
+            for: 10m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: Control plane has failing leader election for 10 minutes and
+                should be scaled to support cluster.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ControlPlaneLeaderElectionFailingSRE.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-control-plane-resizing-alerts
           role: alert-rules
         name: sre-control-plane-resizing-alerts


### PR DESCRIPTION
This PR adds a prometheusRule CR to introduce a new alert to our fleet: controlPlaneLeaderElectionFailingSRE. This alert has a severity=warning and will trigger if leader elections are failing for more than 10 minutes. SOP is work in progress.