### PR TITLE
Fix up generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,29 @@
-FROM openshift/origin-cli:v3.11 AS builder
-
-RUN cp /bin/oc /
+FROM openshift/origin-cli:4.12 AS builder
 
 # Multistage with python
-FROM python:2.7.15 AS runner
+FROM ubi8/python-39 AS runner
 
 # Bring oc binary to python image
-COPY --from=builder /oc /bin/
+COPY --from=builder /bin/oc /bin/
 
 # Environment
 ARG IN_CONTAINER="true"
 ENV REPO_PATH=/managed-cluster-config
 
 # Copy repo into container image:
-COPY . ${REPO_PATH}
+COPY --chown=default . ${REPO_PATH}
 WORKDIR ${REPO_PATH}
 
 # Upgrade pip and install necessasry packages
-RUN pip install oyaml
+RUN pip install --disable-pip-version-check oyaml
+ADD --chown=default https://github.com/stolostron/policy-generator-plugin/releases/download/v1.9.1/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator
+RUN chmod +x /opt/app-root/bin/PolicyGenerator
 
 # Make
 RUN make
 
 # This image will be replaced by the openshift/release
-FROM openshift/origin-cli
+FROM openshift/origin-cli:4.12
 
 # Ensure make ran as expected
 COPY --from=runner /managed-cluster-config/deploy/ deploy

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -17544,11 +17544,6 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: suricata-sa
-        namespace: openshift-suricata
     - kind: SecurityContextConstraints
       apiVersion: security.openshift.io/v1
       metadata:
@@ -17562,6 +17557,11 @@ objects:
         type: RunAsAny
       seLinuxContext:
         type: RunAsAny
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: suricata-sa
+        namespace: openshift-suricata
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -17544,11 +17544,6 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: suricata-sa
-        namespace: openshift-suricata
     - kind: SecurityContextConstraints
       apiVersion: security.openshift.io/v1
       metadata:
@@ -17562,6 +17557,11 @@ objects:
         type: RunAsAny
       seLinuxContext:
         type: RunAsAny
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: suricata-sa
+        namespace: openshift-suricata
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -17544,11 +17544,6 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
-    - apiVersion: v1
-      kind: ServiceAccount
-      metadata:
-        name: suricata-sa
-        namespace: openshift-suricata
     - kind: SecurityContextConstraints
       apiVersion: security.openshift.io/v1
       metadata:
@@ -17562,6 +17557,11 @@ objects:
         type: RunAsAny
       seLinuxContext:
         type: RunAsAny
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: suricata-sa
+        namespace: openshift-suricata
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -21,7 +21,7 @@ directories = [
 policy_generator_config = './scripts/policy-generator-config.yaml'
 config_filename = "config.yaml"
 #go into each directory and copy a subset of manifests that are not SubjectPermissions or config.yaml into a /tmp dir
-for directory in directories:
+for directory in sorted(directories, key=str.casefold):
     #extract the directory name
     policy_name = directory.replace("/", "-")
     temp_directory = os.path.join("/tmp", policy_name)

--- a/scripts/generate-policy.sh
+++ b/scripts/generate-policy.sh
@@ -3,11 +3,11 @@
 DIRECTORY="/tmp/*/"
 FILENAME="policy-generator-config.yaml"
 ROOT_DIR=$PWD
-for dir in $DIRECTORY; do 
+for dir in $DIRECTORY; do
     echo $dir
     cd $dir
     name=$(grep "\- name:" $FILENAME | cut -d: -f2- | xargs)
     echo $name
-    $PolicyGenerator $FILENAME > $ROOT_DIR/deploy/acm-policies/50-GENERATED-$name.Policy.yaml
+    PolicyGenerator $FILENAME > $ROOT_DIR/deploy/acm-policies/50-GENERATED-$name.Policy.yaml
     cd $ROOT_DIR
 done

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -34,7 +34,7 @@ def get_all_yaml_files(path):
                 file_paths.append(os.path.join(r,file))
         # break, so we don't recurse
         break
-    file_paths = sorted(file_paths)
+    file_paths = sorted(file_paths, key=str.casefold)
     return file_paths
 
 def get_all_yaml_obj(file_paths):
@@ -42,7 +42,7 @@ def get_all_yaml_obj(file_paths):
     for file in file_paths:
         raw_objects = get_yaml_all(file)
         # remove None results (happens if a yaml has '---' at the end)
-        objects = [o for o in raw_objects if o] 
+        objects = [o for o in raw_objects if o]
 
         for obj in objects:
             yaml_objs.append(obj)
@@ -89,7 +89,7 @@ def add_sss_for(name, directory, config):
             o['spec']['resources'].append(y)
 
     o['metadata']['name'] = name
-    
+
     # collect the new sss for later processing
     data_sss.append(o)
 
@@ -119,7 +119,7 @@ if __name__ == '__main__':
         if filenames:
             dirpaths.append(dirpath)
 
-    for dirpath in sorted(dirpaths):
+    for dirpath in sorted(dirpaths, key=str.casefold):
         # load config if it exists
         config = {}
         path_config = os.path.join(dirpath, config_filename)
@@ -189,7 +189,7 @@ if __name__ == '__main__':
                 # Catches anyone with a rouge value
                 add_sss_for(sss_name, dirpath, config["selectorSyncSet"])
 
-    # Get the template 
+    # Get the template
     template_data = get_yaml(os.path.join(arguments.template_dir, "template.yaml"))
 
     # Set the REPO_NAME parameter.


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
In certain local cases, generation was failing opaquely. This cleans up the steps a bit, swaps out the image used, and increases logging verbosity.

It also uses case insensitive matching when sorting the files, so that it doesn't run differently depending on if it's run on Linux vs macOS/Windows.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
