### PR TITLE
Removing ramonbutter & georgettica from OWNERS -- OHSS-13011 & OHSS-13013

### DIFF
--- a/deploy/osd-cluster-acks/OWNERS
+++ b/deploy/osd-cluster-acks/OWNERS
@@ -1,4 +1,2 @@
 reviewers:
-- ramonbutter
-- georgettica
 - rafael-azevedo

--- a/deploy/osd-route-monitor-operator/OWNERS
+++ b/deploy/osd-route-monitor-operator/OWNERS
@@ -1,3 +1,2 @@
 reviewers:
-- georgettica
 - RiRa12621


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
PR removes ramonbutter & georgettica from OWNERS files

### Which Jira/Github issue(s) this PR fixes?
[OHSS-13011](https://issues.redhat.com//browse/OHSS-13011) & [OHSS-13013](https://issues.redhat.com//browse/OHSS-13013)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ N/A] Tested latest changes against a cluster
- [ N/A] Included documentation changes with PR

