### PR TITLE
[FedRAMP] clam-files is mounted at /clam for clamsig-puller

### DIFF
--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -16,6 +16,8 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
+        - name: CLAM_DB_DIRECTORY
+          value: "/clam"
         image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
         name: clamsig-puller
         resources:
@@ -170,6 +172,8 @@ spec:
           value: "false"
         - name: INIT_CONTAINER
           value: "true"
+        - name: CLAM_DB_DIRECTORY
+          value: "/clam"
         image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
         name: init-clamsig-puller
         resources:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13551,6 +13551,8 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
+              - name: CLAM_DB_DIRECTORY
+                value: /clam
               image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
               name: clamsig-puller
               resources:
@@ -13705,6 +13707,8 @@ objects:
                 value: 'false'
               - name: INIT_CONTAINER
                 value: 'true'
+              - name: CLAM_DB_DIRECTORY
+                value: /clam
               image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
               name: init-clamsig-puller
               resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13551,6 +13551,8 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
+              - name: CLAM_DB_DIRECTORY
+                value: /clam
               image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
               name: clamsig-puller
               resources:
@@ -13705,6 +13707,8 @@ objects:
                 value: 'false'
               - name: INIT_CONTAINER
                 value: 'true'
+              - name: CLAM_DB_DIRECTORY
+                value: /clam
               image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
               name: init-clamsig-puller
               resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13551,6 +13551,8 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
+              - name: CLAM_DB_DIRECTORY
+                value: /clam
               image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
               name: clamsig-puller
               resources:
@@ -13705,6 +13707,8 @@ objects:
                 value: 'false'
               - name: INIT_CONTAINER
                 value: 'true'
+              - name: CLAM_DB_DIRECTORY
+                value: /clam
               image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
               name: init-clamsig-puller
               resources:


### PR DESCRIPTION
### What type of PR is this?
bugfix

### What this PR does / why we need it?
There's a volume mount for

```yaml
        - mountPath: /clam
          name: clam-files
```

That this environment var needs to point to if it's not at the default `/var/lib/clamav`

### Which Jira/Github issue(s) this PR fixes?

[OSD-13227](https://issues.redhat.com//browse/OSD-13227)

### Special notes for your reviewer:
Affects FedRAMP only