### PR TITLE
added namespaceSelector for SubjectPermissions policies

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -17,6 +17,16 @@ spec:
             metadata:
                 name: backplane-srep-sp
             spec:
+                namespaceSelector:
+                    exclude:
+                        - openshift-backplane-cluster-admin
+                    include:
+                        - kube
+                        - kube-*
+                        - openshift
+                        - openshift-*
+                        - default
+                        - redhat-*
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -17,6 +17,16 @@ spec:
             metadata:
                 name: ccs-dedicated-admins-sp
             spec:
+                namespaceSelector:
+                    exclude:
+                        - openshift-backplane-cluster-admin
+                    include:
+                        - kube
+                        - kube-*
+                        - openshift
+                        - openshift-*
+                        - default
+                        - redhat-*
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -17,6 +17,16 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp
             spec:
+                namespaceSelector:
+                    exclude:
+                        - openshift-backplane-cluster-admin
+                    include:
+                        - kube
+                        - kube-*
+                        - openshift
+                        - openshift-*
+                        - default
+                        - redhat-*
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -641,6 +641,16 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1170,6 +1180,16 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1681,6 +1701,16 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -641,6 +641,16 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1170,6 +1180,16 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1681,6 +1701,16 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -641,6 +641,16 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1170,6 +1180,16 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1681,6 +1701,16 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
               object-templates:
               - complianceType: musthave
                 objectDefinition:

--- a/scripts/generate-subjectpermissions-policy-config.py
+++ b/scripts/generate-subjectpermissions-policy-config.py
@@ -3,7 +3,6 @@
 import oyaml as yaml
 import shutil
 import os
-
 base_directory = "./deploy/"
 # An array of directories you want to generate policies for.
 # Please make sure ONLY the directories you want exist here.
@@ -13,6 +12,14 @@ directories = [
         'backplane/srep',
         'ccs-dedicated-admins'
         ]
+sp_dictionary = dict({
+    'include' : list([
+        'kube', 'kube-*', 'openshift', 'openshift-*', 'default', 'redhat-*'
+        ]),
+    'exclude' : list([
+        'openshift-backplane-cluster-admin'
+        ])
+    })
 policy_generator_config = './scripts/policy-generator-config.yaml'
 config_filename = "config.yaml"
 #go into each directory and copy a subset of manifests that are not SubjectPermissions or config.yaml into a /tmp dir
@@ -35,6 +42,7 @@ for directory in directories:
         policy_template = yaml.safe_load(input_file)
     #fill in the name and path in the policy generator template
     policy_template['metadata']['name'] = 'subjectpermission-policies'
+    policy_template['policyDefaults']['namespaceSelector'] = sp_dictionary
     for p in policy_template['policies']:
         p['name'] =  policy_name + '-sp'
         for m in p['manifests']:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug
### What this PR does / why we need it?
Added namespaceSelector for SubjectPermissions as there are no rbac-permission-operator on Hypershift. 
https://docs.google.com/document/d/1M7gDDl6Cpf20rtU9bBCxHirqqhuV0gWqLRXZImbSztk/edit#heading=h.apt20qhsqouo
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-14144
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
