### PR TITLE
OSD-12547 Rework BZ1980755 script to be more efficient

### DIFF
--- a/deploy/bz1980755/01-bz1980755.ClusterRole.yaml
+++ b/deploy/bz1980755/01-bz1980755.ClusterRole.yaml
@@ -19,3 +19,11 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/bz1980755/10-bz1980755.CronJob.yaml
+++ b/deploy/bz1980755/10-bz1980755.CronJob.yaml
@@ -29,7 +29,7 @@ spec:
           restartPolicy: Never
           containers:
           - name: bz1980755
-            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
             imagePullPolicy: Always
             args:
             - /bin/bash
@@ -40,35 +40,46 @@ spec:
               set -o pipefail
 
               TEMPDIR=$(mktemp -d)
-              for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep "^openshift[-]"`; do
-                  echo "Checking namespace ${ns}"
-                  for sub in `oc get subscriptions.operators.coreos.com -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath="{.items[*].metadata.name}"`; do
-                      echo "Checking subscription ${sub}"
 
-                      NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com -n "${ns}" "${sub}" -o jsonpath="{.status.conditions[?(@.reason == 'ConstraintsNotSatisfiable')].status}")
-                      if [[ "${NEEDS_REPLACE}" != "True" ]]; then
-                          continue
-                      fi
+              echo "Checking for impacted subscriptions.."
+              IMPACTED_SUBS=$(oc get sub -A -l 'hive.openshift.io/managed=true' -o json | jq -r '.items[] | select(.status.conditions[].reason == "ConstraintsNotSatisfiable") | "\(.metadata.namespace),\(.metadata.name)"')
 
-                      echo "Will re-install subscription ${ns}/${sub}"
-                      oc get subscriptions.operators.coreos.com -n "${ns}" "${sub}" -ojson | grep -v "kubectl.kubernetes.io/last-applied-configuration" > ${TEMPDIR}/${sub}.yaml
+              if [[ -z "${IMPACTED_SUBS}" ]]; then
+                 echo "No impacted subscriptions found."
+                 exit 0
+              fi
 
-                      for ip in `oc get installplans.operators.coreos.com -n "${ns}" -o jsonpath="{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}"`; do
-                          echo "Removing installplan ${ip}"
-                          oc delete installplans.operators.coreos.com -n "${ns}" $ip
-                      done
+              while read subAndNS; do
 
-                      for csv in `oc get clusterserviceversions.operators.coreos.com -n "${ns}" -o jsonpath="{.items[*].metadata.name}"`; do
-                          if [[ "${csv}" =~ ^${sub}.* || "openshift-${csv}" =~ ^${sub}.* ]]; then
-                              echo "Removing CSV ${csv}"
-                              oc delete clusterserviceversions.operators.coreos.com -n "${ns}" "${csv}"
-                          fi
-                      done
+                  ns=$(echo "${subAndNS}" | cut -d, -f 1)
+                  sub=$(echo "${subAndNS}" | cut -d, -f 2)
 
-                      echo "Removing subscription ${sub}"
-                      oc delete subscriptions.operators.coreos.com  -n "${ns}" "${sub}"
+                  if [[ -z "${ns}" || -z "${sub}" ]]; then
+                      continue
+                  fi
 
-                      echo "Recreating subscription ${sub}"
-                      oc create -f ${TEMPDIR}/${sub}.yaml
+                  echo "Will re-install subscription ${ns}/${sub}"
+                  oc get subscriptions.operators.coreos.com -n "${ns}" "${sub}" -ojson | grep -v "kubectl.kubernetes.io/last-applied-configuration" > ${TEMPDIR}/${sub}.yaml
+
+                  for ip in `oc get installplans.operators.coreos.com -n "${ns}" -o jsonpath="{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}"`; do
+                      echo "Removing installplan ${ip}"
+                      oc delete installplans.operators.coreos.com -n "${ns}" $ip
                   done
-              done
+
+                  for csv in `oc get clusterserviceversions.operators.coreos.com -n "${ns}" -o jsonpath="{.items[*].metadata.name}"`; do
+                      if [[ "${csv}" =~ ^${sub}.* || "openshift-${csv}" =~ ^${sub}.* ]]; then
+                          echo "Removing CSV ${csv}"
+                          oc delete clusterserviceversions.operators.coreos.com -n "${ns}" "${csv}"
+                      fi
+                  done
+
+                  echo "Removing subscription ${sub}"
+                  oc delete subscriptions.operators.coreos.com  -n "${ns}" "${sub}"
+
+                  echo "Restarting catalog-operator to clear cache"
+                  oc delete pod -n openshift-operator-lifecycle-manager -l app=catalog-operator --wait=true
+
+                  echo "Recreating subscription ${sub}"
+                  oc create -f ${TEMPDIR}/${sub}.yaml
+
+              done <<< "${IMPACTED_SUBS}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4279,6 +4279,14 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -4321,38 +4329,39 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: bz1980755
-                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash
                   - -c
                   - "set -e\nset -o nounset\nset -o pipefail\n\nTEMPDIR=$(mktemp -d)\n\
-                    for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{\"\
-                    \\n\"}{end}' | grep \"^openshift[-]\"`; do\n    echo \"Checking\
-                    \ namespace ${ns}\"\n    for sub in `oc get subscriptions.operators.coreos.com\
-                    \ -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath=\"\
-                    {.items[*].metadata.name}\"`; do\n        echo \"Checking subscription\
-                    \ ${sub}\"\n\n        NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com\
-                    \ -n \"${ns}\" \"${sub}\" -o jsonpath=\"{.status.conditions[?(@.reason\
-                    \ == 'ConstraintsNotSatisfiable')].status}\")\n        if [[ \"\
-                    ${NEEDS_REPLACE}\" != \"True\" ]]; then\n            continue\n\
-                    \        fi\n\n        echo \"Will re-install subscription ${ns}/${sub}\"\
-                    \n        oc get subscriptions.operators.coreos.com -n \"${ns}\"\
-                    \ \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
-                    \ > ${TEMPDIR}/${sub}.yaml\n\n        for ip in `oc get installplans.operators.coreos.com\
+                    \necho \"Checking for impacted subscriptions..\"\nIMPACTED_SUBS=$(oc\
+                    \ get sub -A -l 'hive.openshift.io/managed=true' -o json | jq\
+                    \ -r '.items[] | select(.status.conditions[].reason == \"ConstraintsNotSatisfiable\"\
+                    ) | \"\\(.metadata.namespace),\\(.metadata.name)\"')\n\nif [[\
+                    \ -z \"${IMPACTED_SUBS}\" ]]; then\n   echo \"No impacted subscriptions\
+                    \ found.\"\n   exit 0\nfi\n\nwhile read subAndNS; do\n\n    ns=$(echo\
+                    \ \"${subAndNS}\" | cut -d, -f 1)\n    sub=$(echo \"${subAndNS}\"\
+                    \ | cut -d, -f 2)\n\n    if [[ -z \"${ns}\" || -z \"${sub}\" ]];\
+                    \ then\n        continue\n    fi\n\n    echo \"Will re-install\
+                    \ subscription ${ns}/${sub}\"\n    oc get subscriptions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
+                    \ > ${TEMPDIR}/${sub}.yaml\n\n    for ip in `oc get installplans.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}\"\
-                    `; do\n            echo \"Removing installplan ${ip}\"\n     \
-                    \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
-                    \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
+                    `; do\n        echo \"Removing installplan ${ip}\"\n        oc\
+                    \ delete installplans.operators.coreos.com -n \"${ns}\" $ip\n\
+                    \    done\n\n    for csv in `oc get clusterserviceversions.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
-                    \            if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
-                    \ =~ ^${sub}.* ]]; then\n                echo \"Removing CSV ${csv}\"\
-                    \n                oc delete clusterserviceversions.operators.coreos.com\
-                    \ -n \"${ns}\" \"${csv}\"\n            fi\n        done\n\n  \
-                    \      echo \"Removing subscription ${sub}\"\n        oc delete\
-                    \ subscriptions.operators.coreos.com  -n \"${ns}\" \"${sub}\"\n\
-                    \n        echo \"Recreating subscription ${sub}\"\n        oc\
-                    \ create -f ${TEMPDIR}/${sub}.yaml\n    done\ndone\n"
+                    \        if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
+                    \ =~ ^${sub}.* ]]; then\n            echo \"Removing CSV ${csv}\"\
+                    \n            oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${csv}\"\n        fi\n    done\n\n    echo \"\
+                    Removing subscription ${sub}\"\n    oc delete subscriptions.operators.coreos.com\
+                    \  -n \"${ns}\" \"${sub}\"\n\n    echo \"Restarting catalog-operator\
+                    \ to clear cache\"\n    oc delete pod -n openshift-operator-lifecycle-manager\
+                    \ -l app=catalog-operator --wait=true\n\n    echo \"Recreating\
+                    \ subscription ${sub}\"\n    oc create -f ${TEMPDIR}/${sub}.yaml\n\
+                    \ndone <<< \"${IMPACTED_SUBS}\"\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4279,6 +4279,14 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -4321,38 +4329,39 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: bz1980755
-                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash
                   - -c
                   - "set -e\nset -o nounset\nset -o pipefail\n\nTEMPDIR=$(mktemp -d)\n\
-                    for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{\"\
-                    \\n\"}{end}' | grep \"^openshift[-]\"`; do\n    echo \"Checking\
-                    \ namespace ${ns}\"\n    for sub in `oc get subscriptions.operators.coreos.com\
-                    \ -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath=\"\
-                    {.items[*].metadata.name}\"`; do\n        echo \"Checking subscription\
-                    \ ${sub}\"\n\n        NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com\
-                    \ -n \"${ns}\" \"${sub}\" -o jsonpath=\"{.status.conditions[?(@.reason\
-                    \ == 'ConstraintsNotSatisfiable')].status}\")\n        if [[ \"\
-                    ${NEEDS_REPLACE}\" != \"True\" ]]; then\n            continue\n\
-                    \        fi\n\n        echo \"Will re-install subscription ${ns}/${sub}\"\
-                    \n        oc get subscriptions.operators.coreos.com -n \"${ns}\"\
-                    \ \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
-                    \ > ${TEMPDIR}/${sub}.yaml\n\n        for ip in `oc get installplans.operators.coreos.com\
+                    \necho \"Checking for impacted subscriptions..\"\nIMPACTED_SUBS=$(oc\
+                    \ get sub -A -l 'hive.openshift.io/managed=true' -o json | jq\
+                    \ -r '.items[] | select(.status.conditions[].reason == \"ConstraintsNotSatisfiable\"\
+                    ) | \"\\(.metadata.namespace),\\(.metadata.name)\"')\n\nif [[\
+                    \ -z \"${IMPACTED_SUBS}\" ]]; then\n   echo \"No impacted subscriptions\
+                    \ found.\"\n   exit 0\nfi\n\nwhile read subAndNS; do\n\n    ns=$(echo\
+                    \ \"${subAndNS}\" | cut -d, -f 1)\n    sub=$(echo \"${subAndNS}\"\
+                    \ | cut -d, -f 2)\n\n    if [[ -z \"${ns}\" || -z \"${sub}\" ]];\
+                    \ then\n        continue\n    fi\n\n    echo \"Will re-install\
+                    \ subscription ${ns}/${sub}\"\n    oc get subscriptions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
+                    \ > ${TEMPDIR}/${sub}.yaml\n\n    for ip in `oc get installplans.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}\"\
-                    `; do\n            echo \"Removing installplan ${ip}\"\n     \
-                    \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
-                    \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
+                    `; do\n        echo \"Removing installplan ${ip}\"\n        oc\
+                    \ delete installplans.operators.coreos.com -n \"${ns}\" $ip\n\
+                    \    done\n\n    for csv in `oc get clusterserviceversions.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
-                    \            if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
-                    \ =~ ^${sub}.* ]]; then\n                echo \"Removing CSV ${csv}\"\
-                    \n                oc delete clusterserviceversions.operators.coreos.com\
-                    \ -n \"${ns}\" \"${csv}\"\n            fi\n        done\n\n  \
-                    \      echo \"Removing subscription ${sub}\"\n        oc delete\
-                    \ subscriptions.operators.coreos.com  -n \"${ns}\" \"${sub}\"\n\
-                    \n        echo \"Recreating subscription ${sub}\"\n        oc\
-                    \ create -f ${TEMPDIR}/${sub}.yaml\n    done\ndone\n"
+                    \        if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
+                    \ =~ ^${sub}.* ]]; then\n            echo \"Removing CSV ${csv}\"\
+                    \n            oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${csv}\"\n        fi\n    done\n\n    echo \"\
+                    Removing subscription ${sub}\"\n    oc delete subscriptions.operators.coreos.com\
+                    \  -n \"${ns}\" \"${sub}\"\n\n    echo \"Restarting catalog-operator\
+                    \ to clear cache\"\n    oc delete pod -n openshift-operator-lifecycle-manager\
+                    \ -l app=catalog-operator --wait=true\n\n    echo \"Recreating\
+                    \ subscription ${sub}\"\n    oc create -f ${TEMPDIR}/${sub}.yaml\n\
+                    \ndone <<< \"${IMPACTED_SUBS}\"\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4279,6 +4279,14 @@ objects:
         verbs:
         - get
         - list
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -4321,38 +4329,39 @@ objects:
                 restartPolicy: Never
                 containers:
                 - name: bz1980755
