### PR TITLE
Porting AVO changes to MCC

### DIFF
--- a/deploy/osd-avo-resources/us-gov-east-1/00-osd-avo-VpcEndpoint.yaml
+++ b/deploy/osd-avo-resources/us-gov-east-1/00-osd-avo-VpcEndpoint.yaml
@@ -2,7 +2,6 @@ apiVersion: avo.openshift.io/v1alpha1
 kind: VpcEndpoint
 metadata:
   name: splunk
-  namespace: openshift-aws-vpce-operator
 spec:
   subdomainName: splunk
   serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b

--- a/deploy/osd-avo-resources/us-gov-west-1/00-osd-avo-VpcEndpoint.yaml
+++ b/deploy/osd-avo-resources/us-gov-west-1/00-osd-avo-VpcEndpoint.yaml
@@ -2,7 +2,6 @@ apiVersion: avo.openshift.io/v1alpha1
 kind: VpcEndpoint
 metadata:
   name: splunk
-  namespace: openshift-aws-vpce-operator
 spec:
   subdomainName: splunk
   serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1

--- a/deploy/sre-prometheus/fedramp/100-avo-pendingAcceptance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/fedramp/100-avo-pendingAcceptance.PrometheusRule.yaml
@@ -15,6 +15,6 @@ spec:
       for: 5m
       labels:
         severity: critical
-        namespace: "{{ $labels.namespace }}"
+        namespace: openshift-aws-vpce-operator
       annotations:
-        message: "The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }} has been in a pendingAcceptance state for 5m and requires SRE action."
+        message: "The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name }} has been in a pendingAcceptance state for 5m and requires SRE action."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6013,7 +6013,6 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
-        namespace: openshift-aws-vpce-operator
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
@@ -6060,7 +6059,6 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
-        namespace: openshift-aws-vpce-operator
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
@@ -14082,10 +14080,10 @@ objects:
             for: 5m
             labels:
               severity: critical
-              namespace: '{{ $labels.namespace }}'
+              namespace: openshift-aws-vpce-operator
             annotations:
-              message: The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }}
-                has been in a pendingAcceptance state for 5m and requires SRE action.
+              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name
+                }} has been in a pendingAcceptance state for 5m and requires SRE action.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6013,7 +6013,6 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
-        namespace: openshift-aws-vpce-operator
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
@@ -6060,7 +6059,6 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
-        namespace: openshift-aws-vpce-operator
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
@@ -14082,10 +14080,10 @@ objects:
             for: 5m
             labels:
               severity: critical
-              namespace: '{{ $labels.namespace }}'
+              namespace: openshift-aws-vpce-operator
             annotations:
-              message: The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }}
-                has been in a pendingAcceptance state for 5m and requires SRE action.
+              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name
+                }} has been in a pendingAcceptance state for 5m and requires SRE action.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6013,7 +6013,6 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
-        namespace: openshift-aws-vpce-operator
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
@@ -6060,7 +6059,6 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
-        namespace: openshift-aws-vpce-operator
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
@@ -14082,10 +14080,10 @@ objects:
             for: 5m
             labels:
               severity: critical
-              namespace: '{{ $labels.namespace }}'
+              namespace: openshift-aws-vpce-operator
             annotations:
-              message: The VPC Endpoint {{ $labels.namespace }}/{{ $labels.name }}
-                has been in a pendingAcceptance state for 5m and requires SRE action.
+              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name
+                }} has been in a pendingAcceptance state for 5m and requires SRE action.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Porting changes from https://github.com/openshift/aws-vpce-operator/pull/36, the CRD is now cluster-scoped and a `vpce_id` label now exists on the metric, while the `namespace` label will be deprecated

### Which Jira/Github issue(s) this PR fixes?

[OSD-12540](https://issues.redhat.com//browse/OSD-12540)