### PR TITLE
Make the alert a warning to not block upgrades.

### DIFF
--- a/deploy/sre-prometheus/100-managed-node-metadata-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-node-metadata-operator.PrometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       expr: increase(controller_runtime_reconcile_total{controller="machineset_controller", service="openshift-managed-node-metadata-operator-metrics-service", result="error"}[90m]) >= 5
       for: 15m
       labels:
-        severity: critical
+        severity: warning
         namespace: "{{ $labels.namespace }}"
         maturity: "immature"
         source: "https://issues.redhat.com//browse/OSD-9911"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13255,7 +13255,7 @@ objects:
               result="error"}[90m]) >= 5
             for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: '{{ $labels.namespace }}'
               maturity: immature
               source: https://issues.redhat.com//browse/OSD-9911

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13255,7 +13255,7 @@ objects:
               result="error"}[90m]) >= 5
             for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: '{{ $labels.namespace }}'
               maturity: immature
               source: https://issues.redhat.com//browse/OSD-9911

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13255,7 +13255,7 @@ objects:
               result="error"}[90m]) >= 5
             for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: '{{ $labels.namespace }}'
               maturity: immature
               source: https://issues.redhat.com//browse/OSD-9911


### PR DESCRIPTION
This should remain until the alert is mature enough.

### What type of PR is this?
Bug

### What this PR does / why we need it?

Right now the alert is immature, but can block upgrades.

This is blocking a cluster upgrade, so it should be put to warning instead.

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-11437

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

