### PR TITLE
OSD-13103 Adjust alert to >8GB consumption for SDN pods to tune false positives

### DIFF
--- a/deploy/sre-prometheus/100-runaway-sdn.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-runaway-sdn.PrometheusRule.yaml
@@ -11,12 +11,12 @@ spec:
   - name: sre-runaway-sdn-preventing-container-creation
     rules:
     - alert: RunawaySDNPreventingContainerCreationSRE
-      # OSD-13103: This is an attempt to catch an issue where SDN has no memory limits and can cause pods to be stuck in ContainerCreating on 
-      # worker nodes due to memory exhaustion. It should be fixed in OCPBUGS-773
-      expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"}) by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"} > 1000000000) by (node) 
+      # OSD-13103: This is an attempt to catch an issue where SDN has no memory limits and can cause pods to be stuck in ContainerCreating on
+      # worker nodes due to memory exhaustion. It should be fixed in OCPBUGS-773 or RHOCPPRIO-33
+      expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"}) by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"} > 8000000000) by (node)
       for: 10m
       labels:
         severity: critical
         namespace: openshift-monitoring
       annotations:
-        description: "SDN is consuming excessive memory rendering {{ $labels.node }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed."
+        description: "SDN is consuming excessive memory rendering {{ $labels.node }} unusable. The SDN pod on this node may need to be cycled or the node may need to be replaced until OCPBUGS-773 or RHOCPPRIO-33 is addressed."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -16448,14 +16448,16 @@ objects:
             expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"})
               by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by
               (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"}
-              > 1000000000) by (node)
+              > 8000000000) by (node)
             for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               description: SDN is consuming excessive memory rendering {{ $labels.node
-                }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed.
+                }} unusable. The SDN pod on this node may need to be cycled or the
+                node may need to be replaced until OCPBUGS-773 or RHOCPPRIO-33 is
+                addressed.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -16448,14 +16448,16 @@ objects:
             expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"})
               by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by
               (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"}
-              > 1000000000) by (node)
+              > 8000000000) by (node)
             for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               description: SDN is consuming excessive memory rendering {{ $labels.node
-                }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed.
+                }} unusable. The SDN pod on this node may need to be cycled or the
+                node may need to be replaced until OCPBUGS-773 or RHOCPPRIO-33 is
+                addressed.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -16448,14 +16448,16 @@ objects:
             expr: sum(sum(kube_pod_container_status_waiting_reason{reason="ContainerCreating"})
               by (pod,namespace) * on (pod,namespace) group_right kube_pod_info) by
               (node) > 0 and sum(container_memory_usage_bytes{namespace="openshift-sdn"}
-              > 1000000000) by (node)
+              > 8000000000) by (node)
             for: 10m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               description: SDN is consuming excessive memory rendering {{ $labels.node
-                }} unusable. The node needs to be replaced until OCPBUGS-773 is addressed.
+                }} unusable. The SDN pod on this node may need to be cycled or the
+                node may need to be replaced until OCPBUGS-773 or RHOCPPRIO-33 is
+                addressed.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
The alert is currently misleading and leading to a lot of false positives. As it has a very specific focus at the moment, tuning the SDN pod memory threshold to 8GB for now.

### Which Jira/Github issue(s) this PR fixes?

[OSD-13103](https://issues.redhat.com//browse/OSD-13103)