### PR TITLE
remoteWrite sre slo probe_success

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total)'
+            regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4548,7 +4548,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4548,7 +4548,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4548,7 +4548,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
New recordingRule has been created to capture the needed labels of the `probe_success` metric. This new rule should be sent to centralised obs via remoteWrite. Dashboards will use this rule. Having only the labels we need will reduce cardinality and improve query performance/reliability. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-12530 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
