### PR TITLE
[OSD-12886] set check error increase over 20min window and trigger an alert on error > 0

### DIFF
--- a/deploy/sre-prometheus/100-managed-node-metadata-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-node-metadata-operator.PrometheusRule.yaml
@@ -11,9 +11,8 @@ spec:
   - name: sre-managed-node-metadata-operator-alerts
     rules:
     - alert: MNMOTooManyReconcileErrors15MinSRE
-      # If the amount of reconciliation errors in the last 15 minutes is > 5 trigger an alert.
-      # Currently the window is 90 minutes, because the reconcile loop uses some backoff mechanism for retries and with a 90 minute window the alert will keep on firing.
-      expr: increase(controller_runtime_reconcile_total{controller="machineset_controller", service="openshift-managed-node-metadata-operator-metrics-service", result="error"}[90m]) >= 5
+      # If reconcile errors have occured in the last 15 minutes, trigger an alert.
+      expr: increase(controller_runtime_reconcile_total{controller="machineset_controller", service="managed-node-metadata-operator-metrics-service", result="error"}[20m])>0
       for: 15m
       labels:
         severity: warning
@@ -21,5 +20,5 @@ spec:
         maturity: "immature"
         source: "https://issues.redhat.com//browse/OSD-9911"
       annotations:
-        message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name }} ) have failed in the past 15 minutes.
+        message: Reconciliations of the MNMO operator ( {{ $labels.name }} ) have failed in the past 15 minutes.
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29025,8 +29025,7 @@ objects:
           rules:
           - alert: MNMOTooManyReconcileErrors15MinSRE
             expr: increase(controller_runtime_reconcile_total{controller="machineset_controller",
-              service="openshift-managed-node-metadata-operator-metrics-service",
-              result="error"}[90m]) >= 5
+              service="managed-node-metadata-operator-metrics-service", result="error"}[20m])>0
             for: 15m
             labels:
               severity: warning
@@ -29034,8 +29033,8 @@ objects:
               maturity: immature
               source: https://issues.redhat.com//browse/OSD-9911
             annotations:
-              message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name
-                }} ) have failed in the past 15 minutes.
+              message: Reconciliations of the MNMO operator ( {{ $labels.name }} )
+                have failed in the past 15 minutes.
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29025,8 +29025,7 @@ objects:
           rules:
           - alert: MNMOTooManyReconcileErrors15MinSRE
             expr: increase(controller_runtime_reconcile_total{controller="machineset_controller",
-              service="openshift-managed-node-metadata-operator-metrics-service",
-              result="error"}[90m]) >= 5
+              service="managed-node-metadata-operator-metrics-service", result="error"}[20m])>0
             for: 15m
             labels:
               severity: warning
@@ -29034,8 +29033,8 @@ objects:
               maturity: immature
               source: https://issues.redhat.com//browse/OSD-9911
             annotations:
-              message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name
-                }} ) have failed in the past 15 minutes.
+              message: Reconciliations of the MNMO operator ( {{ $labels.name }} )
+                have failed in the past 15 minutes.
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29025,8 +29025,7 @@ objects:
           rules:
           - alert: MNMOTooManyReconcileErrors15MinSRE
             expr: increase(controller_runtime_reconcile_total{controller="machineset_controller",
-              service="openshift-managed-node-metadata-operator-metrics-service",
-              result="error"}[90m]) >= 5
+              service="managed-node-metadata-operator-metrics-service", result="error"}[20m])>0
             for: 15m
             labels:
               severity: warning
@@ -29034,8 +29033,8 @@ objects:
               maturity: immature
               source: https://issues.redhat.com//browse/OSD-9911
             annotations:
-              message: At least 5 reconciliations of the MNMO operator ( {{ $labels.name
-                }} ) have failed in the past 15 minutes.
+              message: Reconciliations of the MNMO operator ( {{ $labels.name }} )
+                have failed in the past 15 minutes.
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MNMOTooManyReconcileFailures.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
set check error increase over 20min window and trigger an alert on error > 0, update service name to match the name of the deployed service

### What type of PR is this?
_(feature)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-12886](https://issues.redhat.com//browse/OSD-12886)

### Special notes for your reviewer:

if I set the window to 15m I'm seeing gaps, I was told the gaps would make alert resolve, 20m window graph has no gaps, hence the setting. We should reduce the reconcile period to be able to use 15min window

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