-                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   args:
                   - /bin/bash
                   - -c
                   - "set -e\nset -o nounset\nset -o pipefail\n\nTEMPDIR=$(mktemp -d)\n\
-                    for ns in `oc get namespace -o jsonpath='{range .items[*]}{.metadata.name}{\"\
-                    \\n\"}{end}' | grep \"^openshift[-]\"`; do\n    echo \"Checking\
-                    \ namespace ${ns}\"\n    for sub in `oc get subscriptions.operators.coreos.com\
-                    \ -l 'hive.openshift.io/managed=true' -n ${ns} -o jsonpath=\"\
-                    {.items[*].metadata.name}\"`; do\n        echo \"Checking subscription\
-                    \ ${sub}\"\n\n        NEEDS_REPLACE=$(oc get subscriptions.operators.coreos.com\
-                    \ -n \"${ns}\" \"${sub}\" -o jsonpath=\"{.status.conditions[?(@.reason\
-                    \ == 'ConstraintsNotSatisfiable')].status}\")\n        if [[ \"\
-                    ${NEEDS_REPLACE}\" != \"True\" ]]; then\n            continue\n\
-                    \        fi\n\n        echo \"Will re-install subscription ${ns}/${sub}\"\
-                    \n        oc get subscriptions.operators.coreos.com -n \"${ns}\"\
-                    \ \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
-                    \ > ${TEMPDIR}/${sub}.yaml\n\n        for ip in `oc get installplans.operators.coreos.com\
+                    \necho \"Checking for impacted subscriptions..\"\nIMPACTED_SUBS=$(oc\
+                    \ get sub -A -l 'hive.openshift.io/managed=true' -o json | jq\
+                    \ -r '.items[] | select(.status.conditions[].reason == \"ConstraintsNotSatisfiable\"\
+                    ) | \"\\(.metadata.namespace),\\(.metadata.name)\"')\n\nif [[\
+                    \ -z \"${IMPACTED_SUBS}\" ]]; then\n   echo \"No impacted subscriptions\
+                    \ found.\"\n   exit 0\nfi\n\nwhile read subAndNS; do\n\n    ns=$(echo\
+                    \ \"${subAndNS}\" | cut -d, -f 1)\n    sub=$(echo \"${subAndNS}\"\
+                    \ | cut -d, -f 2)\n\n    if [[ -z \"${ns}\" || -z \"${sub}\" ]];\
+                    \ then\n        continue\n    fi\n\n    echo \"Will re-install\
+                    \ subscription ${ns}/${sub}\"\n    oc get subscriptions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${sub}\" -ojson | grep -v \"kubectl.kubernetes.io/last-applied-configuration\"\
+                    \ > ${TEMPDIR}/${sub}.yaml\n\n    for ip in `oc get installplans.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[?(@.metadata.ownerReferences[*].name=='${sub}')].metadata.name}\"\
-                    `; do\n            echo \"Removing installplan ${ip}\"\n     \
-                    \       oc delete installplans.operators.coreos.com -n \"${ns}\"\
-                    \ $ip\n        done\n\n        for csv in `oc get clusterserviceversions.operators.coreos.com\
+                    `; do\n        echo \"Removing installplan ${ip}\"\n        oc\
+                    \ delete installplans.operators.coreos.com -n \"${ns}\" $ip\n\
+                    \    done\n\n    for csv in `oc get clusterserviceversions.operators.coreos.com\
                     \ -n \"${ns}\" -o jsonpath=\"{.items[*].metadata.name}\"`; do\n\
-                    \            if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
-                    \ =~ ^${sub}.* ]]; then\n                echo \"Removing CSV ${csv}\"\
-                    \n                oc delete clusterserviceversions.operators.coreos.com\
-                    \ -n \"${ns}\" \"${csv}\"\n            fi\n        done\n\n  \
-                    \      echo \"Removing subscription ${sub}\"\n        oc delete\
-                    \ subscriptions.operators.coreos.com  -n \"${ns}\" \"${sub}\"\n\
-                    \n        echo \"Recreating subscription ${sub}\"\n        oc\
-                    \ create -f ${TEMPDIR}/${sub}.yaml\n    done\ndone\n"
+                    \        if [[ \"${csv}\" =~ ^${sub}.* || \"openshift-${csv}\"\
+                    \ =~ ^${sub}.* ]]; then\n            echo \"Removing CSV ${csv}\"\
+                    \n            oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"${ns}\" \"${csv}\"\n        fi\n    done\n\n    echo \"\
+                    Removing subscription ${sub}\"\n    oc delete subscriptions.operators.coreos.com\
+                    \  -n \"${ns}\" \"${sub}\"\n\n    echo \"Restarting catalog-operator\
+                    \ to clear cache\"\n    oc delete pod -n openshift-operator-lifecycle-manager\
+                    \ -l app=catalog-operator --wait=true\n\n    echo \"Recreating\
+                    \ subscription ${sub}\"\n    oc create -f ${TEMPDIR}/${sub}.yaml\n\
+                    \ndone <<< \"${IMPACTED_SUBS}\"\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This CronJob attempts to address clusters that have operators impacted by bug [BZ1980755](https://bugzilla.redhat.com/show_bug.cgi?id=1980755).

**Please note this change only impacts staging environments**. Once it is proven to be working fine, a separate change will update the `config.yaml` to remove the environment restriction.

This is a rewrite of the CronJob script to address several issues found when it was last trialled in Production:
- Switch from `openshift/cli` to `openshift/tools` image so that `jq` is available.
- On 4.8 clusters and below, it took too long to execute as it made a lot of `oc` calls which got API-throttled. The number of `oc` calls is now greatly reduced. If a cluster is not impacted at all, only 1 call will be made. (made possible by switching to an image with `jq` in it)
- When the fix was applied to some clusters, OLM did not re-install the operator. The `catalog-operator` pod had gotten into a state requiring a restart. If the script replaces an impacted operator, it now bounces the `catalog-operator` pod before recreating the Subscription to workaround this issue.

### Which Jira/Github issue(s) this PR fixes?

[OSD-12547](https://issues.redhat.com//browse/OSD-12547)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
