### PR TITLE
OSD-13086 clamav-images++

### DIFF
--- a/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
+++ b/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
@@ -22,7 +22,7 @@ spec:
           value: /host/var/log/openshift_managed_malware_scan.log
         - name: POD_LOG_FILE
           value: /host/var/log/openshift_managed_pod_creation.log
-        image: quay.io/app-sre/pod-logger@sha256:465617d4ea307195ed4b2e1d5066ae3c2548344009e84f493e04461f8d24a3da
+        image: quay.io/app-sre/pod-logger@sha256:eabb76b07b59d80cfe04701c5d19cc007f984a2b011416c8a26d31b82f30b6af
         name: logger
         ports:
         - containerPort: 8080

--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+        image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
         name: clamsig-puller
         resources:
           limits:
@@ -33,7 +33,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/clamd@sha256:d9190ef7dfa9881d776a13ab8a22fc9945d94550b4f7ce7f02d3df1ba8f45b0f
+        image: quay.io/app-sre/clamd@sha256:7b80125db49f974a52e67b4042216cbb2450360f2fba4c45d302404907b933d8
         name: clamd
         resources:
           limits:
@@ -50,7 +50,7 @@ spec:
           value: "false"
         - name: CHROOT_PATH
           value: /host
-        image: quay.io/app-sre/container-info@sha256:fdfd73ab7718aabf32278fc3f312c36dfddd49661cbb76592a4192f006a50c52
+        image: quay.io/app-sre/container-info@sha256:df7fe76f2029f7365e238acb77e8537f86e8cb4d58dd85f0ef55d49791973c27
         name: info
         resources:
           limits:
@@ -92,7 +92,7 @@ spec:
           value: /clam/clamd.sock
         - name: INFO_SOCKET
           value: '@rpc.sock'
-        image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+        image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
         name: watcher
         resources:
           limits:
@@ -144,7 +144,7 @@ spec:
           value: openshift-scanning
         - name: HOST_SCAN_DIRS
           value: /host
-        image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+        image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
         name: scheduler
         resources:
           limits:
@@ -170,7 +170,7 @@ spec:
           value: "false"
         - name: INIT_CONTAINER
           value: "true"
-        image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+        image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
         name: init-clamsig-puller
         resources:
           limits:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13484,7 +13484,7 @@ objects:
                 value: /host/var/log/openshift_managed_malware_scan.log
               - name: POD_LOG_FILE
                 value: /host/var/log/openshift_managed_pod_creation.log
-              image: quay.io/app-sre/pod-logger@sha256:465617d4ea307195ed4b2e1d5066ae3c2548344009e84f493e04461f8d24a3da
+              image: quay.io/app-sre/pod-logger@sha256:eabb76b07b59d80cfe04701c5d19cc007f984a2b011416c8a26d31b82f30b6af
               name: logger
               ports:
               - containerPort: 8080
@@ -13551,7 +13551,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+              image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
               name: clamsig-puller
               resources:
                 limits:
@@ -13568,7 +13568,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/clamd@sha256:d9190ef7dfa9881d776a13ab8a22fc9945d94550b4f7ce7f02d3df1ba8f45b0f
+              image: quay.io/app-sre/clamd@sha256:7b80125db49f974a52e67b4042216cbb2450360f2fba4c45d302404907b933d8
               name: clamd
               resources:
                 limits:
@@ -13585,7 +13585,7 @@ objects:
                 value: 'false'
               - name: CHROOT_PATH
                 value: /host
-              image: quay.io/app-sre/container-info@sha256:fdfd73ab7718aabf32278fc3f312c36dfddd49661cbb76592a4192f006a50c52
+              image: quay.io/app-sre/container-info@sha256:df7fe76f2029f7365e238acb77e8537f86e8cb4d58dd85f0ef55d49791973c27
               name: info
               resources:
                 limits:
@@ -13627,7 +13627,7 @@ objects:
                 value: /clam/clamd.sock
               - name: INFO_SOCKET
                 value: '@rpc.sock'
-              image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+              image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
               name: watcher
               resources:
                 limits:
@@ -13679,7 +13679,7 @@ objects:
                 value: openshift-scanning
               - name: HOST_SCAN_DIRS
                 value: /host
-              image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+              image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
               name: scheduler
               resources:
                 limits:
@@ -13705,7 +13705,7 @@ objects:
                 value: 'false'
               - name: INIT_CONTAINER
                 value: 'true'
-              image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+              image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
               name: init-clamsig-puller
               resources:
                 limits:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13484,7 +13484,7 @@ objects:
                 value: /host/var/log/openshift_managed_malware_scan.log
               - name: POD_LOG_FILE
                 value: /host/var/log/openshift_managed_pod_creation.log
-              image: quay.io/app-sre/pod-logger@sha256:465617d4ea307195ed4b2e1d5066ae3c2548344009e84f493e04461f8d24a3da
+              image: quay.io/app-sre/pod-logger@sha256:eabb76b07b59d80cfe04701c5d19cc007f984a2b011416c8a26d31b82f30b6af
               name: logger
               ports:
               - containerPort: 8080
