### PR TITLE
OSD-12156 ensure sre telem is a bool 

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-telemetry-managed-labels-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-telemetry-managed-labels-recording-rules.PrometheusRule.yaml
@@ -14,6 +14,7 @@ spec:
             # Add a label of sre="true"
             # join metrics on sre="true"
             # sum by the labels we care about at the most outer level
+            # ensure value of 1 to use as bool against other metrics
             sum by (_id, provider, region, version, sre)
             (
             label_replace(cluster_id, "sre", "true", "", "")
@@ -23,8 +24,9 @@ spec:
             )
             * on (sre) group_left(provider, region)
             label_replace(sum without (type) (label_replace(cluster_infrastructure_provider, "provider", "$1", "type", "(.*)")), "sre", "true", "", "")
-            )
+            ) > bool 0
             # sre:telemetry:managed_labels{_id="not-a-real-cluster-id", provider="AWS", region="ap-southeast-2", sre="true", version="4.10.18"} => 1654679854 @[1655873133.121]
-          record: sre:telemetry:managed_labels
+          record:
+            sre:telemetry:managed_labels
             # Any metric being sent to centralized observability service needs to include this standardized data for drill down querying.
             # Please see INSERT_ME.md for details regarding standardized data.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13682,7 +13682,7 @@ objects:
               ( label_replace(cluster_version{type="current"}, "sre", "true", "",
               "") ) * on (sre) group_left(provider, region) label_replace(sum without
               (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
-              "type", "(.*)")), "sre", "true", "", "") )
+              "type", "(.*)")), "sre", "true", "", "") ) > bool 0
             record: sre:telemetry:managed_labels
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13682,7 +13682,7 @@ objects:
               ( label_replace(cluster_version{type="current"}, "sre", "true", "",
               "") ) * on (sre) group_left(provider, region) label_replace(sum without
               (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
-              "type", "(.*)")), "sre", "true", "", "") )
+              "type", "(.*)")), "sre", "true", "", "") ) > bool 0
             record: sre:telemetry:managed_labels
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13682,7 +13682,7 @@ objects:
               ( label_replace(cluster_version{type="current"}, "sre", "true", "",
               "") ) * on (sre) group_left(provider, region) label_replace(sum without
               (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
-              "type", "(.*)")), "sre", "true", "", "") )
+              "type", "(.*)")), "sre", "true", "", "") ) > bool 0
             record: sre:telemetry:managed_labels
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Need this recording rule to return a bool value rather than timestamp as a value. This makes it easier to join with other metrics to retrieve labels. 

Example

```
(sum by (_id, provider, region, version, sre)
(
label_replace(cluster_id, "sre", "true", "", "")
* on (sre) group_left(provider, region, version)
(
label_replace(cluster_version{type="current"}, "sre", "true", "", "")
)
* on (sre) group_left(provider, region)
label_replace(sum without (type) (label_replace(cluster_infrastructure_provider, "provider", "$1", "type", "(.*)")), "sre", "true", "", "")
) > bool 0)
* on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"}, "sre", "true", "", "")
```

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-12156

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
