### PR TITLE
Add network policy label to OBO namespace for HyperShift

### DIFF
--- a/deploy/hypershift-mc-namespace-labels/01-openshift-observability-operator.patch.yaml
+++ b/deploy/hypershift-mc-namespace-labels/01-openshift-observability-operator.patch.yaml
@@ -1,0 +1,7 @@
+kind: Namespace
+apiVersion: v1
+name: openshift-observability-operator
+applyMode: AlwaysApply
+patch: |-
+  { "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"} } }
+patchType: merge

--- a/deploy/hypershift-mc-namespace-labels/config.yaml
+++ b/deploy/hypershift-mc-namespace-labels/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8265,6 +8265,32 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-mc-namespace-labels
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    patches:
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-observability-operator
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
+        } }'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8265,6 +8265,32 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-mc-namespace-labels
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    patches:
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-observability-operator
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
+        } }'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8265,6 +8265,32 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-mc-namespace-labels
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    patches:
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-observability-operator
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
+        } }'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
- The `openshift-monitoring` network policy in HCP namespaces allows ingress traffic to all of its pods from the namespace which has the `network.openshift.io/policy-group: monitoring` label.
- With Observability Operator as the default monitoring stack for hosted control planes in HyperShift, this PR adds the `network.openshift.io/policy-group: monitoring` label to the `openshift-observability-operator` namespaces allowing it to scrape metrics from hosted control planes.
- This patch targets HyperShift Management Clusters only, i.e; CD label `ext-hypershift.openshift.io/cluster-type: management-cluster`

JIRA: [OSD-13931](https://issues.redhat.com/browse/OSD-13931)