### PR TITLE
Increase worker node MHC timeout to 30m from 25m

### DIFF
--- a/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -21,4 +21,4 @@ spec:
     timeout: "480s"
     status: "Unknown"
   maxUnhealthy: 3
-  nodeStartupTimeout: 25m
+  nodeStartupTimeout: 30m 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13364,7 +13364,7 @@ objects:
           timeout: 480s
           status: Unknown
         maxUnhealthy: 3
-        nodeStartupTimeout: 25m
+        nodeStartupTimeout: 30m
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13364,7 +13364,7 @@ objects:
           timeout: 480s
           status: Unknown
         maxUnhealthy: 3
-        nodeStartupTimeout: 25m
+        nodeStartupTimeout: 30m
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13364,7 +13364,7 @@ objects:
           timeout: 480s
           status: Unknown
         maxUnhealthy: 3
-        nodeStartupTimeout: 25m
+        nodeStartupTimeout: 30m
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Customers can request `m5zn.metal` EC2 instances as worker nodes and it has been reported by an internal customer + reproduced that it sometimes takes longer than the currently configured 25 minutes for the EC2 instance to become ready. I don't think an associated increase is needed for the infra machinehealthcheck because we control those instance types and haven't seen issues yet and it's desirable to have this time be as low as possible so unhealthy machines do get cycled ASAP. So, this PR is bumping the timeout to 30 minutes.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-13791](https://issues.redhat.com//browse/OSD-13791)