### PR TITLE
Add Cloudformation for Operator roles and OIDC provider

### DIFF
--- a/resources/sts/4.10/cloudformation/openshift_oidc_provider.json
+++ b/resources/sts/4.10/cloudformation/openshift_oidc_provider.json
@@ -1,0 +1,35 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "ClientIDOpenShift": {
+        "Description": "OIDC Client ID OpenShift",
+        "Type": "String",
+        "Default": "openshift"
+      },
+      "ClientIDAWSSTS": { 
+        "Description": "OIDC Client ID AWS STS",
+        "Type": "String",
+        "Default": "sts.amazonaws.com"
+      },
+      "Thumbprint": {
+        "Description": "Thumbprint",
+        "Type": "String",
+		"Default": "a9d53002e97e00e043244f3d170d6f4c414104fd"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "OpenShfitOIDCProvider": {
+            "Type": "AWS::IAM::OIDCProvider",
+            "Properties": {
+                "ClientIdList": [ { "Ref": "ClientIDOpenShift" }, { "Ref": "ClientIDAWSSTS" } ],
+                "ThumbprintList": [ { "Ref": "Thumbprint"} ], 
+                "Url": { "Ref": "IssuerURL" },
+                "Tags": [ {"Key": "red-hat-managed", "Value": "true"} ]
+            }
+        }
+    }
+}

--- a/resources/sts/4.10/cloudformation/openshift_operator_roles.json
+++ b/resources/sts/4.10/cloudformation/openshift_operator_roles.json
@@ -1,0 +1,179 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "OIDCProviderARN": {
+        "Description": "OIDC Provider ARN",
+        "Type": "String"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-cloud-credential-operator:cloud-credential-operator"
+      },
+      "MachineAPIOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-machine-api:machine-api-controllers"
+      },
+      "ImageRegistryOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\" , \"system:serviceaccount:openshift-image-registry:registry\""
+      },
+      "IngressOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-ingress-operator:ingress-operator"
+      },
+      "ClusterCSIDriverEBSSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\""
+      },
+      "NetworkConfigControllerSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"
+      },
+      "CloudCredentialOperatorRoleName": {
+        "Description": "Cloud Credential Operator Role Name",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorPolicyARN": {
+        "Description": "Cloud Credential Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "MachineAPIOperatorRoleName": {
+        "Description": "Machine API Operator Role Name",
+        "Type": "String"
+      },
+      "MachineAPIOperatorPolicyARN": {
+        "Description": "Machine API Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorRoleName": {
+        "Description": "Image Registry Operator Role Name",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorPolicyARN": {
+        "Description": "Image Registry Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "IngressOperatorRoleName": {
+        "Description": "Ingress Operator Role Name",
+        "Type": "String"
+      },
+      "IngressOperatorPolicyARN": {
+        "Description": "Ingress Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSRoleName": {
+        "Description": "Cluster CSI Driver EBS Role Name",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSPolicyARN": {
+        "Description": "Cluster CSI Driver EBS Policy ARN",
+        "Type": "String"
+      },
+      "NetworkConfigControllerRoleName": {
+        "Description": "Network Config Controller Policy Name",
+        "Type": "String"
+      },
+      "NetworkConfigControllerPolicyARN": {
+        "Description": "Network Config Controller Policy ARN",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "CloudCredentialOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "CloudCredentialOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${CloudCredentialOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "CloudCredentialOperatorPolicyARN" }],
+                "Tags":
+					[
+						{"Key": "red-hat-managed", "Value": "true"}
+					]
+				}
+        },
+        "MachineAPIOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "MachineAPIOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${MachineAPIOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{"Ref": "MachineAPIOperatorPolicyARN"}],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ImageRegistryOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ImageRegistryOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"Federated\": [\"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\", \"system:serviceaccount:openshift-image-registry:registry\" ] } } }] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ImageRegistryOperatorPolicyARN" }],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "IngressOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "IngressOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${IngressOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "IngressOperatorPolicyARN"}],
+                "Tags": [
+                	{"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ClusterCSIDriverEBSRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ClusterCSIDriverEBSRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\" ]} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ClusterCSIDriverEBSPolicyARN" }],
+                "Tags": [
+                    {"Key": "red-hat-managed", "Value": "true"}
+                ]
+            }
+        },
+        "NetworkConfigControllerRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "RoleName": { "Ref": "NetworkConfigControllerRoleName" },
+                "AssumeRolePolicyDocument": {
+                "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"Federated\": [\"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": \"${NetworkConfigControllerSAName}\" } } }] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "NetworkConfigControllerPolicyARN" }],
+            	"Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        }
+    },	
+    "Outputs" : {
+        "CloudCredentialOperatorRoleArn": {
+			"Description" : "Cloud Credential Operator Role Arn",
+			"Value" :  { "Fn::GetAtt" : ["CloudCredentialOperatorRole", "Arn"] },
+			"Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-CloudCredentialOperatorRoleArn" }}
+	  }
+	}
+}

--- a/resources/sts/4.7/cloudformation/openshift_oidc_provider.json
+++ b/resources/sts/4.7/cloudformation/openshift_oidc_provider.json
@@ -1,0 +1,35 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "ClientIDOpenShift": {
+        "Description": "OIDC Client ID OpenShift",
+        "Type": "String",
+        "Default": "openshift"
+      },
+      "ClientIDAWSSTS": { 
+        "Description": "OIDC Client ID AWS STS",
+        "Type": "String",
+        "Default": "sts.amazonaws.com"
+      },
+      "Thumbprint": {
+        "Description": "Thumbprint",
+        "Type": "String",
+		"Default": "a9d53002e97e00e043244f3d170d6f4c414104fd"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "OpenShfitOIDCProvider": {
+            "Type": "AWS::IAM::OIDCProvider",
+            "Properties": {
+                "ClientIdList": [ { "Ref": "ClientIDOpenShift" }, { "Ref": "ClientIDAWSSTS" } ],
+                "ThumbprintList": [ { "Ref": "Thumbprint"} ], 
+                "Url": { "Ref": "IssuerURL" },
+                "Tags": [ {"Key": "red-hat-managed", "Value": "true"} ]
+            }
+        }
+    }
+}

--- a/resources/sts/4.7/cloudformation/openshift_operator_roles.json
+++ b/resources/sts/4.7/cloudformation/openshift_operator_roles.json
@@ -1,0 +1,153 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "OIDCProviderARN": {
+        "Description": "OIDC Provider ARN",
+        "Type": "String"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-cloud-credential-operator:cloud-credential-operator"
+      },
+      "MachineAPIOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-machine-api:machine-api-controllers"
+      },
+      "ImageRegistryOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\" , \"system:serviceaccount:openshift-image-registry:registry\""
+      },
+      "IngressOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-ingress-operator:ingress-operator"
+      },
+      "ClusterCSIDriverEBSSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\""
+      },
+      "CloudCredentialOperatorRoleName": {
+        "Description": "Cloud Credential Operator Role Name",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorPolicyARN": {
+        "Description": "Cloud Credential Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "MachineAPIOperatorRoleName": {
+        "Description": "Machine API Operator Role Name",
+        "Type": "String"
+      },
+      "MachineAPIOperatorPolicyARN": {
+        "Description": "Machine API Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorRoleName": {
+        "Description": "Image Registry Operator Role Name",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorPolicyARN": {
+        "Description": "Image Registry Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "IngressOperatorRoleName": {
+        "Description": "Ingress Operator Role Name",
+        "Type": "String"
+      },
+      "IngressOperatorPolicyARN": {
+        "Description": "Ingress Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSRoleName": {
+        "Description": "Cluster CSI Driver EBS Role Name",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSPolicyARN": {
+        "Description": "Cluster CSI Driver EBS Policy ARN",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "CloudCredentialOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "CloudCredentialOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${CloudCredentialOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "CloudCredentialOperatorPolicyARN" }],
+                "Tags":
+					[
+						{"Key": "red-hat-managed", "Value": "true"}
+					]
+				}
+        },
+        "MachineAPIOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "MachineAPIOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${MachineAPIOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{"Ref": "MachineAPIOperatorPolicyARN"}],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ImageRegistryOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ImageRegistryOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"Federated\": [\"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\", \"system:serviceaccount:openshift-image-registry:registry\" ] } } }] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ImageRegistryOperatorPolicyARN" }],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "IngressOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "IngressOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${IngressOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "IngressOperatorPolicyARN"}],
+                "Tags": [
+                	{"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ClusterCSIDriverEBSRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ClusterCSIDriverEBSRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\" ]} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ClusterCSIDriverEBSPolicyARN" }],
+                "Tags": [
+                    {"Key": "red-hat-managed", "Value": "true"}
+                ]
+            }
+        }
+    },	
+    "Outputs" : {
+        "CloudCredentialOperatorRoleArn": {
+			"Description" : "Cloud Credential Operator Role Arn",
+			"Value" :  { "Fn::GetAtt" : ["CloudCredentialOperatorRole", "Arn"] },
+			"Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-CloudCredentialOperatorRoleArn" }}
+	  }
+	}
+}

--- a/resources/sts/4.8/cloudformation/openshift_oidc_provider.json
+++ b/resources/sts/4.8/cloudformation/openshift_oidc_provider.json
@@ -1,0 +1,35 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "ClientIDOpenShift": {
+        "Description": "OIDC Client ID OpenShift",
+        "Type": "String",
+        "Default": "openshift"
+      },
+      "ClientIDAWSSTS": { 
+        "Description": "OIDC Client ID AWS STS",
+        "Type": "String",
+        "Default": "sts.amazonaws.com"
+      },
+      "Thumbprint": {
+        "Description": "Thumbprint",
+        "Type": "String",
+		"Default": "a9d53002e97e00e043244f3d170d6f4c414104fd"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "OpenShfitOIDCProvider": {
+            "Type": "AWS::IAM::OIDCProvider",
+            "Properties": {
+                "ClientIdList": [ { "Ref": "ClientIDOpenShift" }, { "Ref": "ClientIDAWSSTS" } ],
+                "ThumbprintList": [ { "Ref": "Thumbprint"} ], 
+                "Url": { "Ref": "IssuerURL" },
+                "Tags": [ {"Key": "red-hat-managed", "Value": "true"} ]
+            }
+        }
+    }
+}

--- a/resources/sts/4.8/cloudformation/openshift_operator_roles.json
+++ b/resources/sts/4.8/cloudformation/openshift_operator_roles.json
@@ -1,0 +1,153 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "OIDCProviderARN": {
+        "Description": "OIDC Provider ARN",
+        "Type": "String"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-cloud-credential-operator:cloud-credential-operator"
+      },
+      "MachineAPIOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-machine-api:machine-api-controllers"
+      },
+      "ImageRegistryOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\" , \"system:serviceaccount:openshift-image-registry:registry\""
+      },
+      "IngressOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-ingress-operator:ingress-operator"
+      },
+      "ClusterCSIDriverEBSSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\""
+      },
+      "CloudCredentialOperatorRoleName": {
+        "Description": "Cloud Credential Operator Role Name",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorPolicyARN": {
+        "Description": "Cloud Credential Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "MachineAPIOperatorRoleName": {
+        "Description": "Machine API Operator Role Name",
+        "Type": "String"
+      },
+      "MachineAPIOperatorPolicyARN": {
+        "Description": "Machine API Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorRoleName": {
+        "Description": "Image Registry Operator Role Name",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorPolicyARN": {
+        "Description": "Image Registry Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "IngressOperatorRoleName": {
+        "Description": "Ingress Operator Role Name",
+        "Type": "String"
+      },
+      "IngressOperatorPolicyARN": {
+        "Description": "Ingress Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSRoleName": {
+        "Description": "Cluster CSI Driver EBS Role Name",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSPolicyARN": {
+        "Description": "Cluster CSI Driver EBS Policy ARN",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "CloudCredentialOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "CloudCredentialOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${CloudCredentialOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "CloudCredentialOperatorPolicyARN" }],
+                "Tags":
+					[
+						{"Key": "red-hat-managed", "Value": "true"}
+					]
+				}
+        },
+        "MachineAPIOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "MachineAPIOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${MachineAPIOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{"Ref": "MachineAPIOperatorPolicyARN"}],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ImageRegistryOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ImageRegistryOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"Federated\": [\"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\", \"system:serviceaccount:openshift-image-registry:registry\" ] } } }] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ImageRegistryOperatorPolicyARN" }],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "IngressOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "IngressOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${IngressOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "IngressOperatorPolicyARN"}],
+                "Tags": [
+                	{"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ClusterCSIDriverEBSRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ClusterCSIDriverEBSRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\" ]} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ClusterCSIDriverEBSPolicyARN" }],
+                "Tags": [
+                    {"Key": "red-hat-managed", "Value": "true"}
+                ]
+            }
+        }
+    },	
+    "Outputs" : {
+        "CloudCredentialOperatorRoleArn": {
+			"Description" : "Cloud Credential Operator Role Arn",
+			"Value" :  { "Fn::GetAtt" : ["CloudCredentialOperatorRole", "Arn"] },
+			"Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-CloudCredentialOperatorRoleArn" }}
+	  }
+	}
+}

