### PR TITLE
encrypt nodes' root volumes

### DIFF
--- a/deploy/osd-machine-api/009-machine-api.srep-worker-rootvol-encryption.MachineSet.yaml
+++ b/deploy/osd-machine-api/009-machine-api.srep-worker-rootvol-encryption.MachineSet.yaml
@@ -1,0 +1,6 @@
+kind: MachineSet
+apiVersion: machine.openshift.io/v1beta1
+applyMode: AlwaysApply
+patch: |-
+  { "spec": {"template": {"spec": {"providerSpec": {"value": {"blockDevices"[0]: {"ebs": {"encrypted": true } } } } } } } }
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9418,6 +9418,13 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    patches:
+    - kind: MachineSet
+      apiVersion: machine.openshift.io/v1beta1
+      applyMode: AlwaysApply
+      patch: '{ "spec": {"template": {"spec": {"providerSpec": {"value": {"blockDevices"[0]:
+        {"ebs": {"encrypted": true } } } } } } } }'
+      patchType: merge
     resources:
     - apiVersion: machine.openshift.io/v1beta1
       kind: MachineHealthCheck

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9418,6 +9418,13 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    patches:
+    - kind: MachineSet
+      apiVersion: machine.openshift.io/v1beta1
+      applyMode: AlwaysApply
+      patch: '{ "spec": {"template": {"spec": {"providerSpec": {"value": {"blockDevices"[0]:
+        {"ebs": {"encrypted": true } } } } } } } }'
+      patchType: merge
     resources:
     - apiVersion: machine.openshift.io/v1beta1
       kind: MachineHealthCheck

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9418,6 +9418,13 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
     resourceApplyMode: Sync
+    patches:
+    - kind: MachineSet
+      apiVersion: machine.openshift.io/v1beta1
+      applyMode: AlwaysApply
+      patch: '{ "spec": {"template": {"spec": {"providerSpec": {"value": {"blockDevices"[0]:
+        {"ebs": {"encrypted": true } } } } } } } }'
+      patchType: merge
     resources:
     - apiVersion: machine.openshift.io/v1beta1
       kind: MachineHealthCheck


### PR DESCRIPTION
### What type of PR is this?
_cleanup/_

### What this PR does / why we need it?
add a patch sss that will encrypt worker node root volumes per
https://issues.redhat.com/browse/OSD-3822

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-3822

### Special notes for your reviewer:
this has been enabled by default starting in 4.5

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
