### PR TITLE
Update permission for osde2e namespaces

### DIFF
--- a/deploy/backplane/srep/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/20-srep.SubjectPermission.yml
@@ -10,11 +10,11 @@ spec:
   permissions:
   - allowFirst: true
     clusterRoleName: backplane-srep-admins-project
-    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^osde2e-.*)"
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   - allowFirst: true
     clusterRoleName: dedicated-readers
-    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^osde2e-.*)"
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-srep


### PR DESCRIPTION
Added osde2e-* to namespaces to which srep have access without elevating permissions

internal slack thread for ref  https://coreos.slack.com/archives/CCX9DB894/p1669841886918709

### What type of PR is this?
_feature_

### What this PR does / why we need it?
for srep who need to debug osde2e pods. 

### Which Jira/Github issue(s) this PR fixes?

draft: need a jora

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
