### PR TITLE
Add template for PR [OSD-10996]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### What type of PR is this?
+_(bug/feature/cleanup/documentation)_
+
+### What this PR does / why we need it?
+
+### Which Jira/Github issue(s) this PR fixes?
+
+_Fixes #_
+
+### Special notes for your reviewer:
+
+### Pre-checks (if applicable):
+- [ ] Tested latest changes against a cluster
+- [ ] Included documentation changes with PR
+


### PR DESCRIPTION
There are cases where PRs are submitted with no description. This is poor posture from a compliance perspective. This PR adds a template to encourage engineers to answer standard set of questions when submitted to MCC. 