### PR TITLE
osd-cluster-ready++ to only check ds/rs in managed namespaces

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.83-10bd314"
+                managed.openshift.io/version: "v0.1.91-51f9908"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7"
+              image: "quay.io/app-sre/osd-cluster-ready@sha256:4a3dfd1efa2fe3ed563a51c58da15b788fbc14996143a1962bd1cd0afa2f5436"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7448,11 +7448,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.83-10bd314
+              managed.openshift.io/version: v0.1.91-51f9908
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7
+              image: quay.io/app-sre/osd-cluster-ready@sha256:4a3dfd1efa2fe3ed563a51c58da15b788fbc14996143a1962bd1cd0afa2f5436
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7448,11 +7448,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.83-10bd314
+              managed.openshift.io/version: v0.1.91-51f9908
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7
+              image: quay.io/app-sre/osd-cluster-ready@sha256:4a3dfd1efa2fe3ed563a51c58da15b788fbc14996143a1962bd1cd0afa2f5436
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7448,11 +7448,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.83-10bd314
+              managed.openshift.io/version: v0.1.91-51f9908
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:1877269bee5418a839f8cb7a93066913e1862979f5f08ac10fde4ed6c6858ff7
+              image: quay.io/app-sre/osd-cluster-ready@sha256:4a3dfd1efa2fe3ed563a51c58da15b788fbc14996143a1962bd1cd0afa2f5436
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Pulling in updates from https://github.com/openshift/osd-cluster-ready/pull/27 relating to improved checks that focus only on `openshift-*` namespaces for daemonset/replicaset health-checks

### Which Jira/Github issue(s) this PR fixes?
[OHSS-10788](https://issues.redhat.com//browse/OHSS-10788)