### PR TITLE
[MTSRE-611] feat(backplane): onboard backplane config for mcg-osd

### DIFF
--- a/deploy/backplane/mcg/00-mcg.namespace.yml
+++ b/deploy/backplane/mcg/00-mcg.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane-mcg

--- a/deploy/backplane/mcg/config.yaml
+++ b/deploy/backplane/mcg/config.yaml
@@ -1,0 +1,5 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchLabels:
+    api.openshift.com/addon-mcg-osd: "true"
+  matchLabelsApplyMode: "OR"

--- a/deploy/backplane/mcg/mcg-osd/01-mcg-osd-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mcg/mcg-osd/01-mcg-osd-cr-admins.ClusterRole.yml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-mcg-osd-cr-admins
+rules:
+  - apiGroups:
+      - "mcg.openshift.io"
+    resources:
+      - "managedmcgs"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - "noobaa.io"
+    resources:
+      - "namespacestores"
+      - "noobaas"
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+

--- a/deploy/backplane/mcg/mcg-osd/10-mcg-mcg-osd-admins.SubjectPermission.yml
+++ b/deploy/backplane/mcg/mcg-osd/10-mcg-mcg-osd-admins.SubjectPermission.yml
@@ -1,0 +1,15 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-mcg-mcg-osd-admins
+  namespace: openshift-rbac-permissions
+spec:
+  permissions:
+  - allowFirst: true
+    clusterRoleName: admin
+    namespacesAllowedRegex: (^redhat-data-federation$)
+  - allowFirst: true
+    clusterRoleName: backplane-mcg-osd-cr-admins
+    namespacesAllowedRegex: (^redhat-data-federation$)
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-mcg

--- a/deploy/backplane/mcg/mcg-osd/config.yaml
+++ b/deploy/backplane/mcg/mcg-osd/config.yaml
@@ -1,0 +1,4 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchLabels:
+    api.openshift.com/addon-mcg-osd: "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2881,6 +2881,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-mcg-addon-mcg-osd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-mcg-osd: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-mcg
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-mcg-mcg-osd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-mcg-osd: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mcg-osd-cr-admins
+      rules:
+      - apiGroups:
+        - mcg.openshift.io
+        resources:
+        - managedmcgs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - namespacestores
+        - noobaas
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-mcg-mcg-osd-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^redhat-data-federation$)
+        - allowFirst: true
+          clusterRoleName: backplane-mcg-osd-cr-admins
+          namespacesAllowedRegex: (^redhat-data-federation$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-mcg
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-mtsre-addon-managed-odh
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2881,6 +2881,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-mcg-addon-mcg-osd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-mcg-osd: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-mcg
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-mcg-mcg-osd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-mcg-osd: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mcg-osd-cr-admins
+      rules:
+      - apiGroups:
+        - mcg.openshift.io
+        resources:
+        - managedmcgs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - namespacestores
+        - noobaas
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-mcg-mcg-osd-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^redhat-data-federation$)
+        - allowFirst: true
+          clusterRoleName: backplane-mcg-osd-cr-admins
+          namespacesAllowedRegex: (^redhat-data-federation$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-mcg
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-mtsre-addon-managed-odh
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2881,6 +2881,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-mcg-addon-mcg-osd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-mcg-osd: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-mcg
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-mcg-mcg-osd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-mcg-osd: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-mcg-osd-cr-admins
+      rules:
+      - apiGroups:
+        - mcg.openshift.io
+        resources:
+        - managedmcgs
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - noobaa.io
+        resources:
+        - namespacestores
+        - noobaas
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-mcg-mcg-osd-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^redhat-data-federation$)
+        - allowFirst: true
+          clusterRoleName: backplane-mcg-osd-cr-admins
+          namespacesAllowedRegex: (^redhat-data-federation$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-mcg
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-mtsre-addon-managed-odh
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

### What type of PR is this?
feature
### What this PR does / why we need it?
adds backplane config for mcg-osd to utilise while they'll support their addon in its "Service Preview" phase. 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/MTSRE-611

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
