### PR TITLE
OSD-14071 Onboard MultipleDefaultStorageClasses to OAO

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -13,3 +13,11 @@ spec:
         Your cluster's ElasticSearch deployment is detected as being at safe disk consumption levels and no additional action on this issue is required.
       severity: Info
       summary: "ElasticSearch reaching disk capacity"
+    - activeBody: |-
+        Your cluster requires you to take action. SRE has observed that there is more than one default Storage Class configured for your cluster. Please specify one default storage class for your persistent volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage
+      name: MultipleDefaultStorageClasses
+      resendWait: 24
+      resolvedBody: |-
+        Your cluster no longer has multiple default storage classes defined. No further action is required.
+      severity: Info
+      summary: "Multiple Default Storage Classes Configured"

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -19,3 +19,12 @@ spec:
         namespace: openshift-logging
         send_managed_notification: "true"
         managed_notification_template: "LoggingVolumeFillingUp"
+    - alert: MultipleDefaultStorageClassesNotificationSRE
+    # MultipleDefaultStorageClasses alert firing in openshift-logging Namespace.
+      expr: count(ALERTS{alertname="MultipleDefaultStorageClasses", alertstate="firing", namespace="openshift-cluster-storage-operator"}) >= 1
+      for: 30m
+      labels:
+        severity: Info
+        namespace: openshift-cluster-storage-operator
+        send_managed_notification: "true"
+        managed_notification_template: "MultipleDefaultStorageClasses"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8136,6 +8136,16 @@ objects:
             is required.
           severity: Info
           summary: ElasticSearch reaching disk capacity
+        - activeBody: 'Your cluster requires you to take action. SRE has observed
+            that there is more than one default Storage Class configured for your
+            cluster. Please specify one default storage class for your persistent
+            volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage'
+          name: MultipleDefaultStorageClasses
+          resendWait: 24
+          resolvedBody: Your cluster no longer has multiple default storage classes
+            defined. No further action is required.
+          severity: Info
+          summary: Multiple Default Storage Classes Configured
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -18167,6 +18177,15 @@ objects:
               namespace: openshift-logging
               send_managed_notification: 'true'
               managed_notification_template: LoggingVolumeFillingUp
+          - alert: MultipleDefaultStorageClassesNotificationSRE
+            expr: count(ALERTS{alertname="MultipleDefaultStorageClasses", alertstate="firing",
+              namespace="openshift-cluster-storage-operator"}) >= 1
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-cluster-storage-operator
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleDefaultStorageClasses
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8136,6 +8136,16 @@ objects:
             is required.
           severity: Info
           summary: ElasticSearch reaching disk capacity
+        - activeBody: 'Your cluster requires you to take action. SRE has observed
+            that there is more than one default Storage Class configured for your
+            cluster. Please specify one default storage class for your persistent
+            volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage'
+          name: MultipleDefaultStorageClasses
+          resendWait: 24
+          resolvedBody: Your cluster no longer has multiple default storage classes
+            defined. No further action is required.
+          severity: Info
+          summary: Multiple Default Storage Classes Configured
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -18167,6 +18177,15 @@ objects:
               namespace: openshift-logging
               send_managed_notification: 'true'
               managed_notification_template: LoggingVolumeFillingUp
+          - alert: MultipleDefaultStorageClassesNotificationSRE
+            expr: count(ALERTS{alertname="MultipleDefaultStorageClasses", alertstate="firing",
+              namespace="openshift-cluster-storage-operator"}) >= 1
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-cluster-storage-operator
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleDefaultStorageClasses
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8136,6 +8136,16 @@ objects:
             is required.
           severity: Info
           summary: ElasticSearch reaching disk capacity
+        - activeBody: 'Your cluster requires you to take action. SRE has observed
+            that there is more than one default Storage Class configured for your
+            cluster. Please specify one default storage class for your persistent
+            volume claims. Consult the documentation for details: https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage'
+          name: MultipleDefaultStorageClasses
+          resendWait: 24
+          resolvedBody: Your cluster no longer has multiple default storage classes
+            defined. No further action is required.
+          severity: Info
+          summary: Multiple Default Storage Classes Configured
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -18167,6 +18177,15 @@ objects:
               namespace: openshift-logging
               send_managed_notification: 'true'
               managed_notification_template: LoggingVolumeFillingUp
+          - alert: MultipleDefaultStorageClassesNotificationSRE
+            expr: count(ALERTS{alertname="MultipleDefaultStorageClasses", alertstate="firing",
+              namespace="openshift-cluster-storage-operator"}) >= 1
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-cluster-storage-operator
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleDefaultStorageClasses
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Onboards the `MultipleDefaultStorageClasses` alert to ocm-agent-operator as it requires no SRE involvement. (see [SOP](https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleDefaultStorageClasses.md))

Nullifying in CAMO will occur after this is merged.

### Which Jira/Github issue(s) this PR fixes?

[OSD-14071](https://issues.redhat.com//browse/OSD-14071)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
