### PR TITLE
OSD-12049 Ensure openshift-cluster-version is a managed namespace

### DIFF
--- a/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
@@ -19,6 +19,8 @@ data:
       - name: openshift-codeready-workspaces
       - name: openshift-custom-domains-operator
       - name: openshift-customer-monitoring
+      - name: openshift-logging
+      - name: openshift-managed-node-metadata-operator
       - name: openshift-managed-upgrade-operator
       - name: openshift-must-gather-operator
       - name: openshift-ocm-agent-operator
@@ -29,10 +31,10 @@ data:
       - name: openshift-security
       - name: openshift-splunk-forwarder-operator
       - name: openshift-sre-pruning
-      - name: openshift-sre-sshd
       - name: openshift-strimzi
       - name: openshift-validation-webhook
       - name: openshift-velero
       - name: openshift-monitoring
       - name: openshift
+      - name: openshift-cluster-version
 

--- a/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
@@ -19,7 +19,6 @@ data:
       - name: openshift-codeready-workspaces
       - name: openshift-custom-domains-operator
       - name: openshift-customer-monitoring
-      - name: openshift-logging
       - name: openshift-managed-node-metadata-operator
       - name: openshift-managed-upgrade-operator
       - name: openshift-must-gather-operator
@@ -37,4 +36,3 @@ data:
       - name: openshift-monitoring
       - name: openshift
       - name: openshift-cluster-version
-

--- a/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml
@@ -7,6 +7,7 @@ data:
   managed_namespaces.yaml: |
     Resources:
       Namespace:
+      - name: kube-system
       - name: openshift-apiserver
       - name: openshift-apiserver-operator
       - name: openshift-authentication
@@ -14,6 +15,7 @@ data:
       - name: openshift-cloud-controller-manager
       - name: openshift-cloud-controller-manager-operator
       - name: openshift-cloud-credential-operator
+      - name: openshift-cloud-network-config-controller
       - name: openshift-cluster-csi-drivers
       - name: openshift-cluster-machine-approver
       - name: openshift-cluster-node-tuning-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9333,15 +9333,14 @@ objects:
           \  - name: openshift-backplane-srep\n  - name: openshift-build-test\n  -\
           \ name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
           \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-node-metadata-operator\n\
-          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
-          \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
-          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
-          \ - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\
-          \  - name: openshift-cluster-version\n"
+          \  - name: openshift-managed-node-metadata-operator\n  - name: openshift-managed-upgrade-operator\n\
+          \  - name: openshift-must-gather-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-sre-pruning\n  - name: openshift-strimzi\n  - name:\
+          \ openshift-validation-webhook\n  - name: openshift-velero\n  - name: openshift-monitoring\n\
+          \  - name: openshift\n  - name: openshift-cluster-version\n"
     - apiVersion: v1
       kind: ConfigMap
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9333,23 +9333,26 @@ objects:
           \  - name: openshift-backplane-srep\n  - name: openshift-build-test\n  -\
           \ name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
           \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-logging\n  - name: openshift-managed-node-metadata-operator\n\
           \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
           \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
           \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
           \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
           \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
-          \  - name: openshift-sre-sshd\n  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n\
-          \  - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n"
+          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
+          \ - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\
+          \  - name: openshift-cluster-version\n"
     - apiVersion: v1
       kind: ConfigMap
       metadata:
         name: ocp-namespaces
         namespace: openshift-monitoring
       data:
-        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver\n\
-          \  - name: openshift-apiserver-operator\n  - name: openshift-authentication\n\
-          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
-          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: kube-system\n\
+          \  - name: openshift-apiserver\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication\n  - name: openshift-authentication-operator\n\
+          \  - name: openshift-cloud-controller-manager\n  - name: openshift-cloud-controller-manager-operator\n\
+          \  - name: openshift-cloud-credential-operator\n  - name: openshift-cloud-network-config-controller\n\
           \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
           \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
           \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9333,15 +9333,14 @@ objects:
           \  - name: openshift-backplane-srep\n  - name: openshift-build-test\n  -\
           \ name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
           \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-node-metadata-operator\n\
