### PR TITLE
[OSD-12252] removing unsupported-logging for FR

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/unsupported-logging/config.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/unsupported-logging/config.yaml
@@ -5,3 +5,7 @@ selectorSyncSet:
   - key: ext-managed.openshift.io/extended-logging-support
     operator: NotIn
     values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5295,6 +5295,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5295,6 +5295,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5295,6 +5295,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Excluding FedRAMP

### What this PR does / why we need it?
ocm-agent-operator-managednotifications-unsupported-logging is being removed because it is not used in FedRAMP

### Which Jira/Github issue(s) this PR fixes?
OSD-12252

_Fixes #_
Fixes a failing ClusterSync in FedRAMP

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

