### PR TITLE
Add permissions for CS-SRE to create secrets in openshift-must-gather

### DIFF
--- a/deploy/backplane/cssre/20-cssre-mustgather.Role.yml
+++ b/deploy/backplane/cssre/20-cssre-mustgather.Role.yml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-cssre-mustgather
+  namespace: openshift-must-gather-operator
+rules:
+# can create cred secret for mustgathers
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - list
+  - get
+# can create mustgathers CR
+- apiGroups:
+  - managed.openshift.io
+  resources:
+  - mustgathers
+  verbs:
+  - create
+  - list
+  - get
+  - delete
+### END

--- a/deploy/backplane/cssre/30-cssre-mustgather.RoleBinding.yml
+++ b/deploy/backplane/cssre/30-cssre-mustgather.RoleBinding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-cssre-mustgather
+  namespace: openshift-must-gather-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-cee
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-cssre-mustgather
+  namespace: openshift-must-gather-operator


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
CS-SRE team can not run 3scale must-gather script because they are not allowed create secrets in _openshift-must-gather-operator_ namespace

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OHSS-14868

### Special notes for your reviewer:
Have also added permissions to _list_ and _get_ secrets for CS-SRE users. 
