### PR TITLE
added Clusterrolebinding and Rolebinding generation for Subjectpermission

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -17,6 +17,54 @@ spec:
             metadata:
                 name: backplane-srep-sp
             spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
+                        metadata:
+                            name: backplane-srep-c0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: backplane-srep-admins-cluster
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-srep
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: backplane-srep-sp2
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
+                        metadata:
+                            name: backplane-srep-c1
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: backplane-readers-cluster
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-srep
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: backplane-srep-sp3
+            spec:
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin
@@ -30,26 +78,52 @@ spec:
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
-                        apiVersion: managed.openshift.io/v1alpha1
-                        kind: SubjectPermission
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
                         metadata:
-                            name: backplane-srep
-                            namespace: openshift-rbac-permissions
-                        spec:
-                            clusterPermissions:
-                                - backplane-srep-admins-cluster
-                                - backplane-readers-cluster
-                            permissions:
-                                - allowFirst: true
-                                  clusterRoleName: backplane-srep-admins-project
-                                  namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                                  namespacesDeniedRegex: openshift-backplane-cluster-admin
-                                - allowFirst: true
-                                  clusterRoleName: dedicated-readers
-                                  namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                                  namespacesDeniedRegex: openshift-backplane-cluster-admin
-                            subjectKind: Group
-                            subjectName: system:serviceaccounts:openshift-backplane-srep
+                            name: backplane-srep-0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: backplane-srep-admins-project
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-srep
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: backplane-srep-sp4
+            spec:
+                namespaceSelector:
+                    exclude:
+                        - openshift-backplane-cluster-admin
+                    include:
+                        - kube
+                        - kube-*
+                        - openshift
+                        - openshift-*
+                        - default
+                        - redhat-*
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-srep-1
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-readers
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-srep
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -18,33 +18,50 @@ spec:
                 name: ccs-dedicated-admins-sp
             spec:
                 namespaceSelector:
-                    exclude:
-                        - openshift-backplane-cluster-admin
                     include:
-                        - kube
-                        - kube-*
-                        - openshift
-                        - openshift-*
-                        - default
-                        - redhat-*
+                        - openshift-customer-monitoring
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
-                        apiVersion: managed.openshift.io/v1alpha1
-                        kind: SubjectPermission
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
                         metadata:
-                            name: dedicated-admins-customer-monitoring
-                            namespace: openshift-rbac-permissions
-                        spec:
-                            permissions:
-                                - allowFirst: true
-                                  clusterRoleName: dedicated-admins-project
-                                  namespacesAllowedRegex: ^openshift-customer-monitoring$
-                                - allowFirst: true
-                                  clusterRoleName: admin
-                                  namespacesAllowedRegex: ^openshift-customer-monitoring$
-                            subjectKind: Group
-                            subjectName: dedicated-admins
+                            name: dedicated-admins-customer-monitoring-0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-project
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: ccs-dedicated-admins-sp2
+            spec:
+                namespaceSelector:
+                    include:
+                        - openshift-customer-monitoring
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-customer-monitoring-1
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: admin
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -17,93 +17,293 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp
             spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
+                        metadata:
+                            name: dedicated-admin-serviceaccounts-c0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-cluster
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp2
+            spec:
                 namespaceSelector:
                     exclude:
-                        - openshift-backplane-cluster-admin
-                    include:
                         - kube
                         - kube-*
                         - openshift
                         - openshift-*
                         - default
                         - redhat-*
+                    include:
+                        - '*'
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
-                        apiVersion: managed.openshift.io/v1alpha1
-                        kind: SubjectPermission
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
                         metadata:
-                            name: dedicated-admin-serviceaccounts
-                            namespace: openshift-rbac-permissions
-                        spec:
-                            clusterPermissions:
-                                - dedicated-admins-cluster
-                            permissions:
-                                - allowFirst: true
-                                  clusterRoleName: dedicated-admins-project
-                                  namespacesAllowedRegex: .*
-                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                                - allowFirst: true
-                                  clusterRoleName: admin
-                                  namespacesAllowedRegex: .*
-                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                            subjectKind: Group
-                            subjectName: system:serviceaccounts:dedicated-admin
+                            name: dedicated-admin-serviceaccounts-0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-project
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp3
+            spec:
+                namespaceSelector:
+                    exclude:
+                        - kube
+                        - kube-*
+                        - openshift
+                        - openshift-*
+                        - default
+                        - redhat-*
+                    include:
+                        - '*'
+                object-templates:
                     - complianceType: musthave
                       objectDefinition:
-                        apiVersion: managed.openshift.io/v1alpha1
-                        kind: SubjectPermission
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
                         metadata:
-                            name: dedicated-admins
-                            namespace: openshift-rbac-permissions
-                        spec:
-                            clusterPermissions:
-                                - dedicated-admins-cluster
-                            permissions:
-                                - allowFirst: true
-                                  clusterRoleName: dedicated-admins-project
-                                  namespacesAllowedRegex: .*
-                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                                - allowFirst: true
-                                  clusterRoleName: admin
-                                  namespacesAllowedRegex: .*
-                                  namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                            subjectKind: Group
-                            subjectName: dedicated-admins
+                            name: dedicated-admin-serviceaccounts-1
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: admin
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp4
+            spec:
+                object-templates:
                     - complianceType: musthave
                       objectDefinition:
-                        apiVersion: managed.openshift.io/v1alpha1
-                        kind: SubjectPermission
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
                         metadata:
-                            name: dedicated-admins-core-ns
-                            namespace: openshift-rbac-permissions
-                        spec:
-                            permissions:
-                                - allowFirst: true
-                                  clusterRoleName: dedicated-admins-project
-                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                                - allowFirst: true
-                                  clusterRoleName: admin
-                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                            subjectKind: Group
-                            subjectName: dedicated-admins
+                            name: dedicated-admins-c0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-cluster
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp5
+            spec:
+                namespaceSelector:
+                    exclude:
+                        - kube
+                        - kube-*
+                        - openshift
+                        - openshift-*
+                        - default
+                        - redhat-*
+                    include:
+                        - '*'
+                object-templates:
                     - complianceType: musthave
                       objectDefinition:
-                        apiVersion: managed.openshift.io/v1alpha1
-                        kind: SubjectPermission
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
                         metadata:
-                            name: dedicated-admin-serviceaccounts-core-ns
-                            namespace: openshift-rbac-permissions
-                        spec:
-                            permissions:
-                                - allowFirst: true
-                                  clusterRoleName: dedicated-admins-project
-                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                                - allowFirst: true
-                                  clusterRoleName: admin
-                                  namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                            subjectKind: Group
-                            subjectName: system:serviceaccounts:dedicated-admin
+                            name: dedicated-admins-0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-project
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp6
+            spec:
+                namespaceSelector:
+                    exclude:
+                        - kube
+                        - kube-*
+                        - openshift
+                        - openshift-*
+                        - default
+                        - redhat-*
+                    include:
+                        - '*'
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-1
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: admin
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp7
+            spec:
+                namespaceSelector:
+                    include:
+                        - openshift-operators
+                        - openshift-operators-redhat
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-core-ns-0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-project
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp8
+            spec:
+                namespaceSelector:
+                    include:
+                        - openshift-operators
+                        - openshift-operators-redhat
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-core-ns-1
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: admin
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: dedicated-admins
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp9
+            spec:
+                namespaceSelector:
+                    include:
+                        - openshift-operators
+                        - openshift-operators-redhat
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admin-serviceaccounts-core-ns-0
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: dedicated-admins-project
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rbac-permissions-operator-config-sp10
+            spec:
+                namespaceSelector:
+                    include:
+                        - openshift-operators
+                        - openshift-operators-redhat
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admin-serviceaccounts-core-ns-1
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: admin
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:dedicated-admin
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -641,6 +641,54 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: backplane-srep-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-srep-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp2
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: backplane-srep-c1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-readers-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp3
+            spec:
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -654,26 +702,52 @@ objects:
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: backplane-srep
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - backplane-srep-admins-cluster
-                    - backplane-readers-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: backplane-srep-admins-project
-                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                      namespacesDeniedRegex: openshift-backplane-cluster-admin
-                    - allowFirst: true
-                      clusterRoleName: dedicated-readers
-                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                      namespacesDeniedRegex: openshift-backplane-cluster-admin
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:openshift-backplane-srep
+                    name: backplane-srep-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-srep-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp4
+            spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-readers
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -1181,33 +1255,50 @@ objects:
               name: ccs-dedicated-admins-sp
             spec:
               namespaceSelector:
-                exclude:
-                - openshift-backplane-cluster-admin
                 include:
-                - kube
-                - kube-*
-                - openshift
-                - openshift-*
-                - default
-                - redhat-*
+                - openshift-customer-monitoring
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admins-customer-monitoring
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: ^openshift-customer-monitoring$
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: ^openshift-customer-monitoring$
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+                    name: dedicated-admins-customer-monitoring-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: ccs-dedicated-admins-sp2
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-customer-monitoring
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-customer-monitoring-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -1701,93 +1792,293 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp2
+            spec:
               namespaceSelector:
                 exclude:
-                - openshift-backplane-cluster-admin
-                include:
                 - kube
                 - kube-*
                 - openshift
                 - openshift-*
                 - default
                 - redhat-*
+                include:
+                - '*'
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admin-serviceaccounts
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - dedicated-admins-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:dedicated-admin
+                    name: dedicated-admin-serviceaccounts-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp3
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
+                    name: dedicated-admin-serviceaccounts-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp4
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admins-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
                     name: dedicated-admins
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - dedicated-admins-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp5
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admins-core-ns
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+                    name: dedicated-admins-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp6
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admin-serviceaccounts-core-ns
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:dedicated-admin
+                    name: dedicated-admins-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp7
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-core-ns-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp8
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-core-ns-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp9
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp10
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -641,6 +641,54 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: backplane-srep-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-srep-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp2
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: backplane-srep-c1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-readers-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp3
+            spec:
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -654,26 +702,52 @@ objects:
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: backplane-srep
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - backplane-srep-admins-cluster
-                    - backplane-readers-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: backplane-srep-admins-project
-                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                      namespacesDeniedRegex: openshift-backplane-cluster-admin
-                    - allowFirst: true
-                      clusterRoleName: dedicated-readers
-                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                      namespacesDeniedRegex: openshift-backplane-cluster-admin
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:openshift-backplane-srep
+                    name: backplane-srep-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-srep-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp4
+            spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-readers
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -1181,33 +1255,50 @@ objects:
               name: ccs-dedicated-admins-sp
             spec:
               namespaceSelector:
-                exclude:
-                - openshift-backplane-cluster-admin
                 include:
-                - kube
-                - kube-*
-                - openshift
-                - openshift-*
-                - default
-                - redhat-*
+                - openshift-customer-monitoring
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admins-customer-monitoring
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: ^openshift-customer-monitoring$
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: ^openshift-customer-monitoring$
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+                    name: dedicated-admins-customer-monitoring-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: ccs-dedicated-admins-sp2
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-customer-monitoring
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-customer-monitoring-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -1701,93 +1792,293 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp2
+            spec:
               namespaceSelector:
                 exclude:
-                - openshift-backplane-cluster-admin
-                include:
                 - kube
                 - kube-*
                 - openshift
                 - openshift-*
                 - default
                 - redhat-*
+                include:
+                - '*'
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admin-serviceaccounts
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - dedicated-admins-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:dedicated-admin
+                    name: dedicated-admin-serviceaccounts-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp3
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
+                    name: dedicated-admin-serviceaccounts-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp4
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admins-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
                     name: dedicated-admins
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - dedicated-admins-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp5
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admins-core-ns
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+                    name: dedicated-admins-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp6
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admin-serviceaccounts-core-ns
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:dedicated-admin
+                    name: dedicated-admins-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp7
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-core-ns-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp8
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-core-ns-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp9
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp10
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -641,6 +641,54 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: backplane-srep-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-srep-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp2
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: backplane-srep-c1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-readers-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp3
+            spec:
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -654,26 +702,52 @@ objects:
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: backplane-srep
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - backplane-srep-admins-cluster
-                    - backplane-readers-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: backplane-srep-admins-project
-                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                      namespacesDeniedRegex: openshift-backplane-cluster-admin
-                    - allowFirst: true
-                      clusterRoleName: dedicated-readers
-                      namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                      namespacesDeniedRegex: openshift-backplane-cluster-admin
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:openshift-backplane-srep
+                    name: backplane-srep-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: backplane-srep-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-srep-sp4
+            spec:
+              namespaceSelector:
+                exclude:
+                - openshift-backplane-cluster-admin
+                include:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-readers
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -1181,33 +1255,50 @@ objects:
               name: ccs-dedicated-admins-sp
             spec:
               namespaceSelector:
-                exclude:
-                - openshift-backplane-cluster-admin
                 include:
-                - kube
-                - kube-*
-                - openshift
-                - openshift-*
-                - default
-                - redhat-*
+                - openshift-customer-monitoring
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admins-customer-monitoring
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: ^openshift-customer-monitoring$
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: ^openshift-customer-monitoring$
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+                    name: dedicated-admins-customer-monitoring-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: ccs-dedicated-admins-sp2
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-customer-monitoring
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-customer-monitoring-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -1701,93 +1792,293 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp2
+            spec:
               namespaceSelector:
                 exclude:
-                - openshift-backplane-cluster-admin
-                include:
                 - kube
                 - kube-*
                 - openshift
                 - openshift-*
                 - default
                 - redhat-*
+                include:
+                - '*'
               object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admin-serviceaccounts
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - dedicated-admins-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:dedicated-admin
+                    name: dedicated-admin-serviceaccounts-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp3
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
+                    name: dedicated-admin-serviceaccounts-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp4
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: dedicated-admins-c0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
                     name: dedicated-admins
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    clusterPermissions:
-                    - dedicated-admins-cluster
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: .*
-                      namespacesDeniedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp5
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admins-core-ns
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    subjectKind: Group
-                    subjectName: dedicated-admins
+                    name: dedicated-admins-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp6
+            spec:
+              namespaceSelector:
+                exclude:
+                - kube
+                - kube-*
+                - openshift
+                - openshift-*
+                - default
+                - redhat-*
+                include:
+                - '*'
+              object-templates:
               - complianceType: musthave
                 objectDefinition:
-                  apiVersion: managed.openshift.io/v1alpha1
-                  kind: SubjectPermission
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
                   metadata:
-                    name: dedicated-admin-serviceaccounts-core-ns
-                    namespace: openshift-rbac-permissions
-                  spec:
-                    permissions:
-                    - allowFirst: true
-                      clusterRoleName: dedicated-admins-project
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    - allowFirst: true
-                      clusterRoleName: admin
-                      namespacesAllowedRegex: (^openshift-operators$|^openshift-operators-redhat$)
-                    subjectKind: Group
-                    subjectName: system:serviceaccounts:dedicated-admin
+                    name: dedicated-admins-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp7
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-core-ns-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp8
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-core-ns-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp9
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns-0
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: dedicated-admins-project
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rbac-permissions-operator-config-sp10
+            spec:
+              namespaceSelector:
+                include:
+                - openshift-operators
+                - openshift-operators-redhat
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admin-serviceaccounts-core-ns-1
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: admin
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:dedicated-admin
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/scripts/generate-subjectpermissions-policy-config.py
+++ b/scripts/generate-subjectpermissions-policy-config.py
@@ -3,6 +3,8 @@
 import oyaml as yaml
 import shutil
 import os
+from copy import deepcopy
+
 base_directory = "./deploy/"
 # An array of directories you want to generate policies for.
 # Please make sure ONLY the directories you want exist here.
@@ -12,14 +14,33 @@ directories = [
         'backplane/srep',
         'ccs-dedicated-admins'
         ]
-sp_dictionary = dict({
-    'include' : list([
-        'kube', 'kube-*', 'openshift', 'openshift-*', 'default', 'redhat-*'
-        ]),
-    'exclude' : list([
-        'openshift-backplane-cluster-admin'
-        ])
-    })
+rolebinding = \
+{'apiVersion': 'rbac.authorization.k8s.io/v1',
+'kind': 'RoleBinding',
+'metadata': {'name': 'placeholder'},
+'roleRef': {'apiGroup': 'rbac.authorization.k8s.io', 'kind': 'ClusterRole', 'name': 'placeholder'},
+'subjects': [{'apiGroup': 'rbac.authorization.k8s.io', 'kind': 'placeholder', 'name': 'placeholder'}]}
+
+clusterrolebinding = \
+{'apiVersion': 'rbac.authorization.k8s.io/v1',
+'kind': 'ClusterRoleBinding',
+'metadata': {'name': 'placeholder'},
+'roleRef': {'apiGroup': 'rbac.authorization.k8s.io', 'kind': 'ClusterRole', 'name': 'placeholder'},
+'subjects': [{'apiGroup': 'rbac.authorization.k8s.io', 'kind': 'placeholder', 'name': 'placeholder'}]}
+
+# namespace in SubjectPermission is regex, but namespace selector doesn't support regex
+# for most cases using the string match should be enough
+# example "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+def regex_to_strings(regex):
+    regex = regex.replace("(","")
+    regex = regex.replace(")","")
+    strings = regex.split("|")
+    for i in range(len(strings)):
+        strings[i] = strings[i].replace("^","")
+        strings[i] = strings[i].replace("$","")
+        strings[i] = strings[i].replace(".*","*")
+    return strings
+
 policy_generator_config = './scripts/policy-generator-config.yaml'
 config_filename = "config.yaml"
 #go into each directory and copy a subset of manifests that are not SubjectPermissions or config.yaml into a /tmp dir
@@ -27,25 +48,75 @@ for directory in directories:
     #extract the directory name
     policy_name = directory.replace("/", "-")
     temp_directory = os.path.join("/tmp", policy_name + "-subjectpermissions")
+    manifests = []
     #create a temporary path to stores the subset of manifests that will generate policies with
-    path = os.path.join(temp_directory, "configs")
-    os.makedirs(path)
+    configs_directory = os.path.join(temp_directory, "configs")
+    os.makedirs(configs_directory)
     for entry in os.scandir(os.path.join(base_directory, directory)):
         if not entry.is_file():
             continue
         if (entry.name.endswith('.SubjectPermission.yml') or entry.name.endswith('.SubjectPermission.yaml') and not(entry.name == config_filename)):
-            shutil.copy( os.path.join(base_directory, directory, entry.name), path)
-    #create a dir in /resources to hold the newly generated policy-generator-config.yaml
-    #copy over the generator template
-    shutil.copy(policy_generator_config, temp_directory)
-    with open(policy_generator_config,'r') as input_file:
-        policy_template = yaml.safe_load(input_file)
-    #fill in the name and path in the policy generator template
-    policy_template['metadata']['name'] = 'subjectpermission-policies'
-    policy_template['policyDefaults']['namespaceSelector'] = sp_dictionary
-    for p in policy_template['policies']:
-        p['name'] =  policy_name + '-sp'
-        for m in p['manifests']:
-            m['path'] = path
-    with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:
-        yaml.dump(policy_template, output_file)
+            sp_yaml = os.path.join(base_directory, directory, entry.name)
+            with open(sp_yaml,'r') as input_file:
+                sp_obj = yaml.safe_load(input_file)
+                rolebinding_name_prefix = sp_obj["metadata"]["name"]
+                # for each clusterpermission, create a non-namespaced clusterrolebinding and a manifest item
+                if "clusterPermissions" in sp_obj["spec"]:
+                    for i in range(len(sp_obj["spec"]["clusterPermissions"])):
+                        cluster_permission = sp_obj["spec"]["clusterPermissions"][i]
+                        clusterrolebinding_name = rolebinding_name_prefix + "-c" + str(i)
+                        clusterrolebinding["metadata"]["name"] = clusterrolebinding_name
+                        clusterrolebinding["roleRef"]["name"] = cluster_permission
+                        clusterrolebinding["subjects"][0]["kind"] = sp_obj["spec"]["subjectKind"]
+                        clusterrolebinding["subjects"][0]["name"] = sp_obj["spec"]["subjectName"]
+                        # dump a clusterrolebinding yaml file
+                        crb_filename = os.path.join(configs_directory, clusterrolebinding_name + ".yaml")
+                        with open(crb_filename,'w+') as output_file:
+                            yaml.dump(clusterrolebinding, output_file)
+                        # create a manifest item for this clusterrolebinding
+                        manifest = {}
+                        manifest["path"] = crb_filename
+                        manifests.append(manifest)
+
+                # for each permission, create a rolebinding yaml file and a manifest item
+                if "permissions" in sp_obj["spec"]:
+                    for i in range(len(sp_obj["spec"]["permissions"])):
+                        allow_ns = ''
+                        deny_ns = ''
+                        permission = sp_obj["spec"]["permissions"][i]
+                        rolebinding_name = rolebinding_name_prefix + "-" + str(i)
+                        rolebinding["metadata"]["name"] = rolebinding_name
+                        rolebinding["roleRef"]["name"] = permission["clusterRoleName"]
+                        rolebinding["subjects"][0]["kind"] = sp_obj["spec"]["subjectKind"]
+                        rolebinding["subjects"][0]["name"] = sp_obj["spec"]["subjectName"]
+                        if "namespacesAllowedRegex" in permission:
+                            allow_ns = regex_to_strings(permission["namespacesAllowedRegex"])
+                        if "namespacesDeniedRegex" in permission:
+                            deny_ns = regex_to_strings(permission["namespacesDeniedRegex"])
+                        # dump a rolebinding yaml file
+                        rb_filename = os.path.join(configs_directory, rolebinding_name + ".yaml")
+                        with open(rb_filename,'w+') as output_file:
+                            yaml.dump(rolebinding, output_file)
+                        # create a manifest item for this rolebinding with namespace selector
+                        manifest = {}
+                        manifest["path"] = rb_filename
+                        manifest["namespaceSelector"] = {}
+                        if allow_ns:
+                            manifest["namespaceSelector"]["include"] = deepcopy(allow_ns)
+                        if deny_ns:
+                            manifest["namespaceSelector"]["exclude"] = deepcopy(deny_ns)
+                        manifests.append(manifest)
+            #create a dir in /resources to hold the newly generated policy-generator-config.yaml
+            #copy over the generator template
+            policy_generator_config = './scripts/policy-generator-config.yaml'
+            shutil.copy(policy_generator_config, temp_directory)
+            with open(policy_generator_config,'r') as input_file:
+                policy_template = yaml.safe_load(input_file)
+            #fill in the name and path in the policy generator template
+            policy_template['metadata']['name'] = 'subjectpermission-policies'
+            policy_template['policyDefaults']['consolidateManifests'] = False
+            for p in policy_template['policies']:
+                p['name'] =  policy_name + '-sp'
+                p['manifests'] = manifests
+            with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:
+                yaml.dump(policy_template, output_file)


### PR DESCRIPTION

### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug/feature
### What this PR does / why we need it?
Now that we don't have rbac-permission-operators on hypersift, subjectpermissions cannot be reconcile.
we instead rewrite the subjectPermission to rolebinding and clusterrolebindings and add namespaceselector so the policies could watch over them and apply the rolebinding/clusterrolebinding if needed.
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-14144
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
