### PR TITLE
OSD-10920 add job to set proxy for token-refresher

### DIFF
--- a/deploy/osd-set-token-refresher-proxy/00-osd-set-token-refresher-proxy.ServiceAccount.yaml
+++ b/deploy/osd-set-token-refresher-proxy/00-osd-set-token-refresher-proxy.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-set-token-refresher-proxy
+  namespace: openshift-monitoring

--- a/deploy/osd-set-token-refresher-proxy/01-osd-set-token-refresher-proxy.ClusterRole.yaml
+++ b/deploy/osd-set-token-refresher-proxy/01-osd-set-token-refresher-proxy.ClusterRole.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-set-token-refresher-proxy
+rules:
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - proxies
+  verbs:
+    - get
+    - list

--- a/deploy/osd-set-token-refresher-proxy/02-osd-set-token-refresher-proxy.ClusterRoleBinding.yaml
+++ b/deploy/osd-set-token-refresher-proxy/02-osd-set-token-refresher-proxy.ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-set-token-refresher-proxy
+subjects:
+- kind: ServiceAccount
+  name: osd-set-token-refresher-proxy
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-set-token-refresher-proxy

--- a/deploy/osd-set-token-refresher-proxy/03-osd-set-token-refresher-proxy-openshift-monitoring.Role.yaml
+++ b/deploy/osd-set-token-refresher-proxy/03-osd-set-token-refresher-proxy-openshift-monitoring.Role.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-set-token-refresher-proxy-openshift-monitoring
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update

--- a/deploy/osd-set-token-refresher-proxy/03-osd-set-token-refresher-proxy-openshift-monitoring.RoleBinding.yaml
+++ b/deploy/osd-set-token-refresher-proxy/03-osd-set-token-refresher-proxy-openshift-monitoring.RoleBinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-set-token-refresher-proxy-openshift-monitoring
+  namespace: openshift-monitoring
+subjects:
+- kind: ServiceAccount
+  name: osd-set-token-refresher-proxy
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-set-token-refresher-proxy-openshift-monitoring
+  namespace: openshift-monitoring

--- a/deploy/osd-set-token-refresher-proxy/10-osd-set-token-refresher-proxy.CronJob.yaml
+++ b/deploy/osd-set-token-refresher-proxy/10-osd-set-token-refresher-proxy.CronJob.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: osd-set-token-refresher-proxy
+  namespace: openshift-monitoring
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 900
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: "node-role.kubernetes.io/infra"
+                    operator: Exists
+          tolerations:
+          - operator: Exists
+            key: node-role.kubernetes.io/infra
+            effect: NoSchedule
+          serviceAccountName: osd-set-token-refresher-proxy
+          restartPolicy: Never
+          containers:
+          - name: osd-set-token-refresher-proxy
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            env:
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+              - name: POD_NS
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+            command:
+            - /bin/bash
+            - -c
+            - |
+              # ensure we fail if something exits non-zero
+              set -o errexit
+              set -o nounset
+
+              # extract currently set proxy from the cluster or empty string if not set
+              HTTP_PROXY=$(oc get proxy cluster -o jsonpath='{.status.httpProxy}')
+              HTTPS_PROXY=$(oc get proxy cluster -o jsonpath='{.status.httpsProxy}')
+              NO_PROXY=$(oc get proxy cluster -o jsonpath='{.status.noProxy}')
+              
+              echo "$(date): Setting proxy env to HTTP_PROXY='${HTTP_PROXY}' HTTPS_PROXY='${HTTPS_PROXY}' NO_PROXY='${NO_PROXY}'"
+              oc set env -n openshift-monitoring deploy/token-refresher --containers="token-refresher" HTTP_PROXY="${HTTP_PROXY}" HTTPS_PROXY="${HTTPS_PROXY}" NO_PROXY="${NO_PROXY}"
+
+              exit 0

--- a/deploy/osd-set-token-refresher-proxy/OWNERS
+++ b/deploy/osd-set-token-refresher-proxy/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- mrbarge

