### PR TITLE
Only run workflow on fork feature branches, not on fork master branches

### DIFF
--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -1,5 +1,8 @@
 name: Make Generate
-on: push
+on:
+  push:
+    branches-ignore:
+      - master
 
 jobs:
   run:
@@ -7,15 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Make
       run: make
 
     - name: Commit changes
-      uses: EndBug/add-and-commit@v7
+      uses: EndBug/add-and-commit@v9
       with:
         message: "on push: make"
         add: "hack/00-osd-managed-cluster-config*.yaml.tmpl"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Updates the auto make workflow, and only runs it on fork feature branches, not on fork master branches

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
