### PR TITLE
allow dedicated admin to create consoleplugin resource and enable/dis…

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -316,3 +316,22 @@ rules:
   - list
   - watch
 ### END
+### Start - allow dedicated admin to create consoleplugin resource and enable/disable console plugin in the cluster
+# https://issues.redhat.com/browse/OSD-13617
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - consoleplugins
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - consoles
+  verbs:
+  - patch
+  - update
+### END

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -15828,6 +15828,22 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - consoleplugins
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - consoles
+        verbs:
+        - patch
+        - update
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -15828,6 +15828,22 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - consoleplugins
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - consoles
+        verbs:
+        - patch
+        - update
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -15828,6 +15828,22 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - consoleplugins
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - consoles
+        verbs:
+        - patch
+        - update
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Add role required for dedicated admin 
- To create and delete consoleplugin resource
- To enable and disable consoleplugin in the cluster

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-13617](https://issues.redhat.com/browse/OSD-13617)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR