### PR TITLE
OSD-10032; OSD-10033 - Add new managed-upgrade-operator metric to observatorium-mst

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'
+            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/deploy/sre-prometheus/centralized-observability/100-sre-internal-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-internal-slo-recording-rules.PrometheusRule.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-internal-slo-recording-rules
+    role: recording-rules
+  name: sre-internal-slo-recording-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: sre-internal-slo.rules
+      rules:
+        - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts, upgradeconfig_name) label_replace(upgradeoperator_upgrade_result, "sre", "true", "", "")
+          record: sre:slo:upgradeoperator_upgrade_result

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4548,7 +4548,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13665,6 +13665,22 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-internal-slo-recording-rules
+          role: recording-rules
+        name: sre-internal-slo-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-internal-slo.rules
+          rules:
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts,
+              upgradeconfig_name) label_replace(upgradeoperator_upgrade_result, "sre",
+              "true", "", "")
+            record: sre:slo:upgradeoperator_upgrade_result
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4548,7 +4548,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13665,6 +13665,22 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-internal-slo-recording-rules
+          role: recording-rules
+        name: sre-internal-slo-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-internal-slo.rules
+          rules:
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts,
+              upgradeconfig_name) label_replace(upgradeoperator_upgrade_result, "sre",
+              "true", "", "")
+            record: sre:slo:upgradeoperator_upgrade_result
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4548,7 +4548,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
@@ -13665,6 +13665,22 @@ objects:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-internal-slo-recording-rules
+          role: recording-rules
+        name: sre-internal-slo-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-internal-slo.rules
+          rules:
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts,
+              upgradeconfig_name) label_replace(upgradeoperator_upgrade_result, "sre",
+              "true", "", "")
+            record: sre:slo:upgradeoperator_upgrade_result
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
**Feature**

### Which Jira/Github issue(s) this PR fixes?
Fixes [OSD-10032](https://issues.redhat.com/browse/OSD-10032) and [OSD-10033](https://issues.redhat.com/browse/OSD-10033)

### What this PR does / why we need it?
Exports a new metric `upgradeoperator_upgrade_alerted` from managed-upgrade-operator to Observatorium-MST for long-term storage. 

### Special notes for your reviewer:
[managed-upgrade-operator PR](https://github.com/openshift/managed-upgrade-operator/pull/314) which adds this metric

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

