### PR TITLE
OSD-11927 ignore ClusterProxyCAExpiringSRE for upgrade health checks

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -34,6 +34,8 @@ data:
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown
+      # OSD-11927
+      - ClusterProxyCAExpiringSRE
       # https://bugzilla.redhat.com/show_bug.cgi?id=1986981
       - PrometheusRemoteWriteBehind
       - KubePersistentVolumeErrors

--- a/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.5/10-managed-upgrade-operator-configmap.yaml
@@ -40,6 +40,8 @@ data:
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown
+      # OSD-11927
+      - ClusterProxyCAExpiringSRE
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.6/10-managed-upgrade-operator-configmap.yaml
@@ -38,6 +38,8 @@ data:
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown
+      # OSD-11927
+      - ClusterProxyCAExpiringSRE
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
@@ -36,6 +36,8 @@ data:
       - PrometheusRuleFailures
       - CannotRetrieveUpdates
       - FluentdNodeDown
+      # OSD-11927
+      - ClusterProxyCAExpiringSRE
       # https://bugzilla.redhat.com/show_bug.cgi?id=1986981
       - PrometheusRemoteWriteBehind
       - KubePersistentVolumeErrors

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4987,15 +4987,16 @@ objects:
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
-          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
-          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
-          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
-          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
-          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
-          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -5034,13 +5035,13 @@ objects:
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
           \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
-          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
-          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
-          \ kube\n  - default\n"
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5076,13 +5077,14 @@ objects:
           \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
           \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5117,15 +5119,16 @@ objects:
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
           \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
-          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
-          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
-          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
-          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
-          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
-          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  #\
+          \ https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4987,15 +4987,16 @@ objects:
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
-          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
-          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
-          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
-          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
-          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
-          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -5034,13 +5035,13 @@ objects:
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
           \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
-          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
-          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
-          \ kube\n  - default\n"
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5076,13 +5077,14 @@ objects:
           \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
           \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5117,15 +5119,16 @@ objects:
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
           \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
-          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
-          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
-          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
-          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
-          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
-          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  #\
+          \ https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4987,15 +4987,16 @@ objects:
           nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
-          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
-          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
-          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
-          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
-          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
-          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -5034,13 +5035,13 @@ objects:
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
           \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
-          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
-          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
-          \ kube\n  - default\n"
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
+          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
+          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
+          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
+          \  - openshift\n  - kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5076,13 +5077,14 @@ objects:
           \ 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n  -\
           \ DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
           \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  ignoredNamespaces:\n\
-          \  - openshift-logging\n  - openshift-redhat-marketplace\n  - openshift-operators\n\
-          \  - openshift-customer-monitoring\n  - openshift-cnv\n  - openshift-route-monitoring-operator\n\
-          \  - openshift-user-workload-monitoring\n  - openshift-pipelines\nextDependencyAvailabilityChecks:\n\
-          \  http:\n    timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  namespacePrefixesToCheck:\n\
-          \  - openshift\n  - kube\n  - default\n"
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\nverification:\n  ignoredNamespaces:\n\
+          \  - openshift-logging\n  namespacePrefixesToCheck:\n  - openshift\n  -\
+          \ kube\n  - default\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -5117,15 +5119,16 @@ objects:
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - UpgradeClusterCheckFailedSRE\n  -\
           \ PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
-          \  - FluentdNodeDown\n  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n\
-          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
-          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
-          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
-          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
-          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
-          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  #\
+          \ https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Prevent the `ClusterProxyCAExpiringSRE` alert from blocking the commencement of an upgrade.

This alert does not constitute a situation which would necessarily cause an upgrade to block or fail.

### Which Jira/Github issue(s) this PR fixes?
[OSD-11927](https://issues.redhat.com//browse/OSD-11927)
