### PR TITLE
deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak: CronJob pruner

### DIFF
--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/00-OCPBUGS-1341.ServiceAccount.yaml
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/00-OCPBUGS-1341.ServiceAccount.yaml
@@ -1,0 +1,8 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: sre-pod-network-connectivity-check-pruner
+  namespace: openshift-network-diagnostics
+  annotations:
+    kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341 by pruning leaked PodNetworkConnectivityChecks.

--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/01-OCPBUGS-1341.Role.yaml
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/01-OCPBUGS-1341.Role.yaml
@@ -1,0 +1,16 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sre-pod-network-connectivity-check-pruner
+  namespace: openshift-network-diagnostics
+  annotations:
+    kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341 by pruning leaked PodNetworkConnectivityChecks.
+rules:
+  - apiGroups:
+    - controlplane.operator.openshift.io
+    resources:
+    - podnetworkconnectivitychecks
+    verbs:
+    - list
+    - delete

--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/02-OCPBUGS-1341.RoleBinding.yaml
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/02-OCPBUGS-1341.RoleBinding.yaml
@@ -1,0 +1,16 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sre-pod-network-connectivity-check-pruner
+  namespace: openshift-network-diagnostics
+  annotations:
+    kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341 by pruning leaked PodNetworkConnectivityChecks.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sre-pod-network-connectivity-check-pruner
+subjects:
+- kind: ServiceAccount
+  name: sre-pod-network-connectivity-check-pruner
+  namespace: openshift-network-diagnostics

--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/03-OCPBUGS-1341.ClusterRoleBinding.yaml
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/03-OCPBUGS-1341.ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sre-pod-network-connectivity-check-pruner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-reader
+subjects:
+- kind: ServiceAccount
+  name: sre-pod-network-connectivity-check-pruner
+  namespace: openshift-network-diagnostics

--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/10-OCPBUGS-1341.CronJob.yaml
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/10-OCPBUGS-1341.CronJob.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-pod-network-connectivity-check-pruner
+  namespace: openshift-network-diagnostics
+  annotations:
+    kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341 by pruning leaked PodNetworkConnectivityChecks.
+spec:
+  schedule: "0 1 * * *" # 1 AM every day
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          name: sre-pod-network-connectivity-check-pruner
+          namespace: openshift-network-diagnostics
+          annotations:
+            kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341 by pruning leaked PodNetworkConnectivityChecks.
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          containers:
+          - name: pod-network-connectivity-check-pruner
+            image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+            imagePullPolicy: Always
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            command:
+            - /bin/bash
+            args:
+            - -c
+            - |
+              set -euo pipefail
+              set -x
+              comm -23 \
+                  <(oc -n openshift-network-diagnostics get -o name podnetworkconnectivitychecks.controlplane.operator.openshift.io | sed -n 's|.*/\(.*network-check-target.*\)|\1|p' | grep -v service-cluster | sort) \
+                  <(oc get -o json nodes | jq -r '([.items[].metadata.name | split(".")[0]]) as $nodes | $nodes[] | . as $a | $nodes[] | . as $b | [[$a,$b],[$b,$a]][] | "network-check-source-" + .[0] + "-to-network-check-target-" + .[1]' | sort) | \
+                xargs -n10 --no-run-if-empty oc -n openshift-network-diagnostics delete podnetworkconnectivitychecks.controlplane.operator.openshift.io
+          serviceAccountName: sre-pod-network-connectivity-check-pruner
+          automountServiceAccountToken: true
+          restartPolicy: Never

--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/OWNERS
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- wking

--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/README.md
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/README.md
@@ -1,0 +1,16 @@
+# OCPBUGS-1341
+
+## About
+
+This sets up a `CronJob` on the cluster which aims to detect and remediate any PodNetworkConnectivityCheck leakage from [OCPBUGS-1341][].
+
+A cluster which is impacted by this issue:
+- Will have unused PodNetworkConnectivityCheck resources left behind due to node churn.
+
+The fix of the CronJob is to:
+- Remove the leaked PodNetworkConnectivityChecks.
+
+## References:
+* [OCPBUGS-1341][]
+
+[OCPBUGS-1341]: https://issues.redhat.com/browse/OCPBUGS-1341

