### PR TITLE
Change InfraNodeNeedsResizing from warning to critical

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -98,7 +98,7 @@ spec:
         expr: sre:node_infras:need_resize > 0
         for: 2h
         labels:
-          severity: warning
+          severity: critical
           namespace: openshift-monitoring
         annotations:
           message: "The cluster's infra instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -12826,7 +12826,7 @@ objects:
             expr: sre:node_infras:need_resize > 0
             for: 2h
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infra instance has been undersized for 2 hours

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -12826,7 +12826,7 @@ objects:
             expr: sre:node_infras:need_resize > 0
             for: 2h
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infra instance has been undersized for 2 hours

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -12826,7 +12826,7 @@ objects:
             expr: sre:node_infras:need_resize > 0
             for: 2h
             labels:
-              severity: warning
+              severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infra instance has been undersized for 2 hours


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This changes the severity of the `InfraNodesNeedResizingSRE` alert from `warning` to `critical`.

The alert has been missed by SRE Primaries because Primary typically is not reviewing warning-level alerts.

### Special notes for your reviewer:

There are three clusters actively firing this alert currently. 

An analysis of PagerDuty stats has shown this to only fire on five unique clusters from 2022 onwards, so this is not expected to create much more additional stress to SRE Primary if changed to critical. 