### PR TITLE
Make ACM policy generator not to walk directories

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -1,0 +1,396 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: backplane-srep
+    namespace: openshift-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: backplane-srep
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: Namespace
+                        metadata:
+                            name: openshift-backplane-srep
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: backplane-srep-admins-cluster
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - nodes
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - nodes/proxy
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - projects
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - project.openshift.io
+                              resources:
+                                - projects
+                                - projectrequests
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - namespaces
+                                - namespaces/finalize
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - certificates.k8s.io
+                              resources:
+                                - certificatesigningrequests/approval
+                              verbs:
+                                - update
+                            - nonResourceURLs:
+                                - '*'
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - authentication.k8s.io
+                              resources:
+                                - tokenreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - authorization.k8s.io
+                              resources:
+                                - localsubjectaccessreviews
+                                - selfsubjectaccessreviews
+                                - selfsubjectrulesreviews
+                                - subjectaccessreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                                - authorization.openshift.io
+                              resources:
+                                - localresourceaccessreviews
+                                - localsubjectaccessreviews
+                                - resourceaccessreviews
+                                - selfsubjectrulesreviews
+                                - subjectaccessreviews
+                                - subjectrulesreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - user.openshift.io
+                              resources:
+                                - users
+                                - identities
+                              verbs:
+                                - delete
+                                - deletecollection
+                            - apiGroups:
+                                - machineconfiguration.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - machine.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - machine.openshift.io
+                              resources:
+                                - machines
+                              verbs:
+                                - delete
+                            - apiGroups:
+                                - apiserver.openshift.io
+                              resources:
+                                - apirequestcounts
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - certificates.k8s.io
+                              resources:
+                                - certificatesigningrequests
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                                - delete
+                            - apiGroups:
+                                - avo.openshift.io
+                              resources:
+                                - vpcendpoints
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                                - delete
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: backplane-srep-admins-project
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/eviction
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/portforward
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/exec
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - batch
+                              resources:
+                                - jobs
+                              verbs:
+                                - delete
+                                - deletecollection
+                                - create
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - builds
+                              verbs:
+                                - delete
+                                - deletecollection
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                                - pods/attach
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                              verbs:
+                                - delete
+                                - deletecollection
+                            - apiGroups:
+                                - security.openshift.io
+                              resources:
+                                - podsecuritypolicyreviews
+                                - podsecuritypolicyselfsubjectreviews
+                                - podsecuritypolicysubjectreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - authorization.openshift.io
+                              resources:
+                                - localresourceaccessreviews
+                                - localsubjectaccessreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - logging.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - velero.io
+                              resources:
+                                - backups
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - velero.io
+                              resources:
+                                - deletebackuprequests
+                                - downloadrequests
+                                - serverstatusrequests
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - velero.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - persistentvolumeclaims
+                              verbs:
+                                - delete
+                                - patch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - replicationcontrollers/scale
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - deployments/scale
+                                - replicasets/scale
+                                - statefulsets/scale
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs/scale
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - replicasets
+                              verbs:
+                                - delete
+                                - deletecollection
+                            - apiGroups:
+                                - machine.openshift.io
+                              resources:
+                                - machinehealthchecks
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - machine.openshift.io
+                              resources:
+                                - machinesets/scale
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - prometheuses
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - upgrade.managed.openshift.io
+                              resources:
+                                - upgradeconfigs
+                              verbs:
+                                - delete
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - clusterserviceversions
+                                - installplans
+                                - subscriptions
+                              verbs:
+                                - delete
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-srep-mustgather
+                            namespace: openshift-must-gather-operator
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - managed.openshift.io
+                              resources:
+                                - mustgathers
+                              verbs:
+                                - create
+                                - delete
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-srep-mustgather
+                            namespace: openshift-must-gather-operator
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-srep-mustgather
+                            namespace: openshift-must-gather-operator
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-srep
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-backplane-srep
+    namespace: openshift-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-backplane-srep
+    namespace: openshift-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-backplane-srep
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: backplane-srep

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: backplane
+    namespace: openshift-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: backplane
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        aggregationRule:
+                            clusterRoleSelectors:
+                                - matchExpressions:
+                                    - key: rbac.authorization.k8s.io/aggregate-to-view
+                                      operator: In
+                                      values:
+                                        - "true"
+                                    - key: kubernetes.io/bootstrapping
+                                      operator: DoesNotExist
+                                - matchExpressions:
+                                    - key: managed.openshift.io/aggregate-to-dedicated-readers
+                                      operator: In
+                                      values:
+                                        - "true"
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: backplane-readers-cluster
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-backplane
+    namespace: openshift-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-backplane
+    namespace: openshift-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-backplane
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: backplane

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -630,6 +630,466 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-srep
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: openshift-backplane-srep
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-srep-admins-cluster
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes/proxy
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    - projectrequests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    - namespaces/finalize
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests/approval
+                    verbs:
+                    - update
+                  - nonResourceURLs:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - localsubjectaccessreviews
+                    - selfsubjectaccessreviews
+                    - selfsubjectrulesreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    - resourceaccessreviews
+                    - selfsubjectrulesreviews
+                    - subjectaccessreviews
+                    - subjectrulesreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - users
+                    - identities
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - apiserver.openshift.io
+                    resources:
+                    - apirequestcounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                    - delete
+                  - apiGroups:
+                    - avo.openshift.io
+                    resources:
+                    - vpcendpoints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-srep-admins-project
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/eviction
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/exec
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - jobs
+                    verbs:
+                    - delete
+                    - deletecollection
+                    - create
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/attach
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - podsecuritypolicyreviews
+                    - podsecuritypolicyselfsubjectreviews
+                    - podsecuritypolicysubjectreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - logging.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - backups
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - deletebackuprequests
+                    - downloadrequests
+                    - serverstatusrequests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - delete
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicationcontrollers/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments/scale
+                    - replicasets/scale
+                    - statefulsets/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicasets
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machinehealthchecks
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machinesets/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - upgrade.managed.openshift.io
+                    resources:
+                    - upgradeconfigs
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - clusterserviceversions
+                    - installplans
+                    - subscriptions
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - managed.openshift.io
+                    resources:
+                    - mustgathers
+                    verbs:
+                    - create
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-srep
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-srep
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-srep
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-srep
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-view
+                        operator: In
+                        values:
+                        - 'true'
+                      - key: kubernetes.io/bootstrapping
+                        operator: DoesNotExist
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-readers
+                        operator: In
+                        values:
+                        - 'true'
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-readers-cluster
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-rbac-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -630,6 +630,466 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-srep
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: openshift-backplane-srep
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-srep-admins-cluster
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes/proxy
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    - projectrequests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    - namespaces/finalize
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests/approval
+                    verbs:
+                    - update
+                  - nonResourceURLs:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - localsubjectaccessreviews
+                    - selfsubjectaccessreviews
+                    - selfsubjectrulesreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    - resourceaccessreviews
+                    - selfsubjectrulesreviews
+                    - subjectaccessreviews
+                    - subjectrulesreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - users
+                    - identities
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - apiserver.openshift.io
+                    resources:
+                    - apirequestcounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                    - delete
+                  - apiGroups:
+                    - avo.openshift.io
+                    resources:
+                    - vpcendpoints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-srep-admins-project
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/eviction
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/exec
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - jobs
+                    verbs:
+                    - delete
+                    - deletecollection
+                    - create
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/attach
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - podsecuritypolicyreviews
+                    - podsecuritypolicyselfsubjectreviews
+                    - podsecuritypolicysubjectreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - logging.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - backups
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - deletebackuprequests
+                    - downloadrequests
+                    - serverstatusrequests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - delete
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicationcontrollers/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments/scale
+                    - replicasets/scale
+                    - statefulsets/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicasets
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machinehealthchecks
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machinesets/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - upgrade.managed.openshift.io
+                    resources:
+                    - upgradeconfigs
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - clusterserviceversions
+                    - installplans
+                    - subscriptions
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - managed.openshift.io
+                    resources:
+                    - mustgathers
+                    verbs:
+                    - create
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-srep
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-srep
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-srep
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-srep
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-view
+                        operator: In
+                        values:
+                        - 'true'
+                      - key: kubernetes.io/bootstrapping
+                        operator: DoesNotExist
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-readers
+                        operator: In
+                        values:
+                        - 'true'
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-readers-cluster
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-rbac-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -630,6 +630,466 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-srep
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: openshift-backplane-srep
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-srep-admins-cluster
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes/proxy
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    - projectrequests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    - namespaces/finalize
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests/approval
+                    verbs:
+                    - update
+                  - nonResourceURLs:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - localsubjectaccessreviews
+                    - selfsubjectaccessreviews
+                    - selfsubjectrulesreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    - resourceaccessreviews
+                    - selfsubjectrulesreviews
+                    - subjectaccessreviews
+                    - subjectrulesreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - users
+                    - identities
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - apiserver.openshift.io
+                    resources:
+                    - apirequestcounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                    - delete
+                  - apiGroups:
+                    - avo.openshift.io
+                    resources:
+                    - vpcendpoints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-srep-admins-project
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/eviction
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/exec
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - jobs
+                    verbs:
+                    - delete
+                    - deletecollection
+                    - create
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/attach
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - podsecuritypolicyreviews
+                    - podsecuritypolicyselfsubjectreviews
+                    - podsecuritypolicysubjectreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - logging.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - backups
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - deletebackuprequests
+                    - downloadrequests
+                    - serverstatusrequests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - velero.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - delete
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicationcontrollers/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments/scale
+                    - replicasets/scale
+                    - statefulsets/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicasets
+                    verbs:
+                    - delete
+                    - deletecollection
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machinehealthchecks
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machinesets/scale
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - upgrade.managed.openshift.io
+                    resources:
+                    - upgradeconfigs
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - clusterserviceversions
+                    - installplans
+                    - subscriptions
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - managed.openshift.io
+                    resources:
+                    - mustgathers
+                    verbs:
+                    - create
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-mustgather
+                    namespace: openshift-must-gather-operator
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-srep
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-srep
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-srep
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-srep
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  aggregationRule:
+                    clusterRoleSelectors:
+                    - matchExpressions:
+                      - key: rbac.authorization.k8s.io/aggregate-to-view
+                        operator: In
+                        values:
+                        - 'true'
+                      - key: kubernetes.io/bootstrapping
+                        operator: DoesNotExist
+                    - matchExpressions:
+                      - key: managed.openshift.io/aggregate-to-dedicated-readers
+                        operator: In
+                        values:
+                        - 'true'
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-readers-cluster
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
         namespace: openshift-rbac-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -4,35 +4,41 @@ import oyaml as yaml
 import shutil
 import os
 
