### PR TITLE
OSD-12872 Fix openshift-build-test job, now requires go.mod

### DIFF
--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -77,7 +77,13 @@ spec:
 
               # run build
               oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13
-              cat <<EOF > /tmp/main.go
+              mkdir -p /tmp/build
+              cat <<EOF > /tmp/build/go.mod
+              module openshift/managed-cluster-config/sre-build-test
+
+              go 1.17
+              EOF
+              cat <<EOF > /tmp/build/main.go
               package main
               import (
                      "fmt"
@@ -88,7 +94,7 @@ spec:
               }
               EOF
 
-              while ! oc -n "${NS}" start-build "${JOB_PREFIX}" --from-file=/tmp/main.go
+              while ! oc -n "${NS}" start-build "${JOB_PREFIX}" --from-dir=/tmp/build
               do
                 echo "Failed to start build, retrying in 15 seconds."
                 sleep 15s

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -12922,18 +12922,19 @@ objects:
                     \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
                     \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
                     \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
-                    cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
-                    \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
-                    \ :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\
-                    \ --from-file=/tmp/main.go\ndo\n  echo \"Failed to start build,\
-                    \ retrying in 15 seconds.\"\n  sleep 15s\ndone\n\necho \"$(date):\
-                    \ Waiting for build to complete.\"\nwhile :\ndo\n  ST=$(oc -n\
-                    \ \"${NS}\" get build -o custom-columns=STATUS:.status.phase --no-headers)\n\
-                    \  case ${ST} in\n    \"\")\n      # if build status is blank,\
-                    \ assume we are still starting the build\n      ST=\"Starting\"\
-                    \n      ;;\n    Failed)\n      echo \"$(date): Build Failed\"\
-                    \ >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n\
-                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
+                    mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
+                    \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
+                    import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\
+                    Hello Openshift SRE :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build\
+                    \ \"${JOB_PREFIX}\" --from-dir=/tmp/build\ndo\n  echo \"Failed\
+                    \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
+                    \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
+                    do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
+                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
+                    \ status is blank, assume we are still starting the build\n  \
+                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
+                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
                     \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
                     \     echo \"$(date): Build Complete\"\n      JOBS_TO_DELETE=$(oc\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -12922,18 +12922,19 @@ objects:
                     \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
                     \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
                     \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
-                    cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
-                    \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
-                    \ :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\
-                    \ --from-file=/tmp/main.go\ndo\n  echo \"Failed to start build,\
-                    \ retrying in 15 seconds.\"\n  sleep 15s\ndone\n\necho \"$(date):\
-                    \ Waiting for build to complete.\"\nwhile :\ndo\n  ST=$(oc -n\
-                    \ \"${NS}\" get build -o custom-columns=STATUS:.status.phase --no-headers)\n\
-                    \  case ${ST} in\n    \"\")\n      # if build status is blank,\
-                    \ assume we are still starting the build\n      ST=\"Starting\"\
-                    \n      ;;\n    Failed)\n      echo \"$(date): Build Failed\"\
-                    \ >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n\
-                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
+                    mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
+                    \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
+                    import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\
+                    Hello Openshift SRE :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build\
+                    \ \"${JOB_PREFIX}\" --from-dir=/tmp/build\ndo\n  echo \"Failed\
+                    \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
+                    \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
+                    do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
+                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
+                    \ status is blank, assume we are still starting the build\n  \
+                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
+                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
                     \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
                     \     echo \"$(date): Build Complete\"\n      JOBS_TO_DELETE=$(oc\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -12922,18 +12922,19 @@ objects:
                     \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
                     \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
                     \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
-                    cat <<EOF > /tmp/main.go\npackage main\nimport (\n       \"fmt\"\
-                    \n)\n\nfunc main() {\n        fmt.Println(\"Hello Openshift SRE\
-                    \ :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build \"${JOB_PREFIX}\"\
-                    \ --from-file=/tmp/main.go\ndo\n  echo \"Failed to start build,\
-                    \ retrying in 15 seconds.\"\n  sleep 15s\ndone\n\necho \"$(date):\
-                    \ Waiting for build to complete.\"\nwhile :\ndo\n  ST=$(oc -n\
-                    \ \"${NS}\" get build -o custom-columns=STATUS:.status.phase --no-headers)\n\
-                    \  case ${ST} in\n    \"\")\n      # if build status is blank,\
-                    \ assume we are still starting the build\n      ST=\"Starting\"\
-                    \n      ;;\n    Failed)\n      echo \"$(date): Build Failed\"\
-                    \ >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n\
-                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
+                    mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
+                    \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
+                    import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\
+                    Hello Openshift SRE :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build\
+                    \ \"${JOB_PREFIX}\" --from-dir=/tmp/build\ndo\n  echo \"Failed\
+                    \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
+                    \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
+                    do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
+                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
+                    \ status is blank, assume we are still starting the build\n  \
+                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
+                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
                     \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
                     \     echo \"$(date): Build Complete\"\n      JOBS_TO_DELETE=$(oc\


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
While validating #1247, I realized that the temporary build job was failing with:
```
STEP 8/9: RUN /usr/libexec/s2i/assemble
/tmp/src ~
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
go: go.mod file not found in current directory or any parent directory; see 'go help modules'
error: build error: error building at STEP "RUN /usr/libexec/s2i/assemble": error while running runtime: exit status 1
```

After adding a `go.mod`, the build completes successfully again:
```
STEP 8/9: RUN /usr/libexec/s2i/assemble
/tmp/src ~
~
STEP 9/9: CMD /usr/libexec/s2i/run
COMMIT temp.builder.openshift.io/openshift-build-test-manual-h857r/sre-build-test-1:f78194c8
time="2022-08-12T18:53:22Z" level=warning msg="Adding metacopy option, configured globally"
Getting image source signatures
Copying blob sha256:5bf135c4a0de07e52c11282c0954e3e6b7c7ddc6c8834a7fd2803c3dc6a31a69
Copying blob sha256:773711fd02f009e3bc5f9e2b1e859bf2103ba7318b3eb73390490afb3a3a8848
Copying blob sha256:4f7a53ad759d28d9be0b03d0d9b6613034b81b1183ab978b0f9602cf6b2dae9e
Copying blob sha256:658d01b678cf3349dc9f02fa16c93ebcaecff9108afa30998312f8ffd2d08b0c
Copying blob sha256:5b5ac5494779f345c38142f9a60ede778544503ceda5e6bf8fad84d8f29a77f6
Copying blob sha256:4732b7f4838ebe17be10bf6c00fc11d6096235df0453eaf418b6133b2f709e19
Copying config sha256:cdeb3aa01a94a712d9c37560764d9f2843ae51fb468117672f6c5f69fc19acbb
Writing manifest to image destination
Storing signatures
--> cdeb3aa01a9
Successfully tagged temp.builder.openshift.io/openshift-build-test-manual-h857r/sre-build-test-1:f78194c8
cdeb3aa01a94a712d9c37560764d9f2843ae51fb468117672f6c5f69fc19acbb

Pushing image image-registry.openshift-image-registry.svc:5000/openshift-build-test-manual-h857r/sre-build-test:latest ...
Getting image source signatures
Copying blob sha256:545277d800059b32cf03377a9301094e9ac8aa4bb42d809766d7355ca9aa8652
Copying blob sha256:3021c6dcf6dd9bf8e2b2f9487c55ff3e960f00ae1e43ab2471eab5f06ed1cc68
Copying blob sha256:cec9847d7346d4e1cc63c5f09fca649985a4145b8b2604fb5e84aacf67702fde
Copying blob sha256:f70d60810c69edad990aaf0977a87c6d2bcc9cd52904fa6825f08507a9b6e7bc
Copying blob sha256:4732b7f4838ebe17be10bf6c00fc11d6096235df0453eaf418b6133b2f709e19
Copying blob sha256:0c1fd83997e17b079085107d40f89cea2211f9ec3db88d5241019a85d06db5a7
Copying config sha256:cdeb3aa01a94a712d9c37560764d9f2843ae51fb468117672f6c5f69fc19acbb
Writing manifest to image destination
Storing signatures
Successfully pushed image-registry.openshift-image-registry.svc:5000/openshift-build-test-manual-h857r/sre-build-test@sha256:6ffab27006386009b5b4cc07c8cdadb55b5799637b6147261df415706e70c0f2
Push successful
```

### Which Jira/Github issue(s) this PR fixes?

[OSD-12872](https://issues.redhat.com//browse/OSD-12872)