### PR TITLE
Allow dedicated admins to view machine config pools

### DIFF
--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -311,3 +311,12 @@ rules:
   - list
   - watch
 ### End
+# Allow dedicated admins to view machine config pools
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigpools
+  verbs:
+  - get
+  - list
+  - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2401,6 +2401,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
@@ -18145,6 +18153,14 @@ objects:
         - operators.coreos.com
         resources:
         - operators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - machineconfigpools
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2401,6 +2401,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
@@ -18145,6 +18153,14 @@ objects:
         - operators.coreos.com
         resources:
         - operators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - machineconfigpools
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2401,6 +2401,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
@@ -18145,6 +18153,14 @@ objects:
         - operators.coreos.com
         resources:
         - operators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - machineconfigpools
         verbs:
         - get
         - list


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This allows dedicated admins/readers the ability to view MCPs in order to watch rollouts of configuration, in particular during upgrades. Nothing private here.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
