### PR TITLE
feat(alertmanager): duplicate ES alerts

### DIFF
--- a/deploy/sre-prometheus/100-cluster-proxy.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-cluster-proxy.PrometheusRule.yaml
@@ -17,7 +17,7 @@ spec:
             severity: warning
             namespace: openshift-monitoring
           annotations:
-            message: "Cluster proxy certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degredation and/or unavailability"
+            message: "Cluster proxy certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degradation and/or unavailability"
         - alert: ClusterProxyCAExpiringSRE
           expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time() < 86400 * 15
           for: 10m
@@ -25,7 +25,7 @@ spec:
             severity: critical
             namespace: openshift-monitoring
           annotations:
-            message: "Cluster proxy certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degredation and/or unavailability"
+            message: "Cluster proxy certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degradation and/or unavailability"
         - alert: ClusterProxyCAInvalidSRE
           expr: cluster_proxy_enabled{type="trusted_ca"} > 0 and cluster_proxy_ca_valid{name="osd_exporter"} == 0
           for: 15m

--- a/deploy/sre-prometheus/README.md
+++ b/deploy/sre-prometheus/README.md
@@ -10,7 +10,7 @@ In the basic implementation a couple of questions need to be asked:
 * How much budget can we burn worst case until we're alerted?
 * How fast do we want to recover?
 
-The combinaiton of the first and the last question hints that we always want to be implementing at least a short
+The combination of the first and the last question hints that we always want to be implementing at least a short
 and a long window.
 
 We want to avoid flapping alerts therefore a good time period to chose for a condition to exist

--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -1,0 +1,234 @@
+# taken from f029cca0-fd96-4cde-afa4-77c151c5233d
+# using oc get prometheusrule -n openshift-logging elasticsearch-prometheus-rules -oyaml
+# also:
+# oc get csv -n openshift-logging | grep -i -e elastic -elogging
+# cluster-logging.5.3.5-20        Red Hat OpenShift Logging          5.3.5-20 Succeeded
+# elasticsearch-operator.5.3.5-20 OpenShift Elasticsearch Operator   5.3.5-20 Succeeded
+# and
+# https://catalog.redhat.com/software/containers/openshift-logging/cluster-logging-operator-bundle/5fd22f465d2ec16f0da1e8c8
+# where the current latest version is:
+# ```
+# $ date
+# Sun May  1 16:04:22 IDT 2022
+# $ echo "the version is v5.4.0-138" # there is also 5.4.6-46
+# ...
+# ```
+# created this file via
+# ```
+# A=$(curl -sSLo- https://github.com/openshift/elasticsearch-operator/raw/b5e329a3d9967a4933d94e61a32479407911755d/files/prometheus_alerts.yml) yq '.spec = env(A) | .spec.groups[].rules[].alert += "SRE"' ../../../resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml | yq -P > 101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+# ```
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: elasticsearch-prometheus-rules
+  namespace: openshift-logging
+spec:
+  groups:
+    - name: logging_elasticsearch.alerts
+      rules:
+        - alert: ElasticsearchClusterNotHealthySRE
+          annotations:
+            message: Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet.
+            summary: Cluster health status is RED
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
+          expr: |
+            sum by (cluster) (es_cluster_status == 2)
+          for: 7m
+          labels:
+            namespace: openshift-logging
+            severity: critical
+        - alert: ElasticsearchClusterNotHealthySRE
+          annotations:
+            message: Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated.
+            summary: Cluster health status is YELLOW
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
+          expr: |
+            sum by (cluster) (es_cluster_status == 1)
+          for: 20m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+        - alert: ElasticsearchWriteRequestsRejectionJumpsSRE
+          annotations:
+            message: High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed.
+            summary: High Write Rejection Ratio - {{ $value }}%
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
+          expr: |
+            round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+        - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+          annotations:
+            message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node.
+            summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            severity: info
+        - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+          annotations:
+            message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.
+            summary: Disk High Watermark Reached - disk saturation is {{ $value }}%
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            severity: critical
+        - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+          annotations:
+            message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
+            summary: Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            severity: critical
+        - alert: ElasticsearchJVMHeapUseHighSRE
+          annotations:
+            message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
+            summary: JVM Heap usage on the node is high
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
+          expr: |
+            sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: info
+        - alert: AggregatedLoggingSystemCPUHighSRE
+          annotations:
+            message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
+            summary: System CPU usage is high
+            runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
+          expr: |
+            sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+          for: 1m
+          labels:
+            namespace: openshift-logging
+            severity: info
+        - alert: ElasticsearchProcessCPUHighSRE
+          annotations:
+            message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
+            summary: ES process CPU usage is high
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
+          expr: |
+            sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+          for: 1m
+          labels:
+            namespace: openshift-logging
+            severity: info
+        - alert: ElasticsearchDiskSpaceRunningLowSRE
+          annotations:
+            message: Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h.
+            summary: Cluster low on disk space
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
+          expr: |
+            sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: critical
+        - alert: ElasticsearchHighFileDescriptorUsageSRE
+          annotations:
+            message: Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour.
+            summary: Cluster low on file descriptors
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
+          expr: |
+            predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+        - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
+          annotations:
+            message: Elasticsearch Operator CSV has not reconciled successfully.
+            summary: Elasticsearch Operator CSV Not Successful
+          expr: |
+            csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+        - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+          annotations:
+            message: Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node.
+            summary: Disk Low Watermark is predicted to be reached within next 6h.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: warning
+        - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+          annotations:
+            message: Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.
+            summary: Disk High Watermark is predicted to be reached within next 6h.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: warning
+        - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+          annotations:
+            message: Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
+            summary: Disk Flood Stage Watermark is predicted to be reached within next 6h.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: warning

