### PR TITLE
[OSD-13637] Add new rule to monitor missing apiserver pods.

### DIFF
--- a/deploy/sre-prometheus/100-kube-apiserver-missing-on-node.yaml
+++ b/deploy/sre-prometheus/100-kube-apiserver-missing-on-node.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-kube-apiserver-missing-on-node
+    role: alert-rules
+  name: sre-managed-kube-apiserver-missing-on-node
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-kube-apiserver-missing-on-node
+    rules:
+    - alert: KubeAPIServerMissingOnNode60Minutes
+      expr: |
+        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver", pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+      for: 60m
+      labels:
+        severity: warning
+        maturity: "immature"
+        source: "https://issues.redhat.com/browse/OSD-13647"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md"
+      annotations:
+        message: Static pod kube-apiserver is not running on node {{ $labels.node }} for 60 minutes.

--- a/deploy/sre-prometheus/100-kube-controller-manager-missing-on-node.yaml
+++ b/deploy/sre-prometheus/100-kube-controller-manager-missing-on-node.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-kube-controller-manager-missing-on-node
+    role: alert-rules
+  name: sre-managed-kube-controller-manager-missing-on-node
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-kube-controller-manager-missing-on-node
+    rules:
+    - alert: KubeControllerManagerMissingOnNode60Minutes
+      expr: |
+        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager", pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+      for: 60m
+      labels:
+        severity: warning
+        maturity: "immature"
+        source: "https://issues.redhat.com/browse/OSD-13647"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md"
+      annotations:
+        message: Static pod kube-controller-manager is not running on node {{ $labels.node }} for 60 minutes.

--- a/deploy/sre-prometheus/100-kube-scheduler-missing-on-node.yaml
+++ b/deploy/sre-prometheus/100-kube-scheduler-missing-on-node.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-kube-scheduler-missing-on-node
+    role: alert-rules
+  name: sre-managed-kube-scheduler-missing-on-node
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-kube-scheduler-missing-on-node
+    rules:
+    - alert: KubeSchedulerMissingOnNode60Minutes
+      expr: |
+        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler", pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+      for: 60m
+      labels:
+        severity: warning
+        maturity: "immature"
+        source: "https://issues.redhat.com/browse/OSD-13647"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md"
+      annotations:
+        message: Static pod kube-scheduler is not running on node {{ $labels.node }} for 60 minutes.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -19091,6 +19091,84 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-kube-apiserver-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-apiserver-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-apiserver-missing-on-node
+          rules:
+          - alert: KubeAPIServerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver",
+              pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-apiserver is not running on node {{ $labels.node
+                }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-kube-controller-manager-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-controller-manager-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-controller-manager-missing-on-node
+          rules:
+          - alert: KubeControllerManagerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager",
+              pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-controller-manager is not running on node {{
+                $labels.node }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-kube-scheduler-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-scheduler-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-scheduler-missing-on-node
+          rules:
+          - alert: KubeSchedulerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler",
+              pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-scheduler is not running on node {{ $labels.node
+                }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-node-metadata-operator-alerts
           role: alert-rules
         name: sre-managed-node-metadata-operator-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -19091,6 +19091,84 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-kube-apiserver-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-apiserver-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-apiserver-missing-on-node
+          rules:
+          - alert: KubeAPIServerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver",
+              pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-apiserver is not running on node {{ $labels.node
+                }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-kube-controller-manager-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-controller-manager-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-controller-manager-missing-on-node
+          rules:
+          - alert: KubeControllerManagerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager",
+              pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-controller-manager is not running on node {{
+                $labels.node }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-kube-scheduler-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-scheduler-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-scheduler-missing-on-node
+          rules:
+          - alert: KubeSchedulerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler",
+              pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-scheduler is not running on node {{ $labels.node
+                }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-node-metadata-operator-alerts
           role: alert-rules
         name: sre-managed-node-metadata-operator-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -19091,6 +19091,84 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-kube-apiserver-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-apiserver-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-apiserver-missing-on-node
+          rules:
+          - alert: KubeAPIServerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver",
+              pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-apiserver is not running on node {{ $labels.node
+                }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-kube-controller-manager-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-controller-manager-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-controller-manager-missing-on-node
+          rules:
+          - alert: KubeControllerManagerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager",
+              pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-controller-manager is not running on node {{
+                $labels.node }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-kube-scheduler-missing-on-node
+          role: alert-rules
+        name: sre-managed-kube-scheduler-missing-on-node
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-scheduler-missing-on-node
+          rules:
+          - alert: KubeSchedulerMissingOnNode60Minutes
+            expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler",
+              pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-13647
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
+            annotations:
+              message: Static pod kube-scheduler is not running on node {{ $labels.node
+                }} for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-node-metadata-operator-alerts
           role: alert-rules
         name: sre-managed-node-metadata-operator-alerts


### PR DESCRIPTION
Right now if one of the kube-apiservers is going missing no dedicated alert will fire, so this one should be turned into a critical alert once it's mature enough.

It compare the running pods matching the naming pattern of kube-apiserver pods to all master nodes.
This is based on the assumption that every master must run an apiserver and if it isn't something is wrong.

The SOP is added in this PR: https://github.com/openshift/ops-sop/pull/2369

### What type of PR is this?
feature

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-13647](https://issues.redhat.com//browse/OSD-13647)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
