### PR TITLE
Osd 12363 remove cbc ciphers

### DIFF
--- a/deploy/osd-fedramp-machineconfig/99-fedramp-ssh-cipher-configs-master.yaml
+++ b/deploy/osd-fedramp-machineconfig/99-fedramp-ssh-cipher-configs-master.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-ssh-cipher-config
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+          overwrite: true
+          path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+        - contents:
+            source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+          overwrite: true
+          path: /etc/ssh/sshd_config             

--- a/deploy/osd-fedramp-machineconfig/99-fedramp-ssh-cipher-configs-worker.yaml
+++ b/deploy/osd-fedramp-machineconfig/99-fedramp-ssh-cipher-configs-worker.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-ssh-cipher-config
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+            source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+          overwrite: true
+          path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+        - contents:
+            source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+          overwrite: true
+          path: /etc/ssh/sshd_config             

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8743,6 +8743,46 @@ objects:
               mode: 420
               overwrite: true
               path: /etc/chrony.conf
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: master
+        name: 99-master-ssh-cipher-config
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          storage:
+            files:
+            - contents:
+                source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+            - contents:
+                source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/sshd_config
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-ssh-cipher-config
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          storage:
+            files:
+            - contents:
+                source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+            - contents:
+                source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/sshd_config
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8743,6 +8743,46 @@ objects:
               mode: 420
               overwrite: true
               path: /etc/chrony.conf
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: master
+        name: 99-master-ssh-cipher-config
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          storage:
+            files:
+            - contents:
+                source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+            - contents:
+                source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/sshd_config
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-ssh-cipher-config
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          storage:
+            files:
+            - contents:
+                source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+            - contents:
+                source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/sshd_config
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8743,6 +8743,46 @@ objects:
               mode: 420
               overwrite: true
               path: /etc/chrony.conf
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: master
+        name: 99-master-ssh-cipher-config
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          storage:
+            files:
+            - contents:
+                source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+            - contents:
+                source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/sshd_config
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-ssh-cipher-config
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          storage:
+            files:
+            - contents:
+                source: data:,Ciphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/ssh_config.d/10-fedramp-cipher.conf
+            - contents:
+                source: data:,%23%09%24OpenBSD%3A%20sshd_config%2Cv%201.103%202018/04/09%2020%3A41%3A22%20tj%20Exp%20%24%0A%23%20This%20config%20has%20been%20modified%20by%20MCO%20to%20adjust%20the%20allowed%20ciphers%20in%20FedRAMP%0A%0AHostKey%20/etc/ssh/ssh_host_rsa_key%0AHostKey%20/etc/ssh/ssh_host_ecdsa_key%0AHostKey%20/etc/ssh/ssh_host_ed25519_key%0A%0ASyslogFacility%20AUTHPRIV%0A%0APermitRootLogin%20no%0A%0AAuthorizedKeysFile%09.ssh/authorized_keys%0A%0APasswordAuthentication%20no%0A%0AChallengeResponseAuthentication%20no%0A%0AGSSAPIAuthentication%20yes%0AGSSAPICleanupCredentials%20no%0A%0AUsePAM%20yes%0A%0AX11Forwarding%20yes%0A%0APrintMotd%20no%0A%0AClientAliveInterval%20180%0A%0AAcceptEnv%20LANG%20LC_CTYPE%20LC_NUMERIC%20LC_TIME%20LC_COLLATE%20LC_MONETARY%20LC_MESSAGES%0AAcceptEnv%20LC_PAPER%20LC_NAME%20LC_ADDRESS%20LC_TELEPHONE%20LC_MEASUREMENT%0AAcceptEnv%20LC_IDENTIFICATION%20LC_ALL%20LANGUAGE%0AAcceptEnv%20XMODIFIERS%0A%0ASubsystem%09sftp%09/usr/libexec/openssh/sftp-server%0ACiphers%20aes256-gcm%40openssh.com%2Caes256-ctr%2Caes128-gcm%40openssh.com%2Caes128-ctr
+              overwrite: true
+              path: /etc/ssh/sshd_config
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature?

### What this PR does / why we need it?
This PR is to remove weak ciphers from server/client SSH configs, specifically CBC ciphers.  
The change specifically:
* Adds a new file under /etc/ssh/ssh_config.d to specify the allowed ciphers instead of using the default
* Recreates the entire sshd_config file with a line added for the allowed ciphers
     * The reason for updating the entire sshd_config file is because RHCOS does not have an sshd_config.d directory to drop files in, nor the include directive in the sshd_config, so either method would require updating the sshd_config. The modified file is the default config with comments removed and just a new line at the end
     * MCO does not support appending the file so rewrite of file is required
   
These changes will only be applied to FedRAMP clusters. This was a finding in scanning our clusters for vulnerabilities and threats and has been asked to be remediated.

If you'd like to decode the content since they are URL encoded for Ignition, this KB article is super handy: https://access.redhat.com/solutions/4719071

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-12363

_Fixes #_

### Special notes for your reviewer:

I'm not a huge fan of rewriting the entire sshd_config file but don't see another method of handling that with MCC/MCO since we can't do append. I can't imagine the default config changes very much between RHCOS versions so I might just be worrying more than I should but am open to suggestions. There is the potential to use crypto-policies and add a new module that removes the ciphers but that requries running a command to update it which I'm not sure we have something in place to do that on each node? 

### Pre-checks (if applicable):
- [x ] Tested latest changes against a cluster (ran this in my dev test cluster in FedRAMP)
- [ ] Included documentation changes with PR
- [] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
