### PR TITLE
Handle additional csv/sub combinations for BZ1980755 fix

### DIFF
--- a/deploy/bz1980755/10-bz1980755.CronJob.yaml
+++ b/deploy/bz1980755/10-bz1980755.CronJob.yaml
@@ -59,7 +59,7 @@ spec:
                       done
 
                       for csv in `oc get clusterserviceversions.operators.coreos.com -n "${ns}" -o jsonpath="{.items[*].metadata.name}"`; do
-                          if [[ "${csv}" =~ ^${sub}.* ]]; then
+                          if [[ "${csv}" =~ ^${sub}.* || "openshift-${csv}" =~ ^${sub}.* ]]; then
                               echo "Removing CSV ${csv}"
                               oc delete clusterserviceversions.operators.coreos.com -n "${ns}" "${csv}"
                           fi

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4335,14 +4335,14 @@ objects:
                     \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
                     \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
-                    \            if [[ \"${csv}\" =~ ^${sub}.* ]]; then\n        \
-                    \        echo \"Removing CSV ${csv}\"\n                oc delete\
-                    \ clusterserviceversions.operators.coreos.com -n \"${ns}\" \"\
-                    ${csv}\"\n            fi\n        done\n\n        echo \"Removing\
-                    \ subscription ${sub}\"\n        oc delete subscriptions.operators.coreos.com\
-                    \  -n \"${ns}\" \"${sub}\"\n\n        echo \"Recreating subscription\
-                    \ ${sub}\"\n        oc create -f ${TEMPDIR}/${sub}.yaml\n    done\n\
-                    done\n"
+                    \            if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
+                    \ =~ ^${sub}.* ]]; then\n                echo \"Removing CSV ${csv}\"\
+                    \n                oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${csv}\"\n            fi\n        done\n\n  \
+                    \      echo \"Removing subscription ${sub}\"\n        oc delete\
+                    \ subscriptions.operators.coreos.com  -n \"${ns}\" \"${sub}\"\n\
+                    \n        echo \"Recreating subscription ${sub}\"\n        oc\
+                    \ create -f ${TEMPDIR}/${sub}.yaml\n    done\ndone\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4335,14 +4335,14 @@ objects:
                     \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
                     \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
-                    \            if [[ \"${csv}\" =~ ^${sub}.* ]]; then\n        \
-                    \        echo \"Removing CSV ${csv}\"\n                oc delete\
-                    \ clusterserviceversions.operators.coreos.com -n \"${ns}\" \"\
-                    ${csv}\"\n            fi\n        done\n\n        echo \"Removing\
-                    \ subscription ${sub}\"\n        oc delete subscriptions.operators.coreos.com\
-                    \  -n \"${ns}\" \"${sub}\"\n\n        echo \"Recreating subscription\
-                    \ ${sub}\"\n        oc create -f ${TEMPDIR}/${sub}.yaml\n    done\n\
-                    done\n"
+                    \            if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
+                    \ =~ ^${sub}.* ]]; then\n                echo \"Removing CSV ${csv}\"\
+                    \n                oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${csv}\"\n            fi\n        done\n\n  \
+                    \      echo \"Removing subscription ${sub}\"\n        oc delete\
+                    \ subscriptions.operators.coreos.com  -n \"${ns}\" \"${sub}\"\n\
+                    \n        echo \"Recreating subscription ${sub}\"\n        oc\
+                    \ create -f ${TEMPDIR}/${sub}.yaml\n    done\ndone\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4335,14 +4335,14 @@ objects:
                     \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
                     \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
-                    \            if [[ \"${csv}\" =~ ^${sub}.* ]]; then\n        \
-                    \        echo \"Removing CSV ${csv}\"\n                oc delete\
-                    \ clusterserviceversions.operators.coreos.com -n \"${ns}\" \"\
-                    ${csv}\"\n            fi\n        done\n\n        echo \"Removing\
-                    \ subscription ${sub}\"\n        oc delete subscriptions.operators.coreos.com\
-                    \  -n \"${ns}\" \"${sub}\"\n\n        echo \"Recreating subscription\
-                    \ ${sub}\"\n        oc create -f ${TEMPDIR}/${sub}.yaml\n    done\n\
-                    done\n"
+                    \            if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
+                    \ =~ ^${sub}.* ]]; then\n                echo \"Removing CSV ${csv}\"\
+                    \n                oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${csv}\"\n            fi\n        done\n\n  \
+                    \      echo \"Removing subscription ${sub}\"\n        oc delete\
+                    \ subscriptions.operators.coreos.com  -n \"${ns}\" \"${sub}\"\n\
+                    \n        echo \"Recreating subscription ${sub}\"\n        oc\
+                    \ create -f ${TEMPDIR}/${sub}.yaml\n    done\ndone\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
This makes a small correction to the BZ1980755 cronjob.

This fix caters for the splunk-forwarder-operator whose subscription name starts with `openshift-`, unlike the CSV.

### Which Jira/Github issue(s) this PR fixes?
[OSD-12547](https://issues.redhat.com//browse/OSD-12547)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
