### PR TITLE
Add permissions to annotate statefulsets

### DIFF
--- a/deploy/backplane/cssre/redhat-kas-fleetshard/10-mkrts-admins-project.ClusterRole.yml
+++ b/deploy/backplane/cssre/redhat-kas-fleetshard/10-mkrts-admins-project.ClusterRole.yml
@@ -50,3 +50,9 @@ rules:
   - pods/exec
   verbs:
   - create
+- apiGroups:
+  - "apps"
+  resources:
+  - statefulsets
+  verbs:
+  - patch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1681,7 +1681,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
@@ -1760,11 +1760,11 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
-        - patch  
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1839,11 +1839,11 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
-        - patch  
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1918,11 +1918,11 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
-        - patch  
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1680,6 +1680,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1753,6 +1759,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch  
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1826,6 +1838,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch  
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1899,6 +1917,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch  
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1680,6 +1680,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1753,6 +1759,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1826,6 +1838,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1899,6 +1917,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1681,7 +1681,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
@@ -1760,7 +1760,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
@@ -1839,7 +1839,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
@@ -1918,7 +1918,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1680,6 +1680,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1753,6 +1759,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1826,6 +1838,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -1899,6 +1917,12 @@ objects:
         - pods/exec
         verbs:
         - create
+      - apiGroups:
+        - "apps"
+        resources:
+        - statefulsets
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1681,7 +1681,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
@@ -1760,7 +1760,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
@@ -1839,7 +1839,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:
@@ -1918,7 +1918,7 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - "apps"
+        - apps
         resources:
         - statefulsets
         verbs:


### PR DESCRIPTION
SRE currently have to escalate in order to do a rolling restart of Kafka brokers. This is likely a step SRE will need to carry out "regularly" when called upon to troubleshoot kafka issues. 

Jira: https://issues.redhat.com/browse/CSSRE-1975