### PR TITLE
Implementation of timeout-based upgrade SLs

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
@@ -7,17 +7,17 @@ spec:
   notifications:
     - name: UpgradeControlPlaneUpgradeTimeout
       severity: Error
-      summary: "Control plane upgrade timeout"
+      summary: "Control plane upgrade completion delayed"
       activeBody: |-
-        SRE has observed that controlplane cannot be finished in the given time period, SRE will take action on the resolution. 
+        There has been a delay observed in the anticipated completion time of your cluster's Control Plane upgrade. Red Hat SRE has been notified and will commence the investigation.
       resendWait: 12
       resolvedBody: |-
         Your cluster has been upgraded successfully. No further action on this issue is required.
     - name: UpgradeNodeUpgradeTimeout
       severity: Error
-      summary: "Node upgrade timeout"
+      summary: "Node upgrade completion delayed"
       activeBody: |-
-        SRE has observed that nodes upgrade cannot be finished in the given time period, SRE will take action on the resolution.
+        There has been a delay observed in the anticipated completion time of your cluster's Nodes upgrade. Red Hat SRE has been notified and will commence the investigation.
       resendWait: 12
       resolvedBody: |-
         Your cluster has been upgraded successfully. No further action on this issue is required.
@@ -25,7 +25,7 @@ spec:
       severity: Error
       summary: "Node drain failed for upgrading"
       activeBody: |-
-       SRE has observed that node drain takes too long and cannot be finished in the given time period during cluster upgrade, SRE will take action on the resolution.
+        There has been a delay observed in the anticipated completion time of your Nodes' drain for upgrade, Red Hat SRE has been notified and will commence the investigation.
       resendWait: 12
       resolvedBody: |-
         Your cluster has been upgraded successfully. No further action on this issue is required.

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
@@ -1,0 +1,31 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedNotification
+metadata:
+  name: sre-upgrade-managed-notifications
+  namespace: openshift-ocm-agent-operator
+spec:
+  notifications:
+    - name: UpgradeControlPlaneUpgradeTimeout
+      severity: Error
+      summary: "Control plane upgrade timeout"
+      activeBody: |-
+        SRE has observed that controlplane cannot be finished in the given time period, SRE will take action on the resolution. 
+      resendWait: 12
+      resolvedBody: |-
+        Your cluster has been upgraded successfully. No further action on this issue is required.
+    - name: UpgradeNodeUpgradeTimeout
+      severity: Error
+      summary: "Node upgrade timeout"
+      activeBody: |-
+        SRE has observed that nodes upgrade cannot be finished in the given time period, SRE will take action on the resolution.
+      resendWait: 12
+      resolvedBody: |-
+        Your cluster has been upgraded successfully. No further action on this issue is required.
+    - name: UpgradeNodeDrainFailed
+      severity: Error
+      summary: "Node drain failed for upgrading"
+      activeBody: |-
+       SRE has observed that node drain takes too long and cannot be finished in the given time period during cluster upgrade, SRE will take action on the resolution.
+      resendWait: 12
+      resolvedBody: |-
+        Your cluster has been upgraded successfully. No further action on this issue is required.

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
@@ -9,23 +9,7 @@ spec:
       severity: Error
       summary: "Control plane upgrade completion delayed"
       activeBody: |-
