### PR TITLE
[FedRAMP] Allow backplaned SREs to view/delete vpcendpoints

### DIFF
--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -140,7 +140,6 @@ rules:
   - get
   - list
   - watch
-### End
 # SRE can view/delete CSR objects
 - apiGroups:
   - certificates.k8s.io
@@ -152,3 +151,13 @@ rules:
   - watch
   - delete
 ### End
+# SRE can view/delete vpcendpoints
+- apiGroups:
+  - avo.openshift.io
+  resources:
+  - vpcendpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - delete

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3868,6 +3868,15 @@ objects:
         - list
         - watch
         - delete
+      - apiGroups:
+        - avo.openshift.io
+        resources:
+        - vpcendpoints
+        verbs:
+        - get
+        - list
+        - watch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3868,6 +3868,15 @@ objects:
         - list
         - watch
         - delete
+      - apiGroups:
+        - avo.openshift.io
+        resources:
+        - vpcendpoints
+        verbs:
+        - get
+        - list
+        - watch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3868,6 +3868,15 @@ objects:
         - list
         - watch
         - delete
+      - apiGroups:
+        - avo.openshift.io
+        resources:
+        - vpcendpoints
+        verbs:
+        - get
+        - list
+        - watch
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
As a FedRAMP SRE, viewing/deleting `vpcendpoint` CRs is normal behavior not requiring audit alerts for elevation.

### Which Jira/Github issue(s) this PR fixes?
[OSD-12540](https://issues.redhat.com//browse/OSD-12540)

### Special notes for your reviewer:
This CR only exists in FedRAMP at the moment