@@ -13551,7 +13551,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+              image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
               name: clamsig-puller
               resources:
                 limits:
@@ -13568,7 +13568,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/clamd@sha256:d9190ef7dfa9881d776a13ab8a22fc9945d94550b4f7ce7f02d3df1ba8f45b0f
+              image: quay.io/app-sre/clamd@sha256:7b80125db49f974a52e67b4042216cbb2450360f2fba4c45d302404907b933d8
               name: clamd
               resources:
                 limits:
@@ -13585,7 +13585,7 @@ objects:
                 value: 'false'
               - name: CHROOT_PATH
                 value: /host
-              image: quay.io/app-sre/container-info@sha256:fdfd73ab7718aabf32278fc3f312c36dfddd49661cbb76592a4192f006a50c52
+              image: quay.io/app-sre/container-info@sha256:df7fe76f2029f7365e238acb77e8537f86e8cb4d58dd85f0ef55d49791973c27
               name: info
               resources:
                 limits:
@@ -13627,7 +13627,7 @@ objects:
                 value: /clam/clamd.sock
               - name: INFO_SOCKET
                 value: '@rpc.sock'
-              image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+              image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
               name: watcher
               resources:
                 limits:
@@ -13679,7 +13679,7 @@ objects:
                 value: openshift-scanning
               - name: HOST_SCAN_DIRS
                 value: /host
-              image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+              image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
               name: scheduler
               resources:
                 limits:
@@ -13705,7 +13705,7 @@ objects:
                 value: 'false'
               - name: INIT_CONTAINER
                 value: 'true'
-              image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+              image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
               name: init-clamsig-puller
               resources:
                 limits:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13484,7 +13484,7 @@ objects:
                 value: /host/var/log/openshift_managed_malware_scan.log
               - name: POD_LOG_FILE
                 value: /host/var/log/openshift_managed_pod_creation.log
-              image: quay.io/app-sre/pod-logger@sha256:465617d4ea307195ed4b2e1d5066ae3c2548344009e84f493e04461f8d24a3da
+              image: quay.io/app-sre/pod-logger@sha256:eabb76b07b59d80cfe04701c5d19cc007f984a2b011416c8a26d31b82f30b6af
               name: logger
               ports:
               - containerPort: 8080
@@ -13551,7 +13551,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+              image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
               name: clamsig-puller
               resources:
                 limits:
@@ -13568,7 +13568,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/clamd@sha256:d9190ef7dfa9881d776a13ab8a22fc9945d94550b4f7ce7f02d3df1ba8f45b0f
+              image: quay.io/app-sre/clamd@sha256:7b80125db49f974a52e67b4042216cbb2450360f2fba4c45d302404907b933d8
               name: clamd
               resources:
                 limits:
@@ -13585,7 +13585,7 @@ objects:
                 value: 'false'
               - name: CHROOT_PATH
                 value: /host
-              image: quay.io/app-sre/container-info@sha256:fdfd73ab7718aabf32278fc3f312c36dfddd49661cbb76592a4192f006a50c52
+              image: quay.io/app-sre/container-info@sha256:df7fe76f2029f7365e238acb77e8537f86e8cb4d58dd85f0ef55d49791973c27
               name: info
               resources:
                 limits:
@@ -13627,7 +13627,7 @@ objects:
                 value: /clam/clamd.sock
               - name: INFO_SOCKET
                 value: '@rpc.sock'
-              image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+              image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
               name: watcher
               resources:
                 limits:
@@ -13679,7 +13679,7 @@ objects:
                 value: openshift-scanning
               - name: HOST_SCAN_DIRS
                 value: /host
-              image: quay.io/app-sre/watcher@sha256:03be52ccf730497effb8b890f1a3cbfc3814bca6b3a21b91f76702395327b33c
+              image: quay.io/app-sre/watcher@sha256:c95aa56468f8613a1620681794bb806f5f64510d389c72d098f95387c3dc84ca
               name: scheduler
               resources:
                 limits:
@@ -13705,7 +13705,7 @@ objects:
                 value: 'false'
               - name: INIT_CONTAINER
                 value: 'true'
-              image: quay.io/app-sre/clamsig-puller@sha256:cc4037652e1edac0c7619b8388c0fb8787a869777877a03c77d38ad9e4d55593
+              image: quay.io/app-sre/clamsig-puller@sha256:88d863ac46b36ec307a0cd60f0ab5fa37311a79f98f98f4ac5c31e17e880aeee
               name: init-clamsig-puller
               resources:
                 limits:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Bumps the images of clamav-images due to CVEs affecting previous versions

### Which Jira/Github issue(s) this PR fixes?
[OSD-13086](https://issues.redhat.com//browse/OSD-13086)

This only affects FedRAMP