### PR TITLE
Add stopgap alert for OCPBUGS-773

### DIFF
--- a/deploy/sre-prometheus/100-runaway-sdn.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-runaway-sdn.PrometheusRule.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-runaway-sdn-preventing-container-creation
+    role: alert-rules
+  name: sre-runaway-sdn-preventing-container-creation
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-runaway-sdn-preventing-container-creation
+    rules:
+    - alert: RunawaySDNPreventingContainerCreationSRE
+      # OSD-13103: This is an attempt to catch an issue where SDN has no memory limits and can cause pods to be stuck in ContainerCreating on 
+      # worker nodes due to memory exhaustion. It should be fixed in OCPBUGS-773
+      expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"}) by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"} > 1000000000) by (node) 
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        description: "SDN is consuming excessive memory rendering {{ $labels.node }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -16431,6 +16431,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-runaway-sdn-preventing-container-creation
+          role: alert-rules
+        name: sre-runaway-sdn-preventing-container-creation
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-runaway-sdn-preventing-container-creation
+          rules:
+          - alert: RunawaySDNPreventingContainerCreationSRE
+            expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"})
+              by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by
+              (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"}
+              > 1000000000) by (node)
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              description: SDN is consuming excessive memory rendering {{ $labels.node
+                }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: k8s
           role: alert-rules
         name: sre-uptime-sla

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -16431,6 +16431,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-runaway-sdn-preventing-container-creation
+          role: alert-rules
+        name: sre-runaway-sdn-preventing-container-creation
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-runaway-sdn-preventing-container-creation
+          rules:
+          - alert: RunawaySDNPreventingContainerCreationSRE
+            expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"})
+              by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by
+              (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"}
+              > 1000000000) by (node)
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              description: SDN is consuming excessive memory rendering {{ $labels.node
+                }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: k8s
           role: alert-rules
         name: sre-uptime-sla

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -16431,6 +16431,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-runaway-sdn-preventing-container-creation
+          role: alert-rules
+        name: sre-runaway-sdn-preventing-container-creation
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-runaway-sdn-preventing-container-creation
+          rules:
+          - alert: RunawaySDNPreventingContainerCreationSRE
+            expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"})
+              by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by
+              (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"}
+              > 1000000000) by (node)
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              description: SDN is consuming excessive memory rendering {{ $labels.node
+                }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: k8s
           role: alert-rules
         name: sre-uptime-sla


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The SDN pod has no memory limits which can render a customer's worker node unusable. OCPBUGS-773 exists to track the eventual fix upstream, however in the meantime SRE needs to replace a worker node when this happens.

### Which Jira/Github issue(s) this PR fixes?
[OSD-13103](https://issues.redhat.com//browse/OSD-13103)