### PR TITLE
[SDE-1754] Update CR SSS Conditionals To Match AVO 

### DIFF
--- a/deploy/osd-avo-resources/us-gov-east-1/config.yaml
+++ b/deploy/osd-avo-resources/us-gov-east-1/config.yaml
@@ -9,3 +9,11 @@ selectorSyncSet:
     operator: In
     values:
       - "us-gov-east-1"
+  - key: api.openshift.com/sts
+    operator: In
+    values:
+      - "true"
+  - key: api.openshift.com/private-link
+    operator: In
+    values:
+      - "true"

--- a/deploy/osd-avo-resources/us-gov-west-1/config.yaml
+++ b/deploy/osd-avo-resources/us-gov-west-1/config.yaml
@@ -9,3 +9,11 @@ selectorSyncSet:
     operator: In
     values:
       - "us-gov-west-1"
+  - key: api.openshift.com/sts
+    operator: In
+    values:
+      - "true"
+  - key: api.openshift.com/private-link
+    operator: In
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5999,6 +5999,14 @@ objects:
         operator: In
         values:
         - us-gov-east-1
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: avo.openshift.io/v1alpha1
@@ -6038,6 +6046,14 @@ objects:
         operator: In
         values:
         - us-gov-west-1
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: avo.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5999,6 +5999,14 @@ objects:
         operator: In
         values:
         - us-gov-east-1
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: avo.openshift.io/v1alpha1
@@ -6038,6 +6046,14 @@ objects:
         operator: In
         values:
         - us-gov-west-1
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: avo.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5999,6 +5999,14 @@ objects:
         operator: In
         values:
         - us-gov-east-1
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: avo.openshift.io/v1alpha1
@@ -6038,6 +6046,14 @@ objects:
         operator: In
         values:
         - us-gov-west-1
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: avo.openshift.io/v1alpha1


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?
This cleans up some FR clustersyncs on non-sts and non-privatelink clusters where AVO is not deployed.

### Which Jira/Github issue(s) this PR fixes?

_Fixes SDE-1754_

### Reference
https://github.com/openshift/aws-vpce-operator/blob/main/hack/olm-registry/olm-artifacts-template.yaml#L35-L39