-          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
-          \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
-          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
-          \ - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\
-          \  - name: openshift-cluster-version\n"
+          \  - name: openshift-managed-node-metadata-operator\n  - name: openshift-managed-upgrade-operator\n\
+          \  - name: openshift-must-gather-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-sre-pruning\n  - name: openshift-strimzi\n  - name:\
+          \ openshift-validation-webhook\n  - name: openshift-velero\n  - name: openshift-monitoring\n\
+          \  - name: openshift\n  - name: openshift-cluster-version\n"
     - apiVersion: v1
       kind: ConfigMap
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9333,23 +9333,26 @@ objects:
           \  - name: openshift-backplane-srep\n  - name: openshift-build-test\n  -\
           \ name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
           \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-logging\n  - name: openshift-managed-node-metadata-operator\n\
           \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
           \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
           \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
           \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
           \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
-          \  - name: openshift-sre-sshd\n  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n\
-          \  - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n"
+          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
+          \ - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\
+          \  - name: openshift-cluster-version\n"
     - apiVersion: v1
       kind: ConfigMap
       metadata:
         name: ocp-namespaces
         namespace: openshift-monitoring
       data:
-        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver\n\
-          \  - name: openshift-apiserver-operator\n  - name: openshift-authentication\n\
-          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
-          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: kube-system\n\
+          \  - name: openshift-apiserver\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication\n  - name: openshift-authentication-operator\n\
+          \  - name: openshift-cloud-controller-manager\n  - name: openshift-cloud-controller-manager-operator\n\
+          \  - name: openshift-cloud-credential-operator\n  - name: openshift-cloud-network-config-controller\n\
           \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
           \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
           \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9333,15 +9333,14 @@ objects:
           \  - name: openshift-backplane-srep\n  - name: openshift-build-test\n  -\
           \ name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
           \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-node-metadata-operator\n\
-          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
-          \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
-          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
-          \ - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\
-          \  - name: openshift-cluster-version\n"
+          \  - name: openshift-managed-node-metadata-operator\n  - name: openshift-managed-upgrade-operator\n\
+          \  - name: openshift-must-gather-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-sre-pruning\n  - name: openshift-strimzi\n  - name:\
+          \ openshift-validation-webhook\n  - name: openshift-velero\n  - name: openshift-monitoring\n\
+          \  - name: openshift\n  - name: openshift-cluster-version\n"
     - apiVersion: v1
       kind: ConfigMap
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9333,23 +9333,26 @@ objects:
           \  - name: openshift-backplane-srep\n  - name: openshift-build-test\n  -\
           \ name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
           \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-logging\n  - name: openshift-managed-node-metadata-operator\n\
           \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
           \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
           \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
           \  - name: openshift-route-monitor-operator\n  - name: openshift-security\n\
           \  - name: openshift-splunk-forwarder-operator\n  - name: openshift-sre-pruning\n\
-          \  - name: openshift-sre-sshd\n  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n\
-          \  - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n"
+          \  - name: openshift-strimzi\n  - name: openshift-validation-webhook\n \
+          \ - name: openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\
+          \  - name: openshift-cluster-version\n"
     - apiVersion: v1
       kind: ConfigMap
       metadata:
         name: ocp-namespaces
         namespace: openshift-monitoring
       data:
-        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: openshift-apiserver\n\
-          \  - name: openshift-apiserver-operator\n  - name: openshift-authentication\n\
-          \  - name: openshift-authentication-operator\n  - name: openshift-cloud-controller-manager\n\
-          \  - name: openshift-cloud-controller-manager-operator\n  - name: openshift-cloud-credential-operator\n\
+        managed_namespaces.yaml: "Resources:\n  Namespace:\n  - name: kube-system\n\
+          \  - name: openshift-apiserver\n  - name: openshift-apiserver-operator\n\
+          \  - name: openshift-authentication\n  - name: openshift-authentication-operator\n\
+          \  - name: openshift-cloud-controller-manager\n  - name: openshift-cloud-controller-manager-operator\n\
+          \  - name: openshift-cloud-credential-operator\n  - name: openshift-cloud-network-config-controller\n\
           \  - name: openshift-cluster-csi-drivers\n  - name: openshift-cluster-machine-approver\n\
           \  - name: openshift-cluster-node-tuning-operator\n  - name: openshift-cluster-samples-operator\n\
           \  - name: openshift-cluster-storage-operator\n  - name: openshift-config\n\

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -22,6 +22,8 @@ Resources:
     name: sre-stuck-ebs-vols-code
   - namespace: openshift-monitoring
     name: sre-stuck-ebs-vols-trusted-ca-bundle
