### PR TITLE
OSD-12245 Add alert in FedRAMP for AVO VPCE in pendingAcceptance for 5m

### DIFF
--- a/deploy/sre-prometheus/fedramp/100-avo-pendingAcceptance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/fedramp/100-avo-pendingAcceptance.PrometheusRule.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-avo-pendingacceptance
+    role: alert-rules
+  name: sre-avo-pendingacceptance
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-avo-pendingacceptance
+    rules:
+    - alert: VpcEndpointPendingAcceptance
+      expr: sum(aws_vpce_operator_vpce_pendingAcceptance) > 0
+      for: 5m
+      labels:
+        severity: critical
+        namespace: "{{ $labels.namespace }}"
+      annotations:
+        message: "The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }} has been in a pendingAcceptance state for 5m and requires SRE action."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -14028,6 +14028,27 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-avo-pendingacceptance
+          role: alert-rules
+        name: sre-avo-pendingacceptance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-avo-pendingacceptance
+          rules:
+          - alert: VpcEndpointPendingAcceptance
+            expr: sum(aws_vpce_operator_vpce_pendingAcceptance) > 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }}
+                has been in a pendingAcceptance state for 5m and requires SRE action.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-fr-alerts-low-disk-space
           role: alert-rules
         name: sre-fr-alerts-low-disk-space

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -14028,6 +14028,27 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-avo-pendingacceptance
+          role: alert-rules
+        name: sre-avo-pendingacceptance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-avo-pendingacceptance
+          rules:
+          - alert: VpcEndpointPendingAcceptance
+            expr: sum(aws_vpce_operator_vpce_pendingAcceptance) > 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }}
+                has been in a pendingAcceptance state for 5m and requires SRE action.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-fr-alerts-low-disk-space
           role: alert-rules
         name: sre-fr-alerts-low-disk-space

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -14028,6 +14028,27 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-avo-pendingacceptance
+          role: alert-rules
+        name: sre-avo-pendingacceptance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-avo-pendingacceptance
+          rules:
+          - alert: VpcEndpointPendingAcceptance
+            expr: sum(aws_vpce_operator_vpce_pendingAcceptance) > 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }}
+                has been in a pendingAcceptance state for 5m and requires SRE action.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-fr-alerts-low-disk-space
           role: alert-rules
         name: sre-fr-alerts-low-disk-space


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
In FedRAMP, the aws-vpce-operator (AVO) is running and currently creates one VPC Endpoint per customer cluster which an SRE must manually go into AWS and accept. Automation is on the way, but presently an alert is needed to prompt SRE action.

### Which Jira/Github issue(s) this PR fixes?

[OSD-12245](https://issues.redhat.com//browse/OSD-12245)

### Special notes for your reviewer:
Affects FedRAMP only