### PR TITLE
fix: managedocs permissions for the odf addon

### DIFF
--- a/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
@@ -18,6 +18,7 @@ rules:
     resources:
       - "storageclassclaims"
       - "storageconsumers"
+      - "managedocs"
     verbs:
       - get
       - list

--- a/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
@@ -18,6 +18,7 @@ rules:
     resources:
       - "storageclassclaims"
       - "storageconsumers"
+      - "managedocs"
     verbs:
       - get
       - list

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5928,6 +5928,7 @@ objects:
         resources:
         - storageclassclaims
         - storageconsumers
+        - managedocs
         verbs:
         - get
         - list
@@ -6081,6 +6082,7 @@ objects:
         resources:
         - storageclassclaims
         - storageconsumers
+        - managedocs
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5928,6 +5928,7 @@ objects:
         resources:
         - storageclassclaims
         - storageconsumers
+        - managedocs
         verbs:
         - get
         - list
@@ -6081,6 +6082,7 @@ objects:
         resources:
         - storageclassclaims
         - storageconsumers
+        - managedocs
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5928,6 +5928,7 @@ objects:
         resources:
         - storageclassclaims
         - storageconsumers
+        - managedocs
         verbs:
         - get
         - list
@@ -6081,6 +6082,7 @@ objects:
         resources:
         - storageclassclaims
         - storageconsumers
+        - managedocs
         verbs:
         - get
         - list


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <ykukreja@redhat.com>

### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

MT-SRE backplane permissions for ODF forgot to span across one important managedocs API, this PR fixes that.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
