### PR TITLE
reverting FR change for OpHub

### DIFF
--- a/deploy/fedramp-operatorhub/00-operatorhub.cr.yaml
+++ b/deploy/fedramp-operatorhub/00-operatorhub.cr.yaml
@@ -1,6 +1,0 @@
-apiVersion: config.openshift.io/v1
-applyMode: AlwaysApply
-kind: OperatorHub
-name: cluster
-patch: '{"spec":{"disableAllDefaultSources":true}}'
-patchType: merge

--- a/deploy/fedramp-operatorhub/config.yaml
+++ b/deploy/fedramp-operatorhub/config.yaml
@@ -1,7 +1,0 @@
-deploymentMode: "SelectorSyncSet"
-selectorSyncSet:
-  matchExpressions:
-  - key: api.openshift.com/fedramp
-    operator: In
-    values:
-      - "true"

--- a/deploy/osd-curated-operatorsources-revert/config.yaml
+++ b/deploy/osd-curated-operatorsources-revert/config.yaml
@@ -4,7 +4,3 @@ selectorSyncSet:
   - key: api.openshift.com/extended-dedicated-admin
     operator: NotIn
     values: ["false"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values:
-      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4839,31 +4839,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: fedramp-operatorhub
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: In
-        values:
-        - 'true'
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: OperatorHub
-      name: cluster
-      patch: '{"spec":{"disableAllDefaultSources":true}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:
@@ -7424,10 +7399,6 @@ objects:
         operator: NotIn
         values:
         - 'false'
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4839,31 +4839,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: fedramp-operatorhub
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: In
-        values:
-        - 'true'
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: OperatorHub
-      name: cluster
-      patch: '{"spec":{"disableAllDefaultSources":true}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:
@@ -7424,10 +7399,6 @@ objects:
         operator: NotIn
         values:
         - 'false'
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4839,31 +4839,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: fedramp-operatorhub
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: In
-        values:
-        - 'true'
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: OperatorHub
-      name: cluster
-      patch: '{"spec":{"disableAllDefaultSources":true}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:
@@ -7424,10 +7399,6 @@ objects:
         operator: NotIn
         values:
         - 'false'
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Reverting pervious change made for FedRAMP

### What this PR does / why we need it?
The issue this fix was put in place for should be resolved

### Which Jira/Github issue(s) this PR fixes?
[OSD-12252](https://issues.redhat.com/browse/OSD-12252)

_Fixes #_
Add OperatorHub back to FR

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