-#an array of directories you want to generate policies for. Please make sure ONLY the directories you want exist here. if there's entries here, delete it and add yours.
-directory = [
-        './deploy/rbac-permissions-operator-config',
-        './deploy/osd-cluster-admin'
+base_directory = "./deploy/"
+# An array of directories you want to generate policies for.
+# Please make sure ONLY the directories you want exist here.
+# This script doesn't walk the sub-directories.
+directories = [
+        'rbac-permissions-operator-config',
+        'osd-cluster-admin',
+        'backplane',
+        'backplane/srep'
         ]
 policy_generator_config = './scripts/policy-generator-config.yaml'
 config_filename = "config.yaml"
 #go into each directory and copy a subset of manifests that are not SubjectPermissions or config.yaml into a /tmp dir
-for dir in directory:
+for directory in directories:
     #extract the directory name
-    dir_name = os.path.basename(dir)
-    temp_directory = os.path.join("/tmp", dir_name)
+    policy_name = directory.replace("/", "-")
+    temp_directory = os.path.join("/tmp", policy_name)
     #create a temporary path to stores the subset of manifests that will generate policies with
     path = os.path.join(temp_directory, "configs")
     os.makedirs(path)
-    for r,d,f in os.walk(dir):
-        for file in f:
-            if (file.endswith('.yml') or file.endswith('.yaml') and not(file == config_filename)):
-                if 'SubjectPermission' not in file:
-                    shutil.copy( os.path.join(dir, file), path)
-        #create a dir in /resources to hold the newly generated policy-generator-config.yaml
-        #copy over the generator template
-        shutil.copy(policy_generator_config, temp_directory)
-        with open(policy_generator_config,'r') as input_file:
-            policy_template = yaml.safe_load(input_file)
-        #fill in the name and path in the policy generator template
-        for p in policy_template['policies']:
-            p['name'] = dir_name
-            for m in p['manifests']:
-                m['path'] = path
-        with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:
-            yaml.dump(policy_template, output_file)
+    for entry in os.scandir(os.path.join(base_directory, directory)):
+        if not entry.is_file():
+            continue
+        if (entry.name.endswith('.yml') or entry.name.endswith('.yaml') and not(entry.name == config_filename)):
+            if 'SubjectPermission' not in entry.name:
+                shutil.copy( os.path.join(base_directory, directory, entry.name), path)
+    #create a dir in /resources to hold the newly generated policy-generator-config.yaml
+    #copy over the generator template
+    shutil.copy(policy_generator_config, temp_directory)
+    with open(policy_generator_config,'r') as input_file:
+        policy_template = yaml.safe_load(input_file)
+    #fill in the name and path in the policy generator template
+    for p in policy_template['policies']:
+        p['name'] = policy_name
+        for m in p['manifests']:
+            m['path'] = path
+    with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:
+        yaml.dump(policy_template, output_file)


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Bug

### What this PR does / why we need it?
This PR make the generator policy config script not to walk the directory. (Walk means it will scan all the sub-directories till the leaf). With the change of this PR, it will only scan files in the directories specified, not walking into the sub-directories.

Why?
1. If walking through every sub-directories, the filenames can have conflicts. Also the current logic doesn't handle the files in sub-directory well. Eg. 
```
FileNotFoundError: [Errno 2] No such file or directory: './deploy/backplane/20-cee-mustgather.Role.yml'
```
where `20-cee-mustgather.Role.yml` is actually from "./deploy/backplane/cee". [Link](https://github.com/openshift/managed-cluster-config/tree/8b2cf08d8839bc792781b581859b39a7fc405acd/deploy/backplane/cee).

2. The current MCC struct allows sub-directories with different config.yaml. In some case we don't want to concert specific sub-directory to ACM policy. For example,
https://github.com/openshift/managed-cluster-config/tree/8b2cf08d8839bc792781b581859b39a7fc405acd/deploy/backplane/srep/hive
We don't need those hive specific policies to be concerted to ACM.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
