### PR TITLE
osd-cluster-ready++ to remove clusterwide pod healthcheck

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.81-33838ec"
+                managed.openshift.io/version: "v0.1.83-10bd314"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716"
+              image: "quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7136,11 +7136,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.81-33838ec
+              managed.openshift.io/version: v0.1.83-10bd314
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716
+              image: quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7136,11 +7136,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.81-33838ec
+              managed.openshift.io/version: v0.1.83-10bd314
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716
+              image: quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7136,11 +7136,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.81-33838ec
+              managed.openshift.io/version: v0.1.83-10bd314
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:c5064d58b8697f9793f7cd7b169393f3c078d40650613660520a51fab75e8716
+              image: quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
https://github.com/openshift/osd-cluster-ready/pull/23 was made to pull in changes from https://github.com/openshift/osde2e/pull/1117, as the clusterwide pod healthcheck was causing some false negatives where e.g. the kube-controller-manager installer pod fails, but a new retry pod is spun up.

### Which Jira/Github issue(s) this PR fixes?
[OSD-11704](https://issues.redhat.com//browse/OSD-11704)

### Special notes for your reviewer:
Validated working in a stage dev cluster