--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -15,12 +15,12 @@
 # ```
 # created this file via
 # ```
-# A=$(curl -sSLo- https://github.com/openshift/elasticsearch-operator/raw/b5e329a3d9967a4933d94e61a32479407911755d/files/prometheus_alerts.yml) yq '.spec = env(A) | .spec.groups[].rules[].alert += "SRE"' ../../../resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml | yq -P > 101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+# A=$(curl -sSLo- https://github.com/openshift/elasticsearch-operator/raw/b5e329a3d9967a4933d94e61a32479407911755d/files/prometheus_alerts.yml) yq '.spec = env(A) | .spec.groups[].rules[].alert += "SRE" | .metadata.name += "-sre"' ../../../resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml | yq -P > 101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
 # ```
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: elasticsearch-prometheus-rules
+  name: elasticsearch-prometheus-rules-sre
   namespace: openshift-logging
 spec:
   groups:
@@ -170,7 +170,7 @@ spec:
             severity: warning
         - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
           annotations:
-            message: Elasticsearch Operator CSV has not reconciled successfully.
+            message: Elasticsearch Operator CSV has not reconciled succesfully.
             summary: Elasticsearch Operator CSV Not Successful
           expr: |
             csv_succeeded{name =~ "elasticsearch-operator.*"} == 0

--- a/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
@@ -1,0 +1,78 @@
+# taken from f029cca0-fd96-4cde-afa4-77c151c5233d
+# using oc get prometheusrule -n openshift-logging collector -oyaml
+# also:
+# oc get csv -n openshift-logging | grep -i -e elastic -elogging
+# cluster-logging.5.3.5-20        Red Hat OpenShift Logging          5.3.5-20 Succeeded
+# elasticsearch-operator.5.3.5-20 OpenShift Elasticsearch Operator   5.3.5-20 Succeeded
+# and
+# https://catalog.redhat.com/software/containers/openshift-logging/cluster-logging-operator-bundle/5fd22f465d2ec16f0da1e8c8
+# where the current latest version is:
+# ```
+# $ date
+# Sun May  1 16:04:22 IDT 2022
+# $ echo "the version is v5.4.0-138" # there is also 5.4.6-46
+# ...
+# ```
+# created this file via
+# ```
+# A=$(curl -sSLo- https://github.com/openshift/cluster-logging-operator/raw/b26497cce95e7737a4b66b5ff6b822b80a16bc3a/files/fluentd/fluentd_prometheus_alerts.yaml) yq '.spec = env(A) | .spec.groups[].rules[].alert += "SRE" | .spec.groups[].rules[].labels.namespace = "openshift-logging"' ../../../resources/prometheusrules/fluentd_openshift-logging_collector.PrometheusRule.yaml | yq -P > 101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
+# ```#
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: collector
+  namespace: openshift-logging
+spec:
+  groups:
+    - name: logging_fluentd.alerts
+      rules:
+        - alert: FluentdNodeDownSRE
+          annotations:
+            message: Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m.
+            summary: Fluentd cannot be scraped
+          expr: |
+            absent(up{job="collector"} == 1)
+          for: 10m
+          labels:
+            service: fluentd
+            severity: critical
+            namespace: openshift-logging
+        - alert: FluentdQueueLengthIncreasingSRE
+          annotations:
+            message: For the last hour, fluentd {{ $labels.instance }} average buffer queue length has increased continuously.
+            summary: Fluentd unable to keep up with traffic over time.
+          expr: |
+            ( 0 * (kube_pod_start_time{pod=~".*fluentd.*"} < time() - 3600 ) )  + on(pod)  label_replace( ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 ), "pod", "$1", "hostname", "(.*)")
+          for: 1h
+          labels:
+            service: fluentd
+            severity: error
+            namespace: openshift-logging
+        - alert: FluentDHighErrorRateSRE
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.'
+            summary: FluentD output errors are high
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 10
+          for: 15m
+          labels:
+            severity: warning
+            namespace: openshift-logging
+        - alert: FluentDVeryHighErrorRateSRE
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.'
+            summary: FluentD output errors are very high
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 25
+          for: 15m
+          labels:
+            severity: critical
+            namespace: openshift-logging

--- a/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
@@ -15,12 +15,12 @@
 # ```
 # created this file via
 # ```
-# A=$(curl -sSLo- https://github.com/openshift/cluster-logging-operator/raw/b26497cce95e7737a4b66b5ff6b822b80a16bc3a/files/fluentd/fluentd_prometheus_alerts.yaml) yq '.spec = env(A) | .spec.groups[].rules[].alert += "SRE" | .spec.groups[].rules[].labels.namespace = "openshift-logging"' ../../../resources/prometheusrules/fluentd_openshift-logging_collector.PrometheusRule.yaml | yq -P > 101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
-# ```#
+# A=$(curl -sSLo- https://github.com/openshift/cluster-logging-operator/raw/b26497cce95e7737a4b66b5ff6b822b80a16bc3a/files/fluentd/fluentd_prometheus_alerts.yaml) yq '.spec = env(A) | .spec.groups[].rules[].alert += "SRE" | .spec.groups[].rules[].labels.namespace = "openshift-logging" | .metadata.name += "-sre"' ../../../resources/prometheusrules/fluentd_openshift-logging_collector.PrometheusRule.yaml | yq -P > 101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
+# ```
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: collector
+  name: collector-sre
   namespace: openshift-logging
 spec:
   groups:

--- a/deploy/sre-prometheus/extended-logging/README.md
+++ b/deploy/sre-prometheus/extended-logging/README.md
@@ -7,7 +7,7 @@ And [./config.yaml](config.yaml) where we specify the deployment of the alerts o
 
 ## file kinds
 we have here 
