### PR TITLE
Fix formatting on sts policies

### DIFF
--- a/resources/sts/4.10/sts_support_permission_policy.json
+++ b/resources/sts/4.10/sts_support_permission_policy.json
@@ -159,7 +159,9 @@
         },
         {
             "Effect": "Allow",
-            "Action": "s3:ListBucket",
+            "Action": [
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"

--- a/resources/sts/4.11/sts_support_permission_policy.json
+++ b/resources/sts/4.11/sts_support_permission_policy.json
@@ -159,7 +159,9 @@
         },
         {
             "Effect": "Allow",
-            "Action": "s3:ListBucket",
+            "Action": [
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"

--- a/resources/sts/4.7/sts_support_permission_policy.json
+++ b/resources/sts/4.7/sts_support_permission_policy.json
@@ -157,7 +157,9 @@
         },
         {
             "Effect": "Allow",
-            "Action": "s3:ListBucket",
+            "Action": [
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"

--- a/resources/sts/4.8/sts_support_permission_policy.json
+++ b/resources/sts/4.8/sts_support_permission_policy.json
@@ -157,7 +157,9 @@
         },
         {
             "Effect": "Allow",
-            "Action": "s3:ListBucket",
+            "Action": [
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"

--- a/resources/sts/4.9/sts_support_permission_policy.json
+++ b/resources/sts/4.9/sts_support_permission_policy.json
@@ -159,7 +159,9 @@
         },
         {
             "Effect": "Allow",
-            "Action": "s3:ListBucket",
+            "Action": [
+                "s3:ListBucket"
+            ],
             "Resource": [
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This alters the formatting on the support permissions policy to consistently use an array for the Action. This allows a command like `jq .Statement[].Action[] resources/sts/4.11/sts_support_permission_policy.json` to be used without an error to list all the actions used in the policy.

According to https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html, both are valid grammatically, but being consistent is just helpful with tooling.

### Which Jira/Github issue(s) this PR fixes?
None

### Special notes for your reviewer:
