### PR TITLE
enhance UpgradeConfigSyncFailureOver4HrSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -64,7 +64,7 @@ spec:
       # Alert if MUO has been unable to successfully sync with its upgrade policy provider for a four-hour window
       # It will also be used for detecting the connection/authentication between cluster and OCM
       # Should be moved to OCM Agent service eventually
-      expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+      expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod) kube_pod_container_status_ready{container="managed-upgrade-operator", namespace="openshift-managed-upgrade-operator"}
       for: 2m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13568,7 +13568,9 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
+              kube_pod_container_status_ready{container="managed-upgrade-operator",
+              namespace="openshift-managed-upgrade-operator"}
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13568,7 +13568,9 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
+              kube_pod_container_status_ready{container="managed-upgrade-operator",
+              namespace="openshift-managed-upgrade-operator"}
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13568,7 +13568,9 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) == 1
+            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
+              kube_pod_container_status_ready{container="managed-upgrade-operator",
+              namespace="openshift-managed-upgrade-operator"}
             for: 2m
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
This will improve alert `UpgradeConfigSyncFailureOver4HrSRE` so that it will not be triggered for old MUO pod when it gets recreated.
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-9964

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

