### PR TITLE
Add read permissions for velero CRs

### DIFF
--- a/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
@@ -103,6 +103,14 @@ rules:
   - serverstatusrequests
   verbs:
   - '*'
+- apiGroups:
+  - velero.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
 # SRE can resize and delete pvcs
 - apiGroups:
   - ""

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7093,6 +7093,14 @@ objects:
         verbs:
         - '*'
       - apiGroups:
+        - velero.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - ''
         resources:
         - persistentvolumeclaims

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7093,6 +7093,14 @@ objects:
         verbs:
         - '*'
       - apiGroups:
+        - velero.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - ''
         resources:
         - persistentvolumeclaims

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7093,6 +7093,14 @@ objects:
         verbs:
         - '*'
       - apiGroups:
+        - velero.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - ''
         resources:
         - persistentvolumeclaims


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds read permissions for velero CRs to openshift namespaces

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
