### PR TITLE
set security context for prune cronjobs

### DIFF
--- a/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-builds.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: builds-pruner
@@ -40,3 +40,11 @@ spec:
             - --keep-complete=1
             - --keep-failed=1
             - --confirm
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault

--- a/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
+++ b/deploy/sre-pruning/110-pruning-deployments.CronJob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: deployments-pruner
@@ -40,3 +40,11 @@ spec:
             - --keep-younger-than=24h
             - --keep-failed=1
             - --confirm
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -20048,7 +20048,7 @@ objects:
       metadata:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: builds-pruner
@@ -20089,7 +20089,16 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
-    - apiVersion: batch/v1beta1
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: deployments-pruner
@@ -20130,6 +20139,15 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -20048,7 +20048,7 @@ objects:
       metadata:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: builds-pruner
@@ -20089,7 +20089,16 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
-    - apiVersion: batch/v1beta1
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: deployments-pruner
@@ -20130,6 +20139,15 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -20048,7 +20048,7 @@ objects:
       metadata:
         name: sre-pruner-sa
         namespace: openshift-sre-pruning
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: builds-pruner
@@ -20089,7 +20089,16 @@ objects:
                   - --keep-complete=1
                   - --keep-failed=1
                   - --confirm
-    - apiVersion: batch/v1beta1
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: deployments-pruner
@@ -20130,6 +20139,15 @@ objects:
                   - --keep-younger-than=24h
                   - --keep-failed=1
                   - --confirm
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

/cleanup

### What this PR does / why we need it?

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-ocp-osd-aws-nightly-4.12/1598612626013687808

Update the deployments-pruner and builds-pruner APIVersion to v1 (from v1beta1)
and set the pod security context. Within the logs of [these
tests](https://github.com/openshift/osde2e/blob/main/pkg/e2e/operators/prunejob.go#L29-L51),
warnings are printed when we created jobs based on the cronjob:

before:

```
Will run 2 of 125 specs
SSSSSSSS
W1202 11:20:42.988103 1005489 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "deployments-pruner" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "deployments-pruner" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "deployments-pruner" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "deployments-pruner" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
2022/12/02 11:20:43 Waiting 8h19m59.969668603s for deployments-pruner-sl22t job to complete
2022/12/02 11:20:48 Waiting 8h19m54.937339364s for deployments-pruner-sl22t job to complete
•
W1202 11:20:53.199259 1005489 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "deployments-pruner" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "deployments-pruner" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "deployments-pruner" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "deployments-pruner" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
2022/12/02 11:20:53 Waiting 8h19m59.96965303s for deployments-pruner-wphq7 job to complete
2022/12/02 11:20:58 Waiting 8h19m54.939251426s for deployments-pruner-wphq7 job to complete
•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 2 of 125 Specs in 20.440 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 123 Skipped
PASS
```

after:

```
Will run 2 of 125 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
2022/12/02 11:01:20 Waiting 8h19m59.969431149s for deployments-pruner-g9ft8 job to complete
2022/12/02 11:01:25 Waiting 8h19m54.935040033s for deployments-pruner-g9ft8 job to complete
•
2022/12/02 11:01:30 Waiting 8h19m59.968788541s for deployments-pruner-bx8zw job to complete
2022/12/02 11:01:35 Waiting 8h19m54.937429283s for deployments-pruner-bx8zw job to complete
•SSSSSSSSSSSSSSSSSSSSSSSSS
Ran 2 of 125 Specs in 20.452 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 123 Skipped
PASS
```

When creating these resources, you can see the warnings at the CronJob level:

```
Warning: batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "deployments-pruner" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "deployments-pruner" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "deployments-pruner" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "deployments-pruner" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
cronjob.batch/deployments-pruner created
```

after:

```
cronjob.batch/deployments-pruner created
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes [SDCICD-852](https://issues.redhat.com//browse/SDCICD-852)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
