### PR TITLE
Add PrometheusRule for BZ1980755

### DIFF
--- a/deploy/sre-prometheus/bz1980755/100-sre-bz1980755.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/bz1980755/100-sre-bz1980755.PrometheusRule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: sre-bz1980755
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-bz1980755
+    rules:
+    - expr: subscription_sync_total * on(name) group_right label_replace(catalogsource_ready, "name", "$1", "name", "(.*)-(registry|catalog)")
+      record: sre:subscription_sync_total
+    - alert: HighSubscriptionSyncRateSRE
+      annotations:
+        message: "The sync rate for the {{ $labels.name }} operator Subscription is high and may indicate it has not installed successfully."
+      expr: |
+        rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m]) * 100 > 10
+      for: 5m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring

--- a/deploy/sre-prometheus/bz1980755/README.md
+++ b/deploy/sre-prometheus/bz1980755/README.md
@@ -1,0 +1,11 @@
+# bz1980755 HighSubscriptionSyncRateSRE PrometheusRule
+
+This location manages a `PrometheusRule` alert intended to highlight clusters where an operator may be impacted by [BZ1980755](https://bugzilla.redhat.com/show_bug.cgi?id=1980755).
+
+The bug can be observed if the `subscription_sync_total` metric for a subscription rises at a steady rate. Under normal conditions this count should increment very slowly.
+
+The current values have been chosen through observation of impacted clusters in the fleet.
+
+## Contact
+
+Matt Bargenquast mbargenq@redhat.com

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13675,6 +13675,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-bz1980755
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: k8s
+          role: alert-rules
+        name: sre-bz1980755
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-bz1980755
+          rules:
+          - expr: subscription_sync_total * on(name) group_right label_replace(catalogsource_ready,
+              "name", "$1", "name", "(.*)-(registry|catalog)")
+            record: sre:subscription_sync_total
+          - alert: HighSubscriptionSyncRateSRE
+            annotations:
+              message: The sync rate for the {{ $labels.name }} operator Subscription
+                is high and may indicate it has not installed successfully.
+            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m])
+              * 100 > 10
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-centralized-observability
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13675,6 +13675,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-bz1980755
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: k8s
+          role: alert-rules
+        name: sre-bz1980755
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-bz1980755
+          rules:
+          - expr: subscription_sync_total * on(name) group_right label_replace(catalogsource_ready,
+              "name", "$1", "name", "(.*)-(registry|catalog)")
+            record: sre:subscription_sync_total
+          - alert: HighSubscriptionSyncRateSRE
+            annotations:
+              message: The sync rate for the {{ $labels.name }} operator Subscription
+                is high and may indicate it has not installed successfully.
+            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m])
+              * 100 > 10
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-centralized-observability
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13675,6 +13675,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-bz1980755
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: k8s
+          role: alert-rules
+        name: sre-bz1980755
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-bz1980755
+          rules:
+          - expr: subscription_sync_total * on(name) group_right label_replace(catalogsource_ready,
+              "name", "$1", "name", "(.*)-(registry|catalog)")
+            record: sre:subscription_sync_total
+          - alert: HighSubscriptionSyncRateSRE
+            annotations:
+              message: The sync rate for the {{ $labels.name }} operator Subscription
+                is high and may indicate it has not installed successfully.
+            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m])
+              * 100 > 10
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-centralized-observability
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Adds a new `warning` level alert `HighSubscriptionSyncRateSRE` intended to detect clusters that are impacted by bug [BZ1980755](https://bugzilla.redhat.com/show_bug.cgi?id=1980755) whereby operators will install but not be updateable due to  the CSV and Subscription not being correctly associated. This puts the operators in a state where OLM will no longer attempt to update them.

Analysis of Telemetry suggests that this will impact around 67 clusters. As the bug tends to occur at cluster install-time, that number will only grow. 

I'm not expecting SRE to actually do anything about this yet, so a SOP has not yet been written, though I would like to explore remediation via a managed script. 

The alert is checking SRE operators specifically because there is nothing SRE could/should do about customer-installed operators. 

We can, in the future, perhaps use a separate alert and OCM Agent Automation to inform the cluster owner that their operators are impacted by the bug.

### Which Jira/Github issue(s) this PR fixes?

This was first detected in OHSS-12724.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster