### PR TITLE
Add Hypershift HCP pod based alert.

### DIFF
--- a/deploy/sre-prometheus/hypershift-management-cluster/100-sre-hcp-pods.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/hypershift-management-cluster/100-sre-hcp-pods.PrometheusRule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-hcp-pods
+    role: alert-rules
+  name: sre-hcp-pods
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-hcp-pods
+    rules:
+    - alert: HCPKubeApiserverNotAlive
+      annotations:
+        message: No lively kube-apiserver- pods for at least 15min
+      expr: (group by (namespace) (kube_pod_info{namespace=~"clusters-.*", pod=~"kube-apiserver-.*"})) unless on(namespace) (group by (namespace) (prober_probe_total{probe_type="Liveness", namespace=~"clusters-.*", pod=~"kube-apiserver-.*"}))
+      for: 15m
+      labels:
+        namespace: openshift-monitoring
+        prometheus: openshift-monitoring/k8s
+        severity: critical

--- a/deploy/sre-prometheus/hypershift-management-cluster/README.md
+++ b/deploy/sre-prometheus/hypershift-management-cluster/README.md
@@ -1,0 +1,1 @@
+Resources deployed only to the Hypershift Management Clusters.

--- a/deploy/sre-prometheus/hypershift-management-cluster/config.yaml
+++ b/deploy/sre-prometheus/hypershift-management-cluster/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+    matchExpressions:
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/managed
+      operator: In
+      values: ["true"]
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -18281,6 +18281,56 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-hcp-pods
+          role: alert-rules
+        name: sre-hcp-pods
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-hcp-pods
+          rules:
+          - alert: HCPKubeApiserverNotAlive
+            annotations:
+              message: No lively kube-apiserver- pods for at least 15min
+            expr: (group by (namespace) (kube_pod_info{namespace=~"clusters-.*", pod=~"kube-apiserver-.*"}))
+              unless on(namespace) (group by (namespace) (prober_probe_total{probe_type="Liveness",
+              namespace=~"clusters-.*", pod=~"kube-apiserver-.*"}))
+            for: 15m
+            labels:
+              namespace: openshift-monitoring
+              prometheus: openshift-monitoring/k8s
+              severity: critical
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -18281,6 +18281,56 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-hcp-pods
+          role: alert-rules
+        name: sre-hcp-pods
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-hcp-pods
+          rules:
+          - alert: HCPKubeApiserverNotAlive
+            annotations:
+              message: No lively kube-apiserver- pods for at least 15min
+            expr: (group by (namespace) (kube_pod_info{namespace=~"clusters-.*", pod=~"kube-apiserver-.*"}))
+              unless on(namespace) (group by (namespace) (prober_probe_total{probe_type="Liveness",
+              namespace=~"clusters-.*", pod=~"kube-apiserver-.*"}))
+            for: 15m
+            labels:
+              namespace: openshift-monitoring
+              prometheus: openshift-monitoring/k8s
+              severity: critical
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -18281,6 +18281,56 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/managed
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-hcp-pods
+          role: alert-rules
+        name: sre-hcp-pods
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-hcp-pods
+          rules:
+          - alert: HCPKubeApiserverNotAlive
+            annotations:
+              message: No lively kube-apiserver- pods for at least 15min
+            expr: (group by (namespace) (kube_pod_info{namespace=~"clusters-.*", pod=~"kube-apiserver-.*"}))
+              unless on(namespace) (group by (namespace) (prober_probe_total{probe_type="Liveness",
+              namespace=~"clusters-.*", pod=~"kube-apiserver-.*"}))
+            for: 15m
+            labels:
+              namespace: openshift-monitoring
+              prometheus: openshift-monitoring/k8s
+              severity: critical
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
This PR adds an alert to prometheus-k8s on all Hypershift Management Clusters which should detect issues with kube-apiserver pods of the HCPs.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-12616_

### Special notes for your reviewer:
SOP will be written in [OSD-12894](https://issues.redhat.com/browse/OSD-12894).
This alert is based on liveness prober_probes_total metric which is available on the prometheus-k8s, and it's supposed to reflect something similar to DMS from standard OSD clusters (when the hosted control plane doesn't respond).
Most other HCP monitoring (HCP Services for example) will be monitored with RHOBS via prometheus-user-workload-monitoring.

The namespace label is overwritten to enable Pager Duty alerts.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [/] Included documentation changes with PR - SOP in a separate ticket
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```