### PR TITLE
[OSD-12156] sre recording rule for standardized managed labels

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-telemetry-managed-labels-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-telemetry-managed-labels-recording-rules.PrometheusRule.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-telemetry-managed-labels-recording-rules
+    role: recording-rules
+  name: sre-telemetry-managed-labels-recording-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: sre-telemetry-managed-labels.rules
+      rules:
+        - expr:
+            # Add a label of sre="true"
+            # join metrics on sre="true"
+            # sum by the labels we care about at the most outer level
+            sum by (_id, provider, region, version, sre)
+            (
+            label_replace(cluster_id, "sre", "true", "", "")
+            * on (sre) group_left(provider, region, version)
+            (
+            label_replace(cluster_version{type="current"}, "sre", "true", "", "")
+            )
+            * on (sre) group_left(provider, region)
+            label_replace(sum without (type) (label_replace(cluster_infrastructure_provider, "provider", "$1", "type", "(.*)")), "sre", "true", "", "")
+            )
+            # sre:telemetry:managed_labels{_id="not-a-real-cluster-id", provider="AWS", region="ap-southeast-2", sre="true", version="4.10.18"} => 1654679854 @[1655873133.121]
+          record: sre:telemetry:managed_labels
+            # Any metric being sent to centralized observability service needs to include this standardized data for drill down querying.
+            # Please see INSERT_ME.md for details regarding standardized data.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13623,6 +13623,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-centralized-observability
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-telemetry-managed-labels-recording-rules
+          role: recording-rules
+        name: sre-telemetry-managed-labels-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-telemetry-managed-labels.rules
+          rules:
+          - expr: sum by (_id, provider, region, version, sre) ( label_replace(cluster_id,
+              "sre", "true", "", "") * on (sre) group_left(provider, region, version)
+              ( label_replace(cluster_version{type="current"}, "sre", "true", "",
+              "") ) * on (sre) group_left(provider, region) label_replace(sum without
+              (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
+              "type", "(.*)")), "sre", "true", "", "") )
+            record: sre:telemetry:managed_labels
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-extended-logging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13623,6 +13623,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-centralized-observability
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-telemetry-managed-labels-recording-rules
+          role: recording-rules
+        name: sre-telemetry-managed-labels-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-telemetry-managed-labels.rules
+          rules:
+          - expr: sum by (_id, provider, region, version, sre) ( label_replace(cluster_id,
+              "sre", "true", "", "") * on (sre) group_left(provider, region, version)
+              ( label_replace(cluster_version{type="current"}, "sre", "true", "",
+              "") ) * on (sre) group_left(provider, region) label_replace(sum without
+              (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
+              "type", "(.*)")), "sre", "true", "", "") )
+            record: sre:telemetry:managed_labels
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-extended-logging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13623,6 +13623,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-centralized-observability
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-telemetry-managed-labels-recording-rules
+          role: recording-rules
+        name: sre-telemetry-managed-labels-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-telemetry-managed-labels.rules
+          rules:
+          - expr: sum by (_id, provider, region, version, sre) ( label_replace(cluster_id,
+              "sre", "true", "", "") * on (sre) group_left(provider, region, version)
+              ( label_replace(cluster_version{type="current"}, "sre", "true", "",
+              "") ) * on (sre) group_left(provider, region) label_replace(sum without
+              (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
+              "type", "(.*)")), "sre", "true", "", "") )
+            record: sre:telemetry:managed_labels
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-extended-logging
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Provide standardized telemetry labels to be used in combination with any metric sent to RHOBS

### Which Jira/Github issue(s) this PR fixes?
[OSD-12156](https://issues.redhat.com//browse/OSD-12156)

_Fixes #_ [OSD-12156](https://issues.redhat.com//browse/OSD-12156)

### Special notes for your reviewer:

```
[~/s/o/managed-cluster-config]─[sre-telemetry-recording-rules]── ─ (⎈ dofinn-20220621:default) oc -n openshift-monitoring exec prometheus-k8s-0 -- promtool query instant http://127.0.0.1:9090 'sre:telemetry:managed_labels'
sre:telemetry:managed_labels{_id="XXXXX", provider="AWS", region="ap-southeast-2", sre="true", version="4.10.18"} => 1654679854 @[1655875412.76]
```

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

