### PR TITLE
Ship management cluster platform metrics to RHOBS

### DIFF
--- a/deploy/hypershift-cluster-monitoring-config/OWNERS
+++ b/deploy/hypershift-cluster-monitoring-config/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- supreeth7 
+- wanghaoran1988
+- sre-mst-observatorium

--- a/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    prometheusK8s:
+    # If the location of this config changes,
+    # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md
+    # so that killswitch instructions point to the right file!
+      remoteWrite:
+        - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+          remoteTimeout: 30s
+          writeRelabelConfigs:
+          - sourceLabels: [__name__]
+            action: keep
+            regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes)'
+          queueConfig:
+            capacity: 2500
+            maxShards: 1000
+            minShards: 1
+            maxSamplesPerSend: 500
+            batchSendDeadline: 60s
+            minBackoff: 30ms
+            maxBackoff: 5s
+        - url: ${RHOBS_URL}
+          remoteTimeout: 30s
+          oauth2:
+            clientId:
+              secret:
+                key: client-id
+                name: rhobs-hypershift-credential
+            clientSecret:
+                key: client-secret
+                name: rhobs-hypershift-credential
+            tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+          writeRelabelConfigs:
+          - sourceLabels:
+            - __tmp_openshift_cluster_id__
+           targetLabel: cluster_id
+           action: replace
+          - sourceLabels: [__name__]
+            action: keep
+          queueConfig:
+            capacity: 2500
+            maxShards: 1000
+            minShards: 1
+            maxSamplesPerSend: 500
+            batchSendDeadline: 60s
+            minBackoff: 30ms
+            maxBackoff: 5s
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+      retention: 11d
+      retentionSize: 90GB
+      volumeClaimTemplate:
+        metadata:
+          name: prometheus-data
+        spec:
+          resources:
+            requests:
+              storage: 100Gi
+    alertmanagerMain:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+      volumeClaimTemplate:
+        metadata:
+          name: alertmanager-data
+        spec:
+          resources:
+            requests:
+              storage: 10Gi
+    telemeterClient:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+      telemeterServerURL: ${TELEMETER_SERVER_URL}
+    prometheusOperator:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    grafana:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    k8sPrometheusAdapter:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    kubeStateMetrics:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    openshiftStateMetrics:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+    thanosQuerier:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists

--- a/deploy/hypershift-cluster-monitoring-config/config.yaml
+++ b/deploy/hypershift-cluster-monitoring-config/config.yaml
@@ -1,12 +1,15 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchExpressions:
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster"]
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
-      values: ["4.5"]
+      values: ["true"]
     - key: ext-managed.openshift.io/uwm-disabled
       operator: NotIn
       values: ["true"]
-    - key: ext-hypershift.openshift.io/cluster-type
+    - key: api.openshift.com/fedramp
       operator: NotIn
-      values: ["management-cluster"]
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7863,6 +7863,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -8258,6 +8262,86 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-registry-cas-project
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hypershift-cluster-monitoring-config
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
+          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
+          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes)'\n\
+          \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
+          \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n    - url: ${RHOBS_URL}\n\
+          \      remoteTimeout: 30s\n      oauth2:\n        clientId:\n          secret:\n\
+          \            key: client-id\n            name: rhobs-hypershift-credential\n\
+          \        clientSecret:\n            key: client-secret\n            name:\
+          \ rhobs-hypershift-credential\n        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
+          \       targetLabel: cluster_id\n       action: replace\n      - sourceLabels:\
+          \ [__name__]\n        action: keep\n      queueConfig:\n        capacity:\
+          \ 2500\n        maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend:\
+          \ 500\n        batchSendDeadline: 60s\n        minBackoff: 30ms\n      \
+          \  maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
+          prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7863,6 +7863,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -8258,6 +8262,86 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-registry-cas-project
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hypershift-cluster-monitoring-config
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
+          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
+          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes)'\n\
+          \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
+          \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n    - url: ${RHOBS_URL}\n\
+          \      remoteTimeout: 30s\n      oauth2:\n        clientId:\n          secret:\n\
+          \            key: client-id\n            name: rhobs-hypershift-credential\n\
+          \        clientSecret:\n            key: client-secret\n            name:\
+          \ rhobs-hypershift-credential\n        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
+          \       targetLabel: cluster_id\n       action: replace\n      - sourceLabels:\
+          \ [__name__]\n        action: keep\n      queueConfig:\n        capacity:\
+          \ 2500\n        maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend:\
+          \ 500\n        batchSendDeadline: 60s\n        minBackoff: 30ms\n      \
+          \  maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
+          prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7863,6 +7863,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -8258,6 +8262,86 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-registry-cas-project
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hypershift-cluster-monitoring-config
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
+          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
+          # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
+          \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
+          \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes)'\n\
+          \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
+          \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n    - url: ${RHOBS_URL}\n\
+          \      remoteTimeout: 30s\n      oauth2:\n        clientId:\n          secret:\n\
+          \            key: client-id\n            name: rhobs-hypershift-credential\n\
+          \        clientSecret:\n            key: client-secret\n            name:\
+          \ rhobs-hypershift-credential\n        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
+          \       targetLabel: cluster_id\n       action: replace\n      - sourceLabels:\
+          \ [__name__]\n        action: keep\n      queueConfig:\n        capacity:\
+          \ 2500\n        maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend:\
+          \ 500\n        batchSendDeadline: 60s\n        minBackoff: 30ms\n      \
+          \  maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
+          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
+          \ Exists\n  volumeClaimTemplate:\n    metadata:\n      name: alertmanager-data\n\
+          \    spec:\n      resources:\n        requests:\n          storage: 10Gi\n\
+          telemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
+          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\n\
+          prometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Adding selectorsycnset for sending management cluster metrics to RHOBS 

### What this PR does / why we need it?

Remote write all platform metrics from cluster monitoring operator (openshift-monitoring) to hypershift-tenant in RHOBS

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-13646

### Special notes for your reviewer:

CMO now supports remoteWrite via OAuth2, hence we'll be deploying the rhobs-hypershift-tenant secret in the openshift-monitoring namespace.
This will create a new cluster-monitoring-config that would target HyperShift Management Clusters only, [ref](https://github.com/openshift/managed-cluster-config/tree/master/deploy/cluster-monitoring-config).
Documentation: (https://docs.openshift.com/container-platform/4.11/monitoring/configuring-the-monitoring-stack.html#adding-cluster-id-labels-to-metrics_configuring-the-monitoring-stack).

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