--- a/resources/sts/4.9/cloudformation/openshift_oidc_provider.json
+++ b/resources/sts/4.9/cloudformation/openshift_oidc_provider.json
@@ -1,0 +1,35 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "ClientIDOpenShift": {
+        "Description": "OIDC Client ID OpenShift",
+        "Type": "String",
+        "Default": "openshift"
+      },
+      "ClientIDAWSSTS": { 
+        "Description": "OIDC Client ID AWS STS",
+        "Type": "String",
+        "Default": "sts.amazonaws.com"
+      },
+      "Thumbprint": {
+        "Description": "Thumbprint",
+        "Type": "String",
+		"Default": "a9d53002e97e00e043244f3d170d6f4c414104fd"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "OpenShfitOIDCProvider": {
+            "Type": "AWS::IAM::OIDCProvider",
+            "Properties": {
+                "ClientIdList": [ { "Ref": "ClientIDOpenShift" }, { "Ref": "ClientIDAWSSTS" } ],
+                "ThumbprintList": [ { "Ref": "Thumbprint"} ], 
+                "Url": { "Ref": "IssuerURL" },
+                "Tags": [ {"Key": "red-hat-managed", "Value": "true"} ]
+            }
+        }
+    }
+}

--- a/resources/sts/4.9/cloudformation/openshift_operator_roles.json
+++ b/resources/sts/4.9/cloudformation/openshift_operator_roles.json
@@ -1,0 +1,153 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters" : {
+      "OIDCProviderARN": {
+        "Description": "OIDC Provider ARN",
+        "Type": "String"
+      },
+      "IssuerURL": {
+        "Description": "OIDC Issuer URL",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-cloud-credential-operator:cloud-credential-operator"
+      },
+      "MachineAPIOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-machine-api:machine-api-controllers"
+      },
+      "ImageRegistryOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\" , \"system:serviceaccount:openshift-image-registry:registry\""
+      },
+      "IngressOperatorSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "system:serviceaccount:openshift-ingress-operator:ingress-operator"
+      },
+      "ClusterCSIDriverEBSSAName": {
+        "Description": "Service Account Name",
+        "Type": "String",
+        "Default": "\"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\""
+      },
+      "CloudCredentialOperatorRoleName": {
+        "Description": "Cloud Credential Operator Role Name",
+        "Type": "String"
+      },
+      "CloudCredentialOperatorPolicyARN": {
+        "Description": "Cloud Credential Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "MachineAPIOperatorRoleName": {
+        "Description": "Machine API Operator Role Name",
+        "Type": "String"
+      },
+      "MachineAPIOperatorPolicyARN": {
+        "Description": "Machine API Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorRoleName": {
+        "Description": "Image Registry Operator Role Name",
+        "Type": "String"
+      },
+      "ImageRegistryOperatorPolicyARN": {
+        "Description": "Image Registry Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "IngressOperatorRoleName": {
+        "Description": "Ingress Operator Role Name",
+        "Type": "String"
+      },
+      "IngressOperatorPolicyARN": {
+        "Description": "Ingress Operator IAM Policy ARN",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSRoleName": {
+        "Description": "Cluster CSI Driver EBS Role Name",
+        "Type": "String"
+      },
+      "ClusterCSIDriverEBSPolicyARN": {
+        "Description": "Cluster CSI Driver EBS Policy ARN",
+        "Type": "String"
+      }
+    },
+    "Resources": {
+        "CloudCredentialOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "CloudCredentialOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${CloudCredentialOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "CloudCredentialOperatorPolicyARN" }],
+                "Tags":
+					[
+						{"Key": "red-hat-managed", "Value": "true"}
+					]
+				}
+        },
+        "MachineAPIOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "MachineAPIOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${MachineAPIOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{"Ref": "MachineAPIOperatorPolicyARN"}],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ImageRegistryOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ImageRegistryOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Principal\": {\"Federated\": [\"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-image-registry:cluster-image-registry-operator\", \"system:serviceaccount:openshift-image-registry:registry\" ] } } }] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ImageRegistryOperatorPolicyARN" }],
+                "Tags": [
+            	    {"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "IngressOperatorRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "IngressOperatorRoleName" },
+                "AssumeRolePolicyDocument": {
+					"Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\":  \"${IngressOperatorSAName}\"} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "IngressOperatorPolicyARN"}],
+                "Tags": [
+                	{"Key": "red-hat-managed", "Value": "true"}
+            	]
+            }
+        },
+        "ClusterCSIDriverEBSRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+            	"RoleName": { "Ref": "ClusterCSIDriverEBSRoleName" },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": "{\"Version\": \"2012-10-17\",\"Statement\":[{\"Effect\": \"Allow\",\"Principal\":{\"Federated\": [ \"${OIDCProviderARN}\" ]},\"Action\": [\"sts:AssumeRoleWithWebIdentity\"],\"Condition\": {\"StringEquals\": {\"${IssuerURL}:sub\": [ \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-operator\", \"system:serviceaccount:openshift-cluster-csi-drivers:aws-ebs-csi-driver-controller-sa\" ]} } } ] }"
+                },
+                "ManagedPolicyArns": [{ "Ref": "ClusterCSIDriverEBSPolicyARN" }],
+                "Tags": [
+                    {"Key": "red-hat-managed", "Value": "true"}
+                ]
+            }
+        }
+    },	
+    "Outputs" : {
+        "CloudCredentialOperatorRoleArn": {
+			"Description" : "Cloud Credential Operator Role Arn",
+			"Value" :  { "Fn::GetAtt" : ["CloudCredentialOperatorRole", "Arn"] },
+			"Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-CloudCredentialOperatorRoleArn" }}
+	  }
+	}
+}


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This PR adds cloudformation to create operator roles and configure the OIDC provider for STS clusters. Customers can use this cloudformation in place of the ROSA CLI commands, this work is intended to be used in the ROSA UI.

### Which Jira/Github issue(s) this PR fixes?

[OSD-11513](https://issues.redhat.com/browse/OSD-11513)

### Special notes for your reviewer:

To run the cloudformation you will need to pass parameters with the operator policy ARNs, cluster ID, issuer URL and OIDC provider ARN for the cluster. These all can be obtained after running `rosa create cluster --sts` 


#### OIDC provider

```
aws cloudformation create-stack \
 --stack-name oidc-provider \
 --template-body file://templates/cloudformation/openshift_oidc_provider.json \
 --parameters  ParameterKey=IssuerURL,ParameterValue=https://rh-oidc-staging.s3.us-east-1.amazonaws.com/1oj9vqveg4jb20cpuced986us4rra0e5 \
 --region us-east-2
```

#### Operator roles


```
aws cloudformation create-stack \
--stack-name operator-roles-1rrfnpvkl26em3c3fhcaat7hop0jnsn1 \
--template-body file://templates/cloudformation/openshift_oper
ator_roles.json \
--region us-west-1 \
--parameters \
ParameterKey=OIDCProviderARN,ParameterValue=arn:aws:iam::123456789101:oidc-provider/rh-oidc-staging.s3.us-east-1.amazonaws.com/1rrfnpvkl26em3c3fhcaat7hop0jnsn1 \
ParameterKey=IssuerURL,ParameterValue=rh-oidc-staging.s3.us-east-1.amazonaws.com/1rrfnpvkl26em3c3fhcaat7hop0jnsn1 \
ParameterKey=IngressOperatorRoleName,ParameterValue=james-test-openshift-ingress-operator-cloud-credentials \
ParameterKey=IngressOperatorPolicyARN,ParameterValue=arn:aws:iam::123456789101:policy/ManagedOpenShift-openshift-ingress-operator-cloud-credentials \
ParameterKey=ClusterCSIDriverEBSRoleName,ParameterValue=james-test-openshift-cluster-csi-drivers-ebs-cloud-credentials \
ParameterKey=ClusterCSIDriverEBSPolicyARN,ParameterValue=arn:aws:iam::123456789101:policy/ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credent \
ParameterKey=MachineAPIOperatorRoleName,ParameterValue=james-test-openshift-machine-api-aws-cloud-credentials \
ParameterKey=MachineAPIOperatorPolicyARN,ParameterValue=arn:aws:iam::123456789101:policy/ManagedOpenShift-openshift-machine-api-aws-cloud-credentials \
ParameterKey=CloudCredentialOperatorRoleName,ParameterValue=james-test-openshift-cloud-credential-operator-cloud-credential- \
ParameterKey=CloudCredentialOperatorPolicyARN,ParameterValue=arn:aws:iam::123456789101:policy/ManagedOpenShift-openshift-cloud-credential-operator-cloud-crede \
ParameterKey=ImageRegistryOperatorRoleName,ParameterValue=james-test-openshift-image-registry-installer-cloud-credentials \
ParameterKey=ImageRegistryOperatorPolicyARN,ParameterValue=arn:aws:iam::123456789101:policy/ManagedOpenShift-openshift-image-registry-installer-cloud-creden 
--capabilities CAPABILITY_NAMED_IAM 
```


For 4.10 clusters an extra operator requires an extra parameter


```
ParameterKey=NetworkConfigControllerRoleName,ParameterValue=james-test-openshift-cloud-network-config-controller-cloud-crede \
ParameterKey=NetworkConfigControllerPolicyARN,ParameterValue=arn:aws:iam::123456789101:policy/ManagedOpenShift-openshift-network-config-controller-cloud-crede \
```


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

