### PR TITLE
fedramp: Add IAM policy for aws-vpce-operator

### DIFF
--- a/resources/sts/4.10/openshift_aws_vpce_operator_avo_aws_creds_policy.json
+++ b/resources/sts/4.10/openshift_aws_vpce_operator_avo_aws_creds_policy.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DescribeTags",
+        "ec2:DescribeSubnets",
+        "ec2:CreateSecurityGroup",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeSecurityGroups",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:AuthorizeSecurityGroupEgress",
+        "ec2:DescribeSecurityGroupRules",
+        "ec2:CreateVpcEndpoint",
+        "ec2:DeleteVpcEndpoints",
+        "ec2:DescribeVpcEndpoints",
+        "ec2:ModifyVpcEndpoint",
+        "route53:ChangeResourceRecordSets",
+        "route53:ListHostedZonesByName",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR adds a new policy doc needed for running ROSA STS clusters in a FedRAMP High environment, where the aws-vpce-operator is needed.

### Which Jira/Github issue(s) this PR fixes?

* https://issues.redhat.com/browse/SDA-6264

### Special notes for your reviewer:

This policy is used by OCM with this MR: https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/4392 to ensure that only FedRAMP clusters get this operator.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
