### PR TITLE
Add `describe instance type offering` permission to the installer role

### DIFF
--- a/resources/sts/4.10/sts_installer_permission_policy.json
+++ b/resources/sts/4.10/sts_installer_permission_policy.json
@@ -49,6 +49,7 @@
                 "ec2:DescribeInstanceCreditSpecifications",
                 "ec2:DescribeInstances",
                 "ec2:DescribeInstanceStatus",
+                "ec2:DescribeInstanceTypeOfferings",
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeInternetGateways",
                 "ec2:DescribeKeyPairs",

--- a/resources/sts/4.10/sts_ocm_permission_policy.json
+++ b/resources/sts/4.10/sts_ocm_permission_policy.json
@@ -8,6 +8,7 @@
         "ec2:DescribeVpcs",
         "ec2:DescribeRegions",
         "ec2:DescribeRouteTables",
+        "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
         "sts:AssumeRole",
         "sts:AssumeRoleWithWebIdentity",


### PR DESCRIPTION
Add the permission to enable the installer role to list the supported
machine types in the region.

### What type of PR is this?
Bug.

### What this PR does / why we need it?
To fetch the supported machine types in a region via the installer role.

### Which Jira/Github issue(s) this PR fixes?
Related: [SDA-6357](https://issues.redhat.com/browse/SDA-6357)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
