### PR TITLE
[OSD-12648] Add pagerduty service orchestration rule configmap

### DIFF
--- a/deploy/pagerduty-service-orchestration/00-osd-serviceorchestration-configmap.yaml
+++ b/deploy/pagerduty-service-orchestration/00-osd-serviceorchestration-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+data:
+  service-orchestration.json: |
+    {
+    "orchestration_path": {
+    "catch_all": {
+        "actions": {}
+    },
+    "sets": [
+    {
+        "id": "start",
+        "rules": [
+        {     
+            "actions": {
+            "suppress": true
+            },
+            "conditions": [
+            {
+            "expression": "event.severity matches 'Warning'"
+            }
+            ]
+        }
+        ]
+    }
+    ],
+    "type": "service"
+    }
+    }
+kind: ConfigMap
+metadata:
+  name: osd-serviceorchestration
+  namespace: pagerduty-operator

--- a/deploy/pagerduty-service-orchestration/00-osd-serviceorchestration-configmap.yaml
+++ b/deploy/pagerduty-service-orchestration/00-osd-serviceorchestration-configmap.yaml
@@ -30,3 +30,5 @@ kind: ConfigMap
 metadata:
   name: osd-serviceorchestration
   namespace: pagerduty-operator
+  labels:
+    api.openshift.com/managed: "true"

--- a/deploy/pagerduty-service-orchestration/config.yaml
+++ b/deploy/pagerduty-service-orchestration/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "Direct"
+direct:
+    environments: ["integration", "stage"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21561,6 +21561,18 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
+- apiVersion: v1
+  data:
+    service-orchestration.json: "{\n\"orchestration_path\": {\n\"catch_all\": {\n\
+      \    \"actions\": {}\n},\n\"sets\": [\n{\n    \"id\": \"start\",\n    \"rules\"\
+      : [\n    {     \n        \"actions\": {\n        \"suppress\": true\n      \
+      \  },\n        \"conditions\": [\n        {\n        \"expression\": \"event.severity\
+      \ matches 'Warning'\"\n        }\n        ]\n    }\n    ]\n}\n],\n\"type\":\
+      \ \"service\"\n}\n}\n"
+  kind: ConfigMap
+  metadata:
+    name: osd-serviceorchestration
+    namespace: pagerduty-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21573,6 +21573,8 @@ objects:
   metadata:
     name: osd-serviceorchestration
     namespace: pagerduty-operator
+    labels:
+      api.openshift.com/managed: 'true'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21561,6 +21561,18 @@ objects:
   metadata:
     name: hive-environment
     namespace: openshift-config
+- apiVersion: v1
+  data:
+    service-orchestration.json: "{\n\"orchestration_path\": {\n\"catch_all\": {\n\
+      \    \"actions\": {}\n},\n\"sets\": [\n{\n    \"id\": \"start\",\n    \"rules\"\
+      : [\n    {     \n        \"actions\": {\n        \"suppress\": true\n      \
+      \  },\n        \"conditions\": [\n        {\n        \"expression\": \"event.severity\
+      \ matches 'Warning'\"\n        }\n        ]\n    }\n    ]\n}\n],\n\"type\":\
+      \ \"service\"\n}\n}\n"
+  kind: ConfigMap
+  metadata:
+    name: osd-serviceorchestration
+    namespace: pagerduty-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21573,6 +21573,8 @@ objects:
   metadata:
     name: osd-serviceorchestration
     namespace: pagerduty-operator
+    labels:
+      api.openshift.com/managed: 'true'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
- Add configmap which is used by pagerduty-operator for service orchestration rule to suppress warning alerts.

### Which Jira/Github issue(s) this PR fixes?

_Fixes_ #[OSD-12648](https://issues.redhat.com/browse/OSD-12648)