+  - namespace: openshift-monitoring
+    name: token-refresher-trusted-ca-bundle
   - namespace: openshift-security
     name: osd-audit-policy
   - namespace: openshift-validation-webhook
@@ -50,6 +52,8 @@ Resources:
   - name: openshift-codeready-workspaces
   - name: openshift-custom-domains-operator
   - name: openshift-customer-monitoring
+  - name: openshift-logging
+  - name: openshift-managed-node-metadata-operator
   - name: openshift-managed-upgrade-operator
   - name: openshift-must-gather-operator
   - name: openshift-ocm-agent-operator
@@ -60,12 +64,12 @@ Resources:
   - name: openshift-security
   - name: openshift-splunk-forwarder-operator
   - name: openshift-sre-pruning
-  - name: openshift-sre-sshd
   - name: openshift-strimzi
   - name: openshift-validation-webhook
   - name: openshift-velero
   - name: openshift-monitoring
   - name: openshift
+  - name: openshift-cluster-version
   ReplicationController:
   - namespace: openshift-monitoring
     name: sre-ebs-iops-reporter-1
@@ -135,6 +139,7 @@ Resources:
   - name: sre-pod-validation
   - name: sre-regular-user-validation
   - name: sre-scc-validation
+  - name: sre-techpreviewnoupgrade-validation
   DaemonSet:
   - namespace: openshift-monitoring
     name: sre-dns-latency-exporter
@@ -156,13 +161,14 @@ Resources:
   - name: backplane-cee-readers
   - name: backplane-cluster-admin
   - name: backplane-impersonate-cluster-admin
+  - name: backplane-srep-admins-cluster
+  - name: backplane-srep-readers-cluster
   - name: configure-alertmanager-operator-prom
   - name: dedicated-admins-cluster
   - name: dedicated-admins-registry-cas-cluster
   - name: openshift-backplane-managed-scripts-reader
   - name: osd-cluster-ready
   - name: osd-delete-backplane-script-resources
-  - name: osd-delete-ownerrefs-bz1906584
   - name: osd-delete-ownerrefs-serviceaccounts
   - name: osd-patch-subscription-source
   - name: osd-rebalance-infra-nodes
@@ -194,7 +200,6 @@ Resources:
   - name: osd-custom-domains-dedicated-admin-cluster
   - name: osd-delete-backplane-script-resources
   - name: osd-delete-backplane-serviceaccounts
-  - name: osd-delete-ownerrefs-bz1906584
   - name: osd-delete-ownerrefs-serviceaccounts
   - name: osd-get-namespace
   - name: osd-netnamespaces-dedicated-admin-cluster
@@ -235,15 +240,15 @@ Resources:
     name: publishingstrategy
   EndpointSlice:
   - namespace: openshift-monitoring
-    name: sre-dns-latency-exporter-xhgmr
+    name: sre-dns-latency-exporter-c2pcv
   - namespace: openshift-monitoring
-    name: sre-ebs-iops-reporter-74w46
+    name: sre-ebs-iops-reporter-cl89c
   - namespace: openshift-monitoring
-    name: sre-stuck-ebs-vols-fblh4
+    name: sre-stuck-ebs-vols-lxjdv
   - namespace: openshift-monitoring
-    name: token-refresher-fv6ms
+    name: token-refresher-5mv6s
   - namespace: openshift-validation-webhook
-    name: validation-webhook-nc646
+    name: validation-webhook-6v98z
   MachineHealthCheck:
   - namespace: openshift-machine-api
     name: srep-infra-healthcheck
@@ -251,9 +256,11 @@ Resources:
     name: srep-worker-healthcheck
   MachineSet:
   - namespace: openshift-machine-api
-    name: tnierman2-p7x4n-infra-us-west-1a
+    name: pebrown-mcc-kq6gt-infra-ap-southeast-2a
   - namespace: openshift-machine-api
-    name: tnierman2-p7x4n-worker-us-west-1a
+    name: pebrown-mcc-kq6gt-worker-ap-southeast-2a
+  ContainerRuntimeConfig:
+  - name: custom-crio
   KubeletConfig:
   - name: custom-kubelet
   SubjectPermission:
@@ -285,6 +292,13 @@ Resources:
   NetworkPolicy:
   - namespace: openshift-monitoring
     name: token-refresher
+  ManagedNotification:
+  - namespace: openshift-ocm-agent-operator
+    name: sre-elasticsearch-managed-notifications
+  - namespace: openshift-ocm-agent-operator
+    name: sre-managed-notifications
+  - namespace: openshift-ocm-agent-operator
+    name: sre-proxy-managed-notifications
   OcmAgent:
   - namespace: openshift-ocm-agent-operator
     name: ocmagent
@@ -295,6 +309,8 @@ Resources:
     name: cloud-ingress-operator-registry
   - namespace: openshift-custom-domains-operator
     name: custom-domains-operator-registry
+  - namespace: openshift-managed-node-metadata-operator
+    name: managed-node-metadata-operator-registry
   - namespace: openshift-managed-upgrade-operator
     name: managed-upgrade-operator-catalog
   - namespace: openshift-monitoring
@@ -326,6 +342,10 @@ Resources:
     name: custom-domains-operator
   - namespace: openshift-customer-monitoring
     name: openshift-customer-monitoring
+  - namespace: openshift-logging
+    name: openshift-logging
+  - namespace: openshift-managed-node-metadata-operator
+    name: managed-node-metadata-operator
   - namespace: openshift-managed-upgrade-operator
     name: managed-upgrade-operator-og
   - namespace: openshift-must-gather-operator
@@ -351,6 +371,8 @@ Resources:
     name: cloud-ingress-operator
   - namespace: openshift-custom-domains-operator
     name: custom-domains-operator
+  - namespace: openshift-managed-node-metadata-operator
+    name: managed-node-metadata-operator
   - namespace: openshift-managed-upgrade-operator
     name: managed-upgrade-operator
   - namespace: openshift-monitoring
@@ -370,30 +392,32 @@ Resources:
   - namespace: openshift-velero
     name: managed-velero-operator
   PackageManifest:
-  - namespace: openshift-must-gather-operator
-    name: must-gather-operator
-  - namespace: openshift-custom-domains-operator
-    name: custom-domains-operator
-  - namespace: openshift-rbac-permissions
-    name: rbac-permissions-operator
   - namespace: openshift-route-monitor-operator
     name: route-monitor-operator
-  - namespace: openshift-splunk-forwarder-operator
-    name: splunk-forwarder-operator
-  - namespace: openshift-osd-metrics
-    name: osd-metrics-exporter
-  - namespace: openshift-monitoring
-    name: configure-alertmanager-operator
-  - namespace: openshift-velero
-    name: managed-velero-operator
-  - namespace: openshift-cloud-ingress-operator
-    name: cloud-ingress-operator
-  - namespace: openshift-addon-operator
-    name: addon-operator
   - namespace: openshift-ocm-agent-operator
     name: ocm-agent-operator
+  - namespace: openshift-splunk-forwarder-operator
+    name: splunk-forwarder-operator
+  - namespace: openshift-rbac-permissions
+    name: rbac-permissions-operator
+  - namespace: openshift-must-gather-operator
+    name: must-gather-operator
+  - namespace: openshift-monitoring
+    name: configure-alertmanager-operator
+  - namespace: openshift-osd-metrics
+    name: osd-metrics-exporter
   - namespace: openshift-managed-upgrade-operator
     name: managed-upgrade-operator
