### PR TITLE
Add new alert for MNMO reconcile failures.

### DIFF
--- a/deploy/sre-prometheus/100-managed-node-metadata-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-node-metadata-operator.PrometheusRule.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-node-metadata-operator-alerts
+    role: alert-rules
+  name: sre-managed-node-metadata-operator-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-node-metadata-operator-alerts
+    rules:
+    - alert: MNMOTooManyReconcileErrors15MinSRE
+      # If the amount of reconciliation errors in the last 15 minutes is > 5 trigger an alert.
+      # Currently the window is 90 minutes, because the reconcile loop uses some backoff mechanism for retries and with a 90 minute window the alert will keep on firing.
+      expr: increase(controller_runtime_reconcile_total{controller="machineset_controller", service="openshift-managed-node-metadata-operator-metrics-service", result="error"}[90m]) >= 5
+      for: 15m
+      labels:
+        severity: critical
+        namespace: "{{ $labels.namespace }}"
+        maturity: "immature"
+        source: "https://issues.redhat.com//browse/OSD-9911"
+      annotations:
+        message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name }} ) have failed in the past 15 minutes.
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13492,6 +13492,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-node-metadata-operator-alerts
+          role: alert-rules
+        name: sre-managed-node-metadata-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-node-metadata-operator-alerts
+          rules:
+          - alert: MNMOTooManyReconcileErrors15MinSRE
+            expr: increase(controller_runtime_reconcile_total{controller="machineset_controller",
+              service="openshift-managed-node-metadata-operator-metrics-service",
+              result="error"}[90m]) >= 5
+            for: 15m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+              maturity: immature
+              source: https://issues.redhat.com//browse/OSD-9911
+            annotations:
+              message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name
+                }} ) have failed in the past 15 minutes.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-upgrade-operator-alerts
           role: alert-rules
         name: sre-managed-upgrade-operator-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13492,6 +13492,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-node-metadata-operator-alerts
+          role: alert-rules
+        name: sre-managed-node-metadata-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-node-metadata-operator-alerts
+          rules:
+          - alert: MNMOTooManyReconcileErrors15MinSRE
+            expr: increase(controller_runtime_reconcile_total{controller="machineset_controller",
+              service="openshift-managed-node-metadata-operator-metrics-service",
+              result="error"}[90m]) >= 5
+            for: 15m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+              maturity: immature
+              source: https://issues.redhat.com//browse/OSD-9911
+            annotations:
+              message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name
+                }} ) have failed in the past 15 minutes.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-upgrade-operator-alerts
           role: alert-rules
         name: sre-managed-upgrade-operator-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13492,6 +13492,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-node-metadata-operator-alerts
+          role: alert-rules
+        name: sre-managed-node-metadata-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-node-metadata-operator-alerts
+          rules:
+          - alert: MNMOTooManyReconcileErrors15MinSRE
+            expr: increase(controller_runtime_reconcile_total{controller="machineset_controller",
+              service="openshift-managed-node-metadata-operator-metrics-service",
+              result="error"}[90m]) >= 5
+            for: 15m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+              maturity: immature
+              source: https://issues.redhat.com//browse/OSD-9911
+            annotations:
+              message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name
+                }} ) have failed in the past 15 minutes.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-upgrade-operator-alerts
           role: alert-rules
         name: sre-managed-upgrade-operator-alerts


### PR DESCRIPTION
The alert will trigger, when the change rate of errors during
reconciliation exceeds or equals 5 in 5 minutes as perper [OSD-9911](https://issues.redhat.com//browse/OSD-9911).

Merging should probably wait until is merged https://github.com/openshift/ops-sop/pull/1905, so the link to the SOP doesn't point into nothingness.

### What type of PR is this?

Feature

### What this PR does / why we need it?

With the managed-node-metadata-operator making it into production, additional alerting is desired to catch errors early, when the operator fails.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-9911](https://issues.redhat.com//browse/OSD-9911)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

