### PR TITLE
Add sts:DecodeAuthorizationMessage to support policy

### DIFF
--- a/resources/sts/4.10/sts_support_permission_policy.json
+++ b/resources/sts/4.10/sts_support_permission_policy.json
@@ -150,6 +150,7 @@
                 "s3:GetObjectAcl",
                 "s3:GetObjectTagging",
                 "s3:ListAllMyBuckets",
+                "sts:DecodeAuthorizationMessage",
                 "tiros:CreateQuery",
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"

--- a/resources/sts/4.7/sts_support_permission_policy.json
+++ b/resources/sts/4.7/sts_support_permission_policy.json
@@ -148,6 +148,7 @@
                 "s3:GetObjectAcl",
                 "s3:GetObjectTagging",
                 "s3:ListAllMyBuckets",
+                "sts:DecodeAuthorizationMessage",
                 "tiros:CreateQuery",
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"

--- a/resources/sts/4.8/sts_support_permission_policy.json
+++ b/resources/sts/4.8/sts_support_permission_policy.json
@@ -148,6 +148,7 @@
                 "s3:GetObjectAcl",
                 "s3:GetObjectTagging",
                 "s3:ListAllMyBuckets",
+                "sts:DecodeAuthorizationMessage",
                 "tiros:CreateQuery",
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"

--- a/resources/sts/4.9/sts_support_permission_policy.json
+++ b/resources/sts/4.9/sts_support_permission_policy.json
@@ -150,6 +150,7 @@
                 "s3:GetObjectAcl",
                 "s3:GetObjectTagging",
                 "s3:ListAllMyBuckets",
+                "sts:DecodeAuthorizationMessage",
                 "tiros:CreateQuery",
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Adds [`sts:DecodeAuthorizationMessage`](https://docs.aws.amazon.com/STS/latest/APIReference/API_DecodeAuthorizationMessage.html) permission to the support policies.

### Which Jira/Github issue(s) this PR fixes?

fixes [OSD-11276](https://issues.redhat.com//browse/OSD-11276)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

