### PR TITLE
Exclude ACM generated files from roleref check

### DIFF
--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -40,7 +40,7 @@ do
 done
 
 # check if roleref has been modified in a clusterrolebinding/rolebinding as a part of this change
-for fl in $( git diff --name-only --diff-filter=M  origin/master deploy )
+for fl in $( git diff --name-only --diff-filter=M  origin/master deploy ':!deploy/acm-policies/50-GENERATED-*' )
 do
   if cat ${fl} | grep -i "RoleBinding" | grep -q "kind:" ; then
     ROLEREF_MASTER=$(git show origin/master:${fl} | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))' | jq -r '.roleRef' )
@@ -53,5 +53,5 @@ do
   fi
 done
 
-# script needs to pass for app-sre workflow 
+# script needs to pass for app-sre workflow
 exit 0


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
ACM generated policies have multiple YAML docs in them, and will never have direct role binding objects in them. We can exclude them from this check.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
