### PR TITLE
[FedRAMP] AVO metrics are now namespaced

### DIFF
--- a/deploy/sre-prometheus/fedramp/100-avo-pendingAcceptance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/fedramp/100-avo-pendingAcceptance.PrometheusRule.yaml
@@ -15,6 +15,6 @@ spec:
       for: 5m
       labels:
         severity: critical
-        namespace: openshift-aws-vpce-operator
+        namespace: "{{ $labels.namespace }}"
       annotations:
-        message: "The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name }} has been in a pendingAcceptance state for 5m and requires SRE action."
+        message: "The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.namespace }}/{{ $labels.name }} has been in a pendingAcceptance state for 5m and requires SRE action."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -17171,10 +17171,11 @@ objects:
             for: 5m
             labels:
               severity: critical
-              namespace: openshift-aws-vpce-operator
+              namespace: '{{ $labels.namespace }}'
             annotations:
-              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name
-                }} has been in a pendingAcceptance state for 5m and requires SRE action.
+              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.namespace
+                }}/{{ $labels.name }} has been in a pendingAcceptance state for 5m
+                and requires SRE action.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -17171,10 +17171,11 @@ objects:
             for: 5m
             labels:
               severity: critical
-              namespace: openshift-aws-vpce-operator
+              namespace: '{{ $labels.namespace }}'
             annotations:
-              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name
-                }} has been in a pendingAcceptance state for 5m and requires SRE action.
+              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.namespace
+                }}/{{ $labels.name }} has been in a pendingAcceptance state for 5m
+                and requires SRE action.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -17171,10 +17171,11 @@ objects:
             for: 5m
             labels:
               severity: critical
-              namespace: openshift-aws-vpce-operator
+              namespace: '{{ $labels.namespace }}'
             annotations:
-              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.name
-                }} has been in a pendingAcceptance state for 5m and requires SRE action.
+              message: The VPC Endpoint {{ $labels.vpce_id }} created by {{ $labels.namespace
+                }}/{{ $labels.name }} has been in a pendingAcceptance state for 5m
+                and requires SRE action.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Relating to https://github.com/openshift/managed-cluster-config/pull/1271, with the new VPCE CR, the metrics now have a useful namespace and it shouldn't be hardcoded anymore.

### Which Jira/Github issue(s) this PR fixes?

[OSD-13108](https://issues.redhat.com//browse/OSD-13108)

### Special notes for your reviewer:
Affects FedRAMP only