### PR TITLE
[MTSRE-558] feature: adding permission for MTSRE team to manange pods

### DIFF
--- a/deploy/backplane/mtsre/10-mtsre-core-apis.ClusterRole.yml
+++ b/deploy/backplane/mtsre/10-mtsre-core-apis.ClusterRole.yml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-mtsre-pod-manager
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/deploy/backplane/mtsre/20-mtsre-pod-manager.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/20-mtsre-pod-manager.SubjectPermission.yml
@@ -1,0 +1,12 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-mtsre-pod-managers
+  namespace: openshift-rbac-permissions
+spec:
+  permissions:
+  - allowFirst: true
+    clusterRoleName: backplane-mtsre-pod-manager
+    namespacesAllowedRegex: (^openshift-backplane-mtsre$)
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-mtsre


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / why we need it?

Attempts to allow MTSRE team members access to manage pods within the `openshift-backplane-mtsre` namespace for the sole purpose of executing `oc adm must-gather` operations using the elevated privilege granted by their backplane serviceaccount. (See `Special notes...` for more) 

### Which Jira/Github issue(s) this PR fixes?

[MTSRE-558](https://issues.redhat.com//browse/MTSRE-558)

### Special notes for your reviewer:

#### Background

The `oc` cli expects users to be acting as `cluster-admin` when running `oc adm must-gather` commands. Since MTSRE only has namespace-scoped `admin` access to addon namespaces the `must-gather` fails attempting to create a temp `Namespace` and `ClusterRoleBinding`. As a quick fix https://github.com/openshift/oc/pull/1080 was implemented to allow users to specify the namespace where the `must-gather` pods will run. However the pods can only run with the default `serviceaccount` of that namespace preventing cluster-scoped resources or resources in other namespaces to not be collected. Thus the `serviceaccount` used must be specified as well (this is a trivial change to make in `oc`).

#### Reasoning for this change

The only appropriate `serviceaccount` to apply is the one that MTSRE users impersonate while backplaned into a cluster. In order to invoke this `serviceaccount` however the pods to which it's applied must be run in the same namespace, `openshift-backplane-mtsre`.

#### Risks

This is not comprehensive, but some obvious risks are:

- While the backplane namespaces are sparse in terms of deployed resources granting access to create pods exposes `volumes`, `secrets`, `configMaps`, etc... to the creator (assuming they are restricted in that namespace).
- Pods with finalizers could leave the namespace in a terminating state (I think this would only apply if all addons are removed from a cluster which once had them).

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

