### PR TITLE
Grant MT-SRE access to ODF monitoring configs

### DIFF
--- a/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
@@ -72,3 +72,19 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - alertmanagers
+    - alertmanagerconfigs
+    - prometheuses
+    - prometheusrules
+    - servicemonitors
+    - podmonitors
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete

--- a/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
@@ -72,3 +72,19 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - alertmanagers
+    - alertmanagerconfigs
+    - prometheuses
+    - prometheusrules
+    - servicemonitors
+    - podmonitors
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5600,6 +5600,22 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - alertmanagers
+        - alertmanagerconfigs
+        - prometheuses
+        - prometheusrules
+        - servicemonitors
+        - podmonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -5730,6 +5746,22 @@ objects:
         - clusterserviceversions
         - installplans
         - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - alertmanagers
+        - alertmanagerconfigs
+        - prometheuses
+        - prometheusrules
+        - servicemonitors
+        - podmonitors
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5600,6 +5600,22 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - alertmanagers
+        - alertmanagerconfigs
+        - prometheuses
+        - prometheusrules
+        - servicemonitors
+        - podmonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -5730,6 +5746,22 @@ objects:
         - clusterserviceversions
         - installplans
         - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - alertmanagers
+        - alertmanagerconfigs
+        - prometheuses
+        - prometheusrules
+        - servicemonitors
+        - podmonitors
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5600,6 +5600,22 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - alertmanagers
+        - alertmanagerconfigs
+        - prometheuses
+        - prometheusrules
+        - servicemonitors
+        - podmonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -5730,6 +5746,22 @@ objects:
         - clusterserviceversions
         - installplans
         - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - alertmanagers
+        - alertmanagerconfigs
+        - prometheuses
+        - prometheusrules
+        - servicemonitors
+        - podmonitors
         verbs:
         - get
         - list


### PR DESCRIPTION
Signed-off-by: Nico Schieder <nschieder@redhat.com>

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?
A few ODF clusters have stopped sending alerts to DMS. Investigation shows alertmanager to miss all config.
To debug further, we need access to the monitoring APIs configuring alertmanager for ODF.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
