### PR TITLE
Add RHOBS_URL parameter to template

### DIFF
--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
+- name: RHOBS_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
+- name: RHOBS_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
+- name: RHOBS_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
+- name: RHOBS_URL
+  required: true  
 metadata:
   name: selectorsyncset-template
 objects:


### PR DESCRIPTION
### What type of PR is this?
bug
### What this PR does / why we need it?
Fix the RHOBS_URL added in https://github.com/openshift/managed-cluster-config/pull/1349

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
