### PR TITLE
OSD-12458 Update Cronjobs from batch/v1beta1 to batch/v1

### DIFF
--- a/deploy/osd-curated-operatorsources-revert/10-osd-patch-subscription-source.CronJob.yaml
+++ b/deploy/osd-curated-operatorsources-revert/10-osd-patch-subscription-source.CronJob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: osd-patch-subscription-source

--- a/deploy/osd-delete-backplane-script-resources/20-delete-backplane-script-resources.CronJob.yaml
+++ b/deploy/osd-delete-backplane-script-resources/20-delete-backplane-script-resources.CronJob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: osd-delete-backplane-script-resources
@@ -51,7 +51,7 @@ spec:
                   SAS=$(oc get serviceaccount -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name --no-headers)
 
                   # Format: role_name role_ns
-                  ROLES=$(oc get role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace --no-headers) 
+                  ROLES=$(oc get role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace --no-headers)
 
                   # Format: rolebinding_name rolebinding_ns
                   ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace --no-headers)
@@ -67,7 +67,7 @@ spec:
                   # - pods created within THRESHOLD_PERIOD and related resouces.
                   PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \
                     '{
-                    if($2 ~ /Running/){print $1} 
+                    if($2 ~ /Running/){print $1}
                     else{cmd = sprintf("date +\"%%s\" --date=%s", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0 > before+0){print $1}}
                     }' \
                     <<< "$PODS")

--- a/deploy/osd-delete-backplane-serviceaccounts/20-delete-backplane-serviceaccounts.CronJob.yaml
+++ b/deploy/osd-delete-backplane-serviceaccounts/20-delete-backplane-serviceaccounts.CronJob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: osd-delete-backplane-serviceaccounts

--- a/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
+++ b/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: osd-rebalance-infra-nodes

--- a/deploy/osd-serviceaccounts/cronjob/10-osd-delete-ownerrefs.CronJob.yaml
+++ b/deploy/osd-serviceaccounts/cronjob/10-osd-delete-ownerrefs.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: osd-delete-ownerrefs-serviceaccounts

--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: sre-build-test

--- a/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: builds-pruner

--- a/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: deployments-pruner

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7513,7 +7513,7 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: osd-patch-subscription-source
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-patch-subscription-source
@@ -8289,7 +8289,7 @@ objects:
       - kind: ServiceAccount
         name: osd-backplane
         namespace: openshift-backplane-managed-scripts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-backplane-script-resources
@@ -8335,7 +8335,7 @@ objects:
                     \ -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name\
                     \ --no-headers)\n\n# Format: role_name role_ns\nROLES=$(oc get\
                     \ role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
-                    \ --no-headers) \n\n# Format: rolebinding_name rolebinding_ns\n\
+                    \ --no-headers)\n\n# Format: rolebinding_name rolebinding_ns\n\
                     ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
                     \ --no-headers)\n\n# Format: clusterrole_name\nCROLES=$(oc get\
                     \ clusterrole --selector $LABEL -o custom-columns=NAME:.metadata.name\
@@ -8345,7 +8345,7 @@ objects:
                     \ delete.\n# - Current running pods and related resources.\n#\
                     \ - pods created within THRESHOLD_PERIOD and related resouces.\n\
                     PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \\\n  '{\n  if($2\
-                    \ ~ /Running/){print $1} \n  else{cmd = sprintf(\"date +\\\"%%s\\\
+                    \ ~ /Running/){print $1}\n  else{cmd = sprintf(\"date +\\\"%%s\\\
                     \" --date=%s\", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0\
                     \ > before+0){print $1}}\n  }' \\\n  <<< \"$PODS\")\n\nPODS_TO_DEL=$(awk\
                     \ '{print $1}' <<< \"$PODS\")\n\nfor pod in $PODS_TO_KEEP\ndo\n\
@@ -8431,7 +8431,7 @@ objects:
           namespacesAllowedRegex: (^openshift-backplane-.*)
         subjectKind: User
         subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-backplane-serviceaccounts
@@ -8474,7 +8474,7 @@ objects:
                     \ +%s);\n      expiryMins=$(oc get sa $sa -n $ns -o jsonpath='{.metadata.annotations.managed\\\
                     .openshift\\.io/backplane-expiry-duration}');\n      if [[ $(expr\
                     \ $((now-creation)) \\> ${expiryMins:=720} \\* 60) == 1 ]]; then\n\
-                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;"
+                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9980,7 +9980,7 @@ objects:
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
           waitRunningPods splunk-heavy-forwarder openshift-security name"
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-rebalance-infra-nodes
@@ -10742,7 +10742,7 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: osd-delete-ownerrefs-serviceaccounts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-ownerrefs-serviceaccounts
@@ -12669,7 +12669,7 @@ objects:
         verbs:
         - list
         - delete
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: sre-build-test
@@ -14316,7 +14316,7 @@ objects:
       metadata:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: builds-pruner
@@ -14357,7 +14357,7 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: deployments-pruner

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7513,7 +7513,7 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: osd-patch-subscription-source
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-patch-subscription-source
@@ -8289,7 +8289,7 @@ objects:
       - kind: ServiceAccount
         name: osd-backplane
         namespace: openshift-backplane-managed-scripts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-backplane-script-resources
@@ -8335,7 +8335,7 @@ objects:
                     \ -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name\
                     \ --no-headers)\n\n# Format: role_name role_ns\nROLES=$(oc get\
                     \ role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
-                    \ --no-headers) \n\n# Format: rolebinding_name rolebinding_ns\n\
+                    \ --no-headers)\n\n# Format: rolebinding_name rolebinding_ns\n\
                     ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
                     \ --no-headers)\n\n# Format: clusterrole_name\nCROLES=$(oc get\
                     \ clusterrole --selector $LABEL -o custom-columns=NAME:.metadata.name\
@@ -8345,7 +8345,7 @@ objects:
                     \ delete.\n# - Current running pods and related resources.\n#\
                     \ - pods created within THRESHOLD_PERIOD and related resouces.\n\
                     PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \\\n  '{\n  if($2\
-                    \ ~ /Running/){print $1} \n  else{cmd = sprintf(\"date +\\\"%%s\\\
+                    \ ~ /Running/){print $1}\n  else{cmd = sprintf(\"date +\\\"%%s\\\
                     \" --date=%s\", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0\
                     \ > before+0){print $1}}\n  }' \\\n  <<< \"$PODS\")\n\nPODS_TO_DEL=$(awk\
                     \ '{print $1}' <<< \"$PODS\")\n\nfor pod in $PODS_TO_KEEP\ndo\n\
@@ -8431,7 +8431,7 @@ objects:
           namespacesAllowedRegex: (^openshift-backplane-.*)
         subjectKind: User
         subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-backplane-serviceaccounts
@@ -8474,7 +8474,7 @@ objects:
                     \ +%s);\n      expiryMins=$(oc get sa $sa -n $ns -o jsonpath='{.metadata.annotations.managed\\\
                     .openshift\\.io/backplane-expiry-duration}');\n      if [[ $(expr\
                     \ $((now-creation)) \\> ${expiryMins:=720} \\* 60) == 1 ]]; then\n\
-                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;"
+                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9980,7 +9980,7 @@ objects:
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
           waitRunningPods splunk-heavy-forwarder openshift-security name"
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-rebalance-infra-nodes
@@ -10742,7 +10742,7 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: osd-delete-ownerrefs-serviceaccounts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-ownerrefs-serviceaccounts
@@ -12669,7 +12669,7 @@ objects:
         verbs:
         - list
         - delete
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: sre-build-test
@@ -14316,7 +14316,7 @@ objects:
       metadata:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: builds-pruner
