### PR TITLE
Add cronjob to detect and heal from BZ1980755

### DIFF
--- a/deploy/bz1980755/00-bz1980755.ServiceAccount.yaml
+++ b/deploy/bz1980755/00-bz1980755.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bz1980755
+  namespace: openshift-sre-pruning

--- a/deploy/bz1980755/01-bz1980755.ClusterRole.yaml
+++ b/deploy/bz1980755/01-bz1980755.ClusterRole.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bz1980755
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  - installplans                 
+  - subscriptions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list

--- a/deploy/bz1980755/02-bz1980755.ClusterRoleBinding.yaml
+++ b/deploy/bz1980755/02-bz1980755.ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bz1980755
+subjects:
+- kind: ServiceAccount
+  name: bz1980755
+  namespace: openshift-sre-pruning
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bz1980755

--- a/deploy/bz1980755/10-bz1980755.CronJob.yaml
+++ b/deploy/bz1980755/10-bz1980755.CronJob.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: bz1980755
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "25 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: bz1980755
+          restartPolicy: Never
+          containers:
+          - name: bz1980755
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+              set -o nounset
+              set -o pipefail
+
+              TEMPDIR=$(mktemp -d)
+              for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep "^openshift[-]"`; do
+                  echo "Checking namespace ${ns}"
+                  for sub in `oc get subscriptions.operators.coreos.com -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath="{.items[*].metadata.name}"`; do
+                      echo "Checking subscription ${sub}"
+
+                      NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com -n "${ns}" "${sub}" -o jsonpath="{.status.conditions[?(@.reason == 'ConstraintsNotSatisfiable')].status}")
+                      if [[ "${NEEDS_REPLACE}" != "True" ]]; then
+                          continue
+                      fi
+
+                      echo "Will re-install subscription ${ns}/${sub}"
+                      oc get subscriptions.operators.coreos.com -n "${ns}" "${sub}" -ojson | grep -v "kubectl.kubernetes.io/last-applied-configuration" > ${TEMPDIR}/${sub}.yaml
+
+                      for ip in `oc get installplans.operators.coreos.com -n "${ns}" -o jsonpath="{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}"`; do
+                          echo "Removing installplan ${ip}"
+                          oc delete installplans.operators.coreos.com -n "${ns}" $ip
+                      done
+
+                      for csv in `oc get clusterserviceversions.operators.coreos.com -n "${ns}" -o jsonpath="{.items[*].metadata.name}"`; do
+                          if [[ "${csv}" =~ ^${sub}.* ]]; then
+                              echo "Removing CSV ${csv}"
+                              oc delete clusterserviceversions.operators.coreos.com -n "${ns}" "${csv}"
+                          fi
+                      done
+
+                      echo "Removing subscription ${sub}"
+                      oc delete subscriptions.operators.coreos.com  -n "${ns}" "${sub}"
+
+                      echo "Recreating subscription ${sub}"
+                      oc create -f ${TEMPDIR}/${sub}.yaml
+                  done
+              done

--- a/deploy/bz1980755/OWNERS
+++ b/deploy/bz1980755/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- mrbarge

--- a/deploy/bz1980755/README.md
+++ b/deploy/bz1980755/README.md
@@ -1,0 +1,18 @@
+# bz1980755
+
+## About
+
+This sets up a `CronJob` on the cluster which aims to detect and remediate any SRE operators that are impacted by BZ [1980755](https://bugzilla.redhat.com/show_bug.cgi?id=1980755).
+
+An operator which is impacted by this issue:
+- Will have a `ConstraintsNotSatisfied` Subscription status
+- Will no longer update to any future versions whilst impacted.
+
+The fix of the CronJob is to:
+- Remove the impacted `Subscription` and any associated `InstallPlans` and `ClusterServiceVersions`
+- Reinstall the `Subscription` (minus the `last-applied-configuration` annotation which would otherwise break ClusterSyncs)
+
+The CronJob only acts on operators installed into managed namespaces.
+
+## References:
+* [BZ 1980755](https://bugzilla.redhat.com/show_bug.cgi?id=1980755)

--- a/deploy/bz1980755/config.yaml
+++ b/deploy/bz1980755/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4226,6 +4226,119 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1980755
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: bz1980755
+        namespace: openshift-sre-pruning
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: bz1980755
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: bz1980755
+      subjects:
+      - kind: ServiceAccount
+        name: bz1980755
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: bz1980755
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: bz1980755
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 25 3 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: bz1980755
+                restartPolicy: Never
+                containers:
+                - name: bz1980755
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "set -e\nset -o nounset\nset -o pipefail\n\nTEMPDIR=$(mktemp -d)\n\
+                    for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{\"\
+                    \\n\"}{end}' | grep \"^openshift[-]\"`; do\n    echo \"Checking\
+                    \ namespace ${ns}\"\n    for sub in `oc get subscriptions.operators.coreos.com\
+                    \ -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath=\"\
+                    {.items[*].metadata.name}\"`; do\n        echo \"Checking subscription\
+                    \ ${sub}\"\n\n        NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${sub}\" -o jsonpath=\"{.status.conditions[?(@.reason\
+                    \ == 'ConstraintsNotSatisfiable')].status}\")\n        if [[ \"\
+                    ${NEEDS_REPLACE}\" != \"True\" ]]; then\n            continue\n\
+                    \        fi\n\n        echo \"Will re-install subscription ${ns}/${sub}\"\
+                    \n        oc get subscriptions.operators.coreos.com -n \"${ns}\"\
+                    \ \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
+                    \ > ${TEMPDIR}/${sub}.yaml\n\n        for ip in `oc get installplans.operators.coreos.com\
+                    \ -n \"${ns}\" -o jsonpath=\"{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}\"\
+                    `; do\n            echo \"Removing installplan ${ip}\"\n     \
+                    \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
+                    \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
+                    \            if [[ \"${csv}\" =~ ^${sub}.* ]]; then\n        \
+                    \        echo \"Removing CSV ${csv}\"\n                oc delete\
+                    \ clusterserviceversions.operators.coreos.com -n \"${ns}\" \"\
+                    ${csv}\"\n            fi\n        done\n\n        echo \"Removing\
+                    \ subscription ${sub}\"\n        oc delete subscriptions.operators.coreos.com\
+                    \  -n \"${ns}\" \"${sub}\"\n\n        echo \"Recreating subscription\
+                    \ ${sub}\"\n        oc create -f ${TEMPDIR}/${sub}.yaml\n    done\n\
+                    done\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1997062-crio-pid-leak
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4226,6 +4226,119 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1980755
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: bz1980755
+        namespace: openshift-sre-pruning
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: bz1980755
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: bz1980755
+      subjects:
+      - kind: ServiceAccount
+        name: bz1980755
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: bz1980755
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: bz1980755
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 25 3 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: bz1980755
+                restartPolicy: Never
+                containers:
+                - name: bz1980755
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "set -e\nset -o nounset\nset -o pipefail\n\nTEMPDIR=$(mktemp -d)\n\
+                    for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{\"\
+                    \\n\"}{end}' | grep \"^openshift[-]\"`; do\n    echo \"Checking\
+                    \ namespace ${ns}\"\n    for sub in `oc get subscriptions.operators.coreos.com\
+                    \ -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath=\"\
+                    {.items[*].metadata.name}\"`; do\n        echo \"Checking subscription\
+                    \ ${sub}\"\n\n        NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${sub}\" -o jsonpath=\"{.status.conditions[?(@.reason\
+                    \ == 'ConstraintsNotSatisfiable')].status}\")\n        if [[ \"\
+                    ${NEEDS_REPLACE}\" != \"True\" ]]; then\n            continue\n\
+                    \        fi\n\n        echo \"Will re-install subscription ${ns}/${sub}\"\
+                    \n        oc get subscriptions.operators.coreos.com -n \"${ns}\"\
+                    \ \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
+                    \ > ${TEMPDIR}/${sub}.yaml\n\n        for ip in `oc get installplans.operators.coreos.com\
+                    \ -n \"${ns}\" -o jsonpath=\"{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}\"\
+                    `; do\n            echo \"Removing installplan ${ip}\"\n     \
+                    \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
+                    \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
+                    \            if [[ \"${csv}\" =~ ^${sub}.* ]]; then\n        \
+                    \        echo \"Removing CSV ${csv}\"\n                oc delete\
+                    \ clusterserviceversions.operators.coreos.com -n \"${ns}\" \"\
+                    ${csv}\"\n            fi\n        done\n\n        echo \"Removing\
+                    \ subscription ${sub}\"\n        oc delete subscriptions.operators.coreos.com\
+                    \  -n \"${ns}\" \"${sub}\"\n\n        echo \"Recreating subscription\
+                    \ ${sub}\"\n        oc create -f ${TEMPDIR}/${sub}.yaml\n    done\n\
+                    done\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1997062-crio-pid-leak
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4226,6 +4226,119 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: bz1980755
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: bz1980755
+        namespace: openshift-sre-pruning
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: bz1980755
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - '*'
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: bz1980755
+      subjects:
+      - kind: ServiceAccount
+        name: bz1980755
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: bz1980755
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: bz1980755
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 25 3 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: bz1980755
+                restartPolicy: Never
+                containers:
+                - name: bz1980755
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "set -e\nset -o nounset\nset -o pipefail\n\nTEMPDIR=$(mktemp -d)\n\
+                    for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{\"\
+                    \\n\"}{end}' | grep \"^openshift[-]\"`; do\n    echo \"Checking\
+                    \ namespace ${ns}\"\n    for sub in `oc get subscriptions.operators.coreos.com\
+                    \ -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath=\"\
+                    {.items[*].metadata.name}\"`; do\n        echo \"Checking subscription\
+                    \ ${sub}\"\n\n        NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${sub}\" -o jsonpath=\"{.status.conditions[?(@.reason\
+                    \ == 'ConstraintsNotSatisfiable')].status}\")\n        if [[ \"\
+                    ${NEEDS_REPLACE}\" != \"True\" ]]; then\n            continue\n\
+                    \        fi\n\n        echo \"Will re-install subscription ${ns}/${sub}\"\
+                    \n        oc get subscriptions.operators.coreos.com -n \"${ns}\"\
+                    \ \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
+                    \ > ${TEMPDIR}/${sub}.yaml\n\n        for ip in `oc get installplans.operators.coreos.com\
+                    \ -n \"${ns}\" -o jsonpath=\"{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}\"\
+                    `; do\n            echo \"Removing installplan ${ip}\"\n     \
+                    \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
+                    \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
+                    \            if [[ \"${csv}\" =~ ^${sub}.* ]]; then\n        \
+                    \        echo \"Removing CSV ${csv}\"\n                oc delete\
+                    \ clusterserviceversions.operators.coreos.com -n \"${ns}\" \"\
+                    ${csv}\"\n            fi\n        done\n\n        echo \"Removing\
+                    \ subscription ${sub}\"\n        oc delete subscriptions.operators.coreos.com\
+                    \  -n \"${ns}\" \"${sub}\"\n\n        echo \"Recreating subscription\
+                    \ ${sub}\"\n        oc create -f ${TEMPDIR}/${sub}.yaml\n    done\n\
+                    done\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: bz1997062-crio-pid-leak
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This is an attempt to detect and repair operators that are impacted by [BZ1980755](https://bugzilla.redhat.com/show_bug.cgi?id=1980755). An operator impacted by this bug will no longer be updated by OLM.

The PR introduces a `CronJob` which searches managed namespaces for impacted operators (identifiable through a `ConstraintsNotSatisfied` condition in the `Subscription`).

If the operator is impacted, the "csv dance" is performed to remove the subscription and associated install plans & CSVs, then reinstall the subscription.
 
### Which Jira/Github issue(s) this PR fixes?
[OSD-12547](https://issues.redhat.com//browse/OSD-12547)

### Special notes for your reviewer:

- In lieu of a better idea of where to run it, I stuffed it in `openshift-operators-redhat`. Open to better suggestions.

- This is definitely not an elegant solution, but it's the best I could think of that fits within the confines of just being able to use the `oc` client and no `jq` access :cry: 

- The job runs daily. I think it's acceptable to only run once per day and it's fine to leave an impacted cluster in the state for up to 24 hours, as impacted operators will still be running fine - just not being managed by OLM.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