-        There has been a delay observed in the anticipated completion time of your cluster's Control Plane upgrade. Red Hat SRE has been notified and will commence the investigation.
-      resendWait: 12
-      resolvedBody: |-
-        Your cluster has been upgraded successfully. No further action on this issue is required.
-    - name: UpgradeNodeUpgradeTimeout
-      severity: Error
-      summary: "Node upgrade completion delayed"
-      activeBody: |-
-        There has been a delay observed in the anticipated completion time of your cluster's Nodes upgrade. Red Hat SRE has been notified and will commence the investigation.
-      resendWait: 12
-      resolvedBody: |-
-        Your cluster has been upgraded successfully. No further action on this issue is required.
-    - name: UpgradeNodeDrainFailed
-      severity: Error
-      summary: "Node drain failed for upgrading"
-      activeBody: |-
-        There has been a delay observed in the anticipated completion time of your Nodes' drain for upgrade, Red Hat SRE has been notified and will commence the investigation.
-      resendWait: 12
+        There has been a delay observed in the anticipated completion time of your cluster's Control Plane upgrade. Red Hat SRE has been notified of the situation.
+      resendWait: 72
       resolvedBody: |-
         Your cluster has been upgraded successfully. No further action on this issue is required.

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
@@ -11,5 +11,3 @@ spec:
       activeBody: |-
         There has been a delay observed in the anticipated completion time of your cluster's Control Plane upgrade. Red Hat SRE has been notified of the situation
       resendWait: 72
-      resolvedBody: |-
-        Your cluster has been upgraded successfully. No further action on this issue is required.

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-upgrade-cr.yaml
@@ -9,7 +9,7 @@ spec:
       severity: Error
       summary: "Control plane upgrade completion delayed"
       activeBody: |-
-        There has been a delay observed in the anticipated completion time of your cluster's Control Plane upgrade. Red Hat SRE has been notified of the situation.
+        There has been a delay observed in the anticipated completion time of your cluster's Control Plane upgrade. Red Hat SRE has been notified of the situation
       resendWait: 72
       resolvedBody: |-
         Your cluster has been upgraded successfully. No further action on this issue is required.

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent-upgrade.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent-upgrade.PrometheusRule.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
       expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"}) >= 1
-      for: 5m
+      for: 30m
       labels:
         severity: info
         namespace: openshift-monitoring
@@ -21,25 +21,3 @@ spec:
       annotations:
         summary: "Controlplane upgrade timeout for {{ $labels.version }}"
         description: "controlplane upgrade for {{ $labels.version }} cannot be finished in the given time period"
-    - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
-      expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"}) >= 1
-      for: 5m
-      labels:
-        severity: info
-        namespace: openshift-monitoring
-        managed_notification_template: "UpgradeNodeUpgradeTimeout"
-        send_managed_notification: "true"
-      annotations:
-        summary: "Nodes upgrade timeout for {{ $labels.version }}"
-        description: "nodes upgrade for {{ $labels.version }} cannot be finished after the silence expired"
-    - alert: UpgradeNodeDrainFailedNotificationSRE
-      expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"}) >= 1
-      for: 5m
-      labels:
-        severity: info
-        namespace: openshift-monitoring
-        managed_notification_template: "UpgradeNodeDrainFailed"
-        send_managed_notification: "true"
-      annotations:
-        summary: "Node drain failed in the given time period which is not caused by the PDB"
-        description: "node drain takes too long and cannot be finished in the given time period during cluster upgrade"

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent-upgrade.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent-upgrade.PrometheusRule.yaml
@@ -10,33 +10,33 @@ spec:
   groups:
   - name: sre-upgrade-managed-notification-alerts
     rules:
-    - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-      expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
-      for: 10m
+    - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
+      expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"}) >= 1
+      for: 5m
       labels:
-        severity: critical
+        severity: info
         namespace: openshift-monitoring
         managed_notification_template: "UpgradeControlPlaneUpgradeTimeout"
         send_managed_notification: "true"
       annotations:
         summary: "Controlplane upgrade timeout for {{ $labels.version }}"
         description: "controlplane upgrade for {{ $labels.version }} cannot be finished in the given time period"
-    - alert: UpgradeNodeUpgradeTimeoutSRE
-      expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
-      for: 10m
+    - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
+      expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"}) >= 1
+      for: 5m
       labels:
-        severity: critical
+        severity: info
         namespace: openshift-monitoring
         managed_notification_template: "UpgradeNodeUpgradeTimeout"
-        send_managed_notification: "true"        
+        send_managed_notification: "true"
       annotations:
         summary: "Nodes upgrade timeout for {{ $labels.version }}"
         description: "nodes upgrade for {{ $labels.version }} cannot be finished after the silence expired"
