### PR TITLE
[OSD-14160] Add alert to detect stuck node.

### DIFF
--- a/deploy/sre-prometheus/100-node-stuck-terminating-creating.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-stuck-terminating-creating.PrometheusRule.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-node-stuck
+    role: alert-rules
+  name: sre-node-stuck
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-node-stuck
+    rules:
+    - alert: KubeNodeStuckWithCreatingAndTerminatingPodsSRE
+      expr: |
+        sum by (node) ((
+          count(
+            count(kube_pod_container_status_waiting_reason{job="kube-state-metrics", namespace=~"(openshift-.*|kube-.*|default)"}) by (pod, namespace) * on (pod, namespace) group_right kube_pod_info{}) by (node)
+          )
+        * on (node) group_left
+          count(
+            (count(kube_pod_deletion_timestamp) by (pod, namespace) * count(kube_pod_status_reason{reason="NodeLost",namespace=~"(openshift-.*|kube-.*|default)"}  == 0) by (namespace, pod) * on (pod, namespace) group_right kube_pod_info{})
+          ) by (node)
+        ) > 0
+      for: 30m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+        maturity: "immature"
+        source: "https://issues.redhat.com//browse/OSD-14160"
+      annotations:
+        message: "The node {{ $labels.node }} has containers stuck in creating and terminating for more than 30 minutes."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33800,6 +33800,36 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-stuck
+          role: alert-rules
+        name: sre-node-stuck
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-node-stuck
+          rules:
+          - alert: KubeNodeStuckWithCreatingAndTerminatingPodsSRE
+            expr: "sum by (node) ((\n  count(\n    count(kube_pod_container_status_waiting_reason{job=\"\
+              kube-state-metrics\", namespace=~\"(openshift-.*|kube-.*|default)\"\
+              }) by (pod, namespace) * on (pod, namespace) group_right kube_pod_info{})\
+              \ by (node)\n  )\n* on (node) group_left\n  count(\n    (count(kube_pod_deletion_timestamp)\
+              \ by (pod, namespace) * count(kube_pod_status_reason{reason=\"NodeLost\"\
+              ,namespace=~\"(openshift-.*|kube-.*|default)\"}  == 0) by (namespace,\
+              \ pod) * on (pod, namespace) group_right kube_pod_info{})\n  ) by (node)\n\
+              ) > 0\n"
+            for: 30m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              maturity: immature
+              source: https://issues.redhat.com//browse/OSD-14160
+            annotations:
+              message: The node {{ $labels.node }} has containers stuck in creating
+                and terminating for more than 30 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-unschedulable
           role: alert-rules
         name: sre-node-unschedulable

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33800,6 +33800,36 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-stuck
+          role: alert-rules
+        name: sre-node-stuck
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-node-stuck
+          rules:
+          - alert: KubeNodeStuckWithCreatingAndTerminatingPodsSRE
+            expr: "sum by (node) ((\n  count(\n    count(kube_pod_container_status_waiting_reason{job=\"\
+              kube-state-metrics\", namespace=~\"(openshift-.*|kube-.*|default)\"\
+              }) by (pod, namespace) * on (pod, namespace) group_right kube_pod_info{})\
+              \ by (node)\n  )\n* on (node) group_left\n  count(\n    (count(kube_pod_deletion_timestamp)\
+              \ by (pod, namespace) * count(kube_pod_status_reason{reason=\"NodeLost\"\
+              ,namespace=~\"(openshift-.*|kube-.*|default)\"}  == 0) by (namespace,\
+              \ pod) * on (pod, namespace) group_right kube_pod_info{})\n  ) by (node)\n\
+              ) > 0\n"
+            for: 30m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              maturity: immature
+              source: https://issues.redhat.com//browse/OSD-14160
+            annotations:
+              message: The node {{ $labels.node }} has containers stuck in creating
+                and terminating for more than 30 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-unschedulable
           role: alert-rules
         name: sre-node-unschedulable

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33800,6 +33800,36 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-stuck
+          role: alert-rules
+        name: sre-node-stuck
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-node-stuck
+          rules:
+          - alert: KubeNodeStuckWithCreatingAndTerminatingPodsSRE
+            expr: "sum by (node) ((\n  count(\n    count(kube_pod_container_status_waiting_reason{job=\"\
+              kube-state-metrics\", namespace=~\"(openshift-.*|kube-.*|default)\"\
+              }) by (pod, namespace) * on (pod, namespace) group_right kube_pod_info{})\
+              \ by (node)\n  )\n* on (node) group_left\n  count(\n    (count(kube_pod_deletion_timestamp)\
+              \ by (pod, namespace) * count(kube_pod_status_reason{reason=\"NodeLost\"\
+              ,namespace=~\"(openshift-.*|kube-.*|default)\"}  == 0) by (namespace,\
+              \ pod) * on (pod, namespace) group_right kube_pod_info{})\n  ) by (node)\n\
+              ) > 0\n"
+            for: 30m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              maturity: immature
+              source: https://issues.redhat.com//browse/OSD-14160
+            annotations:
+              message: The node {{ $labels.node }} has containers stuck in creating
+                and terminating for more than 30 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-unschedulable
           role: alert-rules
         name: sre-node-unschedulable


### PR DESCRIPTION
Some nodes do not alert, but are broken - one indicator for this is pods being stuck in ContainerCreating as well as Terminating state on the same node.

This alert should detect nodes that have containers stuck in both states at the same time.

### What type of PR is this?
feature

### What this PR does / why we need it?
Adds a new alert to detect broken nodes earlier.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-14160](https://issues.redhat.com//browse/OSD-14160)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster: tested in CRC cluster with stuck pods.
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
