### PR TITLE
Enable pcap-collector-creds secret permissions for CEE/SREP

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -364,6 +364,39 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-srep
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-srep-pcap-collector
+                            namespace: openshift-backplane-managed-scripts
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resourceNames:
+                                - pcap-collector-creds
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
+                                - delete
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-srep-mustgather
+                            namespace: openshift-backplane-managed-scripts
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-srep-pcap-collector
+                            namespace: openshift-backplane-managed-scripts
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-srep
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/backplane/cee/30-cee-pcap-collector.Role.yml
+++ b/deploy/backplane/cee/30-cee-pcap-collector.Role.yml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-cee-pcap-collector
+  namespace: openshift-backplane-managed-scripts
+rules:
+# can create cred secret for mustgathers
+# Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
+- verbs:
+    - "create"
+    - "delete"
+  apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  resourceNames:
+    - "pcap-collector-creds"
+### END

--- a/deploy/backplane/cee/60-cee-pcap-collector.RoleBinding.yml
+++ b/deploy/backplane/cee/60-cee-pcap-collector.RoleBinding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-cee-mustgather
+  namespace: openshift-backplane-managed-scripts
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-cee
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-cee-pcap-collector
+  namespace: openshift-backplane-managed-scripts

--- a/deploy/backplane/srep/30-cee-pcap-collector.Role.yml
+++ b/deploy/backplane/srep/30-cee-pcap-collector.Role.yml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-srep-pcap-collector
+  namespace: openshift-backplane-managed-scripts
+rules:
+# can create cred secret for mustgathers
+# Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
+- verbs:
+    - "create"
+    - "delete"
+  apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  resourceNames:
+    - "pcap-collector-creds"
+### END

--- a/deploy/backplane/srep/40-cee-pcap-collector.RoleBinding.yml
+++ b/deploy/backplane/srep/40-cee-pcap-collector.RoleBinding.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-srep-mustgather
+  namespace: openshift-backplane-managed-scripts
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-srep-pcap-collector
+  namespace: openshift-backplane-managed-scripts

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1067,6 +1067,39 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-pcap-collector
+                    namespace: openshift-backplane-managed-scripts
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - pcap-collector-creds
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-backplane-managed-scripts
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-pcap-collector
+                    namespace: openshift-backplane-managed-scripts
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -3027,6 +3060,21 @@ objects:
         kind: Role
         name: backplane-cee-mustgather
         namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-cee-pcap-collector
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - verbs:
+        - create
+        - delete
+        apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - pcap-collector-creds
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3043,6 +3091,20 @@ objects:
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-cee
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-backplane-managed-scripts
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-cee
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-cee-pcap-collector
+        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -8960,6 +9022,35 @@ objects:
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-pcap-collector
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - verbs:
+        - create
+        - delete
+        apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - pcap-collector-creds
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-backplane-managed-scripts
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-pcap-collector
+        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1067,6 +1067,39 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-pcap-collector
+                    namespace: openshift-backplane-managed-scripts
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - pcap-collector-creds
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-backplane-managed-scripts
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-pcap-collector
+                    namespace: openshift-backplane-managed-scripts
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -3027,6 +3060,21 @@ objects:
         kind: Role
         name: backplane-cee-mustgather
         namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-cee-pcap-collector
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - verbs:
+        - create
+        - delete
+        apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - pcap-collector-creds
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3043,6 +3091,20 @@ objects:
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-cee
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-backplane-managed-scripts
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-cee
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-cee-pcap-collector
+        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -8960,6 +9022,35 @@ objects:
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-pcap-collector
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - verbs:
+        - create
+        - delete
+        apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - pcap-collector-creds
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-backplane-managed-scripts
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-pcap-collector
+        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1067,6 +1067,39 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-pcap-collector
+                    namespace: openshift-backplane-managed-scripts
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - pcap-collector-creds
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                    - delete
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-mustgather
+                    namespace: openshift-backplane-managed-scripts
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-pcap-collector
+                    namespace: openshift-backplane-managed-scripts
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -3027,6 +3060,21 @@ objects:
         kind: Role
         name: backplane-cee-mustgather
         namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-cee-pcap-collector
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - verbs:
+        - create
+        - delete
+        apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - pcap-collector-creds
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -3043,6 +3091,20 @@ objects:
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-cee
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-cee-mustgather
+        namespace: openshift-backplane-managed-scripts
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-cee
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-cee-pcap-collector
+        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -8960,6 +9022,35 @@ objects:
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-pcap-collector
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - verbs:
+        - create
+        - delete
+        apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - pcap-collector-creds
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-mustgather
+        namespace: openshift-backplane-managed-scripts
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-pcap-collector
+        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Allows CEE/SREP users to create a must-gather like SFTP upload to cases. https://github.com/openshift/managed-scripts/pull/97 requires it to work effectively without privilege escalation. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-12258

### Special notes for your reviewer:
Basically allows users to create the kind of secret required in https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml. 
```
    oc create secret generic pcap-collector-creds --from-literal=username=username_from_step_1 --from-literal=internal=result_from_step_2 --from-literal=password=token_from_step_3  --from-literal=caseid=support_case_number_step_0 -n openshift-backplane-managed-scripts
```
### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