-    - alert: UpgradeNodeDrainFailedSRE
-      expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
-      for: 10m
+    - alert: UpgradeNodeDrainFailedNotificationSRE
+      expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"}) >= 1
+      for: 5m
       labels:
-        severity: critical
+        severity: info
         namespace: openshift-monitoring
         managed_notification_template: "UpgradeNodeDrainFailed"
         send_managed_notification: "true"

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent-upgrade.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent-upgrade.PrometheusRule.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-upgrade-managed-notification-alerts
+    role: alert-rules 
+  name: sre-upgrade-send-managed-notification-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-upgrade-managed-notification-alerts
+    rules:
+    - alert: UpgradeControlPlaneUpgradeTimeoutSRE
+      expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: "UpgradeControlPlaneUpgradeTimeout"
+        send_managed_notification: "true"
+      annotations:
+        summary: "Controlplane upgrade timeout for {{ $labels.version }}"
+        description: "controlplane upgrade for {{ $labels.version }} cannot be finished in the given time period"
+    - alert: UpgradeNodeUpgradeTimeoutSRE
+      expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: "UpgradeNodeUpgradeTimeout"
+        send_managed_notification: "true"        
+      annotations:
+        summary: "Nodes upgrade timeout for {{ $labels.version }}"
+        description: "nodes upgrade for {{ $labels.version }} cannot be finished after the silence expired"
+    - alert: UpgradeNodeDrainFailedSRE
+      expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+      for: 10m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: "UpgradeNodeDrainFailed"
+        send_managed_notification: "true"
+      annotations:
+        summary: "Node drain failed in the given time period which is not caused by the PDB"
+        description: "node drain takes too long and cannot be finished in the given time period during cluster upgrade"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9039,8 +9039,6 @@ objects:
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
             of the situation
           resendWait: 72
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9025,6 +9025,38 @@ objects:
           resendWait: 24
           resolvedBody: Your cluster's cluster-wide proxy is no longer raising any
             errors concerning network egress. No further action on this issue is required.
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
+        name: sre-upgrade-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - name: UpgradeControlPlaneUpgradeTimeout
+          severity: Error
+          summary: Control plane upgrade timeout
+          activeBody: 'SRE has observed that controlplane cannot be finished in the
+            given time period, SRE will take action on the resolution. '
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
+        - name: UpgradeNodeUpgradeTimeout
+          severity: Error
+          summary: Node upgrade timeout
+          activeBody: SRE has observed that nodes upgrade cannot be finished in the
+            given time period, SRE will take action on the resolution.
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
+        - name: UpgradeNodeDrainFailed
+          severity: Error
+          summary: Node drain failed for upgrading
+          activeBody: SRE has observed that node drain takes too long and cannot be
+            finished in the given time period during cluster upgrade, SRE will take
+            action on the resolution.
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -18577,6 +18609,55 @@ objects:
             annotations:
               message: Cluster proxy is failing network readiness endpoint checks
                 and may be misconfigured or not running.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-upgrade-managed-notification-alerts
+          role: alert-rules
+        name: sre-upgrade-send-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-upgrade-managed-notification-alerts
+          rules:
+          - alert: UpgradeControlPlaneUpgradeTimeoutSRE
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeControlPlaneUpgradeTimeout
+              send_managed_notification: 'true'
+            annotations:
+              summary: Controlplane upgrade timeout for {{ $labels.version }}
+              description: controlplane upgrade for {{ $labels.version }} cannot be
+                finished in the given time period
+          - alert: UpgradeNodeUpgradeTimeoutSRE
+            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeNodeUpgradeTimeout
+              send_managed_notification: 'true'
+            annotations:
+              summary: Nodes upgrade timeout for {{ $labels.version }}
+              description: nodes upgrade for {{ $labels.version }} cannot be finished
+                after the silence expired
+          - alert: UpgradeNodeDrainFailedSRE
+            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeNodeDrainFailed
+              send_managed_notification: 'true'
+            annotations:
+              summary: Node drain failed in the given time period which is not caused
+                by the PDB
+              description: node drain takes too long and cannot be finished in the
+                given time period during cluster upgrade
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9037,7 +9037,7 @@ objects:
           summary: Control plane upgrade completion delayed
           activeBody: There has been a delay observed in the anticipated completion
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
-            of the situation.
+            of the situation
           resendWait: 72
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9034,26 +9034,28 @@ objects:
         notifications:
         - name: UpgradeControlPlaneUpgradeTimeout
           severity: Error
