### PR TITLE
Add permissions for SRE to view servicemonitors in managed ns

### DIFF
--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -90,8 +90,7 @@ rules:
   verbs:
   - delete
   - deletecollection
-# SREP can view machineconfigs, machineconfigpools, kubeletconfigs,
-#    controllerconfigs
+# SREP can view machineconfigs, machineconfigpools, kubeletconfigs, controllerconfigs
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
@@ -135,7 +134,6 @@ rules:
   - list
   - watch
   - delete
-### End
 # SRE can view/delete vpcendpoints
 - apiGroups:
   - avo.openshift.io

--- a/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
@@ -177,3 +177,12 @@ rules:
   - subscriptions
   verbs:
   - delete
+# SRE can view monitoring.coreos.com CustomResources
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6650,6 +6650,14 @@ objects:
         - subscriptions
         verbs:
         - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6650,6 +6650,14 @@ objects:
         - subscriptions
         verbs:
         - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6650,6 +6650,14 @@ objects:
         - subscriptions
         verbs:
         - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Sometimes SRE needs to inspect ServiceMonitors in managed namespaces, e.g. https://github.com/openshift/ops-sop/blob/master/v4/alerts/UpgradeConfigSyncFailureOver4HrSRE.md#checking-for-muo-servicemonitors

I chose not to add write permissions, as I could see the argument either way. Happy to add them if we think they're needed