### PR TITLE
Move SREP cluster-wide permisions to a direct CRB

### DIFF
--- a/deploy/backplane/srep/20-srep-admins-cluster.ClusterRoleBinding.yml
+++ b/deploy/backplane/srep/20-srep-admins-cluster.ClusterRoleBinding.yml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backplane-srep-admins-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backplane-srep-admins-cluster
+subjects:
+- kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep

--- a/deploy/backplane/srep/20-srep-readers-cluster.ClusterRoleBinding.yml
+++ b/deploy/backplane/srep/20-srep-readers-cluster.ClusterRoleBinding.yml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: backplane-srep-readers-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: backplane-srep-readers-cluster
+subjects:
+- kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep

--- a/deploy/backplane/srep/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/20-srep.SubjectPermission.yml
@@ -4,9 +4,6 @@ metadata:
   name: backplane-srep
   namespace: openshift-rbac-permissions
 spec:
-  clusterPermissions:
-  - backplane-srep-admins-cluster
-  - backplane-srep-readers-cluster
   permissions:
   - allowFirst: true
     clusterRoleName: backplane-srep-admins-project

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3893,15 +3893,34 @@ objects:
       metadata:
         name: backplane-srep-readers-cluster
       rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-srep-admins-cluster
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-srep-admins-cluster
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-srep-readers-cluster
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-srep-readers-cluster
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
         name: backplane-srep
         namespace: openshift-rbac-permissions
       spec:
-        clusterPermissions:
-        - backplane-srep-admins-cluster
-        - backplane-srep-readers-cluster
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-admins-project

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3893,15 +3893,34 @@ objects:
       metadata:
         name: backplane-srep-readers-cluster
       rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-srep-admins-cluster
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-srep-admins-cluster
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-srep-readers-cluster
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-srep-readers-cluster
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
         name: backplane-srep
         namespace: openshift-rbac-permissions
       spec:
-        clusterPermissions:
-        - backplane-srep-admins-cluster
-        - backplane-srep-readers-cluster
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-admins-project

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3893,15 +3893,34 @@ objects:
       metadata:
         name: backplane-srep-readers-cluster
       rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-srep-admins-cluster
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-srep-admins-cluster
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: backplane-srep-readers-cluster
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: backplane-srep-readers-cluster
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
         name: backplane-srep
         namespace: openshift-rbac-permissions
       spec:
-        clusterPermissions:
-        - backplane-srep-admins-cluster
-        - backplane-srep-readers-cluster
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-admins-project


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
When a cluster is freshly installed, and before the rbac-permissions-operator comes up, some of SREP's backplane permissions don't resolved. This is because the trigger to create a `ClusterRoleBinding` is in the `SubjectPermission` CR.

This moves the binding for these cluster-wide permissions to do basic things like `oc get nodes` to a direct `ClusterRoleBinding`. This will allow SREP to do more actions if the rbac-permissions-operator isn't functioning properly without elevating.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

