### PR TITLE
chore: allow backplane-mtsre-monitoring to have prometheus CR accessibility

### DIFF
--- a/deploy/backplane/mtsre/10-mtsre-monitoring-coreos-apis.ClusterRole.yml
+++ b/deploy/backplane/mtsre/10-mtsre-monitoring-coreos-apis.ClusterRole.yml
@@ -8,6 +8,7 @@ rules:
       - "monitoring.coreos.com"
     resources:
       - servicemonitors
+      - prometheuses
     verbs:
       - get
       - list

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2918,6 +2918,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3011,6 +3012,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3104,6 +3106,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3197,6 +3200,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3290,6 +3294,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2918,6 +2918,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3011,6 +3012,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3104,6 +3106,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3197,6 +3200,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3290,6 +3294,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2918,6 +2918,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3011,6 +3012,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3104,6 +3106,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3197,6 +3200,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list
@@ -3290,6 +3294,7 @@ objects:
         - monitoring.coreos.com
         resources:
         - servicemonitors
+        - prometheuses
         verbs:
         - get
         - list


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

### What type of PR is this?
_(chore)_

### What this PR does / why we need it?
This PR enhances the backplane-mtsre-monitoring clusterrole to have its reaches to the `prometheus` CRs as well. We (MTSRE) do require that access for debugging Prometheus remoteWrite failures happening in one of the cluster in the fleet. 
