### PR TITLE
 deploy/ocpbugs-1341-pod-network-connectivity-check-leak: Set base config

### DIFF
--- a/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/config.yaml
+++ b/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: api.openshift.com/environment
+    operator: In
+    values: ["staging", "integration"]
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.8","4.9","4.10","4.11"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8368,6 +8368,19 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
     resourceApplyMode: Sync
     resources:
     - kind: ServiceAccount

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8368,6 +8368,19 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
     resourceApplyMode: Sync
     resources:
     - kind: ServiceAccount

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8368,6 +8368,19 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+        - integration
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
     resourceApplyMode: Sync
     resources:
     - kind: ServiceAccount


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
The base directory of `deploy/ocpbugs-1341-pod-network-connectivity-check-leak` requires a `config.yaml` to only distribute it to:

- staging/integration clusters
- clusters in the 4.8 through 4.11 range

Presently it will distribute everywhere.

Removal of the staging/integration restriction will occur as part of #1280 

### Which Jira/Github issue(s) this PR fixes?
Remediation of OCPBUGS-1341.
