### PR TITLE
Ignore openshift-marketplace for HighSubscriptionSyncRateSRE alert

### DIFF
--- a/deploy/sre-prometheus/bz1980755/100-sre-bz1980755.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/bz1980755/100-sre-bz1980755.PrometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         message: "The sync rate for the {{ $labels.name }} operator Subscription is high and may indicate it has not installed successfully."
       expr: |
-        rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m]) * 100 > 10
+        rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-(operators|marketplace).*"}[30m]) * 100 > 10
       for: 5m
       labels:
         severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13642,7 +13642,7 @@ objects:
             annotations:
               message: The sync rate for the {{ $labels.name }} operator Subscription
                 is high and may indicate it has not installed successfully.
-            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m])
+            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-(operators|marketplace).*"}[30m])
               * 100 > 10
 
               '

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13642,7 +13642,7 @@ objects:
             annotations:
               message: The sync rate for the {{ $labels.name }} operator Subscription
                 is high and may indicate it has not installed successfully.
-            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m])
+            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-(operators|marketplace).*"}[30m])
               * 100 > 10
 
               '

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13642,7 +13642,7 @@ objects:
             annotations:
               message: The sync rate for the {{ $labels.name }} operator Subscription
                 is high and may indicate it has not installed successfully.
-            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-operators.*"}[30m])
+            expr: 'rate(sre:subscription_sync_total{exported_namespace=~"openshift.*",exported_namespace!~"openshift-(operators|marketplace).*"}[30m])
               * 100 > 10
 
               '


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
This applies a tweak to the `HighSubscriptionSyncRateSRE` alert to ignore operators installed in `openshift-marketplace`; there are operators installed in this namespace causing the alert to fire which SRE do not need to action.

Because this alert seems to be working correctly, I've also written up a SOP [[0](https://github.com/openshift/ops-sop/pull/2049)]

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
