### PR TITLE
openshift-backplane-addon-connectors should access all namespace starting with ting with redhat-openshift-connectors

### DIFF
--- a/deploy/backplane/addon-connectors/addon-connectors/10-addon-connectors-admins.SubjectPermission.yml
+++ b/deploy/backplane/addon-connectors/addon-connectors/10-addon-connectors-admins.SubjectPermission.yml
@@ -7,6 +7,6 @@ spec:
   permissions:
   - allowFirst: true
     clusterRoleName: admin
-    namespacesAllowedRegex: (^redhat-openshift-connectors$)
+    namespacesAllowedRegex: (^redhat-openshift-connectors.*$)
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-addon-connectors

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3211,7 +3211,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^redhat-openshift-connectors$)
+          namespacesAllowedRegex: (^redhat-openshift-connectors.*$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-addon-connectors
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3211,7 +3211,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^redhat-openshift-connectors$)
+          namespacesAllowedRegex: (^redhat-openshift-connectors.*$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-addon-connectors
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3211,7 +3211,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: admin
-          namespacesAllowedRegex: (^redhat-openshift-connectors$)
+          namespacesAllowedRegex: (^redhat-openshift-connectors.*$)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-addon-connectors
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
The PR extend permissions for `ting with redhat-openshift-connectors` to all namespaces starting with `ting with redhat-openshift-connectors` not just the one exactly named `ting with redhat-openshift-connectors`

### Which Jira/Github issue(s) this PR fixes?

_Fixes https://issues.redhat.com/browse/MGDCTRS-1746_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] ~~Tested latest changes against a cluster~~
- [ ] ~~Included documentation changes with PR~~
- [ ] ~~If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:~~

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
