### PR TITLE
adding a new recording rule sre:sla:outage_minutes_28d

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -16,7 +16,7 @@ data:
           writeRelabelConfigs:
           - sourceLabels: [__name__]
             action: keep
-            regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total)'
+            regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_minutes_28d)'
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
@@ -18,3 +18,5 @@ spec:
           record: sre:slo:imageregistry_http_requests_total
         - expr: label_replace(sum by (code, verb, subresource) (oauth_server_requests_total), "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version) sre:telemetry:managed_labels
           record: sre:slo:oauth_server_requests_total
+        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(sum_over_time(((count((sum(rate(apiserver_request_total{job="apiserver", code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m]))) == 1)*(count((sum(rate(apiserver_request_total{job="apiserver", code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m]))) == 1)/2+4.5*(1-(count(sum(rate(apiserver_request_total{job="apiserver", code=~"(400|5..)"}[5m] offset 30s))/sum(rate(apiserver_request_total{job="apiserver"}[5m] offset 30s)) == 1) or vector(0))))) or vector(0))[4w:30s]), "sre", "true", "", "")
+          record: sre:sla:outage_minutes_28d

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8209,7 +8209,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_minutes_28d)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
@@ -17890,6 +17890,14 @@ objects:
               "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
               sre:telemetry:managed_labels
             record: sre:slo:oauth_server_requests_total
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(sum_over_time(((count((sum(rate(apiserver_request_total{job="apiserver",
+              code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m])))
+              == 1)*(count((sum(rate(apiserver_request_total{job="apiserver", code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m])))
+              == 1)/2+4.5*(1-(count(sum(rate(apiserver_request_total{job="apiserver",
+              code=~"(400|5..)"}[5m] offset 30s))/sum(rate(apiserver_request_total{job="apiserver"}[5m]
+              offset 30s)) == 1) or vector(0))))) or vector(0))[4w:30s]), "sre", "true",
+              "", "")
+            record: sre:sla:outage_minutes_28d
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8209,7 +8209,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_minutes_28d)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
@@ -17890,6 +17890,14 @@ objects:
               "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
               sre:telemetry:managed_labels
             record: sre:slo:oauth_server_requests_total
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(sum_over_time(((count((sum(rate(apiserver_request_total{job="apiserver",
+              code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m])))
+              == 1)*(count((sum(rate(apiserver_request_total{job="apiserver", code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m])))
+              == 1)/2+4.5*(1-(count(sum(rate(apiserver_request_total{job="apiserver",
+              code=~"(400|5..)"}[5m] offset 30s))/sum(rate(apiserver_request_total{job="apiserver"}[5m]
+              offset 30s)) == 1) or vector(0))))) or vector(0))[4w:30s]), "sre", "true",
+              "", "")
+            record: sre:sla:outage_minutes_28d
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8209,7 +8209,7 @@ objects:
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total)'\n\
+          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_minutes_28d)'\n\
           \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
           \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
           \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
@@ -17890,6 +17890,14 @@ objects:
               "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)
               sre:telemetry:managed_labels
             record: sre:slo:oauth_server_requests_total
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(sum_over_time(((count((sum(rate(apiserver_request_total{job="apiserver",
+              code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m])))
+              == 1)*(count((sum(rate(apiserver_request_total{job="apiserver", code=~"(400|5..)"}[5m]))/sum(rate(apiserver_request_total{job="apiserver"}[5m])))
+              == 1)/2+4.5*(1-(count(sum(rate(apiserver_request_total{job="apiserver",
+              code=~"(400|5..)"}[5m] offset 30s))/sum(rate(apiserver_request_total{job="apiserver"}[5m]
+              offset 30s)) == 1) or vector(0))))) or vector(0))[4w:30s]), "sre", "true",
+              "", "")
+            record: sre:sla:outage_minutes_28d
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
new recording rule to record the number of minutes of outage that counts towards the contractual SLA over a 28d/4w rolling window
