### PR TITLE
SDCICD-772 osd-cluster-ready++ to allow for new healthy CVO status

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.62-24d189f"
+                managed.openshift.io/version: "v0.1.64-f55bb06"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4"
+              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7111,11 +7111,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.62-24d189f
+              managed.openshift.io/version: v0.1.64-f55bb06
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7111,11 +7111,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.62-24d189f
+              managed.openshift.io/version: v0.1.64-f55bb06
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7111,11 +7111,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.62-24d189f
+              managed.openshift.io/version: v0.1.64-f55bb06
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:330b1af0c510ae3bc52f3174c99cc93637a969c29aee59354c659e15bae410d4
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
Associated MCC PR for this osd-cluster-ready PR https://github.com/openshift/osd-cluster-ready/pull/14
which is due to this osde2e PR https://github.com/openshift/osde2e/pull/1094