-### resoruces files
+### resources files
 these are extracted from a sample cluster.
 
 [../../../resources/prometheusrules/README.md](see the files here)

--- a/deploy/sre-prometheus/extended-logging/README.md
+++ b/deploy/sre-prometheus/extended-logging/README.md
@@ -1,0 +1,22 @@
+This folder will duplicate all of the elasticsearch alerts with SRE suffix alerts
+
+you can also see [https://github.com/openshift/configure-alertmanager-operator/pull/224](configure-alertmanager PR) that silences the original alerts.
+
+And [./config.yaml](config.yaml) where we specify the deployment of the alerts only to clusters that have LTS logging enabled
+
+
+## file kinds
+we have here 
+### resoruces files
+these are extracted from a sample cluster.
+
+[../../../resources/prometheusrules/README.md](see the files here)
+
+### `101-*` files
+these are modified with what we got from the openshift-logging repo
+
+these are the files we do want to deploy
+### `100-*` files
+these are copied from  the upper folder, should be consolidated here
+
+this file was moved from the parent repo as it makes more sense it will stay here

--- a/deploy/sre-prometheus/extended-logging/config.yaml
+++ b/deploy/sre-prometheus/extended-logging/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  # if we ever remove this, do not remove the resources
+  resourceApplyMode: "Upsert"
+  matchExpressions:
+
+  - key: ext-managed.openshift.io/extended-logging-support
+    operator: In
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13280,7 +13280,7 @@ objects:
             annotations:
               message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
                 }}. Ensure new certificate is provided prior to expiration to avoid
-                cluster degredation and/or unavailability
+                cluster degradation and/or unavailability
           - alert: ClusterProxyCAExpiringSRE
             expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
               < 86400 * 15
@@ -13291,7 +13291,7 @@ objects:
             annotations:
               message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
                 }}. Ensure new certificate is provided prior to expiration to avoid
-                cluster degredation and/or unavailability
+                cluster degradation and/or unavailability
           - alert: ClusterProxyCAInvalidSRE
             expr: cluster_proxy_enabled{type="trusted_ca"} > 0 and cluster_proxy_ca_valid{name="osd_exporter"}
               == 0
@@ -14047,6 +14047,309 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-extended-logging
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/extended-logging-support
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: elasticsearch-prometheus-rules
+        namespace: openshift-logging
+      spec:
+        groups:
+        - name: logging_elasticsearch.alerts
+          rules:
+          - alert: ElasticsearchClusterNotHealthySRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} health status has been RED for
+                at least 7m. Cluster does not accept writes, shards may be missing
+                or master node hasn't been elected yet.
+              summary: Cluster health status is RED
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
+            expr: 'sum by (cluster) (es_cluster_status == 2)
+
+              '
+            for: 7m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchClusterNotHealthySRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} health status has been YELLOW
+                for at least 20m. Some shard replicas are not allocated.
+              summary: Cluster health status is YELLOW
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
+            expr: 'sum by (cluster) (es_cluster_status == 1)
+
+              '
+            for: 20m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchWriteRequestsRejectionJumpsSRE
+            annotations:
+              message: High Write Rejection Ratio at {{ $labels.node }} node in {{
+                $labels.cluster }} cluster. This node may not be keeping up with the
+                indexing speed.
+              summary: High Write Rejection Ratio - {{ $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
+            expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards
+                can not be allocated to this node anymore. You should consider adding
+                more disk to the node.
+              summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some
+                shards will be re-allocated to different nodes if possible. Make sure
+                more disk space is added to the node or drop old indices allocated
+                to this node.
+              summary: Disk High Watermark Reached - disk saturation is {{ $value
+                }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
+                index having a shard allocated on this node is enforced a read-only
+                block. The index block must be released manually when the disk utilization
+                falls below the high watermark.
+              summary: Disk Flood Stage Watermark Reached - disk saturation is {{
+                $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchJVMHeapUseHighSRE
+            annotations:
+              message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: JVM Heap usage on the node is high
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
+            expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent)
+              > 75
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: AggregatedLoggingSystemCPUHighSRE
+            annotations:
+              message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: System CPU usage is high
+              runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
+            expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+
+              '
+            for: 1m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchProcessCPUHighSRE
+            annotations:
+              message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: ES process CPU usage is high
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
+            expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+
+              '
+            for: 1m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchDiskSpaceRunningLowSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of disk
+                space within the next 6h.
+              summary: Cluster low on disk space
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
+            expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <
+              0
+
+              '
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchHighFileDescriptorUsageSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of file
+                descriptors within the next hour.
+              summary: Cluster low on file descriptors
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
+            expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
+              - predict_linear(es_process_file_descriptors_open_number[1h], 3600)
+              < 0
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
+            annotations:
+              message: Elasticsearch Operator CSV has not reconciled successfully.
+              summary: Elasticsearch Operator CSV Not Successful
+            expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Low Watermark is predicted to be reached within the next
+                6h at {{ $labels.pod }} pod. Shards can not be allocated to this node
+                anymore. You should consider adding more disk to the node.
+              summary: Disk Low Watermark is predicted to be reached within next 6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk High Watermark is predicted to be reached within the next
+                6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different
+                nodes if possible. Make sure more disk space is added to the node
+                or drop old indices allocated to this node.
+              summary: Disk High Watermark is predicted to be reached within next
+                6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Flood Stage Watermark is predicted to be reached within
+                the next 6h at {{ $labels.pod }}. Every index having a shard allocated
+                on this node is enforced a read-only block. The index block must be
+                released manually when the disk utilization falls below the high watermark.
+              summary: Disk Flood Stage Watermark is predicted to be reached within
+                next 6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: collector
+        namespace: openshift-logging
+      spec:
+        groups:
+        - name: logging_fluentd.alerts
+          rules:
+          - alert: FluentdNodeDownSRE
+            annotations:
+              message: Prometheus could not scrape fluentd {{ $labels.instance }}
+                for more than 10m.
+              summary: Fluentd cannot be scraped
+            expr: 'absent(up{job="collector"} == 1)
+
+              '
+            for: 10m
+            labels:
+              service: fluentd
+              severity: critical
+              namespace: openshift-logging
+          - alert: FluentdQueueLengthIncreasingSRE
+            annotations:
+              message: For the last hour, fluentd {{ $labels.instance }} average buffer
+                queue length has increased continuously.
+              summary: Fluentd unable to keep up with traffic over time.
+            expr: '( 0 * (kube_pod_start_time{pod=~".*fluentd.*"} < time() - 3600
+              ) )  + on(pod)  label_replace( ( deriv(fluentd_output_status_buffer_queue_length[10m])
+              > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 ),
+              "pod", "$1", "hostname", "(.*)")
+
+              '
+            for: 1h
+            labels:
+              service: fluentd
+              severity: error
+              namespace: openshift-logging
+          - alert: FluentDHighErrorRateSRE
+            annotations:
+              message: '{{ $value }}% of records have resulted in an error by fluentd
+                {{ $labels.instance }}.'
+              summary: FluentD output errors are high
+            expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+              /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+              ) > 10\n"
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-logging
+          - alert: FluentDVeryHighErrorRateSRE
+            annotations:
+              message: '{{ $value }}% of records have resulted in an error by fluentd
+                {{ $labels.instance }}.'
+              summary: FluentD output errors are very high
+            expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+              /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+              ) > 25\n"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-logging
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -14069,7 +14069,7 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: elasticsearch-prometheus-rules
+        name: elasticsearch-prometheus-rules-sre
         namespace: openshift-logging
       spec:
         groups:
@@ -14233,7 +14233,7 @@ objects:
               severity: warning
           - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
             annotations:
-              message: Elasticsearch Operator CSV has not reconciled successfully.
+              message: Elasticsearch Operator CSV has not reconciled succesfully.
               summary: Elasticsearch Operator CSV Not Successful
             expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
 
@@ -14291,7 +14291,7 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: collector
+        name: collector-sre
         namespace: openshift-logging
       spec:
         groups:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13280,7 +13280,7 @@ objects:
             annotations:
               message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
                 }}. Ensure new certificate is provided prior to expiration to avoid
-                cluster degredation and/or unavailability
+                cluster degradation and/or unavailability
           - alert: ClusterProxyCAExpiringSRE
             expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
               < 86400 * 15
@@ -13291,7 +13291,7 @@ objects:
             annotations:
               message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
                 }}. Ensure new certificate is provided prior to expiration to avoid
-                cluster degredation and/or unavailability
+                cluster degradation and/or unavailability
           - alert: ClusterProxyCAInvalidSRE
             expr: cluster_proxy_enabled{type="trusted_ca"} > 0 and cluster_proxy_ca_valid{name="osd_exporter"}
               == 0
@@ -14047,6 +14047,309 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-extended-logging
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/extended-logging-support
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: elasticsearch-prometheus-rules
+        namespace: openshift-logging
+      spec:
+        groups:
+        - name: logging_elasticsearch.alerts
+          rules:
+          - alert: ElasticsearchClusterNotHealthySRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} health status has been RED for
+                at least 7m. Cluster does not accept writes, shards may be missing
+                or master node hasn't been elected yet.
+              summary: Cluster health status is RED
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
+            expr: 'sum by (cluster) (es_cluster_status == 2)
+
+              '
+            for: 7m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchClusterNotHealthySRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} health status has been YELLOW
+                for at least 20m. Some shard replicas are not allocated.
+              summary: Cluster health status is YELLOW
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
+            expr: 'sum by (cluster) (es_cluster_status == 1)
+
+              '
+            for: 20m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchWriteRequestsRejectionJumpsSRE
+            annotations:
+              message: High Write Rejection Ratio at {{ $labels.node }} node in {{
+                $labels.cluster }} cluster. This node may not be keeping up with the
+                indexing speed.
+              summary: High Write Rejection Ratio - {{ $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
+            expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards
+                can not be allocated to this node anymore. You should consider adding
+                more disk to the node.
+              summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some
+                shards will be re-allocated to different nodes if possible. Make sure
+                more disk space is added to the node or drop old indices allocated
+                to this node.
+              summary: Disk High Watermark Reached - disk saturation is {{ $value
+                }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
+                index having a shard allocated on this node is enforced a read-only
+                block. The index block must be released manually when the disk utilization
+                falls below the high watermark.
+              summary: Disk Flood Stage Watermark Reached - disk saturation is {{
+                $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchJVMHeapUseHighSRE
+            annotations:
+              message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: JVM Heap usage on the node is high
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
+            expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent)
+              > 75
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: AggregatedLoggingSystemCPUHighSRE
+            annotations:
+              message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: System CPU usage is high
+              runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
+            expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+
+              '
+            for: 1m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchProcessCPUHighSRE
+            annotations:
+              message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: ES process CPU usage is high
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
+            expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+
+              '
+            for: 1m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchDiskSpaceRunningLowSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of disk
+                space within the next 6h.
+              summary: Cluster low on disk space
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
+            expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <
+              0
+
+              '
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchHighFileDescriptorUsageSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of file
+                descriptors within the next hour.
+              summary: Cluster low on file descriptors
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
+            expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
+              - predict_linear(es_process_file_descriptors_open_number[1h], 3600)
+              < 0
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
+            annotations:
+              message: Elasticsearch Operator CSV has not reconciled successfully.
+              summary: Elasticsearch Operator CSV Not Successful
+            expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Low Watermark is predicted to be reached within the next
+                6h at {{ $labels.pod }} pod. Shards can not be allocated to this node
+                anymore. You should consider adding more disk to the node.
+              summary: Disk Low Watermark is predicted to be reached within next 6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk High Watermark is predicted to be reached within the next
+                6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different
+                nodes if possible. Make sure more disk space is added to the node
+                or drop old indices allocated to this node.
+              summary: Disk High Watermark is predicted to be reached within next
+                6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Flood Stage Watermark is predicted to be reached within
+                the next 6h at {{ $labels.pod }}. Every index having a shard allocated
+                on this node is enforced a read-only block. The index block must be
+                released manually when the disk utilization falls below the high watermark.
+              summary: Disk Flood Stage Watermark is predicted to be reached within
+                next 6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: collector
+        namespace: openshift-logging
+      spec:
+        groups:
+        - name: logging_fluentd.alerts
+          rules:
+          - alert: FluentdNodeDownSRE
+            annotations:
+              message: Prometheus could not scrape fluentd {{ $labels.instance }}
+                for more than 10m.
+              summary: Fluentd cannot be scraped
+            expr: 'absent(up{job="collector"} == 1)
+
+              '
+            for: 10m
+            labels:
+              service: fluentd
+              severity: critical
+              namespace: openshift-logging
+          - alert: FluentdQueueLengthIncreasingSRE
+            annotations:
+              message: For the last hour, fluentd {{ $labels.instance }} average buffer
+                queue length has increased continuously.
+              summary: Fluentd unable to keep up with traffic over time.
+            expr: '( 0 * (kube_pod_start_time{pod=~".*fluentd.*"} < time() - 3600
+              ) )  + on(pod)  label_replace( ( deriv(fluentd_output_status_buffer_queue_length[10m])
+              > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 ),
+              "pod", "$1", "hostname", "(.*)")
+
+              '
+            for: 1h
+            labels:
+              service: fluentd
+              severity: error
+              namespace: openshift-logging
+          - alert: FluentDHighErrorRateSRE
+            annotations:
+              message: '{{ $value }}% of records have resulted in an error by fluentd
+                {{ $labels.instance }}.'
+              summary: FluentD output errors are high
+            expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+              /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+              ) > 10\n"
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-logging
+          - alert: FluentDVeryHighErrorRateSRE
+            annotations:
+              message: '{{ $value }}% of records have resulted in an error by fluentd
+                {{ $labels.instance }}.'
+              summary: FluentD output errors are very high
+            expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+              /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+              ) > 25\n"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-logging
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -14069,7 +14069,7 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: elasticsearch-prometheus-rules
+        name: elasticsearch-prometheus-rules-sre
         namespace: openshift-logging
       spec:
         groups:
@@ -14233,7 +14233,7 @@ objects:
               severity: warning
           - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
             annotations:
-              message: Elasticsearch Operator CSV has not reconciled successfully.
+              message: Elasticsearch Operator CSV has not reconciled succesfully.
               summary: Elasticsearch Operator CSV Not Successful
             expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
 
@@ -14291,7 +14291,7 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: collector
+        name: collector-sre
         namespace: openshift-logging
       spec:
         groups:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13280,7 +13280,7 @@ objects:
             annotations:
               message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
                 }}. Ensure new certificate is provided prior to expiration to avoid
-                cluster degredation and/or unavailability
+                cluster degradation and/or unavailability
           - alert: ClusterProxyCAExpiringSRE
             expr: cluster_proxy_ca_expiry_timestamp{name="osd_exporter"} - time()
               < 86400 * 15
@@ -13291,7 +13291,7 @@ objects:
             annotations:
               message: Cluster proxy certificate will expire in {{ $value | humanizeDuration
                 }}. Ensure new certificate is provided prior to expiration to avoid
-                cluster degredation and/or unavailability
+                cluster degradation and/or unavailability
           - alert: ClusterProxyCAInvalidSRE
             expr: cluster_proxy_enabled{type="trusted_ca"} > 0 and cluster_proxy_ca_valid{name="osd_exporter"}
               == 0
