### PR TITLE
updated the policies namespace

### DIFF
--- a/deploy/acm-policies/00-openshift-managed-rbac-policies.Namespace.yaml
+++ b/deploy/acm-policies/00-openshift-managed-rbac-policies.Namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-managed-rbac-policies
+  name: openshift-rbac-policies

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -622,7 +622,7 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
-        name: openshift-managed-rbac-policies
+        name: openshift-rbac-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -622,7 +622,7 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
-        name: openshift-managed-rbac-policies
+        name: openshift-rbac-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -622,7 +622,7 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
-        name: openshift-managed-rbac-policies
+        name: openshift-rbac-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug

### What this PR does / why we need it?
the namespace for policies was being mismatched. The selectorsyncset was set to 'openshift-managed-rbac-policies' when the generated policies' namespace is 'openshift-rbac-policies'

Changed all back to 'openshift-rbac-policies'
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
