### PR TITLE
add customer bearer token allowed secrets in openshift-customer-monitoring

### DIFF
--- a/deploy/osd-customer-monitoring/05-prometheus-k8s-role.yaml
+++ b/deploy/osd-customer-monitoring/05-prometheus-k8s-role.yaml
@@ -17,5 +17,10 @@ rules:
   - alertmanager-instance
   - prometheus-auth-proxy
   - alertmanager-auth-proxy
+  - customer-bearer-token-01
+  - customer-bearer-token-02
+  - customer-bearer-token-03
+  - customer-bearer-token-04
+  - customer-bearer-token-05
   verbs:
   - "*"

--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -40,6 +40,11 @@ rules:
   - alertmanager-instance
   - prometheus-auth-proxy
   - alertmanager-auth-proxy
+  - customer-bearer-token-01
+  - customer-bearer-token-02
+  - customer-bearer-token-03
+  - customer-bearer-token-04
+  - customer-bearer-token-05
   verbs:
   - "*"
 - apiGroups:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7652,6 +7652,11 @@ objects:
         - alertmanager-instance
         - prometheus-auth-proxy
         - alertmanager-auth-proxy
+        - customer-bearer-token-01
+        - customer-bearer-token-02
+        - customer-bearer-token-03
+        - customer-bearer-token-04
+        - customer-bearer-token-05
         verbs:
         - '*'
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7603,6 +7603,11 @@ objects:
         - alertmanager-instance
         - prometheus-auth-proxy
         - alertmanager-auth-proxy
+        - customer-bearer-token-01
+        - customer-bearer-token-02
+        - customer-bearer-token-03
+        - customer-bearer-token-04
+        - customer-bearer-token-05
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7652,6 +7652,11 @@ objects:
         - alertmanager-instance
         - prometheus-auth-proxy
         - alertmanager-auth-proxy
+        - customer-bearer-token-01
+        - customer-bearer-token-02
+        - customer-bearer-token-03
+        - customer-bearer-token-04
+        - customer-bearer-token-05
         verbs:
         - '*'
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7603,6 +7603,11 @@ objects:
         - alertmanager-instance
         - prometheus-auth-proxy
         - alertmanager-auth-proxy
+        - customer-bearer-token-01
+        - customer-bearer-token-02
+        - customer-bearer-token-03
+        - customer-bearer-token-04
+        - customer-bearer-token-05
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7652,6 +7652,11 @@ objects:
         - alertmanager-instance
         - prometheus-auth-proxy
         - alertmanager-auth-proxy
+        - customer-bearer-token-01
+        - customer-bearer-token-02
+        - customer-bearer-token-03
+        - customer-bearer-token-04
+        - customer-bearer-token-05
         verbs:
         - '*'
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7603,6 +7603,11 @@ objects:
         - alertmanager-instance
         - prometheus-auth-proxy
         - alertmanager-auth-proxy
+        - customer-bearer-token-01
+        - customer-bearer-token-02
+        - customer-bearer-token-03
+        - customer-bearer-token-04
+        - customer-bearer-token-05
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
There are cases where metrics endpoints need authentication through Bearer tokens. The way to configure a prometheus target with this ability is defining a ServiceMonitor with the BearerTokenSecret attribute pointing to a secret in the same namespace as the ServiceMonitor. Basically the ServiceMonitor needs a reference to a Secret name, and the key to read the bearer token from: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint

The list of Secrets dedicated-admins can create is limited, and this PR adds some "generic" names for customers to be able to manage for this purpose.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/APPSRE-4907

### Special notes for your reviewer:
This is an alternative to #1138