### PR TITLE
[OSD-12562] sre slo recording rules imageregistry oauth

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
@@ -14,3 +14,7 @@ spec:
           record: sre:slo:probe_success_api
         - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"}, "sre", "true", "", "")
           record: sre:slo:probe_success_console
+        - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total), "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version) sre:telemetry:managed_labels
+          record: sre:slo:imageregistry_http_requests_total
+        - expr: label_replace(sum by (code, verb, subresource) (oauth_server_requests_total), "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version) sre:telemetry:managed_labels
+          record: sre:slo:oauth_server_requests_total

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13699,6 +13699,14 @@ objects:
           - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_console
+          - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),
+              "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
+              sre:telemetry:managed_labels
+            record: sre:slo:imageregistry_http_requests_total
+          - expr: label_replace(sum by (code, verb, subresource) (oauth_server_requests_total),
+              "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
+              sre:telemetry:managed_labels
+            record: sre:slo:oauth_server_requests_total
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13699,6 +13699,14 @@ objects:
           - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_console
+          - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),
+              "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
+              sre:telemetry:managed_labels
+            record: sre:slo:imageregistry_http_requests_total
+          - expr: label_replace(sum by (code, verb, subresource) (oauth_server_requests_total),
+              "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
+              sre:telemetry:managed_labels
+            record: sre:slo:oauth_server_requests_total
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13699,6 +13699,14 @@ objects:
           - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_console
+          - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),
+              "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
+              sre:telemetry:managed_labels
+            record: sre:slo:imageregistry_http_requests_total
+          - expr: label_replace(sum by (code, verb, subresource) (oauth_server_requests_total),
+              "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
+              sre:telemetry:managed_labels
+            record: sre:slo:oauth_server_requests_total
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Attaches standardised telemetry labels to metrics

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-12562 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
