### PR TITLE
Allow dedicated-admins to manage UWM Alertmanager

### DIFF
--- a/deploy/osd-user-workload-monitoring/04-dedicated-admins-uwm-am-secret-role.Role.yaml
+++ b/deploy/osd-user-workload-monitoring/04-dedicated-admins-uwm-am-secret-role.Role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-user-workload-monitoring-manage-am-secret
+  namespace: openshift-user-workload-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - alertmanager-user-workload
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/deploy/osd-user-workload-monitoring/05-dedicated-admins-uwm-am-secret-rolebinding.RoleBinding.yaml
+++ b/deploy/osd-user-workload-monitoring/05-dedicated-admins-uwm-am-secret-rolebinding.RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-uwm-managed-am-secret
+  namespace: openshift-user-workload-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-user-workload-monitoring-manage-am-secret

--- a/deploy/osd-user-workload-monitoring/06-dedicated-admins-alert-route-editing.SubjectPermissions.yaml
+++ b/deploy/osd-user-workload-monitoring/06-dedicated-admins-alert-route-editing.SubjectPermissions.yaml
@@ -1,0 +1,14 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: dedicated-admins-alert-routing-edit
+  namespace: openshift-rbac-permissions
+spec:
+  subjectKind: Group
+  subjectName: dedicated-admins
+  permissions:
+    - 
+      clusterRoleName: alert-routing-edit
+      namespacesAllowedRegex: ".*"
+      namespacesDeniedRegex: "(^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)"
+      allowFirst: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -14638,6 +14638,52 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-user-workload-monitoring-create-cm
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-user-workload-monitoring-manage-am-secret
+        namespace: openshift-user-workload-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - alertmanager-user-workload
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-uwm-managed-am-secret
+        namespace: openshift-user-workload-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-user-workload-monitoring-manage-am-secret
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admins-alert-routing-edit
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: dedicated-admins
+        permissions:
+        - clusterRoleName: alert-routing-edit
+          namespacesAllowedRegex: .*
+          namespacesDeniedRegex: (^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          allowFirst: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -14638,6 +14638,52 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-user-workload-monitoring-create-cm
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-user-workload-monitoring-manage-am-secret
+        namespace: openshift-user-workload-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - alertmanager-user-workload
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-uwm-managed-am-secret
+        namespace: openshift-user-workload-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-user-workload-monitoring-manage-am-secret
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admins-alert-routing-edit
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: dedicated-admins
+        permissions:
+        - clusterRoleName: alert-routing-edit
+          namespacesAllowedRegex: .*
+          namespacesDeniedRegex: (^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          allowFirst: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -14638,6 +14638,52 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-user-workload-monitoring-create-cm
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: dedicated-admins-user-workload-monitoring-manage-am-secret
+        namespace: openshift-user-workload-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - alertmanager-user-workload
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-uwm-managed-am-secret
+        namespace: openshift-user-workload-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-user-workload-monitoring-manage-am-secret
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: dedicated-admins-alert-routing-edit
+        namespace: openshift-rbac-permissions
+      spec:
+        subjectKind: Group
+        subjectName: dedicated-admins
+        permissions:
+        - clusterRoleName: alert-routing-edit
+          namespacesAllowedRegex: .*
+          namespacesDeniedRegex: (^kube-.*|^openshift.*|^ops-health-monitoring$|^management-infra$|^default$|^logging$|^sre-app-check$)
+          allowFirst: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

Feature

### What this PR does / why we need it?

Implements the needed changes to enable dedicated-admins to manage UWM Alertmanager configuration

### Which Jira/Github issue(s) this PR fixes?
[SDE-1112](https://issues.redhat.com//browse/SDE-1112)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
