### PR TITLE
OHSS-14590 | feat: add permissions to allow modifying the subscriptions and csvs of odf clusters

### DIFF
--- a/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
@@ -59,3 +59,16 @@ rules:
       - watch
       - patch
       - update
+  - apiGroups:
+    - operators.coreos.com
+    resources:
+    - clusterserviceversions
+    - installplans
+    - subscriptions
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete

--- a/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
@@ -59,3 +59,16 @@ rules:
       - watch
       - patch
       - update
+  - apiGroups:
+    - operators.coreos.com
+    resources:
+    - clusterserviceversions
+    - installplans
+    - subscriptions
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5587,6 +5587,19 @@ objects:
         - watch
         - patch
         - update
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -5711,6 +5724,19 @@ objects:
         - watch
         - patch
         - update
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5587,6 +5587,19 @@ objects:
         - watch
         - patch
         - update
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -5711,6 +5724,19 @@ objects:
         - watch
         - patch
         - update
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5587,6 +5587,19 @@ objects:
         - watch
         - patch
         - update
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -5711,6 +5724,19 @@ objects:
         - watch
         - patch
         - update
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

### What type of PR is this?
_feature_

### What this PR does / why we need it?

Currently, there are 5 cluster in production running ODF addons which are failing because of OLM bug. And to mitigate them, we require updating CSVs and potentially deleting CSVs and Subscriptions.
This PR allows MTSRE to have access to updating and deleting the CSVs and Subscriptions and InstallPlans for the cluster running odf addons to perform those mitigations.

### Associated Jira ticket

https://issues.redhat.com/browse/OHSS-14590 (this ticket represents how we had to resort to SREP for applying the above mitigation for one cluster)

