### PR TITLE
OSD-10945 add suricata logcleanup

### DIFF
--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/anatale/suricata@sha256:00432ce3abb8173c13f55f32f591ddcf77c3bd0003e769cbca281ec8a007483a
+        image: quay.io/app-sre/suricata@sha256:5ff22c23a4f7705d4d5c2d53065bee0732a5a40220396e4b157fe7f3e6ffbd80
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:
@@ -33,7 +33,7 @@ spec:
         - mountPath: /host/
           name: host-filesystem
       - name: log-cleaner
-        image: quay.io/anatale/log-cleaner@sha256:dc8a66cfd2b55f7423835c962b687c5aadf3f2c7caef3d049c3b26da9e41da7f
+        image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
         volumeMounts:
         - mountPath: /host/
           name: host-filesystem        

--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:577fc9bc4816cf9298d12911d000b953dd4e7df4cf6502d4aa5e78219ba0357b
+        image: quay.io/anatale/suricata@sha256:00432ce3abb8173c13f55f32f591ddcf77c3bd0003e769cbca281ec8a007483a
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:
@@ -32,6 +32,11 @@ spec:
         volumeMounts:
         - mountPath: /host/
           name: host-filesystem
+      - name: log-cleaner
+        image: quay.io/anatale/log-cleaner@sha256:dc8a66cfd2b55f7423835c962b687c5aadf3f2c7caef3d049c3b26da9e41da7f
+        volumeMounts:
+        - mountPath: /host/
+          name: host-filesystem        
       dnsPolicy: ClusterFirst
       hostNetwork: true
       nodeSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10967,7 +10967,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:577fc9bc4816cf9298d12911d000b953dd4e7df4cf6502d4aa5e78219ba0357b
+              image: quay.io/app-sre/suricata@sha256:5ff22c23a4f7705d4d5c2d53065bee0732a5a40220396e4b157fe7f3e6ffbd80
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -10980,6 +10980,11 @@ objects:
               securityContext:
                 privileged: true
                 runAsUser: 0
+              volumeMounts:
+              - mountPath: /host/
+                name: host-filesystem
+            - name: log-cleaner
+              image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10967,7 +10967,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:577fc9bc4816cf9298d12911d000b953dd4e7df4cf6502d4aa5e78219ba0357b
+              image: quay.io/app-sre/suricata@sha256:5ff22c23a4f7705d4d5c2d53065bee0732a5a40220396e4b157fe7f3e6ffbd80
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -10980,6 +10980,11 @@ objects:
               securityContext:
                 privileged: true
                 runAsUser: 0
+              volumeMounts:
+              - mountPath: /host/
+                name: host-filesystem
+            - name: log-cleaner
+              image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10967,7 +10967,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:577fc9bc4816cf9298d12911d000b953dd4e7df4cf6502d4aa5e78219ba0357b
+              image: quay.io/app-sre/suricata@sha256:5ff22c23a4f7705d4d5c2d53065bee0732a5a40220396e4b157fe7f3e6ffbd80
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -10980,6 +10980,11 @@ objects:
               securityContext:
                 privileged: true
                 runAsUser: 0
+              volumeMounts:
+              - mountPath: /host/
+                name: host-filesystem
+            - name: log-cleaner
+              image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature

### What this PR does / why we need it?
Suricata is deployed to FedRAMP clusters using MCC, this updates the Suricata daemonset to include a log cleaning sidecar to prevent disk space issues as there is no utility available in the application to clean up logs it creates over time.

### Which Jira/Github issue(s) this PR fixes?
[OSD-10945](https://issues.redhat.com/browse/OSD-10945)

_Fixes #_
- adds sidecar  log-cleaner container to clean up old logs rotated by the suricata container

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

