### PR TITLE
updates suricata log-cleaner to remediate CVE

### DIFF
--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -33,7 +33,7 @@ spec:
         - mountPath: /host/
           name: host-filesystem
       - name: log-cleaner
-        image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
+        image: quay.io/app-sre/log-cleaner@sha256:e22c15f4095445e22d2b885a338b6a004eeabb6fb8181afcd0a02c007e4012d7
         volumeMounts:
         - mountPath: /host/
           name: host-filesystem        

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -14433,7 +14433,7 @@ objects:
               - mountPath: /host/
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
+              image: quay.io/app-sre/log-cleaner@sha256:e22c15f4095445e22d2b885a338b6a004eeabb6fb8181afcd0a02c007e4012d7
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -14433,7 +14433,7 @@ objects:
               - mountPath: /host/
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
+              image: quay.io/app-sre/log-cleaner@sha256:e22c15f4095445e22d2b885a338b6a004eeabb6fb8181afcd0a02c007e4012d7
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -14433,7 +14433,7 @@ objects:
               - mountPath: /host/
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:8a76d5d3ac28e29bb1443e761c55102df55d7bdacf867484035f2b2f251cd299
+              image: quay.io/app-sre/log-cleaner@sha256:e22c15f4095445e22d2b885a338b6a004eeabb6fb8181afcd0a02c007e4012d7
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug

### What this PR does / why we need it?
Updates the log-cleaner image used for Suricata to remove CVE's

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-13309

_Fixes #_
Bumps the version to a newer image that does not have any CVE's

### Special notes for your reviewer:
Required remediation for FedRAMP 

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
