### PR TITLE
Pruning SRE job to warning severity [OSD-10995]

### DIFF
--- a/deploy/sre-prometheus/100-sre-pruning.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-pruning.PrometheusRule.yaml
@@ -14,7 +14,7 @@ spec:
       expr: kube_cronjob_status_active{namespace="openshift-sre-pruning"}>0
       for: 30m
       labels:
-        severity: critical
+        severity: warning
         namespace: openshift-sre-pruning
       annotations:
         message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.cronjob }}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13699,7 +13699,7 @@ objects:
             expr: kube_cronjob_status_active{namespace="openshift-sre-pruning"}>0
             for: 30m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-sre-pruning
             annotations:
               message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.cronjob

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13699,7 +13699,7 @@ objects:
             expr: kube_cronjob_status_active{namespace="openshift-sre-pruning"}>0
             for: 30m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-sre-pruning
             annotations:
               message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.cronjob

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13699,7 +13699,7 @@ objects:
             expr: kube_cronjob_status_active{namespace="openshift-sre-pruning"}>0
             for: 30m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-sre-pruning
             annotations:
               message: SRE Pruning Job {{ $labels.namespace }}/{{ $labels.cronjob


### PR DESCRIPTION
PruningCronjobErrorSRE currently pages SRE with severity of Critical. This alert does not pose immediate danger to data loss or cluster stability. Thus proposal is to reduce this to a warning alert. 