### PR TITLE
Schedule Thanos querier only on infra nodes [OSD-11922]

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -106,3 +106,9 @@ data:
         requests:
           cpu: 5m
           memory: 125Mi
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4558,7 +4558,9 @@ objects:
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
           \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
-          \      cpu: 5m\n      memory: 125Mi\n"
+          \      cpu: 5m\n      memory: 125Mi\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4558,7 +4558,9 @@ objects:
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
           \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
-          \      cpu: 5m\n      memory: 125Mi\n"
+          \      cpu: 5m\n      memory: 125Mi\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4558,7 +4558,9 @@ objects:
           \      operator: Exists\n# https://access.redhat.com/solutions/5685771\n\
           # https://bugzilla.redhat.com/show_bug.cgi?id=1906496\nthanosQuerier:\n\
           \  resources:\n    limits:\n      cpu: 500m\n      memory: 2048Mi\n    requests:\n\
-          \      cpu: 5m\n      memory: 125Mi\n"
+          \      cpu: 5m\n      memory: 125Mi\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
This PR makes sure the thanos querier pods get scheduled on infra nodes as it is SRE workload

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-11922

### Special notes for your reviewer:
N/A

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

