### PR TITLE
deploy/sre-build-test: Set 'ttlSecondsAfterFinished: 86400'

### DIFF
--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -12,6 +12,7 @@ spec:
   jobTemplate:
     spec:
       activeDeadlineSeconds: 900
+      ttlSecondsAfterFinished: 86400
       template:
         spec:
           affinity:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -17873,6 +17873,7 @@ objects:
         jobTemplate:
           spec:
             activeDeadlineSeconds: 900
+            ttlSecondsAfterFinished: 86400
             template:
               spec:
                 affinity:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -17873,6 +17873,7 @@ objects:
         jobTemplate:
           spec:
             activeDeadlineSeconds: 900
+            ttlSecondsAfterFinished: 86400
             template:
               spec:
                 affinity:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -17873,6 +17873,7 @@ objects:
         jobTemplate:
           spec:
             activeDeadlineSeconds: 900
+            ttlSecondsAfterFinished: 86400
             template:
               spec:
                 affinity:


### PR DESCRIPTION
So that failing jobs only trigger `KubeJobFailed` for a day before they get cleaned up.  Ideally somebody notices the failures and checks in to see what's going on.  But if everyone is busy with more important things, and subsequent CronJob runs have been passing, just clean up the mess so folks don't have to do that manually.  And if the underlying issue crops up again later, folks will have another chance to go investigate the failure mode then.

Docs for the property [here][1].

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs

### What type of PR is this?

bug

### What this PR does / why we need it?

Reduces manual work cleaning up after no-longer-interesting messes.

### Which Jira/Github issue(s) this PR fixes?

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
