### PR TITLE
Allow dedicated-admins to manage catalogsources in openshift-marketplace

### DIFF
--- a/deploy/rbac-permissions-operator-config/20-dedicated-admins-marketplace.Role.yaml
+++ b/deploy/rbac-permissions-operator-config/20-dedicated-admins-marketplace.Role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dedicated-admins-openshift-marketplace
+  namespace: openshift-marketplace
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - "*"

--- a/deploy/rbac-permissions-operator-config/20-dedicated-admins-marketplace.RoleBinding.yaml
+++ b/deploy/rbac-permissions-operator-config/20-dedicated-admins-marketplace.RoleBinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dedicated-admins-openshift-marketplace
+  namespace: openshift-marketplace
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins
+- kind: Group
+  name: system:serviceaccounts:dedicated-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dedicated-admins-openshift-marketplace

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -16250,6 +16250,33 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshift-marketplace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
         name: dedicated-admins-openshift-dns
         namespace: openshift-dns
       rules:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -16250,6 +16250,33 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshift-marketplace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
         name: dedicated-admins-openshift-dns
         namespace: openshift-dns
       rules:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -16250,6 +16250,33 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        verbs:
+        - '*'
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: dedicated-admins-openshift-marketplace
+        namespace: openshift-marketplace
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
+      - kind: Group
+        name: system:serviceaccounts:dedicated-admin
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: dedicated-admins-openshift-marketplace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
         name: dedicated-admins-openshift-dns
         namespace: openshift-dns
       rules:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This PR adds RBAC for dedicated-admins to manage `catalogsources.operators.coreos.com` in the `openshift-marketplace` namespace.

### Which Jira/Github issue(s) this PR fixes?
fixes [OSD-13546](https://issues.redhat.com//browse/OSD-13546)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
