### PR TITLE
enable the size based retention for platform prometheus

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/cluster-monitoring-config.yaml
@@ -13,6 +13,7 @@ data:
           key: node-role.kubernetes.io/infra
           operator: Exists
       retention: 11d
+      retentionSize: 90GB
       volumeClaimTemplate:
         metadata:
           name: prometheus-data

--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -32,6 +32,7 @@ data:
           key: node-role.kubernetes.io/infra
           operator: Exists
       retention: 11d
+      retentionSize: 90GB
       volumeClaimTemplate:
         metadata:
           name: prometheus-data

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8195,14 +8195,15 @@ objects:
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \
-          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \ Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -8244,14 +8245,15 @@ objects:
       data:
         config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -8293,14 +8295,15 @@ objects:
       data:
         config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8195,14 +8195,15 @@ objects:
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \
-          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \ Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -8244,14 +8245,15 @@ objects:
       data:
         config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -8293,14 +8295,15 @@ objects:
       data:
         config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8195,14 +8195,15 @@ objects:
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
           \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n    \
-          \  name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \ Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -8244,14 +8245,15 @@ objects:
       data:
         config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
@@ -8293,14 +8295,15 @@ objects:
       data:
         config.yaml: "prometheusK8s:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  volumeClaimTemplate:\n    metadata:\n\
-          \      name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
-          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
-          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
-          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
           \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
           prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Set size based prometheus retention so that we won't need to be alerted for the prometheus PV disk full for large clusters.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #OSD-13455_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
