### PR TITLE
added SubjectPermission Policy generation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ endif
 ifndef GEN_POLICY_CONFIG
 $(error GEN_POLICY_CONFIG is not set; check project.mk file)
 endif
+ifndef GEN_POLICY_CONFIG_SP
+$(error GEN_POLICY_CONFIG_SP is not set; check project.mk file)
+endif
+
 
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
 CONTAINER_RUN_FLAGS=--rm -v `pwd -P`:`pwd -P`:z -w=`pwd` --platform linux/amd64
@@ -59,10 +63,11 @@ generate-rosa-brand-logo:
 generate-hive-templates: generate-oauth-templates
 	if [ -z ${IN_CONTAINER} ]; then \
 		$(CONTAINER_ENGINE) pull quay.io/app-sre/python:3 && $(CONTAINER_ENGINE) tag quay.io/app-sre/python:3 python:3 || true; \
-		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) --user $(id -u):$(id -g) python:3 /bin/sh -c "echo $(shell id -u) ; cd `pwd -P`; pip install oyaml; ${GEN_POLICY_CONFIG}; wget -nc https://github.com/stolostron/policy-generator-plugin/releases/download/v1.9.1/linux-amd64-PolicyGenerator -O /tmp/linux-amd64-PolicyGenerator; echo $(shell id -g); chmod +x /tmp/linux-amd64-PolicyGenerator ; PolicyGenerator=/tmp/linux-amd64-PolicyGenerator ${GEN_POLICY}";\
+		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) --user $(id -u):$(id -g) python:3 /bin/sh -c "echo $(shell id -u) ; cd `pwd -P`; pip install oyaml;${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; wget -nc https://github.com/stolostron/policy-generator-plugin/releases/download/v1.9.1/linux-amd64-PolicyGenerator -O /tmp/linux-amd64-PolicyGenerator; echo $(shell id -g); chmod +x /tmp/linux-amd64-PolicyGenerator ; PolicyGenerator=/tmp/linux-amd64-PolicyGenerator ${GEN_POLICY}";\
 		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) python:3 /bin/sh -c "cd `pwd -P`; pip install oyaml; ${GEN_TEMPLATE}"; \
 	else \
 		${GEN_POLICY_CONFIG};\
+		${GEN_POLICY_CONFIG_SP};\
 		PolicyGenerator=/tmp/linux-amd64-PolicyGenerator ${GEN_POLICY};\
 		${GEN_TEMPLATE}; \
 	fi

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To add a Policy
 - If the manifest of the object you want to convert to policy already exists in ./deploy :  Right now the policies are group by their funtionalities (like the rbac-policies that will generate all the policies for rbac related thing.). So if you want to add an rbac manifest, go to /script/generate-policy-template.py and add the directory you want to convert in the directory array. 
 - If the manifest of the object does not exist; add your manifests; then also add the directory of your manifest into the array in /script/generate-policy-template.py 
 -Policies requires to be deploy in namespaces, so if the new policies don't belong to `openshift-managed-rbac-config`, create a manifest to create a new namespace. Example: ./deploy/acm-policies/00-openshift-managed-rbac-policies.Namespace.yaml 
