### PR TITLE
[OSD-9964] fix alert expression

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -64,7 +64,7 @@ spec:
       # Alert if MUO has been unable to successfully sync with its upgrade policy provider for a four-hour window
       # It will also be used for detecting the connection/authentication between cluster and OCM
       # Should be moved to OCM Agent service eventually
-      expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod) kube_pod_container_status_ready{container="managed-upgrade-operator", namespace="openshift-managed-upgrade-operator"}
+      expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod) kube_pod_container_status_ready{container="managed-upgrade-operator", namespace="openshift-managed-upgrade-operator"} == 1
       for: 2m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13552,7 +13552,7 @@ objects:
           - alert: UpgradeConfigSyncFailureOver4HrSRE
             expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
               kube_pod_container_status_ready{container="managed-upgrade-operator",
-              namespace="openshift-managed-upgrade-operator"}
+              namespace="openshift-managed-upgrade-operator"} == 1
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13552,7 +13552,7 @@ objects:
           - alert: UpgradeConfigSyncFailureOver4HrSRE
             expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
               kube_pod_container_status_ready{container="managed-upgrade-operator",
-              namespace="openshift-managed-upgrade-operator"}
+              namespace="openshift-managed-upgrade-operator"} == 1
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13552,7 +13552,7 @@ objects:
           - alert: UpgradeConfigSyncFailureOver4HrSRE
             expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
               kube_pod_container_status_ready{container="managed-upgrade-operator",
-              namespace="openshift-managed-upgrade-operator"}
+              namespace="openshift-managed-upgrade-operator"} == 1
             for: 2m
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
_fix_

### What this PR does / why we need it?
Currently the alert will be in firing state if the expression is true and returning any value. To fix this we need to set the expression value == 1 so that it will fire once the condition reached to value "1" over 4 hr time period.  

This will be fixing below PR:
 https://github.com/openshift/managed-cluster-config/pull/1139


