### PR TITLE
New task to reschedule pods from 'openshift-' namespaces which aren't on infra nodes

### DIFF
--- a/deploy/osd-rebalance-infra-nodes/06-osd-rebalance-infra-nodes-openshift-pod-rebalance.ClusterRole.yaml
+++ b/deploy/osd-rebalance-infra-nodes/06-osd-rebalance-infra-nodes-openshift-pod-rebalance.ClusterRole.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/osd-rebalance-infra-nodes/06-osd-rebalance-infra-nodes-openshift-pod-rebalance.RoleBinding.yaml
+++ b/deploy/osd-rebalance-infra-nodes/06-osd-rebalance-infra-nodes-openshift-pod-rebalance.RoleBinding.yaml
@@ -1,0 +1,182 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-image-registry
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-cloud-ingress-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-custom-domains-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-managed-node-metadata-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-monitoring
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-must-gather-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-network-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-ocm-agent-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-osd-metrics
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-rbac-permissions
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-route-monitor-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-splunk-forwarder-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+  namespace: openshift-velero
+subjects:
+- kind: ServiceAccount
+  name: osd-rebalance-infra-nodes
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-rebalance-infra-nodes-openshift-pod-rebalance

--- a/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
+++ b/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
@@ -100,6 +100,25 @@ data:
       done
     }
 
+    # infraPodsMisscheduled finds pods from openshift- namespaces which are not scheduled on infra node 
+    #    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution for infra nodes
+    # Notes: this is done as a response to an escalation in https://issues.redhat.com/browse/OSD-13621 
+    # A long term fix will follow 
+    infraPodsMisscheduled(){
+        NODE_TAINT="node-role.kubernetes.io=infra"
+        # The 'none' at the end accounts for pods which are currently being scheduled.
+        # we do not want to reschedule them before knowing where they landed
+        # the output will look like "<node1>|<node2>|none"
+        infranodes_regexp="$(oc get no -l "${NODE_TAINT}" -o go-template='{{range .items}}{{.metadata.name}}{{"|"}}{{end}}')none"
+        
+        # the output will look something like
+        # <namespace> | <pod> | <affinity> | <node>
+        # each pod on the list needs to be rescheduled
+        misscheduled_pods=`for ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob := index .metadata.labels "job-name"}}{{$namespace := .metadata.namespace}}{{$name := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}} | {{.spec.nodeName}} {{"\n" -}} {{end}}{{end}}{{end}}';done |grep "node-role.kubernetes.io/infra" |grep -vE ${infranodes_regexp}`
+    
+        while read line ; do cmd=`echo $line|awk -F'|' '{print "oc -n " $1 " delete po " $2}'`;echo "INFO: $cmd"; eval $cmd;done <<< "$misscheduled_pods"
+    }
+
     echo "INFO: Rebalancing openshift-dns/dns-default Daemonset..."
     kubeDaemonsetMisscheduled "openshift-dns" "dns.operator.openshift.io/daemonset-dns=default"
 
@@ -152,3 +171,6 @@ data:
 
     echo "INFO: Wait for running splunk-heavy-forwarder pods..."
     waitRunningPods splunk-heavy-forwarder openshift-security name
+
+    echo "INFO: Rebalancing misscheduled pods from openshift- namespaces"
+    infraPodsMisscheduled  openshift-cloud-ingress-operator openshift-custom-domains-operator openshift-image-registry openshift-managed-node-metadata-operator openshift-monitoring openshift-must-gather-operator openshift-network-operator openshift-ocm-agent-operator openshift-osd-metrics openshift-rbac-permissions openshift-route-monitor-operator openshift-splunk-forwarder-operator openshift-velero

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13996,6 +13996,188 @@ objects:
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-security
         namespace: openshift-security
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-image-registry
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-cloud-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-custom-domains-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-managed-node-metadata-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-network-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-osd-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-rbac-permissions
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-splunk-forwarder-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -14052,8 +14234,29 @@ objects:
           \"\\n\\\"}}{{end}}{{end}}\")\";\n    for pod in \"${misscheduled_pods[@]}\"\
           ; do\n      if [[ -n \"${pod}\" ]]; then\n        echo \"Deleting misscheduled\
           \ pod ${pod} running on ${node}\"\n        oc delete po -n \"${NS}\" \"\
-          ${pod}\"\n      fi\n    done\n  done\n}\n\necho \"INFO: Rebalancing openshift-dns/dns-default\
-          \ Daemonset...\"\nkubeDaemonsetMisscheduled \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\
+          ${pod}\"\n      fi\n    done\n  done\n}\n\n# infraPodsMisscheduled finds\
+          \ pods from openshift- namespaces which are not scheduled on infra node\
+          \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
+          \ for infra nodes\n# Notes: this is done as a response to an escalation\
+          \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
+          \ follow \ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
+          \n    # The 'none' at the end accounts for pods which are currently being\
+          \ scheduled.\n    # we do not want to reschedule them before knowing where\
+          \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
+          \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
+          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    # the output\
+          \ will look something like\n    # <namespace> | <pod> | <affinity> | <node>\n\
+          \    # each pod on the list needs to be rescheduled\n    misscheduled_pods=`for\
+          \ ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
+          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}';done |grep \"\
+          node-role.kubernetes.io/infra\" |grep -vE ${infranodes_regexp}`\n\n    while\
+          \ read line ; do cmd=`echo $line|awk -F'|' '{print \"oc -n \" $1 \" delete\
+          \ po \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<< \"$misscheduled_pods\"\
+          \n}\n\necho \"INFO: Rebalancing openshift-dns/dns-default Daemonset...\"\
+          \nkubeDaemonsetMisscheduled \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\
           \n\necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
           \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
           \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
@@ -14080,7 +14283,13 @@ objects:
           \ prometheus openshift-user-workload-monitoring app\n\necho \"INFO: Wait\
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
-          waitRunningPods splunk-heavy-forwarder openshift-security name"
+          waitRunningPods splunk-heavy-forwarder openshift-security name\n\necho \"\
+          INFO: Rebalancing misscheduled pods from openshift- namespaces\"\ninfraPodsMisscheduled\
+          \  openshift-cloud-ingress-operator openshift-custom-domains-operator openshift-image-registry\
+          \ openshift-managed-node-metadata-operator openshift-monitoring openshift-must-gather-operator\
+          \ openshift-network-operator openshift-ocm-agent-operator openshift-osd-metrics\
+          \ openshift-rbac-permissions openshift-route-monitor-operator openshift-splunk-forwarder-operator\
+          \ openshift-velero"
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13996,6 +13996,188 @@ objects:
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-security
         namespace: openshift-security
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-image-registry
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-cloud-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-custom-domains-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-managed-node-metadata-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-network-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-osd-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-rbac-permissions
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-splunk-forwarder-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -14052,8 +14234,29 @@ objects:
           \"\\n\\\"}}{{end}}{{end}}\")\";\n    for pod in \"${misscheduled_pods[@]}\"\
           ; do\n      if [[ -n \"${pod}\" ]]; then\n        echo \"Deleting misscheduled\
           \ pod ${pod} running on ${node}\"\n        oc delete po -n \"${NS}\" \"\
-          ${pod}\"\n      fi\n    done\n  done\n}\n\necho \"INFO: Rebalancing openshift-dns/dns-default\
-          \ Daemonset...\"\nkubeDaemonsetMisscheduled \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\
+          ${pod}\"\n      fi\n    done\n  done\n}\n\n# infraPodsMisscheduled finds\
+          \ pods from openshift- namespaces which are not scheduled on infra node\
+          \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
+          \ for infra nodes\n# Notes: this is done as a response to an escalation\
+          \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
+          \ follow \ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
+          \n    # The 'none' at the end accounts for pods which are currently being\
+          \ scheduled.\n    # we do not want to reschedule them before knowing where\
+          \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
+          \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
+          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    # the output\
+          \ will look something like\n    # <namespace> | <pod> | <affinity> | <node>\n\
+          \    # each pod on the list needs to be rescheduled\n    misscheduled_pods=`for\
+          \ ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
+          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}';done |grep \"\
+          node-role.kubernetes.io/infra\" |grep -vE ${infranodes_regexp}`\n\n    while\
+          \ read line ; do cmd=`echo $line|awk -F'|' '{print \"oc -n \" $1 \" delete\
+          \ po \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<< \"$misscheduled_pods\"\
+          \n}\n\necho \"INFO: Rebalancing openshift-dns/dns-default Daemonset...\"\
+          \nkubeDaemonsetMisscheduled \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\
           \n\necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
           \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
           \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
@@ -14080,7 +14283,13 @@ objects:
           \ prometheus openshift-user-workload-monitoring app\n\necho \"INFO: Wait\
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
-          waitRunningPods splunk-heavy-forwarder openshift-security name"
+          waitRunningPods splunk-heavy-forwarder openshift-security name\n\necho \"\
+          INFO: Rebalancing misscheduled pods from openshift- namespaces\"\ninfraPodsMisscheduled\
+          \  openshift-cloud-ingress-operator openshift-custom-domains-operator openshift-image-registry\
+          \ openshift-managed-node-metadata-operator openshift-monitoring openshift-must-gather-operator\
+          \ openshift-network-operator openshift-ocm-agent-operator openshift-osd-metrics\
+          \ openshift-rbac-permissions openshift-route-monitor-operator openshift-splunk-forwarder-operator\
+          \ openshift-velero"
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13996,6 +13996,188 @@ objects:
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-security
         namespace: openshift-security
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-image-registry
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-cloud-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-custom-domains-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-managed-node-metadata-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-network-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-osd-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-rbac-permissions
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-splunk-forwarder-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: osd-rebalance-infra-nodes
+        namespace: openshift-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-rebalance-infra-nodes-openshift-pod-rebalance
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -14052,8 +14234,29 @@ objects:
           \"\\n\\\"}}{{end}}{{end}}\")\";\n    for pod in \"${misscheduled_pods[@]}\"\
           ; do\n      if [[ -n \"${pod}\" ]]; then\n        echo \"Deleting misscheduled\
           \ pod ${pod} running on ${node}\"\n        oc delete po -n \"${NS}\" \"\
-          ${pod}\"\n      fi\n    done\n  done\n}\n\necho \"INFO: Rebalancing openshift-dns/dns-default\
-          \ Daemonset...\"\nkubeDaemonsetMisscheduled \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\
+          ${pod}\"\n      fi\n    done\n  done\n}\n\n# infraPodsMisscheduled finds\
+          \ pods from openshift- namespaces which are not scheduled on infra node\
+          \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
+          \ for infra nodes\n# Notes: this is done as a response to an escalation\
+          \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
+          \ follow \ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
+          \n    # The 'none' at the end accounts for pods which are currently being\
+          \ scheduled.\n    # we do not want to reschedule them before knowing where\
+          \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
+          \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
+          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    # the output\
+          \ will look something like\n    # <namespace> | <pod> | <affinity> | <node>\n\
+          \    # each pod on the list needs to be rescheduled\n    misscheduled_pods=`for\
+          \ ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
+          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}';done |grep \"\
+          node-role.kubernetes.io/infra\" |grep -vE ${infranodes_regexp}`\n\n    while\
+          \ read line ; do cmd=`echo $line|awk -F'|' '{print \"oc -n \" $1 \" delete\
+          \ po \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<< \"$misscheduled_pods\"\
+          \n}\n\necho \"INFO: Rebalancing openshift-dns/dns-default Daemonset...\"\
+          \nkubeDaemonsetMisscheduled \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\
           \n\necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
           \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
           \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
@@ -14080,7 +14283,13 @@ objects:
           \ prometheus openshift-user-workload-monitoring app\n\necho \"INFO: Wait\
           \ for running alertmanager pods...\"\nwaitRunningPods alertmanager openshift-monitoring\
           \ app\n\necho \"INFO: Wait for running splunk-heavy-forwarder pods...\"\n\
-          waitRunningPods splunk-heavy-forwarder openshift-security name"
+          waitRunningPods splunk-heavy-forwarder openshift-security name\n\necho \"\
+          INFO: Rebalancing misscheduled pods from openshift- namespaces\"\ninfraPodsMisscheduled\
+          \  openshift-cloud-ingress-operator openshift-custom-domains-operator openshift-image-registry\
+          \ openshift-managed-node-metadata-operator openshift-monitoring openshift-must-gather-operator\
+          \ openshift-network-operator openshift-ocm-agent-operator openshift-osd-metrics\
+          \ openshift-rbac-permissions openshift-route-monitor-operator openshift-splunk-forwarder-operator\
+          \ openshift-velero"
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
In [OSD-13621](https://issues.redhat.com/browse/OSD-13621) Customers are reporting (and complaining) that some of our operators in `openshift-*` are wrongfully scheduled on workers instead of infra nodes, reducing their available capacity.
The investigation has shown that this is due to the usage of `preferredDuringSchedulingIgnoredDuringExecution` in the node affinity, which will allow the pods to be scheduled on workers if the infra nodes don't exist yet. 

While the node affinity gets corrected, this PR intends to be a workaround (similar to [#1305](https://github.com/openshift/managed-cluster-config/pull/1305)). It will reschedule any pod from `openshift-*` that is intended to run on an infra node but is scheduled on a worker node. This allows the pod to be scheduled on infra nodes once they are available. 
