### PR TITLE
Scope down csa,csm,cse,mobb,tam permissions to use osd-readers

### DIFF
--- a/deploy/backplane/csa/10-csa-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/csa/10-csa-readers-cluster.ClusterRole.yml
@@ -1,14 +1,18 @@
+aggregationRule:
+  clusterRoleSelectors:
+    # aggregate all "view" scope rbac
+    - matchExpressions:
+        - key: rbac.authorization.k8s.io/aggregate-to-view
+          operator: In
+          values:
+            - "true"
+    - matchExpressions:
+        - key: managed.openshift.io/aggregate-to-backplane-csa
+          operator: In
+          values:
+            - "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: backplane-csa-readers-cluster
-rules:
-# TAM can get, list, and watch all resources
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+rules: []

--- a/deploy/backplane/cse/10-cse-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/cse/10-cse-readers-cluster.ClusterRole.yml
@@ -1,14 +1,18 @@
+aggregationRule:
+  clusterRoleSelectors:
+    # aggregate all "view" scope rbac
+    - matchExpressions:
+        - key: rbac.authorization.k8s.io/aggregate-to-view
+          operator: In
+          values:
+            - "true"
+    - matchExpressions:
+        - key: managed.openshift.io/aggregate-to-backplane-cse
+          operator: In
+          values:
+            - "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: backplane-cse-readers-cluster
-rules:
-# TAM can get, list, and watch all resources
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+rules: []

--- a/deploy/backplane/csm/10-csm-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/csm/10-csm-readers-cluster.ClusterRole.yml
@@ -1,14 +1,18 @@
+aggregationRule:
+  clusterRoleSelectors:
+    # aggregate all "view" scope rbac
+    - matchExpressions:
+        - key: rbac.authorization.k8s.io/aggregate-to-view
+          operator: In
+          values:
+            - "true"
+    - matchExpressions:
+        - key: managed.openshift.io/aggregate-to-backplane-csm
+          operator: In
+          values:
+            - "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: backplane-csm-readers-cluster
-rules:
-# TAM can get, list, and watch all resources
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+rules: []

--- a/deploy/backplane/mobb/10-mobb-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/mobb/10-mobb-readers-cluster.ClusterRole.yml
@@ -1,14 +1,18 @@
+aggregationRule:
+  clusterRoleSelectors:
+    # aggregate all "view" scope rbac
+    - matchExpressions:
+        - key: rbac.authorization.k8s.io/aggregate-to-view
+          operator: In
+          values:
+            - "true"
+    - matchExpressions:
+        - key: managed.openshift.io/aggregate-to-backplane-mobb
+          operator: In
+          values:
+            - "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: backplane-mobb-readers-cluster
-rules:
-# TAM can get, list, and watch all resources
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+rules: []

--- a/deploy/backplane/tam/10-tam-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/tam/10-tam-readers-cluster.ClusterRole.yml
@@ -1,14 +1,18 @@
+aggregationRule:
+  clusterRoleSelectors:
+    # aggregate all "view" scope rbac
+    - matchExpressions:
+        - key: rbac.authorization.k8s.io/aggregate-to-view
+          operator: In
+          values:
+            - "true"
+    - matchExpressions:
+        - key: managed.openshift.io/aggregate-to-backplane-tam
+          operator: In
+          values:
+            - "true"
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: backplane-tam-readers-cluster
-rules:
-# TAM can get, list, and watch all resources
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - get
-  - list
-  - watch
+rules: []

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -8,6 +8,13 @@ metadata:
     managed.openshift.io/aggregate-to-backplane-cee: "true"
     managed.openshift.io/aggregate-to-backplane-cssre: "true"
     managed.openshift.io/aggregate-to-backplane-srep: "true"
+    managed.openshift.io/aggregate-to-backplane-csa: "true"
+    managed.openshift.io/aggregate-to-backplane-cse: "true"
+    managed.openshift.io/aggregate-to-backplane-csm: "true"
+    managed.openshift.io/aggregate-to-backplane-mobb: "true"
+    managed.openshift.io/aggregate-to-backplane-tam: "true"
+    
+
   name: osd-readers-aggregate
 rules:
 - apiGroups:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -831,19 +831,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-csa
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-csa
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-csa-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -873,19 +877,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-cse
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-cse
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-cse-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -915,19 +923,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-csm
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-csm
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-csm-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -3397,19 +3409,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-mobb
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-mobb
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-mobb-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -7679,19 +7695,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-tam
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-tam
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-tam-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -15951,6 +15971,11 @@ objects:
           managed.openshift.io/aggregate-to-backplane-cee: 'true'
           managed.openshift.io/aggregate-to-backplane-cssre: 'true'
           managed.openshift.io/aggregate-to-backplane-srep: 'true'
+          managed.openshift.io/aggregate-to-backplane-csa: 'true'
+          managed.openshift.io/aggregate-to-backplane-cse: 'true'
+          managed.openshift.io/aggregate-to-backplane-csm: 'true'
+          managed.openshift.io/aggregate-to-backplane-mobb: 'true'
+          managed.openshift.io/aggregate-to-backplane-tam: 'true'
         name: osd-readers-aggregate
       rules:
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -831,19 +831,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-csa
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-csa
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-csa-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -873,19 +877,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-cse
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-cse
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-cse-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -915,19 +923,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-csm
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-csm
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-csm-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -3397,19 +3409,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-mobb
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-mobb
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-mobb-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -7679,19 +7695,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-tam
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-tam
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-tam-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -15951,6 +15971,11 @@ objects:
           managed.openshift.io/aggregate-to-backplane-cee: 'true'
           managed.openshift.io/aggregate-to-backplane-cssre: 'true'
           managed.openshift.io/aggregate-to-backplane-srep: 'true'
+          managed.openshift.io/aggregate-to-backplane-csa: 'true'
+          managed.openshift.io/aggregate-to-backplane-cse: 'true'
+          managed.openshift.io/aggregate-to-backplane-csm: 'true'
+          managed.openshift.io/aggregate-to-backplane-mobb: 'true'
+          managed.openshift.io/aggregate-to-backplane-tam: 'true'
         name: osd-readers-aggregate
       rules:
       - apiGroups:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -831,19 +831,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-csa
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-csa
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-csa-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -873,19 +877,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-cse
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-cse
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-cse-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -915,19 +923,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-csm
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-csm
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-csm-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -3397,19 +3409,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-mobb
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-mobb
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-mobb-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -7679,19 +7695,23 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-backplane-tam
-    - apiVersion: rbac.authorization.k8s.io/v1
+    - aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: rbac.authorization.k8s.io/aggregate-to-view
+            operator: In
+            values:
+            - 'true'
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-backplane-tam
+            operator: In
+            values:
+            - 'true'
+      apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
         name: backplane-tam-readers-cluster
-      rules:
-      - apiGroups:
-        - '*'
-        resources:
-        - '*'
-        verbs:
-        - get
-        - list
-        - watch
+      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -15951,6 +15971,11 @@ objects:
           managed.openshift.io/aggregate-to-backplane-cee: 'true'
           managed.openshift.io/aggregate-to-backplane-cssre: 'true'
           managed.openshift.io/aggregate-to-backplane-srep: 'true'
+          managed.openshift.io/aggregate-to-backplane-csa: 'true'
+          managed.openshift.io/aggregate-to-backplane-cse: 'true'
+          managed.openshift.io/aggregate-to-backplane-csm: 'true'
+          managed.openshift.io/aggregate-to-backplane-mobb: 'true'
+          managed.openshift.io/aggregate-to-backplane-tam: 'true'
         name: osd-readers-aggregate
       rules:
       - apiGroups:


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?

The current scope of the clusterroles for CSA, CSM, CSE, MOBB and TAM is too permissive. This PR scopes down these users to use `osd-readers` instead