### PR TITLE
Adding s3:GetBucketPolicy to STS installer permissions for 4.11

### DIFF
--- a/resources/sts/4.11/sts_installer_permission_policy.json
+++ b/resources/sts/4.11/sts_installer_permission_policy.json
@@ -150,6 +150,7 @@
                 "s3:GetBucketLocation",
                 "s3:GetBucketLogging",
                 "s3:GetBucketObjectLockConfiguration",
+                "s3:GetBucketPolicy",
                 "s3:GetBucketReplication",
                 "s3:GetBucketRequestPayment",
                 "s3:GetBucketTagging",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

This adds a required s3 permission to the STS installer policy for v4.11

### Which Jira/Github issue(s) this PR fixes?

Gap analysis story for STS: https://issues.redhat.com/browse/OSD-11750
BZ for the specific missing permission: https://bugzilla.redhat.com/show_bug.cgi?id=2109388

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