@@ -14047,6 +14047,309 @@ objects:
             labels:
               severity: critical
               namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-extended-logging
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/extended-logging-support
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: elasticsearch-prometheus-rules
+        namespace: openshift-logging
+      spec:
+        groups:
+        - name: logging_elasticsearch.alerts
+          rules:
+          - alert: ElasticsearchClusterNotHealthySRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} health status has been RED for
+                at least 7m. Cluster does not accept writes, shards may be missing
+                or master node hasn't been elected yet.
+              summary: Cluster health status is RED
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
+            expr: 'sum by (cluster) (es_cluster_status == 2)
+
+              '
+            for: 7m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchClusterNotHealthySRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} health status has been YELLOW
+                for at least 20m. Some shard replicas are not allocated.
+              summary: Cluster health status is YELLOW
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
+            expr: 'sum by (cluster) (es_cluster_status == 1)
+
+              '
+            for: 20m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchWriteRequestsRejectionJumpsSRE
+            annotations:
+              message: High Write Rejection Ratio at {{ $labels.node }} node in {{
+                $labels.cluster }} cluster. This node may not be keeping up with the
+                indexing speed.
+              summary: High Write Rejection Ratio - {{ $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
+            expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards
+                can not be allocated to this node anymore. You should consider adding
+                more disk to the node.
+              summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some
+                shards will be re-allocated to different nodes if possible. Make sure
+                more disk space is added to the node or drop old indices allocated
+                to this node.
+              summary: Disk High Watermark Reached - disk saturation is {{ $value
+                }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
+                index having a shard allocated on this node is enforced a read-only
+                block. The index block must be released manually when the disk utilization
+                falls below the high watermark.
+              summary: Disk Flood Stage Watermark Reached - disk saturation is {{
+                $value }}%
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+              \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+              \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+            for: 5m
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchJVMHeapUseHighSRE
+            annotations:
+              message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: JVM Heap usage on the node is high
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
+            expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent)
+              > 75
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: AggregatedLoggingSystemCPUHighSRE
+            annotations:
+              message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: System CPU usage is high
+              runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
+            expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+
+              '
+            for: 1m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchProcessCPUHighSRE
+            annotations:
+              message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+                }} cluster is {{ $value }}%.
+              summary: ES process CPU usage is high
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
+            expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+
+              '
+            for: 1m
+            labels:
+              namespace: openshift-logging
+              severity: info
+          - alert: ElasticsearchDiskSpaceRunningLowSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of disk
+                space within the next 6h.
+              summary: Cluster low on disk space
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
+            expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <
+              0
+
+              '
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: critical
+          - alert: ElasticsearchHighFileDescriptorUsageSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of file
+                descriptors within the next hour.
+              summary: Cluster low on file descriptors
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
+            expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
+              - predict_linear(es_process_file_descriptors_open_number[1h], 3600)
+              < 0
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
+            annotations:
+              message: Elasticsearch Operator CSV has not reconciled successfully.
+              summary: Elasticsearch Operator CSV Not Successful
+            expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+
+              '
+            for: 10m
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Low Watermark is predicted to be reached within the next
+                6h at {{ $labels.pod }} pod. Shards can not be allocated to this node
+                anymore. You should consider adding more disk to the node.
+              summary: Disk Low Watermark is predicted to be reached within next 6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk High Watermark is predicted to be reached within the next
+                6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different
+                nodes if possible. Make sure more disk space is added to the node
+                or drop old indices allocated to this node.
+              summary: Disk High Watermark is predicted to be reached within next
+                6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchNodeDiskWatermarkReachedSRE
+            annotations:
+              message: Disk Flood Stage Watermark is predicted to be reached within
+                the next 6h at {{ $labels.pod }}. Every index having a shard allocated
+                on this node is enforced a read-only block. The index block must be
+                released manually when the disk utilization falls below the high watermark.
+              summary: Disk Flood Stage Watermark is predicted to be reached within
+                next 6h.
+              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+              \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
+              \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
+              severity: warning
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: collector
+        namespace: openshift-logging
+      spec:
+        groups:
+        - name: logging_fluentd.alerts
+          rules:
+          - alert: FluentdNodeDownSRE
+            annotations:
+              message: Prometheus could not scrape fluentd {{ $labels.instance }}
+                for more than 10m.
+              summary: Fluentd cannot be scraped
+            expr: 'absent(up{job="collector"} == 1)
+
+              '
+            for: 10m
+            labels:
+              service: fluentd
+              severity: critical
+              namespace: openshift-logging
+          - alert: FluentdQueueLengthIncreasingSRE
+            annotations:
+              message: For the last hour, fluentd {{ $labels.instance }} average buffer
+                queue length has increased continuously.
+              summary: Fluentd unable to keep up with traffic over time.
+            expr: '( 0 * (kube_pod_start_time{pod=~".*fluentd.*"} < time() - 3600
+              ) )  + on(pod)  label_replace( ( deriv(fluentd_output_status_buffer_queue_length[10m])
+              > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 ),
+              "pod", "$1", "hostname", "(.*)")
+
+              '
+            for: 1h
+            labels:
+              service: fluentd
+              severity: error
+              namespace: openshift-logging
+          - alert: FluentDHighErrorRateSRE
+            annotations:
+              message: '{{ $value }}% of records have resulted in an error by fluentd
+                {{ $labels.instance }}.'
+              summary: FluentD output errors are high
+            expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+              /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+              ) > 10\n"
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-logging
+          - alert: FluentDVeryHighErrorRateSRE
+            annotations:
+              message: '{{ $value }}% of records have resulted in an error by fluentd
+                {{ $labels.instance }}.'
+              summary: FluentD output errors are very high
+            expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+              /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+              ) > 25\n"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-logging
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -14069,7 +14069,7 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: elasticsearch-prometheus-rules
+        name: elasticsearch-prometheus-rules-sre
         namespace: openshift-logging
       spec:
         groups:
@@ -14233,7 +14233,7 @@ objects:
               severity: warning
           - alert: ElasticsearchOperatorCSVNotSuccessfulSRE
             annotations:
-              message: Elasticsearch Operator CSV has not reconciled successfully.
+              message: Elasticsearch Operator CSV has not reconciled succesfully.
               summary: Elasticsearch Operator CSV Not Successful
             expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
 
@@ -14291,7 +14291,7 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: collector
+        name: collector-sre
         namespace: openshift-logging
       spec:
         groups:

--- a/resources/prometheusrules/README.md
+++ b/resources/prometheusrules/README.md
@@ -1,0 +1,9 @@
+The files here are pulled from other git repos and will serve as a template for generating custom alerts.
+
+each file should have a process of pulling it and the version is was pulled from (in order to check if things have changed over time)
+
+the format is:
+```
+<COMPONENT>_<NAMESPACE>_<NAME>.<TYPE>.yaml
+```
+

--- a/resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/resources/prometheusrules/elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -1,0 +1,267 @@
+# taken from f029cca0-fd96-4cde-afa4-77c151c5233d
+# using oc get prometheusrule -n openshift-logging elasticsearch-prometheus-rules -oyaml
+# also:
+# oc get csv -n openshift-logging | grep -i -e elastic -elogging
+# cluster-logging.5.3.5-20        Red Hat OpenShift Logging          5.3.5-20 Succeeded
+# elasticsearch-operator.5.3.5-20 OpenShift Elasticsearch Operator   5.3.5-20 Succeeded
+# and
+# https://catalog.redhat.com/software/containers/openshift-logging/cluster-logging-operator-bundle/5fd22f465d2ec16f0da1e8c8
+# where the current latest version is:
+# ```
+# $ date
+# Sun May  1 16:04:22 IDT 2022
+# $ echo "the version is v5.4.0-138" # there is also 5.4.6-46
+# ...
+# ```
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: elasticsearch-prometheus-rules
+  namespace: openshift-logging
+spec:
+  groups:
+  - name: logging_elasticsearch.alerts
+    rules:
+    - alert: ElasticsearchClusterNotHealthy
+      annotations:
+        message: Cluster {{ $labels.cluster }} health status has been RED for at least
+          7m. Cluster does not accept writes, shards may be missing or master node
+          hasn't been elected yet.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Cluster-Health-is-Red
+        summary: Cluster health status is RED
+      expr: |
+        sum by (cluster) (es_cluster_status == 2)
+      for: 7m
+      labels:
+        namespace: openshift-logging
+        severity: critical
+    - alert: ElasticsearchClusterNotHealthy
+      annotations:
+        message: Cluster {{ $labels.cluster }} health status has been YELLOW for at
+          least 20m. Some shard replicas are not allocated.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Cluster-Health-is-Yellow
+        summary: Cluster health status is YELLOW
+      expr: |
+        sum by (cluster) (es_cluster_status == 1)
+      for: 20m
+      labels:
+        namespace: openshift-logging
+        severity: warning
+    - alert: ElasticsearchWriteRequestsRejectionJumps
+      annotations:
+        message: High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster
+          }} cluster. This node may not be keeping up with the indexing speed.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Write-Requests-Rejection-Jumps
+        summary: High Write Rejection Ratio - {{ $value }}%
+      expr: |
+        round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+      for: 10m
+      labels:
+        namespace: openshift-logging
+        severity: warning
+    - alert: ElasticsearchNodeDiskWatermarkReached
+      annotations:
+        message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not
+          be allocated to this node anymore. You should consider adding more disk
+          to the node.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Node-Disk-Low-Watermark-Reached
+        summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
+      expr: |
+        sum by (instance, pod) (
+          round(
+            (1 - (
+              es_fs_path_available_bytes /
+              es_fs_path_total_bytes
+            )
+          ) * 100, 0.001)
+        ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+      for: 5m
+      labels:
+        namespace: openshift-logging
+        severity: info
+    - alert: ElasticsearchNodeDiskWatermarkReached
+      annotations:
+        message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards
+          will be re-allocated to different nodes if possible. Make sure more disk
+          space is added to the node or drop old indices allocated to this node.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Node-Disk-High-Watermark-Reached
+        summary: Disk High Watermark Reached - disk saturation is {{ $value }}%
+      expr: |
+        sum by (instance, pod) (
+          round(
+            (1 - (
+              es_fs_path_available_bytes /
+              es_fs_path_total_bytes
+            )
+          ) * 100, 0.001)
+        ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+      for: 5m
+      labels:
+        namespace: openshift-logging
+        severity: critical
+    - alert: ElasticsearchNodeDiskWatermarkReached
+      annotations:
+        message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index
+          having a shard allocated on this node is enforced a read-only block. The
+          index block must be released manually when the disk utilization falls below
+          the high watermark.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Node-Disk-Flood-Watermark-Reached
+        summary: Disk Flood Stage Watermark Reached - disk saturation is {{ $value
+          }}%
+      expr: |
+        sum by (instance, pod) (
+          round(
+            (1 - (
+              es_fs_path_available_bytes /
+              es_fs_path_total_bytes
+            )
+          ) * 100, 0.001)
+        ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+      for: 5m
+      labels:
+        namespace: openshift-logging
+        severity: critical
+    - alert: ElasticsearchJVMHeapUseHigh
+      annotations:
+        message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
+          }} cluster is {{ $value }}%.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-JVM-Heap-Use-is-High
+        summary: JVM Heap usage on the node is high
+      expr: |
+        sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
+      for: 10m
+      labels:
+        namespace: openshift-logging
+        severity: info
+    - alert: AggregatedLoggingSystemCPUHigh
+      annotations:
+        message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+          }} cluster is {{ $value }}%.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Aggregated-Logging-System-CPU-is-High
+        summary: System CPU usage is high
+      expr: |
+        sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+      for: 1m
+      labels:
+        namespace: openshift-logging
+        severity: info
+    - alert: ElasticsearchProcessCPUHigh
+      annotations:
+        message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+          }} cluster is {{ $value }}%.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Process-CPU-is-High
+        summary: ES process CPU usage is high
+      expr: |
+        sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+      for: 1m
+      labels:
+        namespace: openshift-logging
+        severity: info
+    - alert: ElasticsearchDiskSpaceRunningLow
+      annotations:
+        message: Cluster {{ $labels.cluster }} is predicted to be out of disk space
+          within the next 6h.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Disk-Space-is-Running-Low
+        summary: Cluster low on disk space
+      expr: |
+        sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+      for: 1h
+      labels:
+        namespace: openshift-logging
+        severity: critical
+    - alert: ElasticsearchHighFileDescriptorUsage
+      annotations:
+        message: Cluster {{ $labels.cluster }} is predicted to be out of file descriptors
+          within the next hour.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-FileDescriptor-Usage-is-high
+        summary: Cluster low on file descriptors
+      expr: |
+        predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
+      for: 10m
+      labels:
+        namespace: openshift-logging
+        severity: warning
+    - alert: ElasticsearchOperatorCSVNotSuccessful
+      annotations:
+        message: Elasticsearch Operator CSV has not reconciled successfully.
+        summary: Elasticsearch Operator CSV Not Successful
+      expr: |
+        csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+      for: 10m
+      labels:
+        namespace: openshift-logging
+        severity: warning
+    - alert: ElasticsearchNodeDiskWatermarkReached
+      annotations:
+        message: Disk Low Watermark is predicted to be reached within the next 6h
+          at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore.
+          You should consider adding more disk to the node.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Node-Disk-Low-Watermark-Reached
+        summary: Disk Low Watermark is predicted to be reached within next 6h.
+      expr: |
+        sum by (instance, pod) (
+          round(
+            (1 - (
+              predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+              predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+            )
+          ) * 100, 0.001)
+        ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+      for: 1h
+      labels:
+        namespace: openshift-logging
+        severity: warning
+    - alert: ElasticsearchNodeDiskWatermarkReached
+      annotations:
+        message: Disk High Watermark is predicted to be reached within the next 6h
+          at {{ $labels.pod }} pod. Some shards will be re-allocated to different
+          nodes if possible. Make sure more disk space is added to the node or drop
+          old indices allocated to this node.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Node-Disk-High-Watermark-Reached
+        summary: Disk High Watermark is predicted to be reached within next 6h.
+      expr: |
+        sum by (instance, pod) (
+          round(
+            (1 - (
+              predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+              predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+            )
+          ) * 100, 0.001)
+        ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+      for: 1h
+      labels:
+        namespace: openshift-logging
+        severity: warning
+    - alert: ElasticsearchNodeDiskWatermarkReached
+      annotations:
+        message: Disk Flood Stage Watermark is predicted to be reached within the
+          next 6h at {{ $labels.pod }}. Every index having a shard allocated on this
+          node is enforced a read-only block. The index block must be released manually
+          when the disk utilization falls below the high watermark.
+        runbook_url: https://docs.openshift.com/container-platform/latest/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.html#Elasticsearch-Node-Disk-Flood-Watermark-Reached
+        summary: Disk Flood Stage Watermark is predicted to be reached within next
+          6h.
+      expr: |
+        sum by (instance, pod) (
+          round(
+            (1 - (
+              predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+              predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+            )
+          ) * 100, 0.001)
+        ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+      for: 1h
+      labels:
+        namespace: openshift-logging
+        severity: warning
+  - name: logging_elasticsearch.rules
+    rules:
+    - expr: |
+        rate(es_threadpool_threads_count{name="write", type="rejected"}[2m])
+      record: writing:rejected_requests:rate2m
+    - expr: |
+        rate(es_threadpool_threads_count{name="write", type="completed"}[2m])
+      record: writing:completed_requests:rate2m
+    - expr: |
+        sum by (cluster, instance, node) (writing:rejected_requests:rate2m) / on (cluster, instance, node) (writing:completed_requests:rate2m)
+      record: writing:reject_ratio:rate2m

--- a/resources/prometheusrules/fluentd_openshift-logging_collector.PrometheusRule.yaml
+++ b/resources/prometheusrules/fluentd_openshift-logging_collector.PrometheusRule.yaml
@@ -1,0 +1,74 @@
+# taken from f029cca0-fd96-4cde-afa4-77c151c5233d
+# using oc get prometheusrule -n openshift-logging collector -oyaml
+# also:
+# oc get csv -n openshift-logging | grep -i -e elastic -elogging
+# cluster-logging.5.3.5-20        Red Hat OpenShift Logging          5.3.5-20 Succeeded
+# elasticsearch-operator.5.3.5-20 OpenShift Elasticsearch Operator   5.3.5-20 Succeeded
+# and
+# https://catalog.redhat.com/software/containers/openshift-logging/cluster-logging-operator-bundle/5fd22f465d2ec16f0da1e8c8
+# where the current latest version is:
+# ```
+# $ date
+# Sun May  1 16:04:22 IDT 2022
+# $ echo "the version is v5.4.0-138" # there is also 5.4.6-46
+# ...
+# ```
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: collector
+  namespace: openshift-logging
+spec:
+  groups:
+  - name: logging_fluentd.alerts
+    rules:
+    - alert: FluentdNodeDown
+      annotations:
+        message: Prometheus could not scrape fluentd {{ $labels.instance }} for more
+          than 10m.
+        summary: Fluentd cannot be scraped
+      expr: |
+        absent(up{job="collector"} == 1)
+      for: 10m
+      labels:
+        service: fluentd
+        severity: critical
+    - alert: FluentdQueueLengthIncreasing
+      annotations:
+        message: For the last hour, fluentd {{ $labels.instance }} average buffer
+          queue length has increased continuously.
+        summary: Fluentd unable to keep up with traffic over time.
+      expr: |
+        deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1
+      for: 1h
+      labels:
+        service: fluentd
+        severity: error
+    - alert: FluentDHighErrorRate
+      annotations:
+        message: '{{ $value }}% of records have resulted in an error by fluentd {{
+          $labels.instance }}.'
+        summary: FluentD output errors are high
+      expr: |
+        100 * (
+          sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+        /
+          sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+        ) > 10
+      for: 15m
+      labels:
+        severity: warning
+    - alert: FluentDVeryHighErrorRate
+      annotations:
+        message: '{{ $value }}% of records have resulted in an error by fluentd {{
+          $labels.instance }}.'
+        summary: FluentD output errors are very high
+      expr: |
+        100 * (
+          sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+        /
+          sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+        ) > 25
+      for: 15m
+      labels:
+        severity: critical


### PR DESCRIPTION
CURRENT_STATE: CI is passing and names are modified

as we want the alerts to show up only on a specific set of clusters, we need to duplicate them only where we want them

this PR will do that (currently WIP but will be better later)
