### PR TITLE
Remove openshift-sre-sshd namespace from hives

### DIFF
--- a/deploy/osd-ingress/00-openshift-sre-sshd.Namespace.yaml
+++ b/deploy/osd-ingress/00-openshift-sre-sshd.Namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-sre-sshd
-  labels:
-    managed.openshift.io/service-lb-quota-exempt: "true"

--- a/deploy/osd-ingress/config.yaml
+++ b/deploy/osd-ingress/config.yaml
@@ -1,6 +1,0 @@
-deploymentMode: "SelectorSyncSet"
-selectorSyncSet:
-  matchExpressions:
-  - key: ext-managed.openshift.io/hive-shard
-    operator: In
-    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8783,31 +8783,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-ingress
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: ext-managed.openshift.io/hive-shard
-        operator: In
-        values:
-        - 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-sre-sshd
-        labels:
-          managed.openshift.io/service-lb-quota-exempt: 'true'
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-ingress-controller
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8783,31 +8783,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-ingress
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: ext-managed.openshift.io/hive-shard
-        operator: In
-        values:
-        - 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-sre-sshd
-        labels:
-          managed.openshift.io/service-lb-quota-exempt: 'true'
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-ingress-controller
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8783,31 +8783,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-ingress
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: ext-managed.openshift.io/hive-shard
-        operator: In
-        values:
-        - 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: v1
-      kind: Namespace
-      metadata:
-        name: openshift-sre-sshd
-        labels:
-          managed.openshift.io/service-lb-quota-exempt: 'true'
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-ingress-controller
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
Removes the SSHD namespace deployment from hive 
### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com//browse/OSD-11724

### Special notes for your reviewer:

Dependent on https://github.com/openshift/managed-cluster-config/pull/1163 merging

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

