### PR TITLE
OSD-11342 Add upgradeType to MUO config

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
+    upgradeType: OSD
     configManager:
       source: OCM
       ocmBaseUrl: ${OCM_BASE_URL}

--- a/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
+    upgradeType: OSD
     configManager:
       source: OCM
       ocmBaseUrl: ${OCM_BASE_URL}

--- a/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
+    upgradeType: OSD
     configManager:
       source: OCM
       ocmBaseUrl: ${OCM_BASE_URL}

--- a/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-managed-upgrade-operator
 data:
   config.yaml: |
+    upgradeType: OSD
     configManager:
       source: OCM
       ocmBaseUrl: ${OCM_BASE_URL}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5031,15 +5031,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
-          \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
-          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
           \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
           \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
           \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
@@ -5075,23 +5075,24 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # etcdMembersDown - OSD-6138\n    - etcdMembersDown\n\
-          \    # ClusterOperatorDown - OSD-6330\n    - ClusterOperatorDown\n    #\
-          \ ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n  \
-          \  # CloudCredentialOperatorDown - BZ 1889540\n    - CloudCredentialOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # etcdMembersDown\
+          \ - OSD-6138\n    - etcdMembersDown\n    # ClusterOperatorDown - OSD-6330\n\
+          \    - ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n \
+          \   - ClusterOperatorDegraded\n    # CloudCredentialOperatorDown - BZ 1889540\n\
+          \    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
+          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5117,14 +5118,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - OSD-6330\n    -\
-          \ ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n\
-          \    # CloudCredentialOperatorDown - BZ 1889540\n    - CloudCredentialOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - OSD-6330\n    - ClusterOperatorDown\n    # ClusterOperatorDegraded -\
+          \ OSD-6330\n    - ClusterOperatorDegraded\n    # CloudCredentialOperatorDown\
+          \ - BZ 1889540\n    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\n\
+          upgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut:\
+          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
+          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
@@ -5158,15 +5160,16 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - OSD-6330\n    -\
-          \ ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - OSD-6330\n    - ClusterOperatorDown\n    # ClusterOperatorDegraded -\
+          \ OSD-6330\n    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
+          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
           \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
           \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
           \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5031,15 +5031,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
-          \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
-          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
           \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
           \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
           \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
@@ -5075,23 +5075,24 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # etcdMembersDown - OSD-6138\n    - etcdMembersDown\n\
-          \    # ClusterOperatorDown - OSD-6330\n    - ClusterOperatorDown\n    #\
-          \ ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n  \
-          \  # CloudCredentialOperatorDown - BZ 1889540\n    - CloudCredentialOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # etcdMembersDown\
+          \ - OSD-6138\n    - etcdMembersDown\n    # ClusterOperatorDown - OSD-6330\n\
+          \    - ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n \
+          \   - ClusterOperatorDegraded\n    # CloudCredentialOperatorDown - BZ 1889540\n\
+          \    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
+          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5117,14 +5118,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - OSD-6330\n    -\
-          \ ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n\
-          \    # CloudCredentialOperatorDown - BZ 1889540\n    - CloudCredentialOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - OSD-6330\n    - ClusterOperatorDown\n    # ClusterOperatorDegraded -\
+          \ OSD-6330\n    - ClusterOperatorDegraded\n    # CloudCredentialOperatorDown\
+          \ - BZ 1889540\n    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\n\
+          upgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut:\
+          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
+          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
@@ -5158,15 +5160,16 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - OSD-6330\n    -\
-          \ ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - OSD-6330\n    - ClusterOperatorDown\n    # ClusterOperatorDegraded -\
+          \ OSD-6330\n    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
+          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
           \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
           \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
           \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5031,15 +5031,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
-          \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
-          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
           \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
           \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
           \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
@@ -5075,23 +5075,24 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # etcdMembersDown - OSD-6138\n    - etcdMembersDown\n\
-          \    # ClusterOperatorDown - OSD-6330\n    - ClusterOperatorDown\n    #\
-          \ ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n  \
-          \  # CloudCredentialOperatorDown - BZ 1889540\n    - CloudCredentialOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # etcdMembersDown\
+          \ - OSD-6138\n    - etcdMembersDown\n    # ClusterOperatorDown - OSD-6330\n\
+          \    - ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n \
+          \   - ClusterOperatorDegraded\n    # CloudCredentialOperatorDown - BZ 1889540\n\
+          \    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
+          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5117,14 +5118,15 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - OSD-6330\n    -\
-          \ ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n\
-          \    # CloudCredentialOperatorDown - BZ 1889540\n    - CloudCredentialOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - OSD-6330\n    - ClusterOperatorDown\n    # ClusterOperatorDegraded -\
+          \ OSD-6330\n    - ClusterOperatorDegraded\n    # CloudCredentialOperatorDown\
+          \ - BZ 1889540\n    - CloudCredentialOperatorDown\nscale:\n  timeOut: 30\n\
+          upgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut:\
+          \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
+          \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
           \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
           \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
@@ -5158,15 +5160,16 @@ objects:
         name: managed-upgrade-operator-config
         namespace: openshift-managed-upgrade-operator
       data:
-        config.yaml: "configManager:\n  source: OCM\n  ocmBaseUrl: ${OCM_BASE_URL}\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 90\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - OSD-6330\n    -\
-          \ ClusterOperatorDown\n    # ClusterOperatorDegraded - OSD-6330\n    - ClusterOperatorDegraded\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
-          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
-          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 90\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - OSD-6330\n    - ClusterOperatorDown\n    # ClusterOperatorDegraded -\
+          \ OSD-6330\n    - ClusterOperatorDegraded\nscale:\n  timeOut: 30\nupgradeWindow:\n\
+          \  delayTrigger: 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
+          \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
+          \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
           \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
           \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
           \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This adds a new `upgradeType` config to `managed-upgrade-operator`'s ConfigMap, which is used to designate which upgrader MUO will use for upgrades.

### Which Jira/Github issue(s) this PR fixes?

[OSD-11342](https://issues.redhat.com//browse/OSD-11342)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster


