### PR TITLE
Set remote write config maxBackoff to default

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -24,7 +24,7 @@ data:
             maxSamplesPerSend: 500
             batchSendDeadline: 60s
             minBackoff: 30ms
-            maxBackoff: 100ms
+            maxBackoff: 5s
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4551,7 +4551,7 @@ objects:
           \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
-          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
           \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4551,7 +4551,7 @@ objects:
           \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
-          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
           \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4551,7 +4551,7 @@ objects:
           \ [__name__]\n        action: keep\n        regex: '(cluster_admin_enabled|identity_provider|probe_success|probe_duration_seconds|ingress_canary_route_reachable|oauth_server_requests_total|imageregistry_http_requests_total|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
-          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 100ms\n  nodeSelector:\n\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
           \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \


### PR DESCRIPTION
### What this PR does / why we need it?

The current 100ms value is hyper aggressive compared to the default value of 5s.
The 100ms has potential to exacerbate problems for a Prometheus remote write endpoint that is already under pressure.

### Which Jira/Github issue(s) this PR fixes?

This change relates to a [previous incident](https://issues.redhat.com/browse/APPSRE-4549) where the one of the action items from the [RCA](https://docs.google.com/document/d/1006VnOTyCg-FW-H0Y76LMEg0UXVMEI_7-eBMT-g2e3Q/edit#) was around remote write tuning.

We had a later [incident](https://issues.redhat.com/browse/MON-2553) where an action item identified via the RCA was to provide some guides for tenants configuration.

In our [onboarding documentation](https://docs.google.com/document/d/1Laphmtpb_n-YV20CPKe2MSikgHxuS14p8Iud2_CLso0/edit#heading=h.bupciudrwmna) for new tenants, we do not recommend deviating from the default settings for the remote write queue config. 

However the majority of the existing settings look here look unproblematic so I suggest we leave as-is. I do believe we should increase the max backoff setting to the default values of 5s however to effectively support backpressure in an overloaded system (both ingress and remote write).

Note that the Prometheus client will continue to double the wait from the minimum 30ms to max 5s with each failed attempt, so in scenarios where the system recovers quickly, this change would have little to no impact from the client perspective.
