### PR TITLE
Prune invalid CRBs

### DIFF
--- a/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
@@ -40,3 +40,13 @@ rules:
   - builds
   verbs:
   - delete
+# crb pruning
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - list
+  - get
+  - delete
+  - deletecollection

--- a/deploy/sre-pruning/110-pruning-clusterrolebindings.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-clusterrolebindings.CronJob.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: crb-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "0 */1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+          - name: crb-pruner
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - oc
+            - delete
+            - --ignore-not-found
+            - --wait=false
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-csa-readers-cluster-system:serviceaccounts:openshift-backplane-csa
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-cse-readers-cluster-system:serviceaccounts:openshift-backplane-cse
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-csm-readers-cluster-system:serviceaccounts:openshift-backplane-csm
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-mobb-readers-cluster-system:serviceaccounts:openshift-backplane-mobb
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-readers-cluster-system:serviceaccounts:openshift-backplane-mtsre
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-srep-readers-cluster-system:serviceaccounts:openshift-backplane-srep
+            - clusterrolebinding.rbac.authorization.k8s.io/backplane-tam-readers-cluster-system:serviceaccounts:openshift-backplane-tam

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -18337,6 +18337,15 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        verbs:
+        - list
+        - get
+        - delete
+        - deletecollection
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -18395,6 +18404,51 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: crb-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 */1 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: crb-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - oc
+                  - delete
+                  - --ignore-not-found
+                  - --wait=false
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-csa-readers-cluster-system:serviceaccounts:openshift-backplane-csa
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-cse-readers-cluster-system:serviceaccounts:openshift-backplane-cse
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-csm-readers-cluster-system:serviceaccounts:openshift-backplane-csm
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mobb-readers-cluster-system:serviceaccounts:openshift-backplane-mobb
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-readers-cluster-system:serviceaccounts:openshift-backplane-mtsre
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-srep-readers-cluster-system:serviceaccounts:openshift-backplane-srep
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-tam-readers-cluster-system:serviceaccounts:openshift-backplane-tam
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -18337,6 +18337,15 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        verbs:
+        - list
+        - get
+        - delete
+        - deletecollection
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -18395,6 +18404,51 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: crb-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 */1 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: crb-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - oc
+                  - delete
+                  - --ignore-not-found
+                  - --wait=false
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-csa-readers-cluster-system:serviceaccounts:openshift-backplane-csa
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-cse-readers-cluster-system:serviceaccounts:openshift-backplane-cse
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-csm-readers-cluster-system:serviceaccounts:openshift-backplane-csm
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mobb-readers-cluster-system:serviceaccounts:openshift-backplane-mobb
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-readers-cluster-system:serviceaccounts:openshift-backplane-mtsre
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-srep-readers-cluster-system:serviceaccounts:openshift-backplane-srep
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-tam-readers-cluster-system:serviceaccounts:openshift-backplane-tam
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -18337,6 +18337,15 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        verbs:
+        - list
+        - get
+        - delete
+        - deletecollection
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -18395,6 +18404,51 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: crb-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 */1 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: crb-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - oc
+                  - delete
+                  - --ignore-not-found
+                  - --wait=false
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-csa-readers-cluster-system:serviceaccounts:openshift-backplane-csa
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-cse-readers-cluster-system:serviceaccounts:openshift-backplane-cse
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-csm-readers-cluster-system:serviceaccounts:openshift-backplane-csm
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mobb-readers-cluster-system:serviceaccounts:openshift-backplane-mobb
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-mtsre-readers-cluster-system:serviceaccounts:openshift-backplane-mtsre
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-srep-readers-cluster-system:serviceaccounts:openshift-backplane-srep
+                  - clusterrolebinding.rbac.authorization.k8s.io/backplane-tam-readers-cluster-system:serviceaccounts:openshift-backplane-tam
     - apiVersion: batch/v1beta1
       kind: CronJob
       metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Prune some invalid backplane CRBs that were created in error by the rbac-permissions-operator

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