-          summary: Control plane upgrade timeout
-          activeBody: 'SRE has observed that controlplane cannot be finished in the
-            given time period, SRE will take action on the resolution. '
+          summary: Control plane upgrade completion delayed
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
+            and will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
         - name: UpgradeNodeUpgradeTimeout
           severity: Error
-          summary: Node upgrade timeout
-          activeBody: SRE has observed that nodes upgrade cannot be finished in the
-            given time period, SRE will take action on the resolution.
+          summary: Node upgrade completion delayed
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your cluster's Nodes upgrade. Red Hat SRE has been notified and
+            will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
         - name: UpgradeNodeDrainFailed
           severity: Error
           summary: Node drain failed for upgrading
-          activeBody: SRE has observed that node drain takes too long and cannot be
-            finished in the given time period during cluster upgrade, SRE will take
-            action on the resolution.
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your Nodes' drain for upgrade, Red Hat SRE has been notified and
+            will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
@@ -18621,11 +18623,12 @@ objects:
         groups:
         - name: sre-upgrade-managed-notification-alerts
           rules:
-          - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeControlPlaneUpgradeTimeout
               send_managed_notification: 'true'
@@ -18633,11 +18636,12 @@ objects:
               summary: Controlplane upgrade timeout for {{ $labels.version }}
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
-          - alert: UpgradeNodeUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeNodeUpgradeTimeout
               send_managed_notification: 'true'
@@ -18645,11 +18649,12 @@ objects:
               summary: Nodes upgrade timeout for {{ $labels.version }}
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
-          - alert: UpgradeNodeDrainFailedSRE
-            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeNodeDrainFailedNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeNodeDrainFailed
               send_managed_notification: 'true'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9037,26 +9037,8 @@ objects:
           summary: Control plane upgrade completion delayed
           activeBody: There has been a delay observed in the anticipated completion
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
-            and will commence the investigation.
-          resendWait: 12
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
-        - name: UpgradeNodeUpgradeTimeout
-          severity: Error
-          summary: Node upgrade completion delayed
-          activeBody: There has been a delay observed in the anticipated completion
-            time of your cluster's Nodes upgrade. Red Hat SRE has been notified and
-            will commence the investigation.
-          resendWait: 12
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
-        - name: UpgradeNodeDrainFailed
-          severity: Error
-          summary: Node drain failed for upgrading
-          activeBody: There has been a delay observed in the anticipated completion
-            time of your Nodes' drain for upgrade, Red Hat SRE has been notified and
-            will commence the investigation.
-          resendWait: 12
+            of the situation.
+          resendWait: 72
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
 - apiVersion: hive.openshift.io/v1
@@ -18626,7 +18608,7 @@ objects:
           - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
             expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"})
               >= 1
-            for: 5m
+            for: 30m
             labels:
               severity: info
               namespace: openshift-monitoring
@@ -18636,33 +18618,6 @@ objects:
               summary: Controlplane upgrade timeout for {{ $labels.version }}
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
-          - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
-            expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"})
-              >= 1
-            for: 5m
-            labels:
-              severity: info
-              namespace: openshift-monitoring
-              managed_notification_template: UpgradeNodeUpgradeTimeout
-              send_managed_notification: 'true'
-            annotations:
-              summary: Nodes upgrade timeout for {{ $labels.version }}
-              description: nodes upgrade for {{ $labels.version }} cannot be finished
-                after the silence expired
-          - alert: UpgradeNodeDrainFailedNotificationSRE
-            expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"})
-              >= 1
-            for: 5m
-            labels:
-              severity: info
-              namespace: openshift-monitoring
-              managed_notification_template: UpgradeNodeDrainFailed
-              send_managed_notification: 'true'
-            annotations:
-              summary: Node drain failed in the given time period which is not caused
-                by the PDB
-              description: node drain takes too long and cannot be finished in the
-                given time period during cluster upgrade
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9039,8 +9039,6 @@ objects:
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
             of the situation
           resendWait: 72
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9025,6 +9025,38 @@ objects:
           resendWait: 24
           resolvedBody: Your cluster's cluster-wide proxy is no longer raising any
             errors concerning network egress. No further action on this issue is required.
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
+        name: sre-upgrade-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - name: UpgradeControlPlaneUpgradeTimeout
+          severity: Error
+          summary: Control plane upgrade timeout
+          activeBody: 'SRE has observed that controlplane cannot be finished in the
+            given time period, SRE will take action on the resolution. '
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
+        - name: UpgradeNodeUpgradeTimeout
+          severity: Error
+          summary: Node upgrade timeout
+          activeBody: SRE has observed that nodes upgrade cannot be finished in the
+            given time period, SRE will take action on the resolution.
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
+        - name: UpgradeNodeDrainFailed
+          severity: Error
+          summary: Node drain failed for upgrading
+          activeBody: SRE has observed that node drain takes too long and cannot be
+            finished in the given time period during cluster upgrade, SRE will take
+            action on the resolution.
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -18577,6 +18609,55 @@ objects:
             annotations:
               message: Cluster proxy is failing network readiness endpoint checks
                 and may be misconfigured or not running.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-upgrade-managed-notification-alerts
+          role: alert-rules
+        name: sre-upgrade-send-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-upgrade-managed-notification-alerts
+          rules:
+          - alert: UpgradeControlPlaneUpgradeTimeoutSRE
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeControlPlaneUpgradeTimeout
+              send_managed_notification: 'true'
+            annotations:
+              summary: Controlplane upgrade timeout for {{ $labels.version }}
+              description: controlplane upgrade for {{ $labels.version }} cannot be
+                finished in the given time period
+          - alert: UpgradeNodeUpgradeTimeoutSRE
+            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeNodeUpgradeTimeout
+              send_managed_notification: 'true'
+            annotations:
+              summary: Nodes upgrade timeout for {{ $labels.version }}
+              description: nodes upgrade for {{ $labels.version }} cannot be finished
+                after the silence expired
+          - alert: UpgradeNodeDrainFailedSRE
+            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeNodeDrainFailed
+              send_managed_notification: 'true'
+            annotations:
+              summary: Node drain failed in the given time period which is not caused
+                by the PDB
+              description: node drain takes too long and cannot be finished in the
+                given time period during cluster upgrade
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9037,7 +9037,7 @@ objects:
           summary: Control plane upgrade completion delayed
           activeBody: There has been a delay observed in the anticipated completion
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
-            of the situation.
+            of the situation
           resendWait: 72
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9034,26 +9034,28 @@ objects:
         notifications:
         - name: UpgradeControlPlaneUpgradeTimeout
           severity: Error
-          summary: Control plane upgrade timeout
-          activeBody: 'SRE has observed that controlplane cannot be finished in the
-            given time period, SRE will take action on the resolution. '
+          summary: Control plane upgrade completion delayed
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
+            and will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
         - name: UpgradeNodeUpgradeTimeout
           severity: Error
-          summary: Node upgrade timeout
-          activeBody: SRE has observed that nodes upgrade cannot be finished in the
-            given time period, SRE will take action on the resolution.
+          summary: Node upgrade completion delayed
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your cluster's Nodes upgrade. Red Hat SRE has been notified and
+            will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
         - name: UpgradeNodeDrainFailed
           severity: Error
           summary: Node drain failed for upgrading
-          activeBody: SRE has observed that node drain takes too long and cannot be
-            finished in the given time period during cluster upgrade, SRE will take
-            action on the resolution.
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your Nodes' drain for upgrade, Red Hat SRE has been notified and
+            will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
@@ -18621,11 +18623,12 @@ objects:
         groups:
         - name: sre-upgrade-managed-notification-alerts
           rules:
-          - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeControlPlaneUpgradeTimeout
               send_managed_notification: 'true'
@@ -18633,11 +18636,12 @@ objects:
               summary: Controlplane upgrade timeout for {{ $labels.version }}
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
-          - alert: UpgradeNodeUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeNodeUpgradeTimeout
               send_managed_notification: 'true'
@@ -18645,11 +18649,12 @@ objects:
               summary: Nodes upgrade timeout for {{ $labels.version }}
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
-          - alert: UpgradeNodeDrainFailedSRE
-            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeNodeDrainFailedNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeNodeDrainFailed
               send_managed_notification: 'true'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9037,26 +9037,8 @@ objects:
           summary: Control plane upgrade completion delayed
           activeBody: There has been a delay observed in the anticipated completion
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
-            and will commence the investigation.
-          resendWait: 12
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
-        - name: UpgradeNodeUpgradeTimeout
-          severity: Error
-          summary: Node upgrade completion delayed
-          activeBody: There has been a delay observed in the anticipated completion
-            time of your cluster's Nodes upgrade. Red Hat SRE has been notified and
-            will commence the investigation.
-          resendWait: 12
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
-        - name: UpgradeNodeDrainFailed
-          severity: Error
-          summary: Node drain failed for upgrading
-          activeBody: There has been a delay observed in the anticipated completion
-            time of your Nodes' drain for upgrade, Red Hat SRE has been notified and
-            will commence the investigation.
-          resendWait: 12
+            of the situation.
+          resendWait: 72
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
 - apiVersion: hive.openshift.io/v1
@@ -18626,7 +18608,7 @@ objects:
           - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
             expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"})
               >= 1
-            for: 5m
+            for: 30m
             labels:
               severity: info
               namespace: openshift-monitoring
@@ -18636,33 +18618,6 @@ objects:
               summary: Controlplane upgrade timeout for {{ $labels.version }}
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
-          - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
-            expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"})
-              >= 1
-            for: 5m
-            labels:
-              severity: info
-              namespace: openshift-monitoring
-              managed_notification_template: UpgradeNodeUpgradeTimeout
-              send_managed_notification: 'true'
-            annotations:
-              summary: Nodes upgrade timeout for {{ $labels.version }}
-              description: nodes upgrade for {{ $labels.version }} cannot be finished
-                after the silence expired
-          - alert: UpgradeNodeDrainFailedNotificationSRE
-            expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"})
-              >= 1
-            for: 5m
-            labels:
-              severity: info
-              namespace: openshift-monitoring
-              managed_notification_template: UpgradeNodeDrainFailed
-              send_managed_notification: 'true'
-            annotations:
-              summary: Node drain failed in the given time period which is not caused
-                by the PDB
-              description: node drain takes too long and cannot be finished in the
-                given time period during cluster upgrade
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9039,8 +9039,6 @@ objects:
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
             of the situation
           resendWait: 72
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9025,6 +9025,38 @@ objects:
           resendWait: 24
           resolvedBody: Your cluster's cluster-wide proxy is no longer raising any
             errors concerning network egress. No further action on this issue is required.
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
+        name: sre-upgrade-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - name: UpgradeControlPlaneUpgradeTimeout
+          severity: Error
+          summary: Control plane upgrade timeout
+          activeBody: 'SRE has observed that controlplane cannot be finished in the
+            given time period, SRE will take action on the resolution. '
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
+        - name: UpgradeNodeUpgradeTimeout
+          severity: Error
+          summary: Node upgrade timeout
+          activeBody: SRE has observed that nodes upgrade cannot be finished in the
+            given time period, SRE will take action on the resolution.
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
+        - name: UpgradeNodeDrainFailed
+          severity: Error
+          summary: Node drain failed for upgrading
+          activeBody: SRE has observed that node drain takes too long and cannot be
+            finished in the given time period during cluster upgrade, SRE will take
+            action on the resolution.
+          resendWait: 12
+          resolvedBody: Your cluster has been upgraded successfully. No further action
+            on this issue is required.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -18577,6 +18609,55 @@ objects:
             annotations:
               message: Cluster proxy is failing network readiness endpoint checks
                 and may be misconfigured or not running.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-upgrade-managed-notification-alerts
