### PR TITLE
[FedRAMP] Conversion of VPCE to a namespaced CRD

### DIFF
--- a/deploy/osd-avo-resources/us-gov-east-1/00-osd-avo-VpcEndpoint.yaml
+++ b/deploy/osd-avo-resources/us-gov-east-1/00-osd-avo-VpcEndpoint.yaml
@@ -2,6 +2,7 @@ apiVersion: avo.openshift.io/v1alpha1
 kind: VpcEndpoint
 metadata:
   name: splunk
+  namespace: openshift-security
 spec:
   subdomainName: splunk
   serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
@@ -12,4 +13,3 @@ spec:
         protocol: tcp
   externalNameService:
     name: indexer
-    namespace: openshift-security

--- a/deploy/osd-avo-resources/us-gov-west-1/00-osd-avo-VpcEndpoint.yaml
+++ b/deploy/osd-avo-resources/us-gov-west-1/00-osd-avo-VpcEndpoint.yaml
@@ -2,6 +2,7 @@ apiVersion: avo.openshift.io/v1alpha1
 kind: VpcEndpoint
 metadata:
   name: splunk
+  namespace: openshift-security
 spec:
   subdomainName: splunk
   serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
@@ -12,4 +13,3 @@ spec:
         protocol: tcp
   externalNameService:
     name: indexer
-    namespace: openshift-security

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8976,6 +8976,7 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
+        namespace: openshift-security
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
@@ -8986,7 +8987,6 @@ objects:
             protocol: tcp
         externalNameService:
           name: indexer
-          namespace: openshift-security
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9018,6 +9018,7 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
+        namespace: openshift-security
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
@@ -9028,7 +9029,6 @@ objects:
             protocol: tcp
         externalNameService:
           name: indexer
-          namespace: openshift-security
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8976,6 +8976,7 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
+        namespace: openshift-security
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
@@ -8986,7 +8987,6 @@ objects:
             protocol: tcp
         externalNameService:
           name: indexer
-          namespace: openshift-security
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9018,6 +9018,7 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
+        namespace: openshift-security
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
@@ -9028,7 +9029,6 @@ objects:
             protocol: tcp
         externalNameService:
           name: indexer
-          namespace: openshift-security
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8976,6 +8976,7 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
+        namespace: openshift-security
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
@@ -8986,7 +8987,6 @@ objects:
             protocol: tcp
         externalNameService:
           name: indexer
-          namespace: openshift-security
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9018,6 +9018,7 @@ objects:
       kind: VpcEndpoint
       metadata:
         name: splunk
+        namespace: openshift-security
       spec:
         subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
@@ -9028,7 +9029,6 @@ objects:
             protocol: tcp
         externalNameService:
           name: indexer
-          namespace: openshift-security
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
In https://github.com/openshift/aws-vpce-operator/pull/60, the CRD was converted to be namespaced instead of cluster-scoped, so this is updating the CR accordingly

### Which Jira/Github issue(s) this PR fixes?
[OSD-13108](https://issues.redhat.com//browse/OSD-13108)

### Special notes for your reviewer:
Affects FedRAMP only
