### PR TITLE
OSD-13649: updaed MUO configmap to ignore etcdGRPCRequestsSlow alert

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -50,6 +50,8 @@ data:
       - ThanosRuleSenderIsFailingAlerts
       - ThanosRuleHighRuleEvaluationFailures
       - ThanosNoRuleEvaluations
+      # OSD-13649
+      - etcdGRPCRequestsSlow
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
@@ -52,6 +52,7 @@ data:
       - ThanosRuleSenderIsFailingAlerts
       - ThanosRuleHighRuleEvaluationFailures
       - ThanosNoRuleEvaluations
+      # OSD-13649
       - etcdGRPCRequestsSlow
       ignoredNamespaces:
       - openshift-logging

--- a/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
@@ -52,8 +52,6 @@ data:
       - ThanosRuleSenderIsFailingAlerts
       - ThanosRuleHighRuleEvaluationFailures
       - ThanosNoRuleEvaluations
-      # OSD-13649
-      - etcdGRPCRequestsSlow
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/4.7/10-managed-upgrade-operator-configmap.yaml
@@ -52,6 +52,7 @@ data:
       - ThanosRuleSenderIsFailingAlerts
       - ThanosRuleHighRuleEvaluationFailures
       - ThanosNoRuleEvaluations
+      - etcdGRPCRequestsSlow
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8875,9 +8875,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8743,9 +8743,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -8875,7 +8875,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8875,9 +8875,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8875,9 +8875,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8743,9 +8743,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -8875,7 +8875,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8875,9 +8875,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8875,9 +8875,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8743,9 +8743,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1
@@ -8875,7 +8875,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8875,9 +8875,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION


### What this PR does / why we need it?
- etcdGRPCRequestsSlow alert auto-resolve by self in some time within 5-10 mins.
- This alert has been converted into warning as it is self resolvable in nature. 
- MUO can block the upgrade considering this alert as a critical raised by cluster. 
- To avoid the upgrade cancellations due to this scenario, updated the MUO configmap to ignore etcdGRPCRequestsSlow in pre/post upgrade checks. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-13649 