+          role: alert-rules
+        name: sre-upgrade-send-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-upgrade-managed-notification-alerts
+          rules:
+          - alert: UpgradeControlPlaneUpgradeTimeoutSRE
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeControlPlaneUpgradeTimeout
+              send_managed_notification: 'true'
+            annotations:
+              summary: Controlplane upgrade timeout for {{ $labels.version }}
+              description: controlplane upgrade for {{ $labels.version }} cannot be
+                finished in the given time period
+          - alert: UpgradeNodeUpgradeTimeoutSRE
+            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeNodeUpgradeTimeout
+              send_managed_notification: 'true'
+            annotations:
+              summary: Nodes upgrade timeout for {{ $labels.version }}
+              description: nodes upgrade for {{ $labels.version }} cannot be finished
+                after the silence expired
+          - alert: UpgradeNodeDrainFailedSRE
+            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
+            for: 10m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: UpgradeNodeDrainFailed
+              send_managed_notification: 'true'
+            annotations:
+              summary: Node drain failed in the given time period which is not caused
+                by the PDB
+              description: node drain takes too long and cannot be finished in the
+                given time period during cluster upgrade
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9037,7 +9037,7 @@ objects:
           summary: Control plane upgrade completion delayed
           activeBody: There has been a delay observed in the anticipated completion
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
-            of the situation.
+            of the situation
           resendWait: 72
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9034,26 +9034,28 @@ objects:
         notifications:
         - name: UpgradeControlPlaneUpgradeTimeout
           severity: Error
-          summary: Control plane upgrade timeout
-          activeBody: 'SRE has observed that controlplane cannot be finished in the
-            given time period, SRE will take action on the resolution. '
+          summary: Control plane upgrade completion delayed
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
+            and will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
         - name: UpgradeNodeUpgradeTimeout
           severity: Error
-          summary: Node upgrade timeout
-          activeBody: SRE has observed that nodes upgrade cannot be finished in the
-            given time period, SRE will take action on the resolution.
+          summary: Node upgrade completion delayed
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your cluster's Nodes upgrade. Red Hat SRE has been notified and
+            will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
         - name: UpgradeNodeDrainFailed
           severity: Error
           summary: Node drain failed for upgrading
-          activeBody: SRE has observed that node drain takes too long and cannot be
-            finished in the given time period during cluster upgrade, SRE will take
-            action on the resolution.
+          activeBody: There has been a delay observed in the anticipated completion
+            time of your Nodes' drain for upgrade, Red Hat SRE has been notified and
+            will commence the investigation.
           resendWait: 12
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
@@ -18621,11 +18623,12 @@ objects:
         groups:
         - name: sre-upgrade-managed-notification-alerts
           rules:
-          - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeControlPlaneUpgradeTimeout
               send_managed_notification: 'true'
@@ -18633,11 +18636,12 @@ objects:
               summary: Controlplane upgrade timeout for {{ $labels.version }}
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
-          - alert: UpgradeNodeUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_worker_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeNodeUpgradeTimeout
               send_managed_notification: 'true'
@@ -18645,11 +18649,12 @@ objects:
               summary: Nodes upgrade timeout for {{ $labels.version }}
               description: nodes upgrade for {{ $labels.version }} cannot be finished
                 after the silence expired