--- a/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/config.yaml
+++ b/deploy/OCPBUGS-1341-PodNetworkConnectivityCheck-leak/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: api.openshift.com/environment
+    operator: In
+    values: ["staging", "integration"]
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.8","4.9","4.10","4.11"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -601,6 +601,148 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: OCPBUGS-1341-PodNetworkConnectivityCheck-leak
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+    - kind: Role
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      rules:
+      - apiGroups:
+        - controlplane.operator.openshift.io
+        resources:
+        - podnetworkconnectivitychecks
+        verbs:
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: sre-pod-network-connectivity-check-pruner
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:node-reader
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      spec:
+        schedule: 0 1 * * *
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 86400
+            template:
+              metadata:
+                name: sre-pod-network-connectivity-check-pruner
+                namespace: openshift-network-diagnostics
+                annotations:
+                  kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+                    by pruning leaked PodNetworkConnectivityChecks.
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: pod-network-connectivity-check-pruner
+                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                    seccompProfile:
+                      type: RuntimeDefault
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - "set -euo pipefail\nset -x\ncomm -23 \\\n    <(oc -n openshift-network-diagnostics\
+                    \ get -o name podnetworkconnectivitychecks.controlplane.operator.openshift.io\
+                    \ | sed -n 's|.*/\\(.*network-check-target.*\\)|\\1|p' | grep\
+                    \ -v service-cluster | sort) \\\n    <(oc get -o json nodes |\
+                    \ jq -r '([.items[].metadata.name | split(\".\")[0]]) as $nodes\
+                    \ | $nodes[] | . as $a | $nodes[] | . as $b | [[$a,$b],[$b,$a]][]\
+                    \ | \"network-check-source-\" + .[0] + \"-to-network-check-target-\"\
+                    \ + .[1]' | sort) | \\\n  xargs -n10 --no-run-if-empty oc -n openshift-network-diagnostics\
+                    \ delete podnetworkconnectivitychecks.controlplane.operator.openshift.io\n"
+                serviceAccountName: sre-pod-network-connectivity-check-pruner
+                automountServiceAccountToken: true
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -601,6 +601,148 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: OCPBUGS-1341-PodNetworkConnectivityCheck-leak
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+    - kind: Role
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      rules:
+      - apiGroups:
+        - controlplane.operator.openshift.io
+        resources:
+        - podnetworkconnectivitychecks
+        verbs:
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: sre-pod-network-connectivity-check-pruner
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:node-reader
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      spec:
+        schedule: 0 1 * * *
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 86400
+            template:
+              metadata:
+                name: sre-pod-network-connectivity-check-pruner
+                namespace: openshift-network-diagnostics
+                annotations:
+                  kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+                    by pruning leaked PodNetworkConnectivityChecks.
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: pod-network-connectivity-check-pruner
+                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                    seccompProfile:
+                      type: RuntimeDefault
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - "set -euo pipefail\nset -x\ncomm -23 \\\n    <(oc -n openshift-network-diagnostics\
+                    \ get -o name podnetworkconnectivitychecks.controlplane.operator.openshift.io\
+                    \ | sed -n 's|.*/\\(.*network-check-target.*\\)|\\1|p' | grep\
+                    \ -v service-cluster | sort) \\\n    <(oc get -o json nodes |\
+                    \ jq -r '([.items[].metadata.name | split(\".\")[0]]) as $nodes\
+                    \ | $nodes[] | . as $a | $nodes[] | . as $b | [[$a,$b],[$b,$a]][]\
+                    \ | \"network-check-source-\" + .[0] + \"-to-network-check-target-\"\
+                    \ + .[1]' | sort) | \\\n  xargs -n10 --no-run-if-empty oc -n openshift-network-diagnostics\
+                    \ delete podnetworkconnectivitychecks.controlplane.operator.openshift.io\n"
+                serviceAccountName: sre-pod-network-connectivity-check-pruner
+                automountServiceAccountToken: true
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -601,6 +601,148 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: OCPBUGS-1341-PodNetworkConnectivityCheck-leak
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+    - kind: Role
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      rules:
+      - apiGroups:
+        - controlplane.operator.openshift.io
+        resources:
+        - podnetworkconnectivitychecks
+        verbs:
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: sre-pod-network-connectivity-check-pruner
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:node-reader
+      subjects:
+      - kind: ServiceAccount
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-pod-network-connectivity-check-pruner
+        namespace: openshift-network-diagnostics
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+            by pruning leaked PodNetworkConnectivityChecks.
+      spec:
+        schedule: 0 1 * * *
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 86400
+            template:
+              metadata:
+                name: sre-pod-network-connectivity-check-pruner
+                namespace: openshift-network-diagnostics
+                annotations:
+                  kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OCPBUGS-1341
+                    by pruning leaked PodNetworkConnectivityChecks.
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: pod-network-connectivity-check-pruner
+                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                    seccompProfile:
+                      type: RuntimeDefault
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - "set -euo pipefail\nset -x\ncomm -23 \\\n    <(oc -n openshift-network-diagnostics\
+                    \ get -o name podnetworkconnectivitychecks.controlplane.operator.openshift.io\
+                    \ | sed -n 's|.*/\\(.*network-check-target.*\\)|\\1|p' | grep\
+                    \ -v service-cluster | sort) \\\n    <(oc get -o json nodes |\
+                    \ jq -r '([.items[].metadata.name | split(\".\")[0]]) as $nodes\
+                    \ | $nodes[] | . as $a | $nodes[] | . as $b | [[$a,$b],[$b,$a]][]\
+                    \ | \"network-check-source-\" + .[0] + \"-to-network-check-target-\"\
+                    \ + .[1]' | sort) | \\\n  xargs -n10 --no-run-if-empty oc -n openshift-network-diagnostics\
+                    \ delete podnetworkconnectivitychecks.controlplane.operator.openshift.io\n"
+                serviceAccountName: sre-pod-network-connectivity-check-pruner
+                automountServiceAccountToken: true
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Similar to the pruner in openshift/release#32338, as linked from [OCPBUGS-1341][2].

[2]: https://issues.redhat.com/browse/OCPBUGS-1341

### What type of PR is this?

bug

### What this PR does / why we need it?

The pruner removes excess resources leaked via node churn, until the network operator can be patched to stop leaking.  Leaked resources are more likely in managed clusters because of their node churn.  Managed-cluster use of MachineHealthChecks and scaling compute up around OCP-core updates both contribute to node churn across the managed fleet, as do customer decisions to use autoscalers in a subset of the managed fleet.  Significant numbers (tens thousands) of leaked resources lead to excessive memory use, and if left unpruned, will eventually require expensive control-plane scale-ups.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OCPBUGS-1341][2].

### Special notes for your reviewer:

I'm not SD, and this is my first managed-cluster-config pull request.  I'm trying to pattern-match prior commits, but :shrug: don't assume I know what I'm doing ;).

### Pre-checks (if applicable):

- [ ] Tested latest changes against a cluster (sort of.  I've tested openshift/release#32338).
- [ ] Included documentation changes with PR (documentation?)r
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, which I am, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
