### PR TITLE
deploy/ocpbugs-1341-pod-network-connectivity-check-leak/10-OCPBUGS-1341.CronJob: Drop seccompProfile

### DIFF
--- a/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/10-OCPBUGS-1341.CronJob.yaml
+++ b/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/10-OCPBUGS-1341.CronJob.yaml
@@ -42,8 +42,6 @@ spec:
                 drop:
                 - ALL
               runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
             command:
             - /bin/bash
             args:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8480,8 +8480,6 @@ objects:
                       drop:
                       - ALL
                     runAsNonRoot: true
-                    seccompProfile:
-                      type: RuntimeDefault
                   command:
                   - /bin/bash
                   args:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8480,8 +8480,6 @@ objects:
                       drop:
                       - ALL
                     runAsNonRoot: true
-                    seccompProfile:
-                      type: RuntimeDefault
                   command:
                   - /bin/bash
                   args:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8480,8 +8480,6 @@ objects:
                       drop:
                       - ALL
                     runAsNonRoot: true
-                    seccompProfile:
-                      type: RuntimeDefault
                   command:
                   - /bin/bash
                   args:


### PR DESCRIPTION
[Avoid][1]:

    13m         Warning   FailedCreate                 job/sre-pod-network-connectivity-check-pruner-27735841   Error creating: pods "sre-pod-network-connectivity-check-pruner-27735841-2x4qn" is forbidden: unable to validate against any security context constraint: [pod.metadata.annotations.container.seccomp.security.alpha.kubernetes.io/pod-network-connectivity-check-pruner: Forbidden: seccomp may not be set provider "anyuid": Forbidden: not usable by user or serviceaccount provider "nonroot": Forbidden: not usable by user or serviceaccount provider "pcap-dedicated-admins": Forbidden: not usable by user or serviceaccount provider "hostmount-anyuid": ......

On 4.8 through 4.10.  This will break the job on 4.12 and later, where the seccompProfile entry is required for this namespace, but the hive.openshift.io/version-major-minor config is restricting this CronJob to 4.8 through 4.11 clusters today, and the backing bug will probably be fixed (and not need this pruning CronJob) by the time 4.12 is generally available.

[1]: https://github.com/openshift/managed-cluster-config/pull/1280#issuecomment-1257335102