--- a/deploy/osd-set-token-refresher-proxy/README.md
+++ b/deploy/osd-set-token-refresher-proxy/README.md
@@ -1,0 +1,5 @@
+# Setting cluster-wide proxy for token-refresher
+
+This sets up a CronJob to monitor the state of the cluster's cluster-wide proxy and apply appropriate environment variables to the `token-refresher` job to allow it to use the proxy.
+
+If the cluster is not configured with a proxy, the environment variables in the `token-refresher` will be set with an empty value which will have the same effect as not using a proxy at all.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10975,6 +10975,149 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-set-token-refresher-proxy
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-set-token-refresher-proxy
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - proxies
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-set-token-refresher-proxy
+      subjects:
+      - kind: ServiceAccount
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-set-token-refresher-proxy
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/15 * * * *'
+        jobTemplate:
+          spec:
+            activeDeadlineSeconds: 900
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                tolerations:
+                - operator: Exists
+                  key: node-role.kubernetes.io/infra
+                  effect: NoSchedule
+                serviceAccountName: osd-set-token-refresher-proxy
+                restartPolicy: Never
+                containers:
+                - name: osd-set-token-refresher-proxy
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  env:
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: POD_NS
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  command:
+                  - /bin/bash
+                  - -c
+                  - '# ensure we fail if something exits non-zero
+
+                    set -o errexit
+
+                    set -o nounset
+
+
+                    # extract currently set proxy from the cluster or empty string
+                    if not set
+
+                    HTTP_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.httpProxy}'')
+
+                    HTTPS_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.httpsProxy}'')
+
+                    NO_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.noProxy}'')
+
+
+                    echo "$(date): Setting proxy env to HTTP_PROXY=''${HTTP_PROXY}''
+                    HTTPS_PROXY=''${HTTPS_PROXY}'' NO_PROXY=''${NO_PROXY}''"
+
+                    oc set env -n openshift-monitoring deploy/token-refresher --containers="token-refresher"
+                    HTTP_PROXY="${HTTP_PROXY}" HTTPS_PROXY="${HTTPS_PROXY}" NO_PROXY="${NO_PROXY}"
+
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-strimzi-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10975,6 +10975,149 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-set-token-refresher-proxy
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-set-token-refresher-proxy
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - proxies
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-set-token-refresher-proxy
+      subjects:
+      - kind: ServiceAccount
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-set-token-refresher-proxy
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/15 * * * *'
+        jobTemplate:
+          spec:
+            activeDeadlineSeconds: 900
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                tolerations:
+                - operator: Exists
+                  key: node-role.kubernetes.io/infra
+                  effect: NoSchedule
+                serviceAccountName: osd-set-token-refresher-proxy
+                restartPolicy: Never
+                containers:
+                - name: osd-set-token-refresher-proxy
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  env:
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: POD_NS
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  command:
+                  - /bin/bash
+                  - -c
+                  - '# ensure we fail if something exits non-zero
+
+                    set -o errexit
+
+                    set -o nounset
+
+
+                    # extract currently set proxy from the cluster or empty string
+                    if not set
+
+                    HTTP_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.httpProxy}'')
+
+                    HTTPS_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.httpsProxy}'')
+
+                    NO_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.noProxy}'')
+
+
+                    echo "$(date): Setting proxy env to HTTP_PROXY=''${HTTP_PROXY}''
+                    HTTPS_PROXY=''${HTTPS_PROXY}'' NO_PROXY=''${NO_PROXY}''"
+
+                    oc set env -n openshift-monitoring deploy/token-refresher --containers="token-refresher"
+                    HTTP_PROXY="${HTTP_PROXY}" HTTPS_PROXY="${HTTPS_PROXY}" NO_PROXY="${NO_PROXY}"
+
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-strimzi-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10975,6 +10975,149 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-set-token-refresher-proxy
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-set-token-refresher-proxy
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - proxies
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-set-token-refresher-proxy
+      subjects:
+      - kind: ServiceAccount
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-set-token-refresher-proxy
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        verbs:
+        - get
+        - list
+        - patch
+        - update
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-set-token-refresher-proxy-openshift-monitoring
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: osd-set-token-refresher-proxy
+        namespace: openshift-monitoring
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/15 * * * *'
+        jobTemplate:
+          spec:
+            activeDeadlineSeconds: 900
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                tolerations:
+                - operator: Exists
+                  key: node-role.kubernetes.io/infra
+                  effect: NoSchedule
+                serviceAccountName: osd-set-token-refresher-proxy
+                restartPolicy: Never
+                containers:
+                - name: osd-set-token-refresher-proxy
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  env:
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: POD_NS
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  command:
+                  - /bin/bash
+                  - -c
+                  - '# ensure we fail if something exits non-zero
+
+                    set -o errexit
+
+                    set -o nounset
+
+
+                    # extract currently set proxy from the cluster or empty string
+                    if not set
+
+                    HTTP_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.httpProxy}'')
+
+                    HTTPS_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.httpsProxy}'')
+
+                    NO_PROXY=$(oc get proxy cluster -o jsonpath=''{.status.noProxy}'')
+
+
+                    echo "$(date): Setting proxy env to HTTP_PROXY=''${HTTP_PROXY}''
+                    HTTPS_PROXY=''${HTTPS_PROXY}'' NO_PROXY=''${NO_PROXY}''"
+
+                    oc set env -n openshift-monitoring deploy/token-refresher --containers="token-refresher"
+                    HTTP_PROXY="${HTTP_PROXY}" HTTPS_PROXY="${HTTPS_PROXY}" NO_PROXY="${NO_PROXY}"
+
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-strimzi-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This adds:
- a new CronJob to `openshift-monitoring` named `osd-set-token-refresher-proxy`
- a supporting ClusterRole/Binding and Role/Binding named `osd-set-token-refresher-proxy`

The goal of the CronJob is to reflect the state of the cluster's cluster-wide-proxy in the `token-refresher` Deployment's environment variable configuration.

If the cluster is not set up with a cluster-wide proxy, the environment variables will be set with an empty value which has the same effect as not using a Proxy.

- I have verified that ClusterSync will not overwrite the environment variables in the Deployment after they are set on-cluster.
- I have verified that `token-refresher` respects the setting of `HTTP_PROXY` and `HTTPS_PROXY` by verifying that it reports errors communicating via a proxy when the proxy is offline.

Refs [OSD-10920](https://issues.redhat.com/browse/OSD-10920)