### PR TITLE
OSD-12872 Bump sre-build-test image from Go 1.15 to Go 1.17

### DIFF
--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -76,7 +76,7 @@ spec:
               done
 
               # run build
-              oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.15.14-18
+              oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13
               cat <<EOF > /tmp/main.go
               package main
               import (

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -12888,7 +12888,7 @@ objects:
                     \ >/dev/null; do\n  echo \"$(date): Waiting for service account\
                     \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
                     \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
-                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.15.14-18\n\
+                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
                     cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
                     \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
                     \ :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -12888,7 +12888,7 @@ objects:
                     \ >/dev/null; do\n  echo \"$(date): Waiting for service account\
                     \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
                     \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
-                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.15.14-18\n\
+                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
                     cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
                     \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
                     \ :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -12888,7 +12888,7 @@ objects:
                     \ >/dev/null; do\n  echo \"$(date): Waiting for service account\
                     \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
                     \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
-                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.15.14-18\n\
+                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
                     cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
                     \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
                     \ :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
Bumps the image used to run the "Hello World"-esque build test job to Go 1.17 from Go 1.15 (available images listed https://ftp.redhat.com/redhat/containers/rhel8/go-toolset/)

### Which Jira/Github issue(s) this PR fixes?
Fixes [OSD-12872](https://issues.redhat.com//browse/OSD-12872)

### Special notes for your reviewer:
Validated in a stage cluster
