### PR TITLE
Changing image URI to the version allowed in image.config.openshift.io

### DIFF
--- a/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/no-seccomp/10-OCPBUGS-1341.CronJob.yaml
+++ b/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/no-seccomp/10-OCPBUGS-1341.CronJob.yaml
@@ -34,7 +34,7 @@ spec:
               operator: Exists
           containers:
           - name: pod-network-connectivity-check-pruner
-            image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
             imagePullPolicy: Always
             securityContext:
               allowPrivilegeEscalation: false

--- a/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/seccomp/10-OCPBUGS-1341.CronJob.yaml
+++ b/deploy/ocpbugs-1341-pod-network-connectivity-check-leak/seccomp/10-OCPBUGS-1341.CronJob.yaml
@@ -34,7 +34,7 @@ spec:
               operator: Exists
           containers:
           - name: pod-network-connectivity-check-pruner
-            image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
             imagePullPolicy: Always
             securityContext:
               allowPrivilegeEscalation: false

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8496,7 +8496,7 @@ objects:
                   operator: Exists
                 containers:
                 - name: pod-network-connectivity-check-pruner
-                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -8576,7 +8576,7 @@ objects:
                   operator: Exists
                 containers:
                 - name: pod-network-connectivity-check-pruner
-                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8496,7 +8496,7 @@ objects:
                   operator: Exists
                 containers:
                 - name: pod-network-connectivity-check-pruner
-                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -8576,7 +8576,7 @@ objects:
                   operator: Exists
                 containers:
                 - name: pod-network-connectivity-check-pruner
-                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8496,7 +8496,7 @@ objects:
                   operator: Exists
                 containers:
                 - name: pod-network-connectivity-check-pruner
-                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false
@@ -8576,7 +8576,7 @@ objects:
                   operator: Exists
                 containers:
                 - name: pod-network-connectivity-check-pruner
-                  image: image-registry.openshift-image-registry.svc.cluster.local:5000/openshift/tools:latest
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
                   imagePullPolicy: Always
                   securityContext:
                     allowPrivilegeEscalation: false


### PR DESCRIPTION

### What type of PR is this?
bug

### What this PR does / why we need it?
It changes the URI of the image from image-registry.openshift-image-registry.svc.cluster.local to image-registry.openshift-image-registry.svc since only the URI ending in svc is in spec.registrySources.allowedRegistries of image.config.openshift.io/cluster

Functionality doesn't change, it's the same image accessed via a different URI.

### Which Jira/Github issue(s) this PR fixes?

N/A

### Special notes for your reviewer:
It addresses the same repository

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [N/A] Included documentation changes with PR 
- [N/A] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
