### PR TITLE
Increase unhealthyConditions timeout as *.metal instances take a long time to reboot

### DIFF
--- a/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
@@ -36,11 +36,11 @@ spec:
       - "i3.metal"
       - "i3en.metal"
   unhealthyConditions:
-  - type:    "Ready"
-    timeout: "480s"
+  - type: "Ready"
+    timeout: 8m
     status: "False"
-  - type:    "Ready"
-    timeout: "480s"
+  - type: "Ready"
+    timeout: 15m
     status: "Unknown"
   maxUnhealthy: 3
   nodeStartupTimeout: 40m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -13426,10 +13426,10 @@ objects:
             - i3en.metal
         unhealthyConditions:
         - type: Ready
-          timeout: 480s
+          timeout: 8m
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 15m
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 40m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -13426,10 +13426,10 @@ objects:
             - i3en.metal
         unhealthyConditions:
         - type: Ready
-          timeout: 480s
+          timeout: 8m
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 15m
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 40m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -13426,10 +13426,10 @@ objects:
             - i3en.metal
         unhealthyConditions:
         - type: Ready
-          timeout: 480s
+          timeout: 8m
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 15m
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 40m


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
When testing with `m5zn.metal` instances, it was noticed that when machine-config-operator works on these nodes and reboots them, this takes a long time and exceeds the existing 480s timeout for how long a node can have the `Ready: Unknown` status condition. I locally removed the timeout to validate and got data that a node took 13 minutes to get out of that `Unknown` status condition, so I am bumping that specific parameter to 15m

For readability, because math is hard, I also converted the existing 480s timeout to 8m (no-op)

### Which Jira/Github issue(s) this PR fixes?

OSD-13791

### Special notes for your reviewer:
Validated this setting works in stage