### PR TITLE
Decrease pending duration for etcdDivergentRevisionsSRE alert for faster detection [ OSD-11576 ]

### DIFF
--- a/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
+++ b/deploy/bz2068601/10-etcdDivergentRevisionsSRE.PrometheusRule.yaml
@@ -27,7 +27,7 @@ spec:
           extreme circumstances, split brained.
         summary: etcd is reporting divergent member revisions.
       expr: etcd_revision_stddev_sre > 0
-      for: 120m
+      for: 40m
       labels:
         severity: critical
         namespace: openshift-etcd-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4277,7 +4277,7 @@ objects:
                 split brained.
               summary: etcd is reporting divergent member revisions.
             expr: etcd_revision_stddev_sre > 0
-            for: 120m
+            for: 40m
             labels:
               severity: critical
               namespace: openshift-etcd-operator

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4277,7 +4277,7 @@ objects:
                 split brained.
               summary: etcd is reporting divergent member revisions.
             expr: etcd_revision_stddev_sre > 0
-            for: 120m
+            for: 40m
             labels:
               severity: critical
               namespace: openshift-etcd-operator

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4277,7 +4277,7 @@ objects:
                 split brained.
               summary: etcd is reporting divergent member revisions.
             expr: etcd_revision_stddev_sre > 0
-            for: 120m
+            for: 40m
             labels:
               severity: critical
               namespace: openshift-etcd-operator


### PR DESCRIPTION

### What type of PR is this?
_cleanup_

### What this PR does / why we need it?
https://issues.redhat.com/browse/OSD-11576 
We have found a few occassions when this alert fired quite late and it would have been very helpful with detection if this had fired earlier.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-11576


### Special notes for your reviewer:
None, all relevant explanation in https://issues.redhat.com/browse/OSD-11576 (shift-improvement card)

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

