### PR TITLE
Add sss for hypershift tenant config

### DIFF
--- a/deploy/rhobs-hypershift-config/OWNERS
+++ b/deploy/rhobs-hypershift-config/OWNERS
@@ -1,0 +1,3 @@
+reviewers:
+- wanghaoran1988
+- supreeth7

--- a/deploy/rhobs-hypershift-config/README.md
+++ b/deploy/rhobs-hypershift-config/README.md
@@ -1,0 +1,3 @@
+# RHOBS HyperShift configuration
+
+This directory contains a SyncSet that copies the HyperShift RHOBS tenant configuration into all management clusters.

--- a/deploy/rhobs-hypershift-config/integration/00-rhobs-credential-syncset.yaml
+++ b/deploy/rhobs-hypershift-config/integration/00-rhobs-credential-syncset.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: SelectorSyncSet
+metadata:
+  name: rhobs-hypershift-config
+spec:
+  clusterDeploymentSelector:
+    matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+          - "management-cluster"
+  resourceApplyMode: Sync
+  secretMappings:
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-monitoring
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-observability-operator

--- a/deploy/rhobs-hypershift-config/integration/config.yaml
+++ b/deploy/rhobs-hypershift-config/integration/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "Direct"
+direct:
+    environments: ["integration"]

--- a/deploy/rhobs-hypershift-config/production/config.yaml
+++ b/deploy/rhobs-hypershift-config/production/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "Direct"
+direct:
+    environments: ["production"]

--- a/deploy/rhobs-hypershift-config/stage/00-rhobs-credential-syncset.yaml
+++ b/deploy/rhobs-hypershift-config/stage/00-rhobs-credential-syncset.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: hive.openshift.io/v1
+kind: SelectorSyncSet
+metadata:
+  name: rhobs-hypershift-config
+spec:
+  clusterDeploymentSelector:
+    matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+          - "management-cluster"
+  resourceApplyMode: Sync
+  secretMappings:
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-monitoring
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-observability-operator

--- a/deploy/rhobs-hypershift-config/stage/config.yaml
+++ b/deploy/rhobs-hypershift-config/stage/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "Direct"
+direct:
+    environments: ["stage"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -18466,3 +18466,28 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    name: rhobs-hypershift-config
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-monitoring
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-observability-operator

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -18466,3 +18466,28 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    name: rhobs-hypershift-config
+  spec:
+    clusterDeploymentSelector:
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    secretMappings:
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-monitoring
+    - sourceRef:
+        name: rhobs-hypershift-credential
+        namespace: hive
+      targetRef:
+        name: rhobs-hypershift-credential
+        namespace: openshift-observability-operator


### PR DESCRIPTION
### What type of PR is this?
feature
### What this PR does / why we need it?
We need use a sss to sync the hypershift credential to all management clusters.
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-13723](https://issues.redhat.com//browse/OSD-13723)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
