### PR TITLE
Osd 13558 add alert for non system change validation webhook configurations metric

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -21,3 +21,9 @@ spec:
         Your cluster no longer has multiple default storage classes defined. No further action is required.
       severity: Info
       summary: "Multiple Default Storage Classes Configured"
+    - activeBody: |-
+        A user on your system has removed a platform protection webhook. This protection has already been automatically replaced, and no further action is required. Tampering with platform protections can endanger SLAs.
+      name: NonSystemChangeValidationWebhookConfigurations # https://issues.redhat.com/browse/OSD-13558
+      resendWait: 24
+      severity: Error
+      summary: "Platform protections removed by non-Red Hat user"

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -24,6 +24,6 @@ spec:
     - activeBody: |-
         A user on your system has removed a platform protection webhook. This protection has already been automatically replaced, and no further action is required. Tampering with platform protections can endanger SLAs.
       name: NonSystemChangeValidationWebhookConfigurations # https://issues.redhat.com/browse/OSD-13558
-      resendWait: 24
+      resendWait: 1
       severity: Error
       summary: "Platform protections removed by non-Red Hat user"

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -29,8 +29,10 @@ spec:
         send_managed_notification: "true"
         managed_notification_template: "MultipleDefaultStorageClasses"
     - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
-    # splunkforwarder_audit_filter_exposed_splunk_event_total increased in the last 5 minutes
-      expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]) > 0
+    # splunkforwarder_audit_filter_exposed_splunk_event_total is a counter that starts at 1. Therefore, we cannot use increase()
+    # We don't care about the increased value either, we only care if it increased.
+    # Thererfore, we use sum up the changes of all matching metrics. A freshly created metric starting at 1 is considered a change.
+      expr: sum(changes(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])) > 0
       for: 1m
       labels:
         severity: Info

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -29,10 +29,12 @@ spec:
         send_managed_notification: "true"
         managed_notification_template: "MultipleDefaultStorageClasses"
     - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
-    # splunkforwarder_audit_filter_exposed_splunk_event_total is a counter that starts at 1. Therefore, we cannot use increase()
-    # We don't care about the increased value either, we only care if it increased.
-    # Thererfore, we use sum up the changes of all matching metrics. A freshly created metric starting at 1 is considered a change.
-      expr: sum(changes(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])) > 0
+    # splunkforwarder_audit_filter_exposed_splunk_event_total is a counter that starts at 1. 
+    # We cannot use increase(), as there is no increase from 0 to 1. 
+    # See https://github.com/prometheus/prometheus/issues/1673
+    # Therefore, we use the difference between two 5 minute timeslots (and fill up with 0 in case there is no metric)
+    # to check if the value increased
+      expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m] offset 5m) or vector(0)) > 0
       for: 1m
       labels:
         severity: Info

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -28,3 +28,12 @@ spec:
         namespace: openshift-cluster-storage-operator
         send_managed_notification: "true"
         managed_notification_template: "MultipleDefaultStorageClasses"
+    - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
+    # splunkforwarder_audit_filter_exposed_splunk_event_total increased in the last 5 minutes
+      expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: Info
+        namespace: audit-exporter
+        send_managed_notification: "true"
+        managed_notification_template: "NonSystemChangeValidationWebhookConfigurations"

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -35,7 +35,6 @@ spec:
     # Therefore, we use the difference between two 5 minute timeslots (and fill up with 0 in case there is no metric)
     # to check if the value increased
       expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m] offset 5m) or vector(0)) > 0
-      for: 1m
       labels:
         severity: Info
         namespace: audit-exporter

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8158,7 +8158,7 @@ objects:
             This protection has already been automatically replaced, and no further
             action is required. Tampering with platform protections can endanger SLAs.
           name: NonSystemChangeValidationWebhookConfigurations
-          resendWait: 24
+          resendWait: 1
           severity: Error
           summary: Platform protections removed by non-Red Hat user
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -18196,8 +18196,9 @@ objects:
               send_managed_notification: 'true'
               managed_notification_template: MultipleDefaultStorageClasses
           - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
-            expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
-              > 0
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]
+              offset 5m) or vector(0)) > 0
             for: 1m
             labels:
               severity: Info

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8154,6 +8154,13 @@ objects:
             defined. No further action is required.
           severity: Info
           summary: Multiple Default Storage Classes Configured
+        - activeBody: A user on your system has removed a platform protection webhook.
+            This protection has already been automatically replaced, and no further
+            action is required. Tampering with platform protections can endanger SLAs.
+          name: NonSystemChangeValidationWebhookConfigurations
+          resendWait: 24
+          severity: Error
+          summary: Platform protections removed by non-Red Hat user
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -18188,6 +18195,15 @@ objects:
               namespace: openshift-cluster-storage-operator
               send_managed_notification: 'true'
               managed_notification_template: MultipleDefaultStorageClasses
+          - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
+            expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
+              > 0
+            for: 1m
+            labels:
+              severity: Info
+              namespace: audit-exporter
+              send_managed_notification: 'true'
+              managed_notification_template: NonSystemChangeValidationWebhookConfigurations
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -18199,7 +18199,6 @@ objects:
             expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
               or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]
               offset 5m) or vector(0)) > 0
-            for: 1m
             labels:
               severity: Info
               namespace: audit-exporter

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8158,7 +8158,7 @@ objects:
             This protection has already been automatically replaced, and no further
             action is required. Tampering with platform protections can endanger SLAs.
           name: NonSystemChangeValidationWebhookConfigurations
-          resendWait: 24
+          resendWait: 1
           severity: Error
           summary: Platform protections removed by non-Red Hat user
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -18196,8 +18196,9 @@ objects:
               send_managed_notification: 'true'
               managed_notification_template: MultipleDefaultStorageClasses
           - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
-            expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
-              > 0
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]
+              offset 5m) or vector(0)) > 0
             for: 1m
             labels:
               severity: Info

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8154,6 +8154,13 @@ objects:
             defined. No further action is required.
           severity: Info
           summary: Multiple Default Storage Classes Configured
+        - activeBody: A user on your system has removed a platform protection webhook.
+            This protection has already been automatically replaced, and no further
+            action is required. Tampering with platform protections can endanger SLAs.
+          name: NonSystemChangeValidationWebhookConfigurations
+          resendWait: 24
+          severity: Error
+          summary: Platform protections removed by non-Red Hat user
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -18188,6 +18195,15 @@ objects:
               namespace: openshift-cluster-storage-operator
               send_managed_notification: 'true'
               managed_notification_template: MultipleDefaultStorageClasses
+          - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
+            expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
+              > 0
+            for: 1m
+            labels:
+              severity: Info
+              namespace: audit-exporter
+              send_managed_notification: 'true'
+              managed_notification_template: NonSystemChangeValidationWebhookConfigurations
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -18199,7 +18199,6 @@ objects:
             expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
               or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]
               offset 5m) or vector(0)) > 0
-            for: 1m
             labels:
               severity: Info
               namespace: audit-exporter

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8158,7 +8158,7 @@ objects:
             This protection has already been automatically replaced, and no further
             action is required. Tampering with platform protections can endanger SLAs.
           name: NonSystemChangeValidationWebhookConfigurations
-          resendWait: 24
+          resendWait: 1
           severity: Error
           summary: Platform protections removed by non-Red Hat user
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -18196,8 +18196,9 @@ objects:
               send_managed_notification: 'true'
               managed_notification_template: MultipleDefaultStorageClasses
           - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
-            expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
-              > 0
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]
+              offset 5m) or vector(0)) > 0
             for: 1m
             labels:
               severity: Info

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8154,6 +8154,13 @@ objects:
             defined. No further action is required.
           severity: Info
           summary: Multiple Default Storage Classes Configured
+        - activeBody: A user on your system has removed a platform protection webhook.
+            This protection has already been automatically replaced, and no further
+            action is required. Tampering with platform protections can endanger SLAs.
+          name: NonSystemChangeValidationWebhookConfigurations
+          resendWait: 24
+          severity: Error
+          summary: Platform protections removed by non-Red Hat user
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -18188,6 +18195,15 @@ objects:
               namespace: openshift-cluster-storage-operator
               send_managed_notification: 'true'
               managed_notification_template: MultipleDefaultStorageClasses
+          - alert: NonSystemChangeValidatingWebhookConfigurationsNotificationSRE
+            expr: rate(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
+              > 0
+            for: 1m
+            labels:
+              severity: Info
+              namespace: audit-exporter
+              send_managed_notification: 'true'
+              managed_notification_template: NonSystemChangeValidationWebhookConfigurations
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -18199,7 +18199,6 @@ objects:
             expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m])
               or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="NonSystemChangeValidationWebhookConfiguration"}[5m]
               offset 5m) or vector(0)) > 0
-            for: 1m
             labels:
               severity: Info
               namespace: audit-exporter


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?

This PR adds forwarding of splunk events exposed as metrics to ocm-agent. This automates sending SLs for Non-System Change ValidationWebhookConfigurations.

 See [OSD-13558](https://issues.redhat.com/browse/OSD-13558), [OSD-13559](https://issues.redhat.com/browse/OSD-13559)

Further information on the alerting expression: https://coreos.slack.com/archives/C0VMT03S5/p1669897261476509

### Which Jira/Github issue(s) this PR fixes?

_Fixes_ 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
