### PR TITLE
[OSD-12087] update the prometheusrule for UpgradeConfigSyncFailureOver4HrSRE

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -64,7 +64,7 @@ spec:
       # Alert if MUO has been unable to successfully sync with its upgrade policy provider for a four-hour window
       # It will also be used for detecting the connection/authentication between cluster and OCM
       # Should be moved to OCM Agent service eventually
-      expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod) kube_pod_container_status_ready{container="managed-upgrade-operator", namespace="openshift-managed-upgrade-operator"} == 1
+      expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h]) or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
       for: 2m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13003,9 +13003,8 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
-              kube_pod_container_status_ready{container="managed-upgrade-operator",
-              namespace="openshift-managed-upgrade-operator"} == 1
+            expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
+              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13003,9 +13003,8 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
-              kube_pod_container_status_ready{container="managed-upgrade-operator",
-              namespace="openshift-managed-upgrade-operator"} == 1
+            expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
+              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13003,9 +13003,8 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_synced[4h]) * on(pod)
-              kube_pod_container_status_ready{container="managed-upgrade-operator",
-              namespace="openshift-managed-upgrade-operator"} == 1
+            expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
+              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
             for: 2m
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Update the UpgradeConfigSyncFailureOver4HrSRE alert rule to use the new introduced metric in https://github.com/openshift/managed-upgrade-operator/pull/325

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-12087_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
