### PR TITLE
[Hypershift] Add operator policies for hypershift-specific operators

### DIFF
--- a/resources/sts/4.11/openshift_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.11/openshift_capa_controller_manager_credentials_policy.json
@@ -1,0 +1,86 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ec2:AllocateAddress",
+          "ec2:AssociateRouteTable",
+          "ec2:AttachInternetGateway",
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:CreateInternetGateway",
+          "ec2:CreateNatGateway",
+          "ec2:CreateRoute",
+          "ec2:CreateRouteTable",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateSubnet",
+          "ec2:CreateTags",
+          "ec2:DeleteInternetGateway",
+          "ec2:DeleteNatGateway",
+          "ec2:DeleteRouteTable",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DeleteSubnet",
+          "ec2:DeleteTags",
+          "ec2:DescribeAccountAttributes",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeNatGateways",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeNetworkInterfaceAttribute",
+          "ec2:DescribeRouteTables",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcs",
+          "ec2:DescribeVpcAttribute",
+          "ec2:DescribeVolumes",
+          "ec2:DetachInternetGateway",
+          "ec2:DisassociateRouteTable",
+          "ec2:DisassociateAddress",
+          "ec2:ModifyInstanceAttribute",
+          "ec2:ModifyNetworkInterfaceAttribute",
+          "ec2:ModifySubnetAttribute",
+          "ec2:ReleaseAddress",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:RunInstances",
+          "ec2:TerminateInstances",
+          "tag:GetResources",
+          "ec2:CreateLaunchTemplate",
+          "ec2:CreateLaunchTemplateVersion",
+          "ec2:DescribeLaunchTemplates",
+          "ec2:DescribeLaunchTemplateVersions",
+          "ec2:DeleteLaunchTemplate",
+          "ec2:DeleteLaunchTemplateVersions"
+        ],
+        "Resource": [
+          "*"
+        ],
+        "Effect": "Allow"
+      },
+      {
+        "Condition": {
+          "StringLike": {
+            "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+          }
+        },
+        "Action": [
+          "iam:CreateServiceLinkedRole"
+        ],
+        "Resource": [
+          "arn:*:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
+        ],
+        "Effect": "Allow"
+      },
+      {
+        "Action": [
+          "iam:PassRole"
+        ],
+        "Resource": [
+          "arn:*:iam::*:role/*-Worker-Role"
+        ],
+        "Effect": "Allow"
+      }
+    ]
+  }
+  

--- a/resources/sts/4.11/openshift_control_plane_operator_credentials_policy.json
+++ b/resources/sts/4.11/openshift_control_plane_operator_credentials_policy.json
@@ -1,0 +1,25 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+            {
+                    "Effect": "Allow",
+                    "Action": [
+                            "ec2:CreateVpcEndpoint",
+                            "ec2:DescribeVpcEndpoints",
+                            "ec2:ModifyVpcEndpoint",
+                            "ec2:DeleteVpcEndpoints",
+                            "ec2:CreateTags",
+                            "route53:ListHostedZones"
+                    ],
+                    "Resource": "*"
+            },
+            {
+                    "Effect": "Allow",
+                    "Action": [
+                            "route53:ChangeResourceRecordSets",
+                            "route53:ListResourceRecordSets"
+                    ],
+                    "Resource": "*"
+            }
+    ]
+}

--- a/resources/sts/4.11/openshift_kube_controller_manager_credentials_policy.json
+++ b/resources/sts/4.11/openshift_kube_controller_manager_credentials_policy.json
@@ -1,0 +1,66 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ec2:DescribeInstances",
+          "ec2:DescribeImages",
+          "ec2:DescribeRegions",
+          "ec2:DescribeRouteTables",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVolumes",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateTags",
+          "ec2:CreateVolume",
+          "ec2:ModifyInstanceAttribute",
+          "ec2:ModifyVolume",
+          "ec2:AttachVolume",
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:CreateRoute",
+          "ec2:DeleteRoute",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DeleteVolume",
+          "ec2:DetachVolume",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DescribeVpcs",
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:AttachLoadBalancerToSubnets",
+          "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateLoadBalancerPolicy",
+          "elasticloadbalancing:CreateLoadBalancerListeners",
+          "elasticloadbalancing:ConfigureHealthCheck",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:DeleteLoadBalancerListeners",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DetachLoadBalancerFromSubnets",
+          "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+          "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:CreateTargetGroup",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeLoadBalancerPolicies",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+          "iam:CreateServiceLinkedRole",
+          "kms:DescribeKey"
+        ],
+        "Resource": [
+          "*"
+        ],
+        "Effect": "Allow"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR adds the operator policies for Hypershift-specific operators.

### Which Jira/Github issue(s) this PR fixes?
_Relates SDA-6223_

### Special notes for your reviewer:
The policies are taken from the Hypershift repo: https://github.com/openshift/hypershift/blob/45676147134e22f876aaec3ea4239ef3c120fa69/api/v1alpha1/hostedcluster_types.go#L946

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
