### PR TITLE
Add missing RBAC for sre-build-test to get serviceaccounts

### DIFF
--- a/deploy/sre-build-test/20-build-test-ClusterRole.yaml
+++ b/deploy/sre-build-test/20-build-test-ClusterRole.yaml
@@ -13,3 +13,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get

--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -69,8 +69,8 @@ spec:
                 managed.openshift.io/sre-build-test: "${JOB_NAME}"
               EOF
 
-              # wait for sa to be created
-              until oc -n "${NS}" get sa default >/dev/null; do
+              # wait for serviceaccount to be created
+              until oc -n "${NS}" get serviceaccounts default >/dev/null; do
                 echo "$(date): Waiting for service account to be created"
                 sleep 5
               done

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -15886,6 +15886,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -15990,11 +15996,11 @@ objects:
                     \ \"cleanup\" EXIT SIGINT\n\n# create ns\noc create -f - <<EOF\n\
                     apiVersion: v1\nkind: Namespace\nmetadata:\n  name: \"${NS}\"\n\
                     \  managed.openshift.io/sre-build-test: \"${JOB_NAME}\"\nEOF\n\
-                    \n# wait for sa to be created\nuntil oc -n \"${NS}\" get sa default\
-                    \ >/dev/null; do\n  echo \"$(date): Waiting for service account\
-                    \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
-                    \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
-                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
+                    \n# wait for serviceaccount to be created\nuntil oc -n \"${NS}\"\
+                    \ get serviceaccounts default >/dev/null; do\n  echo \"$(date):\
+                    \ Waiting for service account to be created\"\n  sleep 5\ndone\n\
+                    \n# run build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\"\
+                    \ --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
                     mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
                     \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
                     import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -15886,6 +15886,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -15990,11 +15996,11 @@ objects:
                     \ \"cleanup\" EXIT SIGINT\n\n# create ns\noc create -f - <<EOF\n\
                     apiVersion: v1\nkind: Namespace\nmetadata:\n  name: \"${NS}\"\n\
                     \  managed.openshift.io/sre-build-test: \"${JOB_NAME}\"\nEOF\n\
-                    \n# wait for sa to be created\nuntil oc -n \"${NS}\" get sa default\
-                    \ >/dev/null; do\n  echo \"$(date): Waiting for service account\
-                    \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
-                    \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
-                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
+                    \n# wait for serviceaccount to be created\nuntil oc -n \"${NS}\"\
+                    \ get serviceaccounts default >/dev/null; do\n  echo \"$(date):\
+                    \ Waiting for service account to be created\"\n  sleep 5\ndone\n\
+                    \n# run build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\"\
+                    \ --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
                     mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
                     \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
                     import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -15886,6 +15886,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - get
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -15990,11 +15996,11 @@ objects:
                     \ \"cleanup\" EXIT SIGINT\n\n# create ns\noc create -f - <<EOF\n\
                     apiVersion: v1\nkind: Namespace\nmetadata:\n  name: \"${NS}\"\n\
                     \  managed.openshift.io/sre-build-test: \"${JOB_NAME}\"\nEOF\n\
-                    \n# wait for sa to be created\nuntil oc -n \"${NS}\" get sa default\
-                    \ >/dev/null; do\n  echo \"$(date): Waiting for service account\
-                    \ to be created\"\n  sleep 5\ndone\n\n# run build\noc -n \"${NS}\"\
-                    \ new-build --name=\"${JOB_PREFIX}\" --binary --strategy source\
-                    \ --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
+                    \n# wait for serviceaccount to be created\nuntil oc -n \"${NS}\"\
+                    \ get serviceaccounts default >/dev/null; do\n  echo \"$(date):\
+                    \ Waiting for service account to be created\"\n  sleep 5\ndone\n\
+                    \n# run build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\"\
+                    \ --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
                     mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
                     \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
                     import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
* The job sometimes times out because it spins on trying to get a serviceaccount it doesn't have the necessary RBAC to get.
* ~~The `--docker-image` flag has been deprecated in favor of `--image`~~ Reverted due to review feedback as this may not work as expected on <4.9 clusters

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-13298](https://issues.redhat.com//browse/OSD-13298)