### PR TITLE
adding Osd-pcap-collector policy

### DIFF
--- a/deploy/acm-policies/config.yaml
+++ b/deploy/acm-policies/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["service-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/acm-policies/osd-pcap-collector/config.yaml
+++ b/deploy/acm-policies/osd-pcap-collector/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["service-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/acm-policies/osd-pcap-collector/policy-osd-pcap-collector.yaml
+++ b/deploy/acm-policies/osd-pcap-collector/policy-osd-pcap-collector.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: osd-pcap-collector
+    namespace: openshift-managed-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: osd-pcap-collector
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        allowHostNetwork: false
+                        allowPrivilegedContainer: false
+                        allowedCapabilities:
+                            - NET_ADMIN
+                            - NET_RAW
+                        apiVersion: security.openshift.io/v1
+                        kind: SecurityContextConstraints
+                        metadata:
+                            name: pcap-dedicated-admins
+                        runAsUser:
+                            type: RunAsAny
+                        seLinuxContext:
+                            type: RunAsAny
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: pcap-dedicated-admins
+                        rules:
+                            - apiGroups:
+                                - security.openshift.io
+                              resourceNames:
+                                - pcap-dedicated-admins
+                              resources:
+                                - securitycontextconstraints
+                              verbs:
+                                - use
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
+                        metadata:
+                            name: pcap-dedicated-admins
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: pcap-dedicated-admins
+                        subjects:
+                            - kind: Group
+                              name: dedicated-admins
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-osd-pcap-collector
+    namespace: openshift-managed-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-osd-pcap-collector
+    namespace: openshift-managed-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-osd-pcap-collector
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: osd-pcap-collector

--- a/deploy/acm-policies/policy-cluster-admin.yaml
+++ b/deploy/acm-policies/policy-cluster-admin.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: cluster-admin
+    namespace: openshift-managed-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: cluster-admin
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
+                        metadata:
+                            name: osd-cluster-admin
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: cluster-admin
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: cluster-admins
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-cluster-admin
+    namespace: openshift-managed-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-cluster-admin
+    namespace: openshift-managed-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-cluster-admin
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: cluster-admin

--- a/deploy/acm-policies/policy-dedicated-admin.yaml
+++ b/deploy/acm-policies/policy-dedicated-admin.yaml
@@ -1,0 +1,1011 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: dedicated-admin-rbac
+    namespace: openshift-managed-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: dedicated-admin-rbac
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        aggregationRule:
+                            clusterRoleSelectors:
+                                - matchExpressions:
+                                    - key: managed.openshift.io/aggregate-to-dedicated-admins
+                                      operator: In
+                                      values:
+                                        - cluster
+                                - matchExpressions:
+                                    - key: olm.opgroup.permissions/aggregate-to-admin
+                                      operator: In
+                                      values:
+                                        - openshift-logging
+                                        - openshift-operators
+                                        - openshift-operators-redhat
+                                - matchExpressions:
+                                    - key: olm.owner.kind
+                                      operator: In
+                                      values:
+                                        - OperatorGroup
+                                    - key: olm.owner
+                                      operator: NotIn
+                                      values:
+                                        - openshift-cluster-monitoring
+                                        - olm-operators
+                                        - splunk-forwarder-operator-og
+                                        - redhat-layered-product-og
+                                        - addon-rhmi-og
+                                        - addon-rhmi-internal-og
+                                        - rhmi-registry-og
+                                    - key: olm.owner.namespace
+                                      operator: NotIn
+                                      values:
+                                        - openshift-monitoring
+                                        - openshift-operator-lifecycle-manager
+                                        - openshift-splunk-forwarder-operator
+                                        - openshift-managed-upgrade-operator
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: dedicated-admins-cluster
+                        rules: []
+                    - complianceType: musthave
+                      objectDefinition:
+                        aggregationRule:
+                            clusterRoleSelectors:
+                                - matchExpressions:
+                                    - key: managed.openshift.io/aggregate-to-dedicated-admins
+                                      operator: In
+                                      values:
+                                        - project
+                                - matchExpressions:
+                                    - key: rbac.authorization.k8s.io/aggregate-to-admin
+                                      operator: In
+                                      values:
+                                        - "true"
+                                - matchExpressions:
+                                    - key: olm.opgroup.permissions/aggregate-to-admin
+                                      operator: In
+                                      values:
+                                        - openshift-logging
+                                        - openshift-operators
+                                        - openshift-operators-redhat
+                                - matchExpressions:
+                                    - key: olm.owner.kind
+                                      operator: In
+                                      values:
+                                        - OperatorGroup
+                                    - key: olm.owner.namespace
+                                      operator: NotIn
+                                      values:
+                                        - openshift-monitoring
+                                        - openshift-operator-lifecycle-manager
+                                        - openshift-splunk-forwarder-operator
+                                        - openshift-managed-upgrade-operator
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: dedicated-admins-project
+                        rules: []
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            labels:
+                                managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                            name: dedicated-admins-aggregate-cluster
+                        rules:
+                            - apiGroups:
+                                - rbac.authorization.k8s.io
+                              attributeRestrictions: null
+                              resources:
+                                - clusterroles
+                                - clusterrolebindings
+                              verbs:
+                                - create
+                                - delete
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - oauth.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - oauthclientauthorizations
+                              verbs:
+                                - delete
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - authorization.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - resourceaccessreviews
+                                - subjectaccessreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - authorization.k8s.io
+                              attributeRestrictions: null
+                              resources:
+                                - subjectaccessreviews
+                                - selfsubjectaccessreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                                - project.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - projectrequests
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                                - security.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - securitycontextconstraints
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - network.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - netnamespaces
+                              verbs:
+                                - get
+                                - list
+                                - update
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routers/metrics
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - namespaces
+                              verbs:
+                                - get
+                                - list
+                                - update
+                                - patch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - builds
+                                - buildconfigs
+                              verbs:
+                                - list
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - daemonsets
+                                - deployments
+                                - replicasets
+                                - statefulsets
+                              verbs:
+                                - list
+                            - apiGroups:
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs
+                              verbs:
+                                - list
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                                - replicationcontrollers
+                                - services
+                              verbs:
+                                - list
+                                - get
+                                - watch
+                            - apiGroups:
+                                - project.openshift.io
+                              resources:
+                                - projects
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routes
+                              verbs:
+                                - list
+                                - get
+                            - apiGroups:
+                                - authentication.k8s.io
+                              resources:
+                                - tokenreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - authorization.k8s.io
+                              resources:
+                                - subjectaccessreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - operators.coreos.com
+                                - packages.operators.coreos.com
+                              resources:
+                                - '*'
+                              verbs:
+                                - list
+                                - get
+                                - watch
+                            - apiGroups:
+                                - '*'
+                              resources:
+                                - packagemanifests
+                              verbs:
+                                - list
+                            - apiGroups:
+                                - certificates.certmanager.k8s.io
+                                - issuers.certmanager.k8s.io
+                                - clusterissuers.certmanager.k8s.io
+                                - orders.certmanager.k8s.io
+                                - challenges.certmanager.k8s.io
+                                - anchoreengines.anchore.com
+                                - atlasmaps.atlasmap.io
+                                - builds.camel.apache.org
+                                - camelcatalogs.camel.apache.org
+                                - integrations.camel.apache.org
+                                - integrationcontexts.camel.apache.org
+                                - integrationplatforms.camel.apache.org
+                                - couchbaseclusters.couchbase.com
+                                - openliberties.openliberty.io
+                                - opsmxspinnakeroperators.charts.helm.k8s.io
+                                - seldondeployments.machinelearning.seldon.io
+                                - spinnakeroperators.charts.helm.k8s.io
+                                - twistlockconsoles.charts.helm.k8s.io
+                                - tekton.dev
+                              resources:
+                                - '*'
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - user.openshift.io
+                              resources:
+                                - groups
+                                - identities
+                                - users
+                              verbs:
+                                - get
+                                - list
+                                - update
+                                - patch
+                                - create
+                                - delete
+                            - apiGroups:
+                                - user.openshift.io
+                              resources:
+                                - useridentitymappings
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - operator.openshift.io
+                              resourceNames:
+                                - default
+                              resources:
+                                - dnses
+                              verbs:
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - image.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - images
+                                - imagestreamtags
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - security.openshift.io
+                              resourceNames:
+                                - anyuid
+                                - nonroot
+                              resources:
+                                - securitycontextconstraints
+                              verbs:
+                                - use
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - projects
+                              verbs:
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - machine.openshift.io
+                              resources:
+                                - machines
+                                - machinesets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - quota.openshift.io
+                              resources:
+                                - clusterresourcequotas
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - apiserver.openshift.io
+                              resources:
+                                - apirequestcounts
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            labels:
+                                managed.openshift.io/aggregate-to-dedicated-admins: project
+                            name: dedicated-admins-aggregate-project
+                        rules:
+                            - apiGroups:
+                                - ""
+                              attributeRestrictions: null
+                              resources:
+                                - limitranges
+                                - resourcequotas
+                              verbs:
+                                - create
+                                - delete
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - network.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - egressnetworkpolicies
+                              verbs:
+                                - create
+                                - delete
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - extensions
+                              attributeRestrictions: null
+                              resources:
+                                - daemonsets
+                              verbs:
+                                - create
+                                - delete
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - rbac.authorization.k8s.io
+                              attributeRestrictions: null
+                              resources:
+                                - clusterrolebindings
+                                - rolebindings
+                              verbs:
+                                - create
+                                - delete
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - ""
+                              attributeRestrictions: null
+                              resources:
+                                - events
+                                - namespaces
+                                - pods
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - network.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - clusternetworks
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - image.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - images
+                                - imagestreamtags
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - build.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - buildconfigs
+                                - builds
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - alertmanagers
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - prometheuses
+                                - prometheusrules
+                                - servicemonitors
+                                - podmonitors
+                                - thanosrulers
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - kafka.strimzi.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - create
+                                - delete
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - apiextensions.k8s.io
+                              resources:
+                                - customresourcedefinitions
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - prow.k8s.io
+                              resources:
+                                - prowjobs
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - events
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - metering.openshift.io
+                              resources:
+                                - reports/export
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - coordination.k8s.io
+                              resources:
+                                - leases
+                              verbs:
+                                - '*'
+                    - complianceType: musthave
+                      objectDefinition:
+                        aggregationRule:
+                            clusterRoleSelectors:
+                                - matchExpressions:
+                                    - key: rbac.authorization.k8s.io/aggregate-to-view
+                                      operator: In
+                                      values:
+                                        - "true"
+                                - matchExpressions:
+                                    - key: managed.openshift.io/aggregate-to-dedicated-readers
+                                      operator: In
+                                      values:
+                                        - "true"
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            labels:
+                                managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                            name: dedicated-readers
+                        rules: []
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            labels:
+                                managed.openshift.io/aggregate-to-backplane-cee: "true"
+                                managed.openshift.io/aggregate-to-backplane-cssre: "true"
+                                managed.openshift.io/aggregate-to-backplane-srep: "true"
+                                managed.openshift.io/aggregate-to-dedicated-readers: "true"
+                                managed.openshift.io/aggregate-to-devaccess: "true"
+                            name: osd-readers-aggregate
+                        rules:
+                            - apiGroups:
+                                - ""
+                              attributeRestrictions: null
+                              resources:
+                                - nodes
+                                - persistentvolumes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - quota.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - clusterresourcequotas
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - authorization.openshift.io
+                              attributeRestrictions: null
+                              resources:
+                                - clusterpolicybindings
+                              verbs:
+                                - get
+                                - list
+                            - apiGroups:
+                                - metrics.k8s.io
+                              resources:
+                                - nodes
+                                - pods
+                              verbs:
+                                - list
+                            - apiGroups:
+                                - coordination.k8s.io
+                              resources:
+                                - leases
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - admissionregistration.k8s.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apiextensions.k8s.io
+                              resources:
+                                - customresourcedefinitions
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apiregistration.k8s.io
+                              resources:
+                                - apiservices
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - authentication.k8s.io
+                              resources:
+                                - tokenreviews
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - authorization.openshift.io
+                              resources:
+                                - clusterrolebindings
+                                - clusterroles
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - autoscaling.openshift.io
+                              resources:
+                                - clusterautoscalers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - console.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - flowcontrol.apiserver.k8s.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - image.openshift.io
+                              resources:
+                                - images
+                                - imagesignatures
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - imageregistry.operator.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - metal3.io
+                              resources:
+                                - provisionings
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - migration.k8s.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - network.openshift.io
+                              resources:
+                                - clusternetworks
+                                - hostsubnets
+                                - netnamespaces
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - networking.k8s.io
+                              resources:
+                                - ingressclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - node.k8s.io
+                              resources:
+                                - runtimeclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - operator.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - policy
+                              resources:
+                                - podsecuritypolicies
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - project.openshift.io
+                              resources:
+                                - projectrequests
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - rbac.authorization.k8s.io
+                              resources:
+                                - clusterroles
+                                - clusterrolebindings
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - samples.operator.openshift.io
+                              resources:
+                                - configs
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - scheduling.k8s.io
+                              resources:
+                                - priorityclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - security.openshift.io
+                              resources:
+                                - securitycontextconstraints
+                                - rangeallocations
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - snapshot.storage.k8s.io
+                              resources:
+                                - volumesnapshotcontents
+                                - volumesnapshotclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - storage.k8s.io
+                              resources:
+                                - storageclasses
+                                - volumeattachments
+                                - csinodes
+                                - csidrivers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - template.openshift.io
+                              resources:
+                                - brokertemplateinstances
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - user.openshift.io
+                              resources:
+                                - groups
+                                - identities
+                                - users
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - operators
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
+                        metadata:
+                            name: dedicated-admins-cluster
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-cluster
+                        subjects:
+                            - kind: Group
+                              name: dedicated-admins
+                            - kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: dedicated-admins-openshift-operators
+                            namespace: openshift-operators
+                        rules:
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - installplans
+                                - subscriptions
+                                - clusterserviceversions
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - events
+                              verbs:
+                                - list
+                                - get
+                                - watch
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-openshift-operators
+                            namespace: openshift-operators
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: dedicated-admins-openshift-operators
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                            - kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: dedicated-admins-openshift-marketplace
+                            namespace: openshift-marketplace
+                        rules:
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - catalogsourceconfigs
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - '*'
+                              resources:
+                                - packagemanifests
+                              verbs:
+                                - list
+                                - get
+                                - watch
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-openshift-marketplace
+                            namespace: openshift-marketplace
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: dedicated-admins-openshift-marketplace
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                            - kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: dedicated-admins-openshift-dns
+                            namespace: openshift-dns
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - configmaps
+                              verbs:
+                                - list
+                                - get
+                                - watch
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-openshift-dns
+                            namespace: openshift-dns
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: dedicated-admins-openshift-dns
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                            - kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-dedicated-admin-rbac
+    namespace: openshift-managed-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-dedicated-admin-rbac
+    namespace: openshift-managed-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-dedicated-admin-rbac
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: dedicated-admin-rbac

--- a/deploy/acm-policies/policy-namespace.yaml
+++ b/deploy/acm-policies/policy-namespace.yaml
@@ -1,0 +1,5 @@
+#Create a namespace called 'openshift-managed-rbac-policies' on service cluster that the generated policies are later created in.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-mananged-rbac-policies

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -601,6 +601,1101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: acm-policies
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: cluster-admin
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: cluster-admin
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: osd-cluster-admin
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: cluster-admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: cluster-admins
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-cluster-admin
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-cluster-admin
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-cluster-admin
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: cluster-admin
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: dedicated-admin-rbac
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-admins
+                        operator: In
+                        values:
+                        - cluster
+                    - matchExpressions:
+                      - key: olm.opgroup.permissions/aggregate-to-admin
+                        operator: In
+                        values:
+                        - openshift-logging
+                        - openshift-operators
+                        - openshift-operators-redhat
+                    - matchExpressions:
+                      - key: olm.owner.kind
+                        operator: In
+                        values:
+                        - OperatorGroup
+                      - key: olm.owner
+                        operator: NotIn
+                        values:
+                        - openshift-cluster-monitoring
+                        - olm-operators
+                        - splunk-forwarder-operator-og
+                        - redhat-layered-product-og
+                        - addon-rhmi-og
+                        - addon-rhmi-internal-og
+                        - rhmi-registry-og
+                      - key: olm.owner.namespace
+                        operator: NotIn
+                        values:
+                        - openshift-monitoring
+                        - openshift-operator-lifecycle-manager
+                        - openshift-splunk-forwarder-operator
+                        - openshift-managed-upgrade-operator
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: dedicated-admins-cluster
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-admins
+                        operator: In
+                        values:
+                        - project
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-admin
+                        operator: In
+                        values:
+                        - 'true'
+                    - matchExpressions:
+                      - key: olm.opgroup.permissions/aggregate-to-admin
+                        operator: In
+                        values:
+                        - openshift-logging
+                        - openshift-operators
+                        - openshift-operators-redhat
+                    - matchExpressions:
+                      - key: olm.owner.kind
+                        operator: In
+                        values:
+                        - OperatorGroup
+                      - key: olm.owner.namespace
+                        operator: NotIn
+                        values:
+                        - openshift-monitoring
+                        - openshift-operator-lifecycle-manager
+                        - openshift-splunk-forwarder-operator
+                        - openshift-managed-upgrade-operator
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: dedicated-admins-project
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                    name: dedicated-admins-aggregate-cluster
+                  rules:
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - oauth.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - oauthclientauthorizations
+                    verbs:
+                    - delete
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - resourceaccessreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - subjectaccessreviews
+                    - selfsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - security.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - update
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routers/metrics
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - update
+                    - patch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    - buildconfigs
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - replicasets
+                    - statefulsets
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - replicationcontrollers
+                    - services
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - list
+                    - get
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - operators.coreos.com
+                    - packages.operators.coreos.com
+                    resources:
+                    - '*'
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - '*'
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - certificates.certmanager.k8s.io
+                    - issuers.certmanager.k8s.io
+                    - clusterissuers.certmanager.k8s.io
+                    - orders.certmanager.k8s.io
+                    - challenges.certmanager.k8s.io
+                    - anchoreengines.anchore.com
+                    - atlasmaps.atlasmap.io
+                    - builds.camel.apache.org
+                    - camelcatalogs.camel.apache.org
+                    - integrations.camel.apache.org
+                    - integrationcontexts.camel.apache.org
+                    - integrationplatforms.camel.apache.org
+                    - couchbaseclusters.couchbase.com
+                    - openliberties.openliberty.io
+                    - opsmxspinnakeroperators.charts.helm.k8s.io
+                    - seldondeployments.machinelearning.seldon.io
+                    - spinnakeroperators.charts.helm.k8s.io
+                    - twistlockconsoles.charts.helm.k8s.io
+                    - tekton.dev
+                    resources:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - update
+                    - patch
+                    - create
+                    - delete
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - useridentitymappings
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - operator.openshift.io
+                    resourceNames:
+                    - default
+                    resources:
+                    - dnses
+                    verbs:
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - images
+                    - imagestreamtags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - anyuid
+                    - nonroot
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    - machinesets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - apiserver.openshift.io
+                    resources:
+                    - apirequestcounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: project
+                    name: dedicated-admins-aggregate-project
+                  rules:
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - limitranges
+                    - resourcequotas
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - egressnetworkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    attributeRestrictions: null
+                    resources:
+                    - daemonsets
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterrolebindings
+                    - rolebindings
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - events
+                    - namespaces
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusternetworks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - images
+                    - imagestreamtags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - buildconfigs
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - podmonitors
+                    - thanosrulers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - kafka.strimzi.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - prow.k8s.io
+                    resources:
+                    - prowjobs
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - metering.openshift.io
+                    resources:
+                    - reports/export
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - '*'
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-view
+                        operator: In
+                        values:
+                        - 'true'
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-readers
+                        operator: In
+                        values:
+                        - 'true'
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                    name: dedicated-readers
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-backplane-cee: 'true'
+                      managed.openshift.io/aggregate-to-backplane-cssre: 'true'
+                      managed.openshift.io/aggregate-to-backplane-srep: 'true'
+                      managed.openshift.io/aggregate-to-dedicated-readers: 'true'
+                      managed.openshift.io/aggregate-to-devaccess: 'true'
+                    name: osd-readers-aggregate
+                  rules:
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - nodes
+                    - persistentvolumes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterpolicybindings
+                    verbs:
+                    - get
+                    - list
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - nodes
+                    - pods
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - admissionregistration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiregistration.k8s.io
+                    resources:
+                    - apiservices
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - clusterrolebindings
+                    - clusterroles
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - clusterautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - console.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - flowcontrol.apiserver.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - images
+                    - imagesignatures
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - imageregistry.operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metal3.io
+                    resources:
+                    - provisionings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - migration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - network.openshift.io
+                    resources:
+                    - clusternetworks
+                    - hostsubnets
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingressclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - node.k8s.io
+                    resources:
+                    - runtimeclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - podsecuritypolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - samples.operator.openshift.io
+                    resources:
+                    - configs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - scheduling.k8s.io
+                    resources:
+                    - priorityclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    - rangeallocations
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshotcontents
+                    - volumesnapshotclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    - volumeattachments
+                    - csinodes
+                    - csidrivers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - brokertemplateinstances
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - operators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admins-cluster
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-operators
+                    namespace: openshift-operators
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - installplans
+                    - subscriptions
+                    - clusterserviceversions
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-operators
+                    namespace: openshift-operators
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-operators
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-marketplace
+                    namespace: openshift-marketplace
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - catalogsourceconfigs
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - '*'
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-marketplace
+                    namespace: openshift-marketplace
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-marketplace
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-dns
+                    namespace: openshift-dns
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-dns
+                    namespace: openshift-dns
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-dns
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-dedicated-admin-rbac
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: dedicated-admin-rbac
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-mananged-rbac-policies
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1696,6 +1696,118 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: acm-policies-osd-pcap-collector
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-pcap-collector
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  allowHostNetwork: false
+                  allowPrivilegedContainer: false
+                  allowedCapabilities:
+                  - NET_ADMIN
+                  - NET_RAW
+                  apiVersion: security.openshift.io/v1
+                  kind: SecurityContextConstraints
+                  metadata:
+                    name: pcap-dedicated-admins
+                  runAsUser:
+                    type: RunAsAny
+                  seLinuxContext:
+                    type: RunAsAny
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: pcap-dedicated-admins
+                  rules:
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - pcap-dedicated-admins
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: pcap-dedicated-admins
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: pcap-dedicated-admins
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-pcap-collector
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-pcap-collector
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -601,6 +601,1101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: acm-policies
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: cluster-admin
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: cluster-admin
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: osd-cluster-admin
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: cluster-admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: cluster-admins
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-cluster-admin
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-cluster-admin
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-cluster-admin
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: cluster-admin
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: dedicated-admin-rbac
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-admins
+                        operator: In
+                        values:
+                        - cluster
+                    - matchExpressions:
+                      - key: olm.opgroup.permissions/aggregate-to-admin
+                        operator: In
+                        values:
+                        - openshift-logging
+                        - openshift-operators
+                        - openshift-operators-redhat
+                    - matchExpressions:
+                      - key: olm.owner.kind
+                        operator: In
+                        values:
+                        - OperatorGroup
+                      - key: olm.owner
+                        operator: NotIn
+                        values:
+                        - openshift-cluster-monitoring
+                        - olm-operators
+                        - splunk-forwarder-operator-og
+                        - redhat-layered-product-og
+                        - addon-rhmi-og
+                        - addon-rhmi-internal-og
+                        - rhmi-registry-og
+                      - key: olm.owner.namespace
+                        operator: NotIn
+                        values:
+                        - openshift-monitoring
+                        - openshift-operator-lifecycle-manager
+                        - openshift-splunk-forwarder-operator
+                        - openshift-managed-upgrade-operator
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: dedicated-admins-cluster
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-admins
+                        operator: In
+                        values:
+                        - project
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-admin
+                        operator: In
+                        values:
+                        - 'true'
+                    - matchExpressions:
+                      - key: olm.opgroup.permissions/aggregate-to-admin
+                        operator: In
+                        values:
+                        - openshift-logging
+                        - openshift-operators
+                        - openshift-operators-redhat
+                    - matchExpressions:
+                      - key: olm.owner.kind
+                        operator: In
+                        values:
+                        - OperatorGroup
+                      - key: olm.owner.namespace
+                        operator: NotIn
+                        values:
+                        - openshift-monitoring
+                        - openshift-operator-lifecycle-manager
+                        - openshift-splunk-forwarder-operator
+                        - openshift-managed-upgrade-operator
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: dedicated-admins-project
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                    name: dedicated-admins-aggregate-cluster
+                  rules:
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - oauth.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - oauthclientauthorizations
+                    verbs:
+                    - delete
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - resourceaccessreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - subjectaccessreviews
+                    - selfsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - security.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - update
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routers/metrics
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - update
+                    - patch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    - buildconfigs
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - replicasets
+                    - statefulsets
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - replicationcontrollers
+                    - services
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - list
+                    - get
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - operators.coreos.com
+                    - packages.operators.coreos.com
+                    resources:
+                    - '*'
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - '*'
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - certificates.certmanager.k8s.io
+                    - issuers.certmanager.k8s.io
+                    - clusterissuers.certmanager.k8s.io
+                    - orders.certmanager.k8s.io
+                    - challenges.certmanager.k8s.io
+                    - anchoreengines.anchore.com
+                    - atlasmaps.atlasmap.io
+                    - builds.camel.apache.org
+                    - camelcatalogs.camel.apache.org
+                    - integrations.camel.apache.org
+                    - integrationcontexts.camel.apache.org
+                    - integrationplatforms.camel.apache.org
+                    - couchbaseclusters.couchbase.com
+                    - openliberties.openliberty.io
+                    - opsmxspinnakeroperators.charts.helm.k8s.io
+                    - seldondeployments.machinelearning.seldon.io
+                    - spinnakeroperators.charts.helm.k8s.io
+                    - twistlockconsoles.charts.helm.k8s.io
+                    - tekton.dev
+                    resources:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - update
+                    - patch
+                    - create
+                    - delete
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - useridentitymappings
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - operator.openshift.io
+                    resourceNames:
+                    - default
+                    resources:
+                    - dnses
+                    verbs:
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - images
+                    - imagestreamtags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - anyuid
+                    - nonroot
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    - machinesets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - apiserver.openshift.io
+                    resources:
+                    - apirequestcounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: project
+                    name: dedicated-admins-aggregate-project
+                  rules:
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - limitranges
+                    - resourcequotas
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - egressnetworkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    attributeRestrictions: null
+                    resources:
+                    - daemonsets
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterrolebindings
+                    - rolebindings
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - events
+                    - namespaces
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusternetworks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - images
+                    - imagestreamtags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - buildconfigs
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - podmonitors
+                    - thanosrulers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - kafka.strimzi.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - prow.k8s.io
+                    resources:
+                    - prowjobs
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - metering.openshift.io
+                    resources:
+                    - reports/export
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - '*'
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-view
+                        operator: In
+                        values:
+                        - 'true'
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-readers
+                        operator: In
+                        values:
+                        - 'true'
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                    name: dedicated-readers
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-backplane-cee: 'true'
+                      managed.openshift.io/aggregate-to-backplane-cssre: 'true'
+                      managed.openshift.io/aggregate-to-backplane-srep: 'true'
+                      managed.openshift.io/aggregate-to-dedicated-readers: 'true'
+                      managed.openshift.io/aggregate-to-devaccess: 'true'
+                    name: osd-readers-aggregate
+                  rules:
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - nodes
+                    - persistentvolumes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterpolicybindings
+                    verbs:
+                    - get
+                    - list
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - nodes
+                    - pods
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - admissionregistration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiregistration.k8s.io
+                    resources:
+                    - apiservices
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - clusterrolebindings
+                    - clusterroles
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - clusterautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - console.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - flowcontrol.apiserver.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - images
+                    - imagesignatures
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - imageregistry.operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metal3.io
+                    resources:
+                    - provisionings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - migration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - network.openshift.io
+                    resources:
+                    - clusternetworks
+                    - hostsubnets
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingressclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - node.k8s.io
+                    resources:
+                    - runtimeclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - podsecuritypolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - samples.operator.openshift.io
+                    resources:
+                    - configs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - scheduling.k8s.io
+                    resources:
+                    - priorityclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    - rangeallocations
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshotcontents
+                    - volumesnapshotclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    - volumeattachments
+                    - csinodes
+                    - csidrivers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - brokertemplateinstances
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - operators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admins-cluster
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-operators
+                    namespace: openshift-operators
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - installplans
+                    - subscriptions
+                    - clusterserviceversions
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-operators
+                    namespace: openshift-operators
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-operators
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-marketplace
+                    namespace: openshift-marketplace
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - catalogsourceconfigs
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - '*'
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-marketplace
+                    namespace: openshift-marketplace
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-marketplace
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-dns
+                    namespace: openshift-dns
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-dns
+                    namespace: openshift-dns
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-dns
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-dedicated-admin-rbac
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: dedicated-admin-rbac
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-mananged-rbac-policies
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1696,6 +1696,118 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: acm-policies-osd-pcap-collector
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-pcap-collector
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  allowHostNetwork: false
+                  allowPrivilegedContainer: false
+                  allowedCapabilities:
+                  - NET_ADMIN
+                  - NET_RAW
+                  apiVersion: security.openshift.io/v1
+                  kind: SecurityContextConstraints
+                  metadata:
+                    name: pcap-dedicated-admins
+                  runAsUser:
+                    type: RunAsAny
+                  seLinuxContext:
+                    type: RunAsAny
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: pcap-dedicated-admins
+                  rules:
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - pcap-dedicated-admins
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: pcap-dedicated-admins
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: pcap-dedicated-admins
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-pcap-collector
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-pcap-collector
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -601,6 +601,1101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: acm-policies
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: cluster-admin
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: cluster-admin
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: osd-cluster-admin
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: cluster-admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: cluster-admins
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-cluster-admin
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-cluster-admin
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-cluster-admin
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: cluster-admin
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: dedicated-admin-rbac
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-admins
+                        operator: In
+                        values:
+                        - cluster
+                    - matchExpressions:
+                      - key: olm.opgroup.permissions/aggregate-to-admin
+                        operator: In
+                        values:
+                        - openshift-logging
+                        - openshift-operators
+                        - openshift-operators-redhat
+                    - matchExpressions:
+                      - key: olm.owner.kind
+                        operator: In
+                        values:
+                        - OperatorGroup
+                      - key: olm.owner
+                        operator: NotIn
+                        values:
+                        - openshift-cluster-monitoring
+                        - olm-operators
+                        - splunk-forwarder-operator-og
+                        - redhat-layered-product-og
+                        - addon-rhmi-og
+                        - addon-rhmi-internal-og
+                        - rhmi-registry-og
+                      - key: olm.owner.namespace
+                        operator: NotIn
+                        values:
+                        - openshift-monitoring
+                        - openshift-operator-lifecycle-manager
+                        - openshift-splunk-forwarder-operator
+                        - openshift-managed-upgrade-operator
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: dedicated-admins-cluster
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-admins
+                        operator: In
+                        values:
+                        - project
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-admin
+                        operator: In
+                        values:
+                        - 'true'
+                    - matchExpressions:
+                      - key: olm.opgroup.permissions/aggregate-to-admin
+                        operator: In
+                        values:
+                        - openshift-logging
+                        - openshift-operators
+                        - openshift-operators-redhat
+                    - matchExpressions:
+                      - key: olm.owner.kind
+                        operator: In
+                        values:
+                        - OperatorGroup
+                      - key: olm.owner.namespace
+                        operator: NotIn
+                        values:
+                        - openshift-monitoring
+                        - openshift-operator-lifecycle-manager
+                        - openshift-splunk-forwarder-operator
+                        - openshift-managed-upgrade-operator
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: dedicated-admins-project
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                    name: dedicated-admins-aggregate-cluster
+                  rules:
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - oauth.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - oauthclientauthorizations
+                    verbs:
+                    - delete
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - resourceaccessreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - subjectaccessreviews
+                    - selfsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - security.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - update
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routers/metrics
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - update
+                    - patch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    - buildconfigs
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - replicasets
+                    - statefulsets
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - replicationcontrollers
+                    - services
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - list
+                    - get
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - operators.coreos.com
+                    - packages.operators.coreos.com
+                    resources:
+                    - '*'
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - '*'
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - certificates.certmanager.k8s.io
+                    - issuers.certmanager.k8s.io
+                    - clusterissuers.certmanager.k8s.io
+                    - orders.certmanager.k8s.io
+                    - challenges.certmanager.k8s.io
+                    - anchoreengines.anchore.com
+                    - atlasmaps.atlasmap.io
+                    - builds.camel.apache.org
+                    - camelcatalogs.camel.apache.org
+                    - integrations.camel.apache.org
+                    - integrationcontexts.camel.apache.org
+                    - integrationplatforms.camel.apache.org
+                    - couchbaseclusters.couchbase.com
+                    - openliberties.openliberty.io
+                    - opsmxspinnakeroperators.charts.helm.k8s.io
+                    - seldondeployments.machinelearning.seldon.io
+                    - spinnakeroperators.charts.helm.k8s.io
+                    - twistlockconsoles.charts.helm.k8s.io
+                    - tekton.dev
+                    resources:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - update
+                    - patch
+                    - create
+                    - delete
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - useridentitymappings
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - operator.openshift.io
+                    resourceNames:
+                    - default
+                    resources:
+                    - dnses
+                    verbs:
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - images
+                    - imagestreamtags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - anyuid
+                    - nonroot
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    - machinesets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - apiserver.openshift.io
+                    resources:
+                    - apirequestcounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: project
+                    name: dedicated-admins-aggregate-project
+                  rules:
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - limitranges
+                    - resourcequotas
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - egressnetworkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    attributeRestrictions: null
+                    resources:
+                    - daemonsets
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterrolebindings
+                    - rolebindings
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - events
+                    - namespaces
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - network.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusternetworks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - images
+                    - imagestreamtags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - buildconfigs
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - podmonitors
+                    - thanosrulers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - kafka.strimzi.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - prow.k8s.io
+                    resources:
+                    - prowjobs
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - metering.openshift.io
+                    resources:
+                    - reports/export
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - '*'
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-view
+                        operator: In
+                        values:
+                        - 'true'
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-readers
+                        operator: In
+                        values:
+                        - 'true'
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-dedicated-admins: cluster
+                    name: dedicated-readers
+                  rules: []
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    labels:
+                      managed.openshift.io/aggregate-to-backplane-cee: 'true'
+                      managed.openshift.io/aggregate-to-backplane-cssre: 'true'
+                      managed.openshift.io/aggregate-to-backplane-srep: 'true'
+                      managed.openshift.io/aggregate-to-dedicated-readers: 'true'
+                      managed.openshift.io/aggregate-to-devaccess: 'true'
+                    name: osd-readers-aggregate
+                  rules:
+                  - apiGroups:
+                    - ''
+                    attributeRestrictions: null
+                    resources:
+                    - nodes
+                    - persistentvolumes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    attributeRestrictions: null
+                    resources:
+                    - clusterpolicybindings
+                    verbs:
+                    - get
+                    - list
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - nodes
+                    - pods
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - admissionregistration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiregistration.k8s.io
+                    resources:
+                    - apiservices
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - clusterrolebindings
+                    - clusterroles
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - clusterautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - console.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - flowcontrol.apiserver.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - images
+                    - imagesignatures
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - imageregistry.operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metal3.io
+                    resources:
+                    - provisionings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - migration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - network.openshift.io
+                    resources:
+                    - clusternetworks
+                    - hostsubnets
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingressclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - node.k8s.io
+                    resources:
+                    - runtimeclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - podsecuritypolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - samples.operator.openshift.io
+                    resources:
+                    - configs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - scheduling.k8s.io
+                    resources:
+                    - priorityclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    - rangeallocations
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshotcontents
+                    - volumesnapshotclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    - volumeattachments
+                    - csinodes
+                    - csidrivers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - brokertemplateinstances
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - operators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admins-cluster
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-operators
+                    namespace: openshift-operators
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - installplans
+                    - subscriptions
+                    - clusterserviceversions
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-operators
+                    namespace: openshift-operators
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-operators
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-marketplace
+                    namespace: openshift-marketplace
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - catalogsourceconfigs
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - '*'
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-marketplace
+                    namespace: openshift-marketplace
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-marketplace
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-dns
+                    namespace: openshift-dns
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    verbs:
+                    - list
+                    - get
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-dns
+                    namespace: openshift-dns
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-dns
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-dedicated-admin-rbac
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-dedicated-admin-rbac
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: dedicated-admin-rbac
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-mananged-rbac-policies
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1696,6 +1696,118 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: acm-policies-osd-pcap-collector
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-pcap-collector
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  allowHostNetwork: false
+                  allowPrivilegedContainer: false
+                  allowedCapabilities:
+                  - NET_ADMIN
+                  - NET_RAW
+                  apiVersion: security.openshift.io/v1
+                  kind: SecurityContextConstraints
+                  metadata:
+                    name: pcap-dedicated-admins
+                  runAsUser:
+                    type: RunAsAny
+                  seLinuxContext:
+                    type: RunAsAny
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: pcap-dedicated-admins
+                  rules:
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - pcap-dedicated-admins
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: pcap-dedicated-admins
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: pcap-dedicated-admins
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-pcap-collector
+        namespace: openshift-managed-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-pcap-collector
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-pcap-collector
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_Adding SelectorSyncSet for osd-pcap-collector policy

### What this PR does / why we need it?
Create SelectorSyncSet that would land the ACM policies for osd-pcap-collector rbac on the Hypershift service cluster
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-13912
_Fixes #_

### Special notes for your reviewer:
Policy Generator: https://github.com/stolostron/policy-generator-plugin
Doc on Generating Policy: https://cloud.redhat.com/blog/generating-governance-policies-using-kustomize-and-gitops
More Doc on working with policies: https://docs.google.com/document/d/1ZsaaY3KcdUyZp-Nn5fVVmsYRFG8y4cdHPO4FoCFUmGw/edit#

Deployements included in the policy:
https://github.com/openshift/managed-cluster-config/tree/master/deploy/osd-pcap-collector

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
