### PR TITLE
Refactor osd-cluster-ready to new image location: quay.io/app-sre

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.66-bb79af5"
+                managed.openshift.io/version: "v0.1.81-33838ec"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437"
+              image: "quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7239,11 +7239,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.66-bb79af5
+              managed.openshift.io/version: v0.1.81-33838ec
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7239,11 +7239,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.66-bb79af5
+              managed.openshift.io/version: v0.1.81-33838ec
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7239,11 +7239,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.66-bb79af5
+              managed.openshift.io/version: v0.1.81-33838ec
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/openshift-sre/osd-cluster-ready@sha256:84d0c91e5df7455f164eb6cc5544a09e271e94e5c7d0a7644332de69127c8437
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
In OSD-6272, PR checks and build CI was added to https://github.com/openshift/osd-cluster-ready, as part of this the image is low located in https://quay.io/app-sre/osd-cluster-ready

### Which Jira/Github issue(s) this PR fixes?

OSD-6272