### PR TITLE
OSD-10740 remove UpgradeNodeScalingFailedSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -30,16 +30,6 @@ spec:
       annotations:
         summary: "cluster check failed"
         description: "basic cluster checks failed on either before the upgrade or after the upgrade"
-    - alert: UpgradeNodeScalingFailedSRE
-      # Alert if the cluster has set its compute capacity scaling failure metric for a ten-minute average window
-      expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
-      for: 10m
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
-      annotations:
-        summary: "node scaling failed"
-        description: "The extra machine/node was not ready before the upgrade started"
     - alert: UpgradeControlPlaneUpgradeTimeoutSRE
       # Alert if the control plane timeout metric has been set for a ten-minute average window
       expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13274,16 +13274,6 @@ objects:
               summary: cluster check failed
               description: basic cluster checks failed on either before the upgrade
                 or after the upgrade
-          - alert: UpgradeNodeScalingFailedSRE
-            expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
-            for: 10m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: node scaling failed
-              description: The extra machine/node was not ready before the upgrade
-                started
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
             expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
             for: 10m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13274,16 +13274,6 @@ objects:
               summary: cluster check failed
               description: basic cluster checks failed on either before the upgrade
                 or after the upgrade
-          - alert: UpgradeNodeScalingFailedSRE
-            expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
-            for: 10m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: node scaling failed
-              description: The extra machine/node was not ready before the upgrade
-                started
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
             expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
             for: 10m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13274,16 +13274,6 @@ objects:
               summary: cluster check failed
               description: basic cluster checks failed on either before the upgrade
                 or after the upgrade
-          - alert: UpgradeNodeScalingFailedSRE
-            expr: avg_over_time(upgradeoperator_scaling_failed[10m]) == 1
-            for: 10m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: node scaling failed
-              description: The extra machine/node was not ready before the upgrade
-                started
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
             expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
             for: 10m


### PR DESCRIPTION
This removes the `managed-upgrade-operator` alert `UpgradeNodeScalingFailedSRE`.

This situation no longer requires SRE intervention, as an upgrade will continue if capacity scaling can't be satisfied (OSD-7108).

Refs [OSD-10740](https://issues.redhat.com//browse/OSD-10740)

Corresponding update to SOPs: https://github.com/openshift/ops-sop/pull/1874