-          - alert: UpgradeNodeDrainFailedSRE
-            expr: avg_over_time(upgradeoperator_node_drain_timeout[10m]) == 1
-            for: 10m
+          - alert: UpgradeNodeDrainFailedNotificationSRE
+            expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"})
+              >= 1
+            for: 5m
             labels:
-              severity: critical
+              severity: info
               namespace: openshift-monitoring
               managed_notification_template: UpgradeNodeDrainFailed
               send_managed_notification: 'true'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9037,26 +9037,8 @@ objects:
           summary: Control plane upgrade completion delayed
           activeBody: There has been a delay observed in the anticipated completion
             time of your cluster's Control Plane upgrade. Red Hat SRE has been notified
-            and will commence the investigation.
-          resendWait: 12
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
-        - name: UpgradeNodeUpgradeTimeout
-          severity: Error
-          summary: Node upgrade completion delayed
-          activeBody: There has been a delay observed in the anticipated completion
-            time of your cluster's Nodes upgrade. Red Hat SRE has been notified and
-            will commence the investigation.
-          resendWait: 12
-          resolvedBody: Your cluster has been upgraded successfully. No further action
-            on this issue is required.
-        - name: UpgradeNodeDrainFailed
-          severity: Error
-          summary: Node drain failed for upgrading
-          activeBody: There has been a delay observed in the anticipated completion
-            time of your Nodes' drain for upgrade, Red Hat SRE has been notified and
-            will commence the investigation.
-          resendWait: 12
+            of the situation.
+          resendWait: 72
           resolvedBody: Your cluster has been upgraded successfully. No further action
             on this issue is required.
 - apiVersion: hive.openshift.io/v1
@@ -18626,7 +18608,7 @@ objects:
           - alert: UpgradeControlPlaneUpgradeTimeoutNotificationSRE
             expr: count(ALERTS{alertname="UpgradeControlPlaneUpgradeTimeoutSRE", alertstate="firing"})
               >= 1
-            for: 5m
+            for: 30m
             labels:
               severity: info
               namespace: openshift-monitoring
@@ -18636,33 +18618,6 @@ objects:
               summary: Controlplane upgrade timeout for {{ $labels.version }}
               description: controlplane upgrade for {{ $labels.version }} cannot be
                 finished in the given time period
-          - alert: UpgradeNodeUpgradeTimeoutNotificationSRE
-            expr: count(ALERTS{alertname="UpgradeNodeUpgradeTimeoutSRE", alertstate="firing"})
-              >= 1
-            for: 5m
-            labels:
-              severity: info
-              namespace: openshift-monitoring
-              managed_notification_template: UpgradeNodeUpgradeTimeout
-              send_managed_notification: 'true'
-            annotations:
-              summary: Nodes upgrade timeout for {{ $labels.version }}
-              description: nodes upgrade for {{ $labels.version }} cannot be finished
-                after the silence expired
-          - alert: UpgradeNodeDrainFailedNotificationSRE
-            expr: count(ALERTS{alertname="UpgradeNodeDrainFailedSRE", alertstate="firing"})
-              >= 1
-            for: 5m
-            labels:
-              severity: info
-              namespace: openshift-monitoring
-              managed_notification_template: UpgradeNodeDrainFailed
-              send_managed_notification: 'true'
-            annotations:
-              summary: Node drain failed in the given time period which is not caused
-                by the PDB
-              description: node drain takes too long and cannot be finished in the
-                given time period during cluster upgrade
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
As an SRE I want customers to be automatically informed when a cluster upgrade is stuck so that the customer knows an SRE is investigating into the matter. Below three alerts are going to send SL to CU  to notify them we are working on this as well as the alert comes out.
*UpgradeControlPlaneUpgradeTimeoutSRE*
*UpgradeNodeUpgradeTimeoutSRE*
*UpgradeNodeDrainFailedSRE*
### Which Jira/Github issue(s) this PR fixes?
[OSD-13323](https://issues.redhat.com/browse/OSD-13323) & [OSD-13454](https://issues.redhat.com/browse/OSD-13454)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
