### PR TITLE
Add friendly warning when adding new resources that may not be intended for FedRAMP

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,4 +12,11 @@ _Fixes #_
 ### Pre-checks (if applicable):
 - [ ] Tested latest changes against a cluster
 - [ ] Included documentation changes with PR
+- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:
 
+    ```yaml
+    matchExpressions:
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+    ```


### PR DESCRIPTION
### What type of PR is this?
documentation

### What this PR does / why we need it?
As an SRE adding resources to MCC in the past, commercial was the only environment affected, but now FedRAMP is also potentially affected by MCC changes and currently the environment isn't totally 1-1. To aid visibility, adding a PR template pre-check for excluding their deployment in FedRAMP if it's not intended for FedRAMP.

### Which Jira/Github issue(s) this PR fixes?

[OSD-12252](https://issues.redhat.com//browse/OSD-12252)