### PR TITLE
[MTSRE-739] chore: provide mtsre the permissions to deal with OLM resources in the openshift-addon-operator ns

### DIFF
--- a/deploy/backplane/mtsre/10-mtsre-addon-operator-olm-apis.ClusterRole.yml
+++ b/deploy/backplane/mtsre/10-mtsre-addon-operator-olm-apis.ClusterRole.yml
@@ -1,17 +1,18 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: backplane-mtsre-addon-operator-admin
+  name: backplane-mtsre-addon-operator-olm-admin
 rules:
   - apiGroups:
-    - "addons.managed.openshift.io"
+    - operators.coreos.com
     resources:
-      - "addonoperators"
-      - "addons"
+    - clusterserviceversions
+    - installplans
+    - subscriptions
     verbs:
       - get
       - list
       - watch
       - patch
       - update
-
+      - delete

--- a/deploy/backplane/mtsre/20-mtsre-addon-operator.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/20-mtsre-addon-operator.SubjectPermission.yml
@@ -11,9 +11,11 @@ spec:
   - allowFirst: true
     clusterRoleName: admin
     namespacesAllowedRegex: (^openshift-addon-operator$)
-  permissions:
   - allowFirst: true
     clusterRoleName: backplane-mtsre-monitoring
+    namespacesAllowedRegex: (^openshift-addon-operator$)
+  - allowFirst: true
+    clusterRoleName: backplane-mtsre-addon-operator-olm-admin
     namespacesAllowedRegex: (^openshift-addon-operator$)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3459,6 +3459,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3510,7 +3528,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3552,6 +3576,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3603,7 +3645,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3645,6 +3693,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3696,7 +3762,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3738,6 +3810,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3789,7 +3879,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3831,6 +3927,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3882,7 +3996,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3924,6 +4044,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3975,7 +4113,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4017,6 +4161,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4068,7 +4230,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4110,6 +4278,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4161,7 +4347,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4203,6 +4395,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4254,7 +4464,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4296,6 +4512,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4347,7 +4581,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4389,6 +4629,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4440,7 +4698,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4482,6 +4746,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4533,7 +4815,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4575,6 +4863,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4626,7 +4932,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4668,6 +4980,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4719,7 +5049,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4761,6 +5097,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4812,7 +5166,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4854,6 +5214,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4905,7 +5283,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4947,6 +5331,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4998,7 +5400,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5040,6 +5448,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5091,7 +5517,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5133,6 +5565,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5184,7 +5634,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5226,6 +5682,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5277,7 +5751,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5319,6 +5799,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5370,7 +5868,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5412,6 +5916,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5463,7 +5985,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5505,6 +6033,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5556,7 +6102,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5598,6 +6150,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5649,7 +6219,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5691,6 +6267,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5742,7 +6336,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5784,6 +6384,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5835,7 +6453,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5877,6 +6501,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5928,7 +6570,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5970,6 +6618,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -6021,7 +6687,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3459,6 +3459,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3510,7 +3528,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3552,6 +3576,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3603,7 +3645,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3645,6 +3693,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3696,7 +3762,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3738,6 +3810,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3789,7 +3879,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3831,6 +3927,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3882,7 +3996,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3924,6 +4044,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3975,7 +4113,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4017,6 +4161,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4068,7 +4230,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4110,6 +4278,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4161,7 +4347,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4203,6 +4395,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4254,7 +4464,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4296,6 +4512,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4347,7 +4581,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4389,6 +4629,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4440,7 +4698,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4482,6 +4746,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4533,7 +4815,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4575,6 +4863,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4626,7 +4932,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4668,6 +4980,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4719,7 +5049,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4761,6 +5097,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4812,7 +5166,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4854,6 +5214,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4905,7 +5283,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4947,6 +5331,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4998,7 +5400,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5040,6 +5448,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5091,7 +5517,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5133,6 +5565,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5184,7 +5634,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5226,6 +5682,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5277,7 +5751,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5319,6 +5799,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5370,7 +5868,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5412,6 +5916,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5463,7 +5985,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5505,6 +6033,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5556,7 +6102,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5598,6 +6150,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5649,7 +6219,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5691,6 +6267,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5742,7 +6336,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5784,6 +6384,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5835,7 +6453,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5877,6 +6501,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5928,7 +6570,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5970,6 +6618,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -6021,7 +6687,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3459,6 +3459,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3510,7 +3528,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3552,6 +3576,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3603,7 +3645,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3645,6 +3693,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3696,7 +3762,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3738,6 +3810,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3789,7 +3879,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3831,6 +3927,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3882,7 +3996,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -3924,6 +4044,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -3975,7 +4113,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4017,6 +4161,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4068,7 +4230,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4110,6 +4278,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4161,7 +4347,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4203,6 +4395,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4254,7 +4464,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4296,6 +4512,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4347,7 +4581,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4389,6 +4629,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4440,7 +4698,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4482,6 +4746,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4533,7 +4815,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4575,6 +4863,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4626,7 +4932,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4668,6 +4980,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4719,7 +5049,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4761,6 +5097,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4812,7 +5166,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4854,6 +5214,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4905,7 +5283,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -4947,6 +5331,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -4998,7 +5400,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5040,6 +5448,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5091,7 +5517,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5133,6 +5565,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5184,7 +5634,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5226,6 +5682,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5277,7 +5751,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5319,6 +5799,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5370,7 +5868,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5412,6 +5916,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5463,7 +5985,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5505,6 +6033,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5556,7 +6102,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5598,6 +6150,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5649,7 +6219,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5691,6 +6267,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5742,7 +6336,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5784,6 +6384,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5835,7 +6453,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5877,6 +6501,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -5928,7 +6570,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre
@@ -5970,6 +6618,24 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
+        name: backplane-mtsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
         name: backplane-mtsre-monitoring
       rules:
       - apiGroups:
@@ -6021,7 +6687,13 @@ objects:
         - backplane-mtsre-readers-cluster
         permissions:
         - allowFirst: true
+          clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
           clusterRoleName: backplane-mtsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - allowFirst: true
+          clusterRoleName: backplane-mtsre-addon-operator-olm-admin
           namespacesAllowedRegex: (^openshift-addon-operator$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-mtsre


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

### What type of PR is this?
_(chore)_

### What this PR does / why we need it?

This PR makes the mt-sre team capable of having enough amount of backplane permissions to update CSV/Subscription/InstallPlan associated with addon-operator.

We need this because we have stumbled across multiple situations in the past where we needed to update such resources in certain customer clusters to mitigate issues like addon operator csv failures, OOMKills, etc. but the absence of such permissions slowed down the mitigation process tremendously.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/MTSRE-739

PS: this is well-scoped to the openshift-addon-operator namespace via the existing `SubjectPermission` defined in the PR