@@ -14357,7 +14357,7 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: deployments-pruner

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7513,7 +7513,7 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: osd-patch-subscription-source
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-patch-subscription-source
@@ -8289,7 +8289,7 @@ objects:
       - kind: ServiceAccount
         name: osd-backplane
         namespace: openshift-backplane-managed-scripts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-backplane-script-resources
@@ -8335,7 +8335,7 @@ objects:
                     \ -n $NS --selector $LABEL -o custom-columns=NAME:.metadata.name\
                     \ --no-headers)\n\n# Format: role_name role_ns\nROLES=$(oc get\
                     \ role -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
-                    \ --no-headers) \n\n# Format: rolebinding_name rolebinding_ns\n\
+                    \ --no-headers)\n\n# Format: rolebinding_name rolebinding_ns\n\
                     ROLEBINDINGS=$(oc get rolebinding -A --selector $LABEL -o custom-columns=NAME:.metadata.name,NS:.metadata.namespace\
                     \ --no-headers)\n\n# Format: clusterrole_name\nCROLES=$(oc get\
                     \ clusterrole --selector $LABEL -o custom-columns=NAME:.metadata.name\
@@ -8345,7 +8345,7 @@ objects:
                     \ delete.\n# - Current running pods and related resources.\n#\
                     \ - pods created within THRESHOLD_PERIOD and related resouces.\n\
                     PODS_TO_KEEP=$(awk -v before=$DEL_ONLY_BEFORE \\\n  '{\n  if($2\
-                    \ ~ /Running/){print $1} \n  else{cmd = sprintf(\"date +\\\"%%s\\\
+                    \ ~ /Running/){print $1}\n  else{cmd = sprintf(\"date +\\\"%%s\\\
                     \" --date=%s\", $3); cmd|getline unix_sec; close(cmd); if(unix_sec+0\
                     \ > before+0){print $1}}\n  }' \\\n  <<< \"$PODS\")\n\nPODS_TO_DEL=$(awk\
                     \ '{print $1}' <<< \"$PODS\")\n\nfor pod in $PODS_TO_KEEP\ndo\n\
@@ -8431,7 +8431,7 @@ objects:
           namespacesAllowedRegex: (^openshift-backplane-.*)
         subjectKind: User
         subjectName: system:serviceaccount:openshift-backplane:osd-delete-backplane-serviceaccounts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-backplane-serviceaccounts
@@ -8474,7 +8474,7 @@ objects:
                     \ +%s);\n      expiryMins=$(oc get sa $sa -n $ns -o jsonpath='{.metadata.annotations.managed\\\
                     .openshift\\.io/backplane-expiry-duration}');\n      if [[ $(expr\
                     \ $((now-creation)) \\> ${expiryMins:=720} \\* 60) == 1 ]]; then\n\
-                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;"
+                    \        oc delete sa $sa -n $ns\n      fi\n    done;\ndone;\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9980,7 +9980,7 @@ objects:
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
           waitRunningPods splunk-heavy-forwarder openshift-security name"
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-rebalance-infra-nodes
@@ -10742,7 +10742,7 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: osd-delete-ownerrefs-serviceaccounts
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: osd-delete-ownerrefs-serviceaccounts
@@ -12669,7 +12669,7 @@ objects:
         verbs:
         - list
         - delete
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: sre-build-test
@@ -14316,7 +14316,7 @@ objects:
       metadata:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: builds-pruner
@@ -14357,7 +14357,7 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: deployments-pruner


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
cronjobs.v1beta1.batch has been deprecated starting in K8s v1.21 and removed in v1.25+ and has since been replaced with batch/v1

### Which Jira/Github issue(s) this PR fixes?
[OSD-12458](https://issues.redhat.com//browse/OSD-12458)

### Special notes for your reviewer:
Left https://github.com/openshift/managed-cluster-config/blob/master/deploy/sre-pruning/images-pre-4.6/01-pruning-images.CronJob.yaml alone as it targets pre-4.6 versions - should we delete this perhaps?