### PR TITLE
updating clamsig-puller options and image

### DIFF
--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -18,12 +18,16 @@ spec:
           value: "false"
         - name: CLAM_DB_DIRECTORY
           value: "/clam"
-        image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+        - name: CLAM_SECRETS_FILE
+          value: /secrets/clam_update_config.json
+        - name: DEBUG_SECRETS
+          value: "false"
+        image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
         name: clamsig-puller
         resources:
           limits:
             cpu: 100m
-            memory: 200Mi
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 50Mi
@@ -40,10 +44,10 @@ spec:
         resources:
           limits:
             cpu: 300m
-            memory: 1Gi
+            memory: 3Gi
           requests:
             cpu: 100m
-            memory: 600Mi
+            memory: 800Mi
         volumeMounts:
         - mountPath: /var/lib/clamav
           name: clam-files
@@ -174,12 +178,16 @@ spec:
           value: "true"
         - name: CLAM_DB_DIRECTORY
           value: "/clam"
-        image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+        - name: CLAM_SECRETS_FILE
+          value: /secrets/clam_update_config.json
+        - name: DEBUG_SECRETS
+          value: "false"
+        image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
         name: init-clamsig-puller
         resources:
           limits:
             cpu: 100m
-            memory: 200Mi
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 50Mi

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13794,12 +13794,16 @@ objects:
                 value: 'false'
               - name: CLAM_DB_DIRECTORY
                 value: /clam
-              image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+              - name: CLAM_SECRETS_FILE
+                value: /secrets/clam_update_config.json
+              - name: DEBUG_SECRETS
+                value: 'false'
+              image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
               name: clamsig-puller
               resources:
                 limits:
                   cpu: 100m
-                  memory: 200Mi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 50Mi
@@ -13816,10 +13820,10 @@ objects:
               resources:
                 limits:
                   cpu: 300m
-                  memory: 1Gi
+                  memory: 3Gi
                 requests:
                   cpu: 100m
-                  memory: 600Mi
+                  memory: 800Mi
               volumeMounts:
               - mountPath: /var/lib/clamav
                 name: clam-files
@@ -13950,12 +13954,16 @@ objects:
                 value: 'true'
               - name: CLAM_DB_DIRECTORY
                 value: /clam
-              image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+              - name: CLAM_SECRETS_FILE
+                value: /secrets/clam_update_config.json
+              - name: DEBUG_SECRETS
+                value: 'false'
+              image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
               name: init-clamsig-puller
               resources:
                 limits:
                   cpu: 100m
-                  memory: 200Mi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 50Mi

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13794,12 +13794,16 @@ objects:
                 value: 'false'
               - name: CLAM_DB_DIRECTORY
                 value: /clam
-              image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+              - name: CLAM_SECRETS_FILE
+                value: /secrets/clam_update_config.json
+              - name: DEBUG_SECRETS
+                value: 'false'
+              image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
               name: clamsig-puller
               resources:
                 limits:
                   cpu: 100m
-                  memory: 200Mi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 50Mi
@@ -13816,10 +13820,10 @@ objects:
               resources:
                 limits:
                   cpu: 300m
-                  memory: 1Gi
+                  memory: 3Gi
                 requests:
                   cpu: 100m
-                  memory: 600Mi
+                  memory: 800Mi
               volumeMounts:
               - mountPath: /var/lib/clamav
                 name: clam-files
@@ -13950,12 +13954,16 @@ objects:
                 value: 'true'
               - name: CLAM_DB_DIRECTORY
                 value: /clam
-              image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+              - name: CLAM_SECRETS_FILE
+                value: /secrets/clam_update_config.json
+              - name: DEBUG_SECRETS
+                value: 'false'
+              image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
               name: init-clamsig-puller
               resources:
                 limits:
                   cpu: 100m
-                  memory: 200Mi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 50Mi

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13794,12 +13794,16 @@ objects:
                 value: 'false'
               - name: CLAM_DB_DIRECTORY
                 value: /clam
-              image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+              - name: CLAM_SECRETS_FILE
+                value: /secrets/clam_update_config.json
+              - name: DEBUG_SECRETS
+                value: 'false'
+              image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
               name: clamsig-puller
               resources:
                 limits:
                   cpu: 100m
-                  memory: 200Mi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 50Mi
@@ -13816,10 +13820,10 @@ objects:
               resources:
                 limits:
                   cpu: 300m
-                  memory: 1Gi
+                  memory: 3Gi
                 requests:
                   cpu: 100m
-                  memory: 600Mi
+                  memory: 800Mi
               volumeMounts:
               - mountPath: /var/lib/clamav
                 name: clam-files
@@ -13950,12 +13954,16 @@ objects:
                 value: 'true'
               - name: CLAM_DB_DIRECTORY
                 value: /clam
-              image: quay.io/app-sre/clamsig-puller@sha256:afb6cb240d67398bb4d6bb404372867d2f46571e542b427a0de0eb7c489b9ffa
+              - name: CLAM_SECRETS_FILE
+                value: /secrets/clam_update_config.json
+              - name: DEBUG_SECRETS
+                value: 'false'
+              image: quay.io/app-sre/clamsig-puller@sha256:7e9b4ba25e97f4a05003f419949039ebdcf7143e4714310a83025971cb657202
               name: init-clamsig-puller
               resources:
                 limits:
                   cpu: 100m
-                  memory: 200Mi
+                  memory: 2Gi
                 requests:
                   cpu: 100m
                   memory: 50Mi


### PR DESCRIPTION
### What type of PR is this?
Bugfix PR.

### What this PR does / why we need it?
Update image digests for clamsig-puller after reverting a commit to its image repo.
Upping memory limits to give extra headroom for the containers that load signature databases into memory.
Adding environment variables for some default config values.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
[OSD-13408](https://issues.redhat.com//browse/OSD-13408)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster: crc
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
