### PR TITLE
Add fluentd job label to FluentdNodeDownSRE alert expr

### DIFF
--- a/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
@@ -31,7 +31,7 @@ spec:
             message: Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m.
             summary: Fluentd cannot be scraped
           expr: |
-            absent(up{job="collector"} == 1) or absent(up{job="fluentd"} == 1)
+            absent(up{job="collector"} == 1) and absent(up{job="fluentd"} == 1)
           for: 10m
           labels:
             service: fluentd

--- a/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_fluentd_openshift-logging_collector.PrometheusRule.yaml
@@ -31,7 +31,7 @@ spec:
             message: Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m.
             summary: Fluentd cannot be scraped
           expr: |
-            absent(up{job="collector"} == 1)
+            absent(up{job="collector"} == 1) or absent(up{job="fluentd"} == 1)
           for: 10m
           labels:
             service: fluentd

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -17359,7 +17359,8 @@ objects:
               message: Prometheus could not scrape fluentd {{ $labels.instance }}
                 for more than 10m.
               summary: Fluentd cannot be scraped
-            expr: 'absent(up{job="collector"} == 1)
+            expr: 'absent(up{job="collector"} == 1) or absent(up{job="fluentd"} ==
+              1)
 
               '
             for: 10m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -17359,7 +17359,7 @@ objects:
               message: Prometheus could not scrape fluentd {{ $labels.instance }}
                 for more than 10m.
               summary: Fluentd cannot be scraped
-            expr: 'absent(up{job="collector"} == 1) or absent(up{job="fluentd"} ==
+            expr: 'absent(up{job="collector"} == 1) and absent(up{job="fluentd"} ==
               1)
 
               '

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -17359,7 +17359,8 @@ objects:
               message: Prometheus could not scrape fluentd {{ $labels.instance }}
                 for more than 10m.
               summary: Fluentd cannot be scraped
-            expr: 'absent(up{job="collector"} == 1)
+            expr: 'absent(up{job="collector"} == 1) or absent(up{job="fluentd"} ==
+              1)
 
               '
             for: 10m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -17359,7 +17359,7 @@ objects:
               message: Prometheus could not scrape fluentd {{ $labels.instance }}
                 for more than 10m.
               summary: Fluentd cannot be scraped
-            expr: 'absent(up{job="collector"} == 1) or absent(up{job="fluentd"} ==
+            expr: 'absent(up{job="collector"} == 1) and absent(up{job="fluentd"} ==
               1)
 
               '

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -17359,7 +17359,8 @@ objects:
               message: Prometheus could not scrape fluentd {{ $labels.instance }}
                 for more than 10m.
               summary: Fluentd cannot be scraped
-            expr: 'absent(up{job="collector"} == 1)
+            expr: 'absent(up{job="collector"} == 1) or absent(up{job="fluentd"} ==
+              1)
 
               '
             for: 10m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -17359,7 +17359,7 @@ objects:
               message: Prometheus could not scrape fluentd {{ $labels.instance }}
                 for more than 10m.
               summary: Fluentd cannot be scraped
-            expr: 'absent(up{job="collector"} == 1) or absent(up{job="fluentd"} ==
+            expr: 'absent(up{job="collector"} == 1) and absent(up{job="fluentd"} ==
               1)
 
               '


### PR DESCRIPTION
### What type of PR is this?
Fix

### What this PR does / why we need it?
Adds the fluentd job label to the FluentdNodeDownSRE alert expression to prevent false alerts for clusters with older versions of CLO/ESO.

### Which Jira/Github issue(s) this PR fixes?
[OSD-13044](https://issues.redhat.com//browse/OSD-13044)
