### PR TITLE
Node startup timeout

### DIFF
--- a/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -21,3 +21,4 @@ spec:
     timeout: "480s"
     status: "Unknown"
   maxUnhealthy: 3
+  nodeStartupTimeout: 25m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9454,6 +9454,7 @@ objects:
           timeout: 480s
           status: Unknown
         maxUnhealthy: 3
+        nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9454,6 +9454,7 @@ objects:
           timeout: 480s
           status: Unknown
         maxUnhealthy: 3
+        nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9454,6 +9454,7 @@ objects:
           timeout: 480s
           status: Unknown
         maxUnhealthy: 3
+        nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

This change is to accommodate metal instance types and that the change is + 15 minutes since the [default](https://github.com/openshift/machine-api-operator/blob/128c5c90918c009172c6d24d5715888e0e1d59e4/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go#L47) is 10.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-12657](https://issues.redhat.com//browse/OSD-12657)
