### PR TITLE
Update osd-cluster-ready Job Image

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.64-f55bb06"
+                managed.openshift.io/version: "v0.1.66-bb79af5"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680"
+              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7111,11 +7111,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.64-f55bb06
+              managed.openshift.io/version: v0.1.66-bb79af5
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7111,11 +7111,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.64-f55bb06
+              managed.openshift.io/version: v0.1.66-bb79af5
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7111,11 +7111,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.64-f55bb06
+              managed.openshift.io/version: v0.1.66-bb79af5
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:1e977ed7e1ceab93b64a8da51ed41fdc9ccfb06b1ce50b29b4d77f9eb622b680
+              image: quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
This updates the osd-cluster-ready job image to pull in the following fixes from osde2e and osd-cluster-ready to fix the healthcheck for jobs with long names:
* https://github.com/openshift/osd-cluster-ready/pull/16
* https://github.com/openshift/osde2e/pull/1100