### PR TITLE
[OSD-13577] Allow SRE-P to use must-gather-operator without cluster admin elevation

### DIFF
--- a/deploy/backplane/srep/10-srep-mustgather.Role.yml
+++ b/deploy/backplane/srep/10-srep-mustgather.Role.yml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-srep-mustgather
+  namespace: openshift-must-gather-operator
+rules:
+# can create cred secret for mustgathers
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+# can create mustgathers CR
+- apiGroups:
+  - managed.openshift.io
+  resources:
+  - mustgathers
+  verbs:
+  - create
+  - delete
+### END

--- a/deploy/backplane/srep/20-srep-mustgather.RoleBinding.yml
+++ b/deploy/backplane/srep/20-srep-mustgather.RoleBinding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-srep-mustgather
+  namespace: openshift-must-gather-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-srep-mustgather
+  namespace: openshift-must-gather-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7519,6 +7519,25 @@ objects:
         verbs:
         - patch
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
       aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:
@@ -7546,6 +7565,20 @@ objects:
       subjects:
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7519,6 +7519,25 @@ objects:
         verbs:
         - patch
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
       aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:
@@ -7546,6 +7565,20 @@ objects:
       subjects:
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7519,6 +7519,25 @@ objects:
         verbs:
         - patch
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
       aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:
@@ -7546,6 +7565,20 @@ objects:
       subjects:
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-mustgather
+        namespace: openshift-must-gather-operator
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Allows SRE-P to create mustgather CRs and secret under `openshift-must-gather-operator` namespace to be able to get must gather from cluster using must gather operator wihout elevating to cluster admin

### Which Jira/Github issue(s) this PR fixes?

_Fixes # https://issues.redhat.com/browse/OSD-13577_

### Special notes for your reviewer:
This is a similar permission to what MCS team already have [20-cee-mustgather.Role.yml](https://github.com/openshift/managed-cluster-config/blob/master/deploy/backplane/cee/20-cee-mustgather.Role.yml) and [30-cee-mustgather.RoleBinding.yml](https://github.com/openshift/managed-cluster-config/blob/master/deploy/backplane/cee/30-cee-mustgather.RoleBinding.yml)

Mainly to avoid audit tickets as getting must-gather from a cluster should be standard SRE action.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
