### PR TITLE
Unblock AVO deployment to non-STS FedRAMP clusters

### DIFF
--- a/deploy/osd-avo-resources/us-gov-east-1/config.yaml
+++ b/deploy/osd-avo-resources/us-gov-east-1/config.yaml
@@ -9,10 +9,6 @@ selectorSyncSet:
     operator: In
     values:
       - "us-gov-east-1"
-  - key: api.openshift.com/sts
-    operator: In
-    values:
-      - "true"
   - key: api.openshift.com/private-link
     operator: In
     values:

--- a/deploy/osd-avo-resources/us-gov-west-1/config.yaml
+++ b/deploy/osd-avo-resources/us-gov-west-1/config.yaml
@@ -9,10 +9,6 @@ selectorSyncSet:
     operator: In
     values:
       - "us-gov-west-1"
-  - key: api.openshift.com/sts
-    operator: In
-    values:
-      - "true"
   - key: api.openshift.com/private-link
     operator: In
     values:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8339,10 +8339,6 @@ objects:
         operator: In
         values:
         - us-gov-east-1
-      - key: api.openshift.com/sts
-        operator: In
-        values:
-        - 'true'
       - key: api.openshift.com/private-link
         operator: In
         values:
@@ -8385,10 +8381,6 @@ objects:
         operator: In
         values:
         - us-gov-west-1
-      - key: api.openshift.com/sts
-        operator: In
-        values:
-        - 'true'
       - key: api.openshift.com/private-link
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8339,10 +8339,6 @@ objects:
         operator: In
         values:
         - us-gov-east-1
-      - key: api.openshift.com/sts
-        operator: In
-        values:
-        - 'true'
       - key: api.openshift.com/private-link
         operator: In
         values:
@@ -8385,10 +8381,6 @@ objects:
         operator: In
         values:
         - us-gov-west-1
-      - key: api.openshift.com/sts
-        operator: In
-        values:
-        - 'true'
       - key: api.openshift.com/private-link
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8339,10 +8339,6 @@ objects:
         operator: In
         values:
         - us-gov-east-1
-      - key: api.openshift.com/sts
-        operator: In
-        values:
-        - 'true'
       - key: api.openshift.com/private-link
         operator: In
         values:
@@ -8385,10 +8381,6 @@ objects:
         operator: In
         values:
         - us-gov-west-1
-      - key: api.openshift.com/sts
-        operator: In
-        values:
-        - 'true'
       - key: api.openshift.com/private-link
         operator: In
         values:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Per https://github.com/openshift/aws-vpce-operator/pull/44, AVO was enabled to run on non-STS clusters, so now it can be deployed!

### Which Jira/Github issue(s) this PR fixes?
[OSD-12750](https://issues.redhat.com//browse/OSD-12750)

### Special notes for your reviewer:
Only FedRAMP impacting

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
