### PR TITLE
[OSD-12523] sre slo probe_success recordingrules

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-slo-recording-rules
+    role: recording-rules
+  name: sre-slo-recording-rules
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: sre-slo.rules
+      rules:
+        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"}, "sre", "true", "", "")
+          record: sre:slo:probe_success_api
+        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"}, "sre", "true", "", "")
+          record: sre:slo:probe_success_console

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13669,6 +13669,24 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-slo-recording-rules
+          role: recording-rules
+        name: sre-slo-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-slo.rules
+          rules:
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"},
+              "sre", "true", "", "")
+            record: sre:slo:probe_success_api
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
+              "sre", "true", "", "")
+            record: sre:slo:probe_success_console
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-telemetry-managed-labels-recording-rules
           role: recording-rules
         name: sre-telemetry-managed-labels-recording-rules

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13669,6 +13669,24 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-slo-recording-rules
+          role: recording-rules
+        name: sre-slo-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-slo.rules
+          rules:
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"},
+              "sre", "true", "", "")
+            record: sre:slo:probe_success_api
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
+              "sre", "true", "", "")
+            record: sre:slo:probe_success_console
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-telemetry-managed-labels-recording-rules
           role: recording-rules
         name: sre-telemetry-managed-labels-recording-rules

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13669,6 +13669,24 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-slo-recording-rules
+          role: recording-rules
+        name: sre-slo-recording-rules
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-slo.rules
+          rules:
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"},
+              "sre", "true", "", "")
+            record: sre:slo:probe_success_api
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
+              "sre", "true", "", "")
+            record: sre:slo:probe_success_console
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-telemetry-managed-labels-recording-rules
           role: recording-rules
         name: sre-telemetry-managed-labels-recording-rules


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Combines the probe_success metrics from RMO with standardised telemetry to send via remoteWrite. Enables standardised drilldowns. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-12523 

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
