### PR TITLE
Add the `iam:CreatePolicy` permission to the OCM admin role

### DIFF
--- a/resources/sts/4.11/sts_ocm_admin_permission_policy.json
+++ b/resources/sts/4.11/sts_ocm_admin_permission_policy.json
@@ -6,6 +6,7 @@
       "Action": [
         "iam:AttachRolePolicy",
         "iam:CreateOpenIDConnectProvider",
+        "iam:CreatePolicy",
         "iam:CreatePolicyVersion",
         "iam:CreateRole",
         "iam:DeleteOpenIDConnectProvider",


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Creating ROSA STS cluster auto mode for the UI flow.

In the past, the command `rosa create account roles` created the operator policies.
As part of refactoring the ROSA CLI, the creation of the operator policies was moved to
the `rosa create operator roles` command.

Currently, for the auto flow, the user runs only `create account-roles` and `create cluster`
resulting in missing operator policies, therefore adding the permission to the **ocm role** 
to create the operator policies.

### Which Jira/Github issue(s) this PR fixes?
[SDA-6578](https://issues.redhat.com/browse/SDA-6578)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
