### PR TITLE
Update staging insights endpoints

### DIFF
--- a/deploy/insights-staging/01-support.Secret.yaml
+++ b/deploy/insights-staging/01-support.Secret.yaml
@@ -6,3 +6,5 @@ metadata:
 type: Opaque
 data:
   endpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbmdyZXNzL3YxL3VwbG9hZA==
+  reportEndpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbnNpZ2h0cy1yZXN1bHRzLWFnZ3JlZ2F0b3IvdjEvY2x1c3RlcnMvJXMvcmVwb3J0
+  scaEndpoint: aHR0cHM6Ly9hcGkuc3RhZ2Uub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4876,6 +4876,8 @@ objects:
       type: Opaque
       data:
         endpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbmdyZXNzL3YxL3VwbG9hZA==
+        reportEndpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbnNpZ2h0cy1yZXN1bHRzLWFnZ3JlZ2F0b3IvdjEvY2x1c3RlcnMvJXMvcmVwb3J0
+        scaEndpoint: aHR0cHM6Ly9hcGkuc3RhZ2Uub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4876,6 +4876,8 @@ objects:
       type: Opaque
       data:
         endpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbmdyZXNzL3YxL3VwbG9hZA==
+        reportEndpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbnNpZ2h0cy1yZXN1bHRzLWFnZ3JlZ2F0b3IvdjEvY2x1c3RlcnMvJXMvcmVwb3J0
+        scaEndpoint: aHR0cHM6Ly9hcGkuc3RhZ2Uub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4876,6 +4876,8 @@ objects:
       type: Opaque
       data:
         endpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbmdyZXNzL3YxL3VwbG9hZA==
+        reportEndpoint: aHR0cHM6Ly9jbG91ZC5zdGFnZS5yZWRoYXQuY29tL2FwaS9pbnNpZ2h0cy1yZXN1bHRzLWFnZ3JlZ2F0b3IvdjEvY2x1c3RlcnMvJXMvcmVwb3J0
+        scaEndpoint: aHR0cHM6Ly9hcGkuc3RhZ2Uub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Adds some additional overrides to staging insights endpoints

### Which Jira/Github issue(s) this PR fixes?
related to [RHCLOUD-17289](https://issues.redhat.com//browse/RHCLOUD-17289)

### Special notes for your reviewer:
While this data is stored in a `secret` object, the actual values aren't secret and are as follows:
```
{
  "endpoint": "https://cloud.stage.redhat.com/api/ingress/v1/upload",
  "reportEndpoint": "https://cloud.stage.redhat.com/api/insights-results-aggregator/v1/clusters/%s/report",
  "scaEndpoint": "https://api.stage.openshift.com/api/accounts_mgmt/v1/certificates"
}
```

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
