### PR TITLE
Only look at the last sequential build status

### DIFF
--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -103,7 +103,7 @@ spec:
               echo "$(date): Waiting for build to complete."
               while :
               do
-                ST=$(oc -n "${NS}" get build -o custom-columns=STATUS:.status.phase --no-headers | tail -1)
+                ST=$(oc -n "${NS}" get build -o custom-columns=STATUS:.status.phase --sort-by=.status.startTimestamp --no-headers | tail -1)
                 case ${ST} in
                   "")
                     # if build status is blank, assume we are still starting the build

--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -103,7 +103,7 @@ spec:
               echo "$(date): Waiting for build to complete."
               while :
               do
-                ST=$(oc -n "${NS}" get build -o custom-columns=STATUS:.status.phase --no-headers)
+                ST=$(oc -n "${NS}" get build -o custom-columns=STATUS:.status.phase --no-headers | tail -1)
                 case ${ST} in
                   "")
                     # if build status is blank, assume we are still starting the build

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -15857,9 +15857,9 @@ objects:
                     \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
                     \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
                     do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
-                    \ status is blank, assume we are still starting the build\n  \
-                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ --no-headers | tail -1)\n  case ${ST} in\n    \"\")\n      #\
+                    \ if build status is blank, assume we are still starting the build\n\
+                    \      ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
                     \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
                     \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -15857,11 +15857,12 @@ objects:
                     \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
                     \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
                     do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers | tail -1)\n  case ${ST} in\n    \"\")\n      #\
-                    \ if build status is blank, assume we are still starting the build\n\
-                    \      ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
-                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
-                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
+                    \ --sort-by=.status.startTimestamp --no-headers | tail -1)\n \
+                    \ case ${ST} in\n    \"\")\n      # if build status is blank,\
+                    \ assume we are still starting the build\n      ST=\"Starting\"\
+                    \n      ;;\n    Failed)\n      echo \"$(date): Build Failed\"\
+                    \ >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n\
+                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
                     \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
                     \     echo \"$(date): Build Complete\"\n      JOBS_TO_DELETE=$(oc\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -15857,9 +15857,9 @@ objects:
                     \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
                     \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
                     do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
-                    \ status is blank, assume we are still starting the build\n  \
-                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ --no-headers | tail -1)\n  case ${ST} in\n    \"\")\n      #\
+                    \ if build status is blank, assume we are still starting the build\n\
+                    \      ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
                     \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
                     \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -15857,11 +15857,12 @@ objects:
                     \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
                     \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
                     do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers | tail -1)\n  case ${ST} in\n    \"\")\n      #\
-                    \ if build status is blank, assume we are still starting the build\n\
-                    \      ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
-                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
-                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
+                    \ --sort-by=.status.startTimestamp --no-headers | tail -1)\n \
+                    \ case ${ST} in\n    \"\")\n      # if build status is blank,\
+                    \ assume we are still starting the build\n      ST=\"Starting\"\
+                    \n      ;;\n    Failed)\n      echo \"$(date): Build Failed\"\
+                    \ >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n\
+                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
                     \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
                     \     echo \"$(date): Build Complete\"\n      JOBS_TO_DELETE=$(oc\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -15857,9 +15857,9 @@ objects:
                     \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
                     \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
                     do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers)\n  case ${ST} in\n    \"\")\n      # if build\
-                    \ status is blank, assume we are still starting the build\n  \
-                    \    ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
+                    \ --no-headers | tail -1)\n  case ${ST} in\n    \"\")\n      #\
+                    \ if build status is blank, assume we are still starting the build\n\
+                    \      ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
                     \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
                     \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -15857,11 +15857,12 @@ objects:
                     \ to start build, retrying in 15 seconds.\"\n  sleep 15s\ndone\n\
                     \necho \"$(date): Waiting for build to complete.\"\nwhile :\n\
                     do\n  ST=$(oc -n \"${NS}\" get build -o custom-columns=STATUS:.status.phase\
-                    \ --no-headers | tail -1)\n  case ${ST} in\n    \"\")\n      #\
-                    \ if build status is blank, assume we are still starting the build\n\
-                    \      ST=\"Starting\"\n      ;;\n    Failed)\n      echo \"$(date):\
-                    \ Build Failed\" >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\
-                    \n      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
+                    \ --sort-by=.status.startTimestamp --no-headers | tail -1)\n \
+                    \ case ${ST} in\n    \"\")\n      # if build status is blank,\
+                    \ assume we are still starting the build\n      ST=\"Starting\"\
+                    \n      ;;\n    Failed)\n      echo \"$(date): Build Failed\"\
+                    \ >&2\n      oc logs -n \"${NS}\" -c build \"${JOB_PREFIX}\"\n\
+                    \      exit 1\n      ;;\n    Cancelled)\n      echo \"$(date):\
                     \ Build was Cancelled\" >&2\n      oc logs -n \"${NS}\" -c build\
                     \ \"${JOB_PREFIX}\"\n      exit 1\n      ;;\n    Complete)\n \
                     \     echo \"$(date): Build Complete\"\n      JOBS_TO_DELETE=$(oc\


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
In certain cases, the build test creation can encounter issues.  The build is Cancelled.  Multiple retries to create the build are done.

The script that checks the status of the build, though, does not take this into account and you'll get _all_ the build statuses as output, and not just the last one, which leads to strings like the following being compared in the switch statement:

```
Cancelled
Cancelled
Cancelled
Complete
```

Where the first 3 builds in the example above are cancelled before they're started, and we retry creation afterwards.  The last build is successful, but the entire string including newlines is being compared, which ends up failing to compare.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-13202_


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster (tested the subcommand with the pipe in a cluster)
