### PR TITLE
OSD-13445: adds vpceacceptance objects for FedRAMP

### DIFF
--- a/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-east-1.yaml
+++ b/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-east-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: osd-fr-splunk-acceptance
   namespace: openshift-aws-vpce-operator
 spec:
-  id: "vpce-svc-0838533cd2d6d2b8b"
+  id: "${FR_SPLUNK_GOVEAST_VPCE_SERVICE_ID}"
   assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
   region: "us-gov-east-1"
   acceptanceCriteria:

--- a/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-east-1.yaml
+++ b/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-east-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: avo.openshift.io/v1alpha1
+kind: VpcEndpointAcceptance
+metadata:
+  name: osd-fr-splunk-acceptance
+  namespace: openshift-aws-vpce-operator
+spec:
+  id: "vpce-svc-0838533cd2d6d2b8b"
+  assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+  region: "us-gov-east-1"
+  acceptanceCriteria:
+    awsAccountOperatorAccount:
+      namespace: aws-account-operator

--- a/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-west-1.yaml
+++ b/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-west-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: avo.openshift.io/v1alpha1
+kind: VpcEndpointAcceptance
+metadata:
+  name: osd-fr-splunk-acceptance
+  namespace: openshift-aws-vpce-operator
+spec:
+  id: "vpce-svc-06225ed6e3620e8e1"
+  assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+  region: "us-gov-west-1"
+  acceptanceCriteria:
+    awsAccountOperatorAccount:
+      namespace: aws-account-operator

--- a/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-west-1.yaml
+++ b/deploy/osd-avo-resources/fedramp-vpce-acceptance/00-osd-avo-vpcendpointacceptance-us-gov-west-1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: osd-fr-splunk-acceptance
   namespace: openshift-aws-vpce-operator
 spec:
-  id: "vpce-svc-06225ed6e3620e8e1"
+  id: "${FR_SPLUNK_GOVWEST_VPCE_SERVICE_ID}"
   assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
   region: "us-gov-west-1"
   acceptanceCriteria:

--- a/deploy/osd-avo-resources/fedramp-vpce-acceptance/config.yaml
+++ b/deploy/osd-avo-resources/fedramp-vpce-acceptance/config.yaml
@@ -1,0 +1,11 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: In
+    values:
+      - "true"
+  - key: ext-managed.openshift.io/hive-shard
+    operator: In
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9906,7 +9906,7 @@ objects:
         name: osd-fr-splunk-acceptance
         namespace: openshift-aws-vpce-operator
       spec:
-        id: vpce-svc-0838533cd2d6d2b8b
+        id: ${FR_SPLUNK_GOVEAST_VPCE_SERVICE_ID}
         assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
         region: us-gov-east-1
         acceptanceCriteria:
@@ -9918,7 +9918,7 @@ objects:
         name: osd-fr-splunk-acceptance
         namespace: openshift-aws-vpce-operator
       spec:
-        id: vpce-svc-06225ed6e3620e8e1
+        id: ${FR_SPLUNK_GOVWEST_VPCE_SERVICE_ID}
         assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
         region: us-gov-west-1
         acceptanceCriteria:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9884,6 +9884,53 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-avo-resources-fedramp-vpce-acceptance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: avo.openshift.io/v1alpha1
+      kind: VpcEndpointAcceptance
+      metadata:
+        name: osd-fr-splunk-acceptance
+        namespace: openshift-aws-vpce-operator
+      spec:
+        id: vpce-svc-0838533cd2d6d2b8b
+        assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+        region: us-gov-east-1
+        acceptanceCriteria:
+          awsAccountOperatorAccount:
+            namespace: aws-account-operator
+    - apiVersion: avo.openshift.io/v1alpha1
+      kind: VpcEndpointAcceptance
+      metadata:
+        name: osd-fr-splunk-acceptance
+        namespace: openshift-aws-vpce-operator
+      spec:
+        id: vpce-svc-06225ed6e3620e8e1
+        assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+        region: us-gov-west-1
+        acceptanceCriteria:
+          awsAccountOperatorAccount:
+            namespace: aws-account-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-avo-resources-us-gov-east-1
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9906,7 +9906,7 @@ objects:
         name: osd-fr-splunk-acceptance
         namespace: openshift-aws-vpce-operator
       spec:
-        id: vpce-svc-0838533cd2d6d2b8b
+        id: ${FR_SPLUNK_GOVEAST_VPCE_SERVICE_ID}
         assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
         region: us-gov-east-1
         acceptanceCriteria:
@@ -9918,7 +9918,7 @@ objects:
         name: osd-fr-splunk-acceptance
         namespace: openshift-aws-vpce-operator
       spec:
-        id: vpce-svc-06225ed6e3620e8e1
+        id: ${FR_SPLUNK_GOVWEST_VPCE_SERVICE_ID}
         assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
         region: us-gov-west-1
         acceptanceCriteria:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9884,6 +9884,53 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-avo-resources-fedramp-vpce-acceptance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: avo.openshift.io/v1alpha1
+      kind: VpcEndpointAcceptance
+      metadata:
+        name: osd-fr-splunk-acceptance
+        namespace: openshift-aws-vpce-operator
+      spec:
+        id: vpce-svc-0838533cd2d6d2b8b
+        assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+        region: us-gov-east-1
+        acceptanceCriteria:
+          awsAccountOperatorAccount:
+            namespace: aws-account-operator
+    - apiVersion: avo.openshift.io/v1alpha1
+      kind: VpcEndpointAcceptance
+      metadata:
+        name: osd-fr-splunk-acceptance
+        namespace: openshift-aws-vpce-operator
+      spec:
+        id: vpce-svc-06225ed6e3620e8e1
+        assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+        region: us-gov-west-1
+        acceptanceCriteria:
+          awsAccountOperatorAccount:
+            namespace: aws-account-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-avo-resources-us-gov-east-1
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9906,7 +9906,7 @@ objects:
         name: osd-fr-splunk-acceptance
         namespace: openshift-aws-vpce-operator
       spec:
-        id: vpce-svc-0838533cd2d6d2b8b
+        id: ${FR_SPLUNK_GOVEAST_VPCE_SERVICE_ID}
         assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
         region: us-gov-east-1
         acceptanceCriteria:
@@ -9918,7 +9918,7 @@ objects:
         name: osd-fr-splunk-acceptance
         namespace: openshift-aws-vpce-operator
       spec:
-        id: vpce-svc-06225ed6e3620e8e1
+        id: ${FR_SPLUNK_GOVWEST_VPCE_SERVICE_ID}
         assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
         region: us-gov-west-1
         acceptanceCriteria:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9884,6 +9884,53 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-avo-resources-fedramp-vpce-acceptance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: avo.openshift.io/v1alpha1
+      kind: VpcEndpointAcceptance
+      metadata:
+        name: osd-fr-splunk-acceptance
+        namespace: openshift-aws-vpce-operator
+      spec:
+        id: vpce-svc-0838533cd2d6d2b8b
+        assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+        region: us-gov-east-1
+        acceptanceCriteria:
+          awsAccountOperatorAccount:
+            namespace: aws-account-operator
+    - apiVersion: avo.openshift.io/v1alpha1
+      kind: VpcEndpointAcceptance
+      metadata:
+        name: osd-fr-splunk-acceptance
+        namespace: openshift-aws-vpce-operator
+      spec:
+        id: vpce-svc-06225ed6e3620e8e1
+        assumeRoleArn: ${FR_SPLUNK_VPCE_ACCEPTANCE_ARN}
+        region: us-gov-west-1
+        acceptanceCriteria:
+          awsAccountOperatorAccount:
+            namespace: aws-account-operator
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-avo-resources-us-gov-east-1
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature

### What this PR does / why we need it?
This PR adds aws-vpce-operator VpcEndpointAcceptance objects to be deployed to FedRAMP hives to handle auto-acceptance of vpce endpoints in new customer clusters for Splunk. This allows us to forward audit logging in a Privatelink network from customer clusters to the FedRAMP splunk instance. Each hive should get a CR for each region to ensure all customer clusters in east and west are setup for logging.

Note, the `assumeRoleArn` and vpce service `id` have been converted to a variable that will be passed via saas file in the FedRAMP  gitlab instance. This seemed like it might be Fedramp-team-eyes-only sensitive data, so I converted it to variable. 

### Which Jira/Github issue(s) this PR fixes?
[OSD-13445](https://issues.redhat.com/browse/OSD-13445)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
