### PR TITLE
OSD-10920 Proxy-enable token-refresher

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.ClusterRole.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.ClusterRole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: token-refresher
+rules:
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - proxies
+  verbs:
+    - get
+    - list
+- apiGroups:
+    - ""               
+  resources:           
+    - secrets             
+  verbs:
+  - get
+  - update         
+  - create
+  - patch

--- a/deploy/osd-token-refresher/01-token-refresher.ClusterRoleBinding.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: token-refresher
+subjects:
+- kind: ServiceAccount
+  name: token-refresher
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: token-refresher

--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -32,6 +32,7 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/infra
           operator: Exists
+      serviceAccountName: token-refresher
       volumes:
       - configMap:
           defaultMode: 420
@@ -40,6 +41,28 @@ spec:
               path: ca-certificates.crt
           name: token-refresher-trusted-ca-bundle
         name: token-refresher-trusted-ca-bundle
+      initContainers:
+      - name: proxy-setup
+        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        args:
+        - /bin/bash
+        - -c
+        - |
+          set -o nounset
+          set -o pipefail
+
+          HTTP_PROXY_VAL=""
+          HTTPS_PROXY_VAL=""
+          NO_PROXY_VAL=""
+
+          PROXY=$(oc get proxy cluster -o json)
+          if [[ $? == 0 && ! -z "${PROXY}" ]]; then
+            HTTP_PROXY_VAL=$(echo ${PROXY} | jq -r '.status.httpProxy | values')
+            HTTPS_PROXY_VAL=$(echo ${PROXY} | jq -r '.status.httpsProxy | values')
+            NO_PROXY_VAL=$(echo ${PROXY} | jq -r '.status.noProxy | values')
+          fi
+
+          oc create secret generic -n openshift-monitoring token-refresher-proxy --from-literal=HTTP_PROXY=${HTTP_PROXY_VAL} --from-literal=HTTPS_PROXY=${HTTPS_PROXY_VAL} --from-literal=NO_PROXY=${NO_PROXY_VAL} -o json --dry-run=client | oc apply -f-
       containers:
       - args:
         - --oidc.audience=observatorium-telemeter
@@ -65,6 +88,21 @@ spec:
               key: receiver-url
         - name: ISSUER_URL
           value: "https://sso.redhat.com/auth/realms/redhat-external"
+        - name: HTTP_PROXY
+          valueFrom:
+            secretKeyRef:
+              name: token-refresher-proxy
+              key: HTTP_PROXY
+        - name: HTTPS_PROXY
+          valueFrom:
+            secretKeyRef:
+              name: token-refresher-proxy
+              key: HTTPS_PROXY
+        - name: NO_PROXY
+          valueFrom:
+            secretKeyRef:
+              name: token-refresher-proxy
+              key: NO_PROXY
         image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
         name: token-refresher
         ports:

--- a/deploy/osd-token-refresher/01-token-refresher.ServiceAccount.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: token-refresher
+  namespace: openshift-monitoring 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13500,6 +13500,39 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: token-refresher
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - proxies
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - update
+        - create
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: token-refresher
+      subjects:
+      - kind: ServiceAccount
+        name: token-refresher
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: token-refresher
     - apiVersion: apps/v1
       kind: Deployment
       metadata:
@@ -13534,6 +13567,7 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
+            serviceAccountName: token-refresher
             volumes:
             - configMap:
                 defaultMode: 420
@@ -13542,6 +13576,21 @@ objects:
                   path: ca-certificates.crt
                 name: token-refresher-trusted-ca-bundle
               name: token-refresher-trusted-ca-bundle
+            initContainers:
+            - name: proxy-setup
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              args:
+              - /bin/bash
+              - -c
+              - "set -o nounset\nset -o pipefail\n\nHTTP_PROXY_VAL=\"\"\nHTTPS_PROXY_VAL=\"\
+                \"\nNO_PROXY_VAL=\"\"\n\nPROXY=$(oc get proxy cluster -o json)\nif\
+                \ [[ $? == 0 && ! -z \"${PROXY}\" ]]; then\n  HTTP_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.httpProxy | values')\n  HTTPS_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.httpsProxy | values')\n  NO_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.noProxy | values')\nfi\n\noc create secret\
+                \ generic -n openshift-monitoring token-refresher-proxy --from-literal=HTTP_PROXY=${HTTP_PROXY_VAL}\
+                \ --from-literal=HTTPS_PROXY=${HTTPS_PROXY_VAL} --from-literal=NO_PROXY=${NO_PROXY_VAL}\
+                \ -o json --dry-run=client | oc apply -f-\n"
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
@@ -13567,6 +13616,21 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
+              - name: HTTP_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: HTTP_PROXY
+              - name: HTTPS_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: HTTPS_PROXY
+              - name: NO_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: NO_PROXY
               image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
               name: token-refresher
               ports:
@@ -13576,6 +13640,11 @@ objects:
               - mountPath: /etc/ssl/certs/
                 name: token-refresher-trusted-ca-bundle
                 readOnly: true
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: token-refresher
+        namespace: openshift-monitoring
     - apiVersion: v1
       kind: Service
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13500,6 +13500,39 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: token-refresher
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - proxies
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - update
+        - create
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: token-refresher
+      subjects:
+      - kind: ServiceAccount
+        name: token-refresher
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: token-refresher
     - apiVersion: apps/v1
       kind: Deployment
       metadata:
@@ -13534,6 +13567,7 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
+            serviceAccountName: token-refresher
             volumes:
             - configMap:
                 defaultMode: 420
@@ -13542,6 +13576,21 @@ objects:
                   path: ca-certificates.crt
                 name: token-refresher-trusted-ca-bundle
               name: token-refresher-trusted-ca-bundle
+            initContainers:
+            - name: proxy-setup
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              args:
+              - /bin/bash
+              - -c
+              - "set -o nounset\nset -o pipefail\n\nHTTP_PROXY_VAL=\"\"\nHTTPS_PROXY_VAL=\"\
+                \"\nNO_PROXY_VAL=\"\"\n\nPROXY=$(oc get proxy cluster -o json)\nif\
+                \ [[ $? == 0 && ! -z \"${PROXY}\" ]]; then\n  HTTP_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.httpProxy | values')\n  HTTPS_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.httpsProxy | values')\n  NO_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.noProxy | values')\nfi\n\noc create secret\
+                \ generic -n openshift-monitoring token-refresher-proxy --from-literal=HTTP_PROXY=${HTTP_PROXY_VAL}\
+                \ --from-literal=HTTPS_PROXY=${HTTPS_PROXY_VAL} --from-literal=NO_PROXY=${NO_PROXY_VAL}\
+                \ -o json --dry-run=client | oc apply -f-\n"
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
@@ -13567,6 +13616,21 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
+              - name: HTTP_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: HTTP_PROXY
+              - name: HTTPS_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: HTTPS_PROXY
+              - name: NO_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: NO_PROXY
               image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
               name: token-refresher
               ports:
@@ -13576,6 +13640,11 @@ objects:
               - mountPath: /etc/ssl/certs/
                 name: token-refresher-trusted-ca-bundle
                 readOnly: true
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: token-refresher
+        namespace: openshift-monitoring
     - apiVersion: v1
       kind: Service
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13500,6 +13500,39 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: token-refresher
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - proxies
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - update
+        - create
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: token-refresher
+      subjects:
+      - kind: ServiceAccount
+        name: token-refresher
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: token-refresher
     - apiVersion: apps/v1
       kind: Deployment
       metadata:
@@ -13534,6 +13567,7 @@ objects:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
               operator: Exists
+            serviceAccountName: token-refresher
             volumes:
             - configMap:
                 defaultMode: 420
@@ -13542,6 +13576,21 @@ objects:
                   path: ca-certificates.crt
                 name: token-refresher-trusted-ca-bundle
               name: token-refresher-trusted-ca-bundle
+            initContainers:
+            - name: proxy-setup
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              args:
+              - /bin/bash
+              - -c
+              - "set -o nounset\nset -o pipefail\n\nHTTP_PROXY_VAL=\"\"\nHTTPS_PROXY_VAL=\"\
+                \"\nNO_PROXY_VAL=\"\"\n\nPROXY=$(oc get proxy cluster -o json)\nif\
+                \ [[ $? == 0 && ! -z \"${PROXY}\" ]]; then\n  HTTP_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.httpProxy | values')\n  HTTPS_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.httpsProxy | values')\n  NO_PROXY_VAL=$(echo\
+                \ ${PROXY} | jq -r '.status.noProxy | values')\nfi\n\noc create secret\
+                \ generic -n openshift-monitoring token-refresher-proxy --from-literal=HTTP_PROXY=${HTTP_PROXY_VAL}\
+                \ --from-literal=HTTPS_PROXY=${HTTPS_PROXY_VAL} --from-literal=NO_PROXY=${NO_PROXY_VAL}\
+                \ -o json --dry-run=client | oc apply -f-\n"
             containers:
             - args:
               - --oidc.audience=observatorium-telemeter
@@ -13567,6 +13616,21 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
+              - name: HTTP_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: HTTP_PROXY
+              - name: HTTPS_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: HTTPS_PROXY
+              - name: NO_PROXY
+                valueFrom:
+                  secretKeyRef:
+                    name: token-refresher-proxy
+                    key: NO_PROXY
               image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
               name: token-refresher
               ports:
@@ -13576,6 +13640,11 @@ objects:
               - mountPath: /etc/ssl/certs/
                 name: token-refresher-trusted-ca-bundle
                 readOnly: true
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: token-refresher
+        namespace: openshift-monitoring
     - apiVersion: v1
       kind: Service
       metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
- Creates a `token-refresher` ServiceAccount which the `token-refresher` Deployment now runs as.
- Adds an init container to the token-refresher `Deployment` which checks if the cluster has a cluster-wide proxy enabled, and if so, populates a new `token-refresher-proxy` `Secret` with the related values. Those values are then mounted from the `Secret` into the `token-refresher` pod as environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`).
- Adds RBAC for the `token-refresher` ServiceAccount to be able to do the above task.

If the cluster has no proxy enabled, the `Secret` is still created and mounted, but the proxy values will be empty.

This is a desirable change because it is a common occurrence for clusters using a cluster-wide-proxy to end up with a crashlooping `token-refresher` as it cannot successfully contact `sso.redhat.com`. We do have a [documented requirement](https://docs.openshift.com/rosa/networking/configuring-cluster-wide-proxy.html#cluster-wide-proxy-network-prereqs_cluster-wide-proxy-configuration) to exclude `sso.redhat.com` from proxy traffic, but this would eliminate the need for that requirement.

### Which Jira/Github issue(s) this PR fixes?
[OSD-10920](https://issues.redhat.com//browse/OSD-10920)

### Special notes for your reviewer:
This was previously attempted in #1123 but that PR was rightly rejected because a `CronJob` is not the way to solve this. Hopefully this is more amenable.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster (proxy-enabled and non-proxy-enabled)