+- If the manifest is SubjectPermission, add the directory of the manifest into the array in /script/generate-subjectpermissions-policy-template.py. then run `make` as usually
 
 Then Run `make`
 `make` will look for the `policy-generator-config.yaml` files, runs it with the PolicyGenerator binary and save the output to `./deploy/acm-policies` directory. `make` will then automatically

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: backplane-srep-sp
+    namespace: openshift-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: backplane-srep-sp
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: managed.openshift.io/v1alpha1
+                        kind: SubjectPermission
+                        metadata:
+                            name: backplane-srep
+                            namespace: openshift-rbac-permissions
+                        spec:
+                            clusterPermissions:
+                                - backplane-srep-admins-cluster
+                                - backplane-readers-cluster
+                            permissions:
+                                - allowFirst: true
+                                  clusterRoleName: backplane-srep-admins-project
+                                  namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                                  namespacesDeniedRegex: openshift-backplane-cluster-admin
+                                - allowFirst: true
+                                  clusterRoleName: dedicated-readers
+                                  namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                                  namespacesDeniedRegex: openshift-backplane-cluster-admin
+                            subjectKind: Group
+                            subjectName: system:serviceaccounts:openshift-backplane-srep
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-backplane-srep-sp
+    namespace: openshift-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-backplane-srep-sp
+    namespace: openshift-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-backplane-srep-sp
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: backplane-srep-sp

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: ccs-dedicated-admins-sp
+    namespace: openshift-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: ccs-dedicated-admins-sp
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: managed.openshift.io/v1alpha1
+                        kind: SubjectPermission
+                        metadata:
+                            name: dedicated-admins-customer-monitoring
+                            namespace: openshift-rbac-permissions
+                        spec:
+                            permissions:
+                                - allowFirst: true
+                                  clusterRoleName: dedicated-admins-project
+                                  namespacesAllowedRegex: ^openshift-customer-monitoring$
+                                - allowFirst: true
+                                  clusterRoleName: admin
+                                  namespacesAllowedRegex: ^openshift-customer-monitoring$
+                            subjectKind: Group
+                            subjectName: dedicated-admins
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-ccs-dedicated-admins-sp
+    namespace: openshift-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-ccs-dedicated-admins-sp
+    namespace: openshift-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-ccs-dedicated-admins-sp
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: ccs-dedicated-admins-sp

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: rbac-permissions-operator-config-sp
+    namespace: openshift-rbac-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: managed.openshift.io/v1alpha1
+                        kind: SubjectPermission
+                        metadata:
+                            name: dedicated-admin-serviceaccounts
+                            namespace: openshift-rbac-permissions
+                        spec:
+                            clusterPermissions:
+                                - dedicated-admins-cluster
+                            permissions:
+                                - allowFirst: true
+                                  clusterRoleName: dedicated-admins-project
+                                  namespacesAllowedRegex: .*
+                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                                - allowFirst: true
+                                  clusterRoleName: admin
+                                  namespacesAllowedRegex: .*
+                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                            subjectKind: Group
+                            subjectName: system:serviceaccounts:dedicated-admin
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: managed.openshift.io/v1alpha1
+                        kind: SubjectPermission
+                        metadata:
+                            name: dedicated-admins
+                            namespace: openshift-rbac-permissions
+                        spec:
+                            clusterPermissions:
+                                - dedicated-admins-cluster
+                            permissions:
+                                - allowFirst: true
+                                  clusterRoleName: dedicated-admins-project
+                                  namespacesAllowedRegex: .*
+                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                                - allowFirst: true
+                                  clusterRoleName: admin
+                                  namespacesAllowedRegex: .*
+                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                            subjectKind: Group
+                            subjectName: dedicated-admins
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: managed.openshift.io/v1alpha1
+                        kind: SubjectPermission
+                        metadata:
+                            name: dedicated-admins-core-ns
+                            namespace: openshift-rbac-permissions
+                        spec:
+                            permissions:
+                                - allowFirst: true
+                                  clusterRoleName: dedicated-admins-project
+                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                                - allowFirst: true
+                                  clusterRoleName: admin
+                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                            subjectKind: Group
+                            subjectName: dedicated-admins
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: managed.openshift.io/v1alpha1
+                        kind: SubjectPermission
+                        metadata:
+                            name: dedicated-admin-serviceaccounts-core-ns
+                            namespace: openshift-rbac-permissions
+                        spec:
+                            permissions:
+                                - allowFirst: true
+                                  clusterRoleName: dedicated-admins-project
+                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                                - allowFirst: true
+                                  clusterRoleName: admin
+                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                            subjectKind: Group
+                            subjectName: system:serviceaccounts:dedicated-admin
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-rbac-permissions-operator-config-sp
+    namespace: openshift-rbac-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-rbac-permissions-operator-config-sp
+    namespace: openshift-rbac-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-rbac-permissions-operator-config-sp
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: rbac-permissions-operator-config-sp

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -870,6 +870,14 @@ spec:
                                 - get
                                 - list
                                 - watch
+                            - apiGroups:
+                                - machineconfiguration.openshift.io
+                              resources:
+                                - machineconfigpools
+                              verbs:
+                                - get
+                                - list
+                                - watch
                     - complianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -630,6 +630,75 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-srep-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: backplane-srep
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - backplane-srep-admins-cluster
+                    - backplane-readers-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: backplane-srep-admins-project
+                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                      namespacesDeniedRegex: openshift-backplane-cluster-admin
+                    - allowFirst: true
+                      clusterRoleName: dedicated-readers
+                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                      namespacesDeniedRegex: openshift-backplane-cluster-admin
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-srep-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-srep-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-srep-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-srep-sp
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
         namespace: openshift-rbac-policies
       spec:
@@ -1090,6 +1159,70 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: ccs-dedicated-admins-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins-customer-monitoring
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: ^openshift-customer-monitoring$
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: ^openshift-customer-monitoring$
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-ccs-dedicated-admins-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: ccs-dedicated-admins-sp
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
         namespace: openshift-rbac-policies
       spec:
@@ -1530,6 +1663,129 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: osd-pcap-collector
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admin-serviceaccounts
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - dedicated-admins-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - dedicated-admins-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins-core-ns
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rbac-permissions-operator-config-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rbac-permissions-operator-config-sp
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -630,6 +630,75 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-srep-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: backplane-srep
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - backplane-srep-admins-cluster
+                    - backplane-readers-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: backplane-srep-admins-project
+                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                      namespacesDeniedRegex: openshift-backplane-cluster-admin
+                    - allowFirst: true
+                      clusterRoleName: dedicated-readers
+                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                      namespacesDeniedRegex: openshift-backplane-cluster-admin
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-srep-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-srep-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-srep-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-srep-sp
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
         namespace: openshift-rbac-policies
       spec:
@@ -1090,6 +1159,70 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: ccs-dedicated-admins-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins-customer-monitoring
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: ^openshift-customer-monitoring$
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: ^openshift-customer-monitoring$
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-ccs-dedicated-admins-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: ccs-dedicated-admins-sp
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
         namespace: openshift-rbac-policies
       spec:
@@ -1530,6 +1663,129 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: osd-pcap-collector
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admin-serviceaccounts
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - dedicated-admins-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - dedicated-admins-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins-core-ns
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rbac-permissions-operator-config-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rbac-permissions-operator-config-sp
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -630,6 +630,75 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-srep-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: backplane-srep
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - backplane-srep-admins-cluster
+                    - backplane-readers-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: backplane-srep-admins-project
+                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                      namespacesDeniedRegex: openshift-backplane-cluster-admin
+                    - allowFirst: true
+                      clusterRoleName: dedicated-readers
+                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                      namespacesDeniedRegex: openshift-backplane-cluster-admin
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-srep-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-srep-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-srep-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-srep-sp
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
         namespace: openshift-rbac-policies
       spec:
@@ -1090,6 +1159,70 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: ccs-dedicated-admins-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins-customer-monitoring
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: ^openshift-customer-monitoring$
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: ^openshift-customer-monitoring$
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-ccs-dedicated-admins-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-ccs-dedicated-admins-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: ccs-dedicated-admins-sp
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
         namespace: openshift-rbac-policies
       spec:
@@ -1530,6 +1663,129 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: osd-pcap-collector
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admin-serviceaccounts
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - dedicated-admins-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:dedicated-admin
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    clusterPermissions:
+                    - dedicated-admins-cluster
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: .*
+                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admins-core-ns
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    subjectKind: Group
+                    subjectName: dedicated-admins
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: managed.openshift.io/v1alpha1
+                  kind: SubjectPermission
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns
+                    namespace: openshift-rbac-permissions
+                  spec:
+                    permissions:
+                    - allowFirst: true
+                      clusterRoleName: dedicated-admins-project
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    - allowFirst: true
+                      clusterRoleName: admin
+                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
+                    subjectKind: Group
+                    subjectName: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rbac-permissions-operator-config-sp
+        namespace: openshift-rbac-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rbac-permissions-operator-config-sp
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rbac-permissions-operator-config-sp
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/project.mk
+++ b/project.mk
@@ -10,3 +10,4 @@ REPO_NAME=managed-cluster-config
 GEN_TEMPLATE?=scripts/generate_template.py -t ${SELECTOR_SYNC_SET_TEMPLATE_DIR} -y ${YAML_DIRECTORY} -d ${GIT_ROOT}/hack/ -r ${REPO_NAME}
 GEN_POLICY?=scripts/generate-policy.sh
 GEN_POLICY_CONFIG?=scripts/generate-policy-config.py 
+GEN_POLICY_CONFIG_SP?=scripts/generate-subjectpermissions-policy-config.py

--- a/scripts/generate-subjectpermissions-policy-config.py
+++ b/scripts/generate-subjectpermissions-policy-config.py
@@ -10,13 +10,8 @@ base_directory = "./deploy/"
 # This script doesn't walk the sub-directories.
 directories = [
         'rbac-permissions-operator-config',
-        'osd-cluster-admin',
-        'backplane',
         'backplane/srep',
-        'ccs-dedicated-admins',
-        'customer-registry-cas',
-        'osd-openshift-operators-redhat',
-        'osd-pcap-collector',
+        'ccs-dedicated-admins'
         ]
 policy_generator_config = './scripts/policy-generator-config.yaml'
 config_filename = "config.yaml"
@@ -24,25 +19,24 @@ config_filename = "config.yaml"
 for directory in directories:
     #extract the directory name
     policy_name = directory.replace("/", "-")
-    temp_directory = os.path.join("/tmp", policy_name)
+    temp_directory = os.path.join("/tmp", policy_name + "-subjectpermissions")
     #create a temporary path to stores the subset of manifests that will generate policies with
     path = os.path.join(temp_directory, "configs")
     os.makedirs(path)
     for entry in os.scandir(os.path.join(base_directory, directory)):
         if not entry.is_file():
             continue
-        if (entry.name.endswith('.yml') or entry.name.endswith('.yaml') and not(entry.name == config_filename)):
-            if 'SubjectPermission' not in entry.name:
-                shutil.copy( os.path.join(base_directory, directory, entry.name), path)
+        if (entry.name.endswith('.SubjectPermission.yml') or entry.name.endswith('.SubjectPermission.yaml') and not(entry.name == config_filename)):
+            shutil.copy( os.path.join(base_directory, directory, entry.name), path)
     #create a dir in /resources to hold the newly generated policy-generator-config.yaml
     #copy over the generator template
     shutil.copy(policy_generator_config, temp_directory)
     with open(policy_generator_config,'r') as input_file:
         policy_template = yaml.safe_load(input_file)
     #fill in the name and path in the policy generator template
-    policy_template['metadata']['name'] = 'rbac-policies'
+    policy_template['metadata']['name'] = 'subjectpermission-policies'
     for p in policy_template['policies']:
-        p['name'] = policy_name
+        p['name'] =  policy_name + '-sp'
         for m in p['manifests']:
             m['path'] = path
     with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: PolicyGenerator
 metadata:
-    name: rbac-policies
+    name: #Filled by script
 policyDefaults:
     namespace: openshift-rbac-policies
     placement:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature
### What this PR does / why we need it?
Added SubjectPermission policy generation script and generated policies for SubjectPermissions in /backplane/srep, /rbac-permission-operator-config, and /ccs-dedicated-admin
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-14144
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
