### PR TITLE
OSD-1007 Use fixed version of the watcher images in ClamAV workloads

### DIFF
--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -92,7 +92,7 @@ spec:
           value: /clam/clamd.sock
         - name: INFO_SOCKET
           value: '@rpc.sock'
-        image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+        image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
         name: watcher
         resources:
           limits:
@@ -144,7 +144,7 @@ spec:
           value: openshift-scanning
         - name: HOST_SCAN_DIRS
           value: /host
-        image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+        image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
         name: scheduler
         resources:
           limits:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10886,7 +10886,7 @@ objects:
                 value: /clam/clamd.sock
               - name: INFO_SOCKET
                 value: '@rpc.sock'
-              image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+              image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
               name: watcher
               resources:
                 limits:
@@ -10938,7 +10938,7 @@ objects:
                 value: openshift-scanning
               - name: HOST_SCAN_DIRS
                 value: /host
-              image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+              image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
               name: scheduler
               resources:
                 limits:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10886,7 +10886,7 @@ objects:
                 value: /clam/clamd.sock
               - name: INFO_SOCKET
                 value: '@rpc.sock'
-              image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+              image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
               name: watcher
               resources:
                 limits:
@@ -10938,7 +10938,7 @@ objects:
                 value: openshift-scanning
               - name: HOST_SCAN_DIRS
                 value: /host
-              image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+              image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
               name: scheduler
               resources:
                 limits:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10886,7 +10886,7 @@ objects:
                 value: /clam/clamd.sock
               - name: INFO_SOCKET
                 value: '@rpc.sock'
-              image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+              image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
               name: watcher
               resources:
                 limits:
@@ -10938,7 +10938,7 @@ objects:
                 value: openshift-scanning
               - name: HOST_SCAN_DIRS
                 value: /host
-              image: quay.io/app-sre/watcher@sha256:fd417ba6b13e76d00fd9d22417c3d2779fab62e2d8e11253bf6ab22a6f5513d4
+              image: quay.io/app-sre/watcher@sha256:876dda74db09d2da7304d2d6eef62a0fda89c44b03ed68a8c027665e7e471b42
               name: scheduler
               resources:
                 limits:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
It was found that the previous version of this image had a misnamed binary that was preventing it from starting correctly. A new image has been built to remediate that: https://quay.io/repository/app-sre/watcher?tab=tags&tag=latest

### Which Jira/Github issue(s) this PR fixes?
[OSD-10007](https://issues.redhat.com//browse/OSD-10007)

### Special notes for your reviewer:
This change affects FedRAMP only