+  - namespace: openshift-cloud-ingress-operator
+    name: cloud-ingress-operator
+  - namespace: openshift-managed-node-metadata-operator
+    name: managed-node-metadata-operator
+  - namespace: openshift-velero
+    name: managed-velero-operator
+  - namespace: openshift-custom-domains-operator
+    name: custom-domains-operator
+  - namespace: openshift-addon-operator
+    name: addon-operator
   Status:
   - {}
   Project:
@@ -409,6 +433,8 @@ Resources:
   - name: openshift-codeready-workspaces
   - name: openshift-custom-domains-operator
   - name: openshift-customer-monitoring
+  - name: openshift-logging
+  - name: openshift-managed-node-metadata-operator
   - name: openshift-managed-upgrade-operator
   - name: openshift-must-gather-operator
   - name: openshift-ocm-agent-operator
@@ -419,7 +445,6 @@ Resources:
   - name: openshift-security
   - name: openshift-splunk-forwarder-operator
   - name: openshift-sre-pruning
-  - name: openshift-sre-sshd
   - name: openshift-strimzi
   - name: openshift-validation-webhook
   - name: openshift-velero

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -433,7 +433,6 @@ Resources:
   - name: openshift-codeready-workspaces
   - name: openshift-custom-domains-operator
   - name: openshift-customer-monitoring
-  - name: openshift-logging
   - name: openshift-managed-node-metadata-operator
   - name: openshift-managed-upgrade-operator
   - name: openshift-must-gather-operator

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -52,7 +52,6 @@ Resources:
   - name: openshift-codeready-workspaces
   - name: openshift-custom-domains-operator
   - name: openshift-customer-monitoring
-  - name: openshift-logging
   - name: openshift-managed-node-metadata-operator
   - name: openshift-managed-upgrade-operator
   - name: openshift-must-gather-operator

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -342,8 +342,6 @@ Resources:
     name: custom-domains-operator
   - namespace: openshift-customer-monitoring
     name: openshift-customer-monitoring
-  - namespace: openshift-logging
-    name: openshift-logging
   - namespace: openshift-managed-node-metadata-operator
     name: managed-node-metadata-operator
   - namespace: openshift-managed-upgrade-operator

--- a/scripts/managed-resources/generate-managed-list.py
+++ b/scripts/managed-resources/generate-managed-list.py
@@ -23,7 +23,8 @@ data:
 # are still being managed by SRE-P.
 ADDITIONAL_MANAGED_NAMESPACES = [
     {"name": "openshift-monitoring"},
-    {"name": "openshift"}
+    {"name": "openshift"},
+    {"name": "openshift-cluster-version"}
 ]
 
 
@@ -57,6 +58,9 @@ def collect_ocp_release_namespaces():
         yaml_file_paths = [
             os.path.join(tmpdir, f) for f in os.listdir(tmpdir) if f.endswith(".yaml")
         ]
+        # make sure a bare = sign doesn't break our loader
+        # temporary fix for https://github.com/yaml/pyyaml/issues/89
+        yaml.FullLoader.yaml_implicit_resolvers.pop('=')
         for file_path in yaml_file_paths:
             with open(file_path, "r") as f:
                 manifests = yaml.full_load_all(f)
@@ -201,6 +205,13 @@ def main():
         required=True,
         choices=["yaml", "configmap"],
         help="Output format of managed resource list [required]",
+    )
+    parser.add_argument(
+        "--source",
+        "-s",
+        required=True,
+        choices=["osd-all", "osd-namespaces", "ocp-namespaces"],
+        help="Choose to output all OSD managed resources, or just the managed namespaces for OSD or OCP [required]",
     )
     parser.add_argument(
         "--namespace",


### PR DESCRIPTION
This is to ensure the ClusterOperator* alerts get sent to PD

### What type of PR is this?
bug

### What this PR does / why we need it?
ClusterOperator* alerts were not being sent to pagerduty because openshift-cluster-version was not marked as a managed namespace.

### Which Jira/Github issue(s) this PR fixes?

[OSD-12049](https://issues.redhat.com//browse/OSD-12049)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
