### PR TITLE
Add SREP architects alias and restrict approvals for backplane dir

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,3 +27,7 @@ aliases:
   sre-mst-observatorium:
     - jeremyeder
     - jharrington22
+  srep-architects
+    - jewzaam
+    - jharrington22
+    - cblecker

--- a/deploy/backplane/OWNERS
+++ b/deploy/backplane/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- srep-functional-leads
+- srep-team-leads
+approvers:
+- srep-team-leads
+- srep-architects
+options:
+  no_parent_owners: true


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This PR restricts approvals for backplane RBAC changes to SREP team leads and SREP architects only.

- Adds an `srep-architects` alias
- Adds an OWNERS file to the `deploy/backplane` dir restricting changes to TL's and Architects
