### PR TITLE
OSD-10326 Returning openshift-sre-token-scraper to FedRAMP

### DIFF
--- a/deploy/osd-fedramp-token-scraper/00-scraper-clusterrole.yaml
+++ b/deploy/osd-fedramp-token-scraper/00-scraper-clusterrole.yaml
@@ -11,3 +11,10 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+      - "hive.openshift.io"
+    resources:
+      - "clusterdeployments"
+    verbs:
+      - get
+      - list

--- a/deploy/osd-fedramp-token-scraper/00-scraper-clusterrole.yaml
+++ b/deploy/osd-fedramp-token-scraper/00-scraper-clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openshift-sre-token-scraper
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+    verbs:
+      - get
+      - list

--- a/deploy/osd-fedramp-token-scraper/00-scraper-namespace.yaml
+++ b/deploy/osd-fedramp-token-scraper/00-scraper-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sre-token-scraper

--- a/deploy/osd-fedramp-token-scraper/10-replacer-role.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-replacer-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-sre-token-replacer
+  namespace: openshift-sre-token-scraper
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - patch

--- a/deploy/osd-fedramp-token-scraper/10-replacer-rolebinding.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-replacer-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-sre-token-replacer
+  namespace: openshift-sre-token-scraper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-sre-token-replacer
+subjects:
+  - kind: ServiceAccount
+    name: openshift-sre-token-scraper
+    namespace: openshift-sre-token-scraper

--- a/deploy/osd-fedramp-token-scraper/10-scraper-clusterrolebinding.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-scraper-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-sre-token-scraper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-sre-token-scraper
+subjects:
+  - kind: ServiceAccount
+    name: openshift-sre-token-scraper
+    namespace: openshift-sre-token-scraper

--- a/deploy/osd-fedramp-token-scraper/10-scraper-serviceaccount.yaml
+++ b/deploy/osd-fedramp-token-scraper/10-scraper-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-sre-token-scraper
+  namespace: openshift-sre-token-scraper
+automountServiceAccountToken: false

--- a/deploy/osd-fedramp-token-scraper/20-scraper-cronjob.yaml
+++ b/deploy/osd-fedramp-token-scraper/20-scraper-cronjob.yaml
@@ -26,12 +26,13 @@ spec:
                 - |
                   readarray -t clusters < <(oc get ns -l "hive.openshift.io/managed=true" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
                   for cluster in "${clusters[@]}";
+                    apiurl="$(oc get cd -n ${cluster} -ojson | jq -r '.items[0].status.apiURL')";
                     do oc get secret -n "${cluster}" -l "hive.openshift.io/secret-type=kubeconfig" -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > "/tmp/${cluster}.config";
                     readarray -t sres < <(oc get sa --kubeconfig "/tmp/${cluster}.config" -n openshift-config -l app=sre-cluster-admin -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
                     for sre in "${sres[@]}";
                       do token=$(oc get secret --kubeconfig "/tmp/${cluster}.config" -n openshift-config -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{$created_by := index .metadata.annotations "kubernetes.io/created-by"}}{{if not $created_by}}{{ $sa_name := index .metadata.annotations "kubernetes.io/service-account.name" }}{{ if eq $sa_name "'${sre}'" }}{{ .metadata.name }}{{ "\n" }}{{end}}{{end}}{{ end }}{{end}}');
                       oc delete secret -n openshift-sre-token-scraper "${cluster}-${sre}" --ignore-not-found;
-                      oc create secret generic -n openshift-sre-token-scraper "${cluster}-${sre}" --from-literal=token="$(oc get secret --kubeconfig "/tmp/${cluster}.config" -n openshift-config "${token}" -ojsonpath='{.data.token}' | base64 -d)";
+                      oc create secret generic -n openshift-sre-token-scraper "${cluster}-${sre}" --from-literal=apiserver="${apiurl}" --from-literal=token="$(oc get secret --kubeconfig "/tmp/${cluster}.config" -n openshift-config "${token}" -ojsonpath='{.data.token}' | base64 -d)";
                       oc label secret -n openshift-sre-token-scraper "${cluster}-${sre}" app=openshift-sre-token-scraper;
                     done;
                   done;

--- a/deploy/osd-fedramp-token-scraper/20-scraper-cronjob.yaml
+++ b/deploy/osd-fedramp-token-scraper/20-scraper-cronjob.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: openshift-sre-token-scraper
+  namespace: openshift-sre-token-scraper
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          automountServiceAccountToken: true
+          serviceAccountName: openshift-sre-token-scraper
+          containers:
+            - name: scraper
+              image: "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
+              imagePullPolicy: IfNotPresent
+              command:
+                - 'bash'
+                - '-c'
+              # For each managed cluster, get the admin kubeconfig
+              # For each sre-cluster-admin ServiceAccount, get the associated token
+              # Update the token in-place in hive's openshift-sre-token-scraper namespace
+              args:
+                - |
+                  readarray -t clusters < <(oc get ns -l "hive.openshift.io/managed=true" -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
+                  for cluster in "${clusters[@]}";
+                    do oc get secret -n "${cluster}" -l "hive.openshift.io/secret-type=kubeconfig" -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > "/tmp/${cluster}.config";
+                    readarray -t sres < <(oc get sa --kubeconfig "/tmp/${cluster}.config" -n openshift-config -l app=sre-cluster-admin -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}');
+                    for sre in "${sres[@]}";
+                      do token=$(oc get secret --kubeconfig "/tmp/${cluster}.config" -n openshift-config -o go-template='{{ range .items }}{{ if eq .type "kubernetes.io/service-account-token" }}{{$created_by := index .metadata.annotations "kubernetes.io/created-by"}}{{if not $created_by}}{{ $sa_name := index .metadata.annotations "kubernetes.io/service-account.name" }}{{ if eq $sa_name "'${sre}'" }}{{ .metadata.name }}{{ "\n" }}{{end}}{{end}}{{ end }}{{end}}');
+                      oc delete secret -n openshift-sre-token-scraper "${cluster}-${sre}" --ignore-not-found;
+                      oc create secret generic -n openshift-sre-token-scraper "${cluster}-${sre}" --from-literal=token="$(oc get secret --kubeconfig "/tmp/${cluster}.config" -n openshift-config "${token}" -ojsonpath='{.data.token}' | base64 -d)";
+                      oc label secret -n openshift-sre-token-scraper "${cluster}-${sre}" app=openshift-sre-token-scraper;
+                    done;
+                  done;
+          restartPolicy: OnFailure

--- a/deploy/osd-fedramp-token-scraper/config.yaml
+++ b/deploy/osd-fedramp-token-scraper/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchLabels:
+    api.openshift.com/fedramp: "true"
+    ext-managed.openshift.io/hive-shard: "true"
+  resourceApplyMode: "Sync"
+  matchLabelsApplyMode: "AND"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8412,6 +8412,26 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-fedramp-token-scraper
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/fedramp: 'true'
+        ext-managed.openshift.io/hive-shard: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-sre-token-scraper
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-gcp-ssd-storage
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8421,10 +8421,114 @@ objects:
         ext-managed.openshift.io/hive-shard: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        - secrets
+        verbs:
+        - get
+        - list
     - apiVersion: v1
       kind: Namespace
       metadata:
         name: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: openshift-sre-token-replacer
+        namespace: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - delete
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: openshift-sre-token-replacer
+        namespace: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: openshift-sre-token-replacer
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: openshift-sre-token-scraper
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      automountServiceAccountToken: false
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      spec:
+        schedule: '*/15 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                automountServiceAccountToken: true
+                serviceAccountName: openshift-sre-token-scraper
+                containers:
+                - name: scraper
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: IfNotPresent
+                  command:
+                  - bash
+                  - -c
+                  args:
+                  - "readarray -t clusters < <(oc get ns -l \"hive.openshift.io/managed=true\"\
+                    \ -o go-template='{{range .items}}{{.metadata.name}}{{\"\\n\"\
+                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  do oc get\
+                    \ secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
+                    \ -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > \"/tmp/${cluster}.config\"\
+                    ;\n  readarray -t sres < <(oc get sa --kubeconfig \"/tmp/${cluster}.config\"\
+                    \ -n openshift-config -l app=sre-cluster-admin -o go-template='{{range\
+                    \ .items}}{{.metadata.name}}{{\"\\n\"}}{{end}}');\n  for sre in\
+                    \ \"${sres[@]}\";\n    do token=$(oc get secret --kubeconfig \"\
+                    /tmp/${cluster}.config\" -n openshift-config -o go-template='{{\
+                    \ range .items }}{{ if eq .type \"kubernetes.io/service-account-token\"\
+                    \ }}{{$created_by := index .metadata.annotations \"kubernetes.io/created-by\"\
+                    }}{{if not $created_by}}{{ $sa_name := index .metadata.annotations\
+                    \ \"kubernetes.io/service-account.name\" }}{{ if eq $sa_name \"\
+                    '${sre}'\" }}{{ .metadata.name }}{{ \"\\n\" }}{{end}}{{end}}{{\
+                    \ end }}{{end}}');\n    oc delete secret -n openshift-sre-token-scraper\
+                    \ \"${cluster}-${sre}\" --ignore-not-found;\n    oc create secret\
+                    \ generic -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
+                    \ --from-literal=token=\"$(oc get secret --kubeconfig \"/tmp/${cluster}.config\"\
+                    \ -n openshift-config \"${token}\" -ojsonpath='{.data.token}'\
+                    \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
+                    \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
+                    done;\n"
+                restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8434,6 +8434,13 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
     - apiVersion: v1
       kind: Namespace
       metadata:
@@ -8507,8 +8514,9 @@ objects:
                   args:
                   - "readarray -t clusters < <(oc get ns -l \"hive.openshift.io/managed=true\"\
                     \ -o go-template='{{range .items}}{{.metadata.name}}{{\"\\n\"\
-                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  do oc get\
-                    \ secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
+                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  apiurl=\"\
+                    $(oc get cd -n ${cluster} -ojson | jq -r '.items[0].status.apiURL')\"\
+                    ;\n  do oc get secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
                     \ -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > \"/tmp/${cluster}.config\"\
                     ;\n  readarray -t sres < <(oc get sa --kubeconfig \"/tmp/${cluster}.config\"\
                     \ -n openshift-config -l app=sre-cluster-admin -o go-template='{{range\
@@ -8523,11 +8531,11 @@ objects:
                     \ end }}{{end}}');\n    oc delete secret -n openshift-sre-token-scraper\
                     \ \"${cluster}-${sre}\" --ignore-not-found;\n    oc create secret\
                     \ generic -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
-                    \ --from-literal=token=\"$(oc get secret --kubeconfig \"/tmp/${cluster}.config\"\
-                    \ -n openshift-config \"${token}\" -ojsonpath='{.data.token}'\
-                    \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
-                    \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
-                    done;\n"
+                    \ --from-literal=apiserver=\"${apiurl}\" --from-literal=token=\"\
+                    $(oc get secret --kubeconfig \"/tmp/${cluster}.config\" -n openshift-config\
+                    \ \"${token}\" -ojsonpath='{.data.token}' | base64 -d)\";\n  \
+                    \  oc label secret -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
+                    \ app=openshift-sre-token-scraper;\n  done;\ndone;\n"
                 restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8412,6 +8412,26 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-fedramp-token-scraper
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/fedramp: 'true'
+        ext-managed.openshift.io/hive-shard: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-sre-token-scraper
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-gcp-ssd-storage
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8421,10 +8421,114 @@ objects:
         ext-managed.openshift.io/hive-shard: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        - secrets
+        verbs:
+        - get
+        - list
     - apiVersion: v1
       kind: Namespace
       metadata:
         name: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: openshift-sre-token-replacer
+        namespace: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - delete
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: openshift-sre-token-replacer
+        namespace: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: openshift-sre-token-replacer
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: openshift-sre-token-scraper
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      automountServiceAccountToken: false
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      spec:
+        schedule: '*/15 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                automountServiceAccountToken: true
+                serviceAccountName: openshift-sre-token-scraper
+                containers:
+                - name: scraper
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: IfNotPresent
+                  command:
+                  - bash
+                  - -c
+                  args:
+                  - "readarray -t clusters < <(oc get ns -l \"hive.openshift.io/managed=true\"\
+                    \ -o go-template='{{range .items}}{{.metadata.name}}{{\"\\n\"\
+                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  do oc get\
+                    \ secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
+                    \ -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > \"/tmp/${cluster}.config\"\
+                    ;\n  readarray -t sres < <(oc get sa --kubeconfig \"/tmp/${cluster}.config\"\
+                    \ -n openshift-config -l app=sre-cluster-admin -o go-template='{{range\
+                    \ .items}}{{.metadata.name}}{{\"\\n\"}}{{end}}');\n  for sre in\
+                    \ \"${sres[@]}\";\n    do token=$(oc get secret --kubeconfig \"\
+                    /tmp/${cluster}.config\" -n openshift-config -o go-template='{{\
+                    \ range .items }}{{ if eq .type \"kubernetes.io/service-account-token\"\
+                    \ }}{{$created_by := index .metadata.annotations \"kubernetes.io/created-by\"\
+                    }}{{if not $created_by}}{{ $sa_name := index .metadata.annotations\
+                    \ \"kubernetes.io/service-account.name\" }}{{ if eq $sa_name \"\
+                    '${sre}'\" }}{{ .metadata.name }}{{ \"\\n\" }}{{end}}{{end}}{{\
+                    \ end }}{{end}}');\n    oc delete secret -n openshift-sre-token-scraper\
+                    \ \"${cluster}-${sre}\" --ignore-not-found;\n    oc create secret\
+                    \ generic -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
+                    \ --from-literal=token=\"$(oc get secret --kubeconfig \"/tmp/${cluster}.config\"\
+                    \ -n openshift-config \"${token}\" -ojsonpath='{.data.token}'\
+                    \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
+                    \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
+                    done;\n"
+                restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8434,6 +8434,13 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
     - apiVersion: v1
       kind: Namespace
       metadata:
@@ -8507,8 +8514,9 @@ objects:
                   args:
                   - "readarray -t clusters < <(oc get ns -l \"hive.openshift.io/managed=true\"\
                     \ -o go-template='{{range .items}}{{.metadata.name}}{{\"\\n\"\
-                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  do oc get\
-                    \ secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
+                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  apiurl=\"\
+                    $(oc get cd -n ${cluster} -ojson | jq -r '.items[0].status.apiURL')\"\
+                    ;\n  do oc get secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
                     \ -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > \"/tmp/${cluster}.config\"\
                     ;\n  readarray -t sres < <(oc get sa --kubeconfig \"/tmp/${cluster}.config\"\
                     \ -n openshift-config -l app=sre-cluster-admin -o go-template='{{range\
@@ -8523,11 +8531,11 @@ objects:
                     \ end }}{{end}}');\n    oc delete secret -n openshift-sre-token-scraper\
                     \ \"${cluster}-${sre}\" --ignore-not-found;\n    oc create secret\
                     \ generic -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
-                    \ --from-literal=token=\"$(oc get secret --kubeconfig \"/tmp/${cluster}.config\"\
-                    \ -n openshift-config \"${token}\" -ojsonpath='{.data.token}'\
-                    \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
-                    \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
-                    done;\n"
+                    \ --from-literal=apiserver=\"${apiurl}\" --from-literal=token=\"\
+                    $(oc get secret --kubeconfig \"/tmp/${cluster}.config\" -n openshift-config\
+                    \ \"${token}\" -ojsonpath='{.data.token}' | base64 -d)\";\n  \
+                    \  oc label secret -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
+                    \ app=openshift-sre-token-scraper;\n  done;\ndone;\n"
                 restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8412,6 +8412,26 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-fedramp-token-scraper
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/fedramp: 'true'
+        ext-managed.openshift.io/hive-shard: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-sre-token-scraper
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-gcp-ssd-storage
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8421,10 +8421,114 @@ objects:
         ext-managed.openshift.io/hive-shard: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        - secrets
+        verbs:
+        - get
+        - list
     - apiVersion: v1
       kind: Namespace
       metadata:
         name: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: openshift-sre-token-replacer
+        namespace: openshift-sre-token-scraper
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - delete
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: openshift-sre-token-replacer
+        namespace: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: openshift-sre-token-replacer
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: openshift-sre-token-scraper
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: openshift-sre-token-scraper
+      subjects:
+      - kind: ServiceAccount
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      automountServiceAccountToken: false
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: openshift-sre-token-scraper
+        namespace: openshift-sre-token-scraper
+      spec:
+        schedule: '*/15 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                automountServiceAccountToken: true
+                serviceAccountName: openshift-sre-token-scraper
+                containers:
+                - name: scraper
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: IfNotPresent
+                  command:
+                  - bash
+                  - -c
+                  args:
+                  - "readarray -t clusters < <(oc get ns -l \"hive.openshift.io/managed=true\"\
+                    \ -o go-template='{{range .items}}{{.metadata.name}}{{\"\\n\"\
+                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  do oc get\
+                    \ secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
+                    \ -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > \"/tmp/${cluster}.config\"\
+                    ;\n  readarray -t sres < <(oc get sa --kubeconfig \"/tmp/${cluster}.config\"\
+                    \ -n openshift-config -l app=sre-cluster-admin -o go-template='{{range\
+                    \ .items}}{{.metadata.name}}{{\"\\n\"}}{{end}}');\n  for sre in\
+                    \ \"${sres[@]}\";\n    do token=$(oc get secret --kubeconfig \"\
+                    /tmp/${cluster}.config\" -n openshift-config -o go-template='{{\
+                    \ range .items }}{{ if eq .type \"kubernetes.io/service-account-token\"\
+                    \ }}{{$created_by := index .metadata.annotations \"kubernetes.io/created-by\"\
+                    }}{{if not $created_by}}{{ $sa_name := index .metadata.annotations\
+                    \ \"kubernetes.io/service-account.name\" }}{{ if eq $sa_name \"\
+                    '${sre}'\" }}{{ .metadata.name }}{{ \"\\n\" }}{{end}}{{end}}{{\
+                    \ end }}{{end}}');\n    oc delete secret -n openshift-sre-token-scraper\
+                    \ \"${cluster}-${sre}\" --ignore-not-found;\n    oc create secret\
+                    \ generic -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
+                    \ --from-literal=token=\"$(oc get secret --kubeconfig \"/tmp/${cluster}.config\"\
+                    \ -n openshift-config \"${token}\" -ojsonpath='{.data.token}'\
+                    \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
+                    \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
+                    done;\n"
+                restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8434,6 +8434,13 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
     - apiVersion: v1
       kind: Namespace
       metadata:
@@ -8507,8 +8514,9 @@ objects:
                   args:
                   - "readarray -t clusters < <(oc get ns -l \"hive.openshift.io/managed=true\"\
                     \ -o go-template='{{range .items}}{{.metadata.name}}{{\"\\n\"\
-                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  do oc get\
-                    \ secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
+                    }}{{end}}');\nfor cluster in \"${clusters[@]}\";\n  apiurl=\"\
+                    $(oc get cd -n ${cluster} -ojson | jq -r '.items[0].status.apiURL')\"\
+                    ;\n  do oc get secret -n \"${cluster}\" -l \"hive.openshift.io/secret-type=kubeconfig\"\
                     \ -o jsonpath='{.items[0].data.kubeconfig}' | base64 -d > \"/tmp/${cluster}.config\"\
                     ;\n  readarray -t sres < <(oc get sa --kubeconfig \"/tmp/${cluster}.config\"\
                     \ -n openshift-config -l app=sre-cluster-admin -o go-template='{{range\
@@ -8523,11 +8531,11 @@ objects:
                     \ end }}{{end}}');\n    oc delete secret -n openshift-sre-token-scraper\
                     \ \"${cluster}-${sre}\" --ignore-not-found;\n    oc create secret\
                     \ generic -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
-                    \ --from-literal=token=\"$(oc get secret --kubeconfig \"/tmp/${cluster}.config\"\
-                    \ -n openshift-config \"${token}\" -ojsonpath='{.data.token}'\
-                    \ | base64 -d)\";\n    oc label secret -n openshift-sre-token-scraper\
-                    \ \"${cluster}-${sre}\" app=openshift-sre-token-scraper;\n  done;\n\
-                    done;\n"
+                    \ --from-literal=apiserver=\"${apiurl}\" --from-literal=token=\"\
+                    $(oc get secret --kubeconfig \"/tmp/${cluster}.config\" -n openshift-config\
+                    \ \"${token}\" -ojsonpath='{.data.token}' | base64 -d)\";\n  \
+                    \  oc label secret -n openshift-sre-token-scraper \"${cluster}-${sre}\"\
+                    \ app=openshift-sre-token-scraper;\n  done;\ndone;\n"
                 restartPolicy: OnFailure
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
Reverted two previous commits:
* 52728d4e76a71c8c427730ee83ece41b9c9561fe
* 47a2ac0e886ea52de248a0a7d00cadcb065e4c56

and then added the kube apiserver URL to the secret itself since the vaulter in qontract-reconcile does not collect that data.