### PR TITLE
Add env label for the metrics on management clusters

### DIFF
--- a/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -7,6 +7,8 @@ data:
   config.yaml: |
     enableUserWorkload: true
     prometheusK8s:
+      externalLabels:
+        env: ${ENV}
     # If the location of this config changes,
     # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md
     # so that killswitch instructions point to the right file!

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9952,8 +9952,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
-          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  externalLabels:\n\
+          \    env: ${ENV}\n# If the location of this config changes,\n# make sure\
+          \ to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9952,8 +9952,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
-          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  externalLabels:\n\
+          \    env: ${ENV}\n# If the location of this config changes,\n# make sure\
+          \ to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9952,8 +9952,9 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n# If the location\
-          \ of this config changes,\n# make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  externalLabels:\n\
+          \    env: ${ENV}\n# If the location of this config changes,\n# make sure\
+          \ to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md\n\
           # so that killswitch instructions point to the right file!\n  remoteWrite:\n\
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?
We will ship all stg hypershift metrics to production tenant due to capacity issue on staging hypershift tenant.
### Which Jira/Github issue(s) this PR fixes?


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
