### PR TITLE
enable dedicated-admins to manage secrets in openshift-customer-monitoring

### DIFF
--- a/deploy/osd-customer-monitoring/05-prometheus-k8s-role.yaml
+++ b/deploy/osd-customer-monitoring/05-prometheus-k8s-role.yaml
@@ -8,14 +8,5 @@ rules:
   - ""
   resources:
   - secrets
-  resourceNames:
-  - alertmanager-main
-  - alertmanager-main-proxy
-  - prometheus-additional-scrape-config
-  - prometheus-additional-scrape-config-2
-  - prometheus-additional-alertmanager-config
-  - alertmanager-instance
-  - prometheus-auth-proxy
-  - alertmanager-auth-proxy
   verbs:
   - "*"

--- a/deploy/osd-customer-monitoring/05-role.yaml
+++ b/deploy/osd-customer-monitoring/05-role.yaml
@@ -31,15 +31,6 @@ rules:
   - ""
   resources:
   - secrets
-  resourceNames:
-  - alertmanager-main
-  - alertmanager-main-proxy
-  - prometheus-additional-scrape-config
-  - prometheus-additional-scrape-config-2
-  - prometheus-additional-alertmanager-config
-  - alertmanager-instance
-  - prometheus-auth-proxy
-  - alertmanager-auth-proxy
   verbs:
   - "*"
 - apiGroups:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7594,15 +7594,6 @@ objects:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - alertmanager-main
-        - alertmanager-main-proxy
-        - prometheus-additional-scrape-config
-        - prometheus-additional-scrape-config-2
-        - prometheus-additional-alertmanager-config
-        - alertmanager-instance
-        - prometheus-auth-proxy
-        - alertmanager-auth-proxy
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -7638,15 +7629,6 @@ objects:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - alertmanager-main
-        - alertmanager-main-proxy
-        - prometheus-additional-scrape-config
-        - prometheus-additional-scrape-config-2
-        - prometheus-additional-alertmanager-config
-        - alertmanager-instance
-        - prometheus-auth-proxy
-        - alertmanager-auth-proxy
         verbs:
         - '*'
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7594,15 +7594,6 @@ objects:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - alertmanager-main
-        - alertmanager-main-proxy
-        - prometheus-additional-scrape-config
-        - prometheus-additional-scrape-config-2
-        - prometheus-additional-alertmanager-config
-        - alertmanager-instance
-        - prometheus-auth-proxy
-        - alertmanager-auth-proxy
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -7638,15 +7629,6 @@ objects:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - alertmanager-main
-        - alertmanager-main-proxy
-        - prometheus-additional-scrape-config
-        - prometheus-additional-scrape-config-2
-        - prometheus-additional-alertmanager-config
-        - alertmanager-instance
-        - prometheus-auth-proxy
-        - alertmanager-auth-proxy
         verbs:
         - '*'
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7594,15 +7594,6 @@ objects:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - alertmanager-main
-        - alertmanager-main-proxy
-        - prometheus-additional-scrape-config
-        - prometheus-additional-scrape-config-2
-        - prometheus-additional-alertmanager-config
-        - alertmanager-instance
-        - prometheus-auth-proxy
-        - alertmanager-auth-proxy
         verbs:
         - '*'
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -7638,15 +7629,6 @@ objects:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - alertmanager-main
-        - alertmanager-main-proxy
-        - prometheus-additional-scrape-config
-        - prometheus-additional-scrape-config-2
-        - prometheus-additional-alertmanager-config
-        - alertmanager-instance
-        - prometheus-auth-proxy
-        - alertmanager-auth-proxy
         verbs:
         - '*'
       - apiGroups:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
There are cases where metrics endpoints need authentication through Bearer tokens. The way to configure a prometheus target with this ability is defining a ServiceMonitor with the BearerTokenSecret attribute pointing to a secret in the same namespace as the ServiceMonitor. Basically the ServiceMonitor needs a reference to a Secret name, and the key to read the bearer token from: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint

The list of Secrets only limits cli interaction with the secret, but in reality -
a customer can run any pod they want in the namespace, and that pod can mount any secret it wants, which grants access for a customer to the secret content.

This PR removes the secret name limitation altogether, as it is limiting, but not securing.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/APPSRE-4907

### Special notes for your reviewer:
This is an alternative to #1137