### PR TITLE
OSD-14247 fix sre-build-test race condition

### DIFF
--- a/deploy/sre-build-test/50-source-build-test.CronJob.yaml
+++ b/deploy/sre-build-test/50-source-build-test.CronJob.yaml
@@ -76,6 +76,12 @@ spec:
                 sleep 5
               done
 
+              # wait for rolebindings needed for build to be created
+               until (oc -n "${NS}" get rolebindings system:deployers >/dev/null) && (oc -n "${NS}" get rolebindings system:image-builders >/dev/null) && (oc -n "${NS}" get rolebindings system:image-pullers >/dev/null); do
+                 echo "$(date): Waiting for rolebindings to be created"
+                 sleep 5
+               done
+
               # run build
               oc -n "${NS}" new-build --name="${JOB_PREFIX}" --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13
               mkdir -p /tmp/build

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -19501,9 +19501,15 @@ objects:
                     \n# wait for serviceaccount to be created\nuntil oc -n \"${NS}\"\
                     \ get serviceaccounts default >/dev/null; do\n  echo \"$(date):\
                     \ Waiting for service account to be created\"\n  sleep 5\ndone\n\
-                    \n# run build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\"\
-                    \ --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
-                    mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
+                    \n# wait for rolebindings needed for build to be created\n until\
+                    \ (oc -n \"${NS}\" get rolebindings system:deployers >/dev/null)\
+                    \ && (oc -n \"${NS}\" get rolebindings system:image-builders >/dev/null)\
+                    \ && (oc -n \"${NS}\" get rolebindings system:image-pullers >/dev/null);\
+                    \ do\n   echo \"$(date): Waiting for rolebindings to be created\"\
+                    \n   sleep 5\n done\n\n# run build\noc -n \"${NS}\" new-build\
+                    \ --name=\"${JOB_PREFIX}\" --binary --strategy source --docker-image\
+                    \ registry.redhat.io/ubi8/go-toolset:1.17.7-13\nmkdir -p /tmp/build\n\
+                    cat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
                     \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
                     import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\
                     Hello Openshift SRE :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -19501,9 +19501,15 @@ objects:
                     \n# wait for serviceaccount to be created\nuntil oc -n \"${NS}\"\
                     \ get serviceaccounts default >/dev/null; do\n  echo \"$(date):\
                     \ Waiting for service account to be created\"\n  sleep 5\ndone\n\
-                    \n# run build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\"\
-                    \ --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
-                    mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
+                    \n# wait for rolebindings needed for build to be created\n until\
+                    \ (oc -n \"${NS}\" get rolebindings system:deployers >/dev/null)\
+                    \ && (oc -n \"${NS}\" get rolebindings system:image-builders >/dev/null)\
+                    \ && (oc -n \"${NS}\" get rolebindings system:image-pullers >/dev/null);\
+                    \ do\n   echo \"$(date): Waiting for rolebindings to be created\"\
+                    \n   sleep 5\n done\n\n# run build\noc -n \"${NS}\" new-build\
+                    \ --name=\"${JOB_PREFIX}\" --binary --strategy source --docker-image\
+                    \ registry.redhat.io/ubi8/go-toolset:1.17.7-13\nmkdir -p /tmp/build\n\
+                    cat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
                     \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
                     import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\
                     Hello Openshift SRE :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -19501,9 +19501,15 @@ objects:
                     \n# wait for serviceaccount to be created\nuntil oc -n \"${NS}\"\
                     \ get serviceaccounts default >/dev/null; do\n  echo \"$(date):\
                     \ Waiting for service account to be created\"\n  sleep 5\ndone\n\
-                    \n# run build\noc -n \"${NS}\" new-build --name=\"${JOB_PREFIX}\"\
-                    \ --binary --strategy source --docker-image registry.redhat.io/ubi8/go-toolset:1.17.7-13\n\
-                    mkdir -p /tmp/build\ncat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
+                    \n# wait for rolebindings needed for build to be created\n until\
+                    \ (oc -n \"${NS}\" get rolebindings system:deployers >/dev/null)\
+                    \ && (oc -n \"${NS}\" get rolebindings system:image-builders >/dev/null)\
+                    \ && (oc -n \"${NS}\" get rolebindings system:image-pullers >/dev/null);\
+                    \ do\n   echo \"$(date): Waiting for rolebindings to be created\"\
+                    \n   sleep 5\n done\n\n# run build\noc -n \"${NS}\" new-build\
+                    \ --name=\"${JOB_PREFIX}\" --binary --strategy source --docker-image\
+                    \ registry.redhat.io/ubi8/go-toolset:1.17.7-13\nmkdir -p /tmp/build\n\
+                    cat <<EOF > /tmp/build/go.mod\nmodule openshift/managed-cluster-config/sre-build-test\n\
                     \ngo 1.17\nEOF\ncat <<EOF > /tmp/build/main.go\npackage main\n\
                     import (\n       \"fmt\"\n)\n\nfunc main() {\n        fmt.Println(\"\
                     Hello Openshift SRE :)\")\n}\nEOF\n\nwhile ! oc -n \"${NS}\" start-build\


### PR DESCRIPTION
### What type of PR is this?
_bug/_

### What this PR does / why we need it?

This PR fixes the sre-build-test job to wait for the necessary rolebindings to be created before running the build process. 

The error that is encountered when the permissions are missing looks like this:
```
error: can't lookup images: imagestreamimports.image.openshift.io is forbidden: User "system:serviceaccount:openshift-build-test:sre-build-test" cannot create resource "imagestreamimports" in API group "image.openshift.io" in the namespace "openshift-build-test-27850151-vjkr9"
error: unable to locate any local docker images with name "registry.redhat.io/ubi8/go-toolset:1.17.7-13"
```

In those cases the `rbac-permissions-operator` cannot apply the permissions because the namespace is already cleaned up by the job:
```
1.6710137627098532e+09    ERROR    controller.namespace    Reconciler error    {"reconciler group": "", "reconciler kind": "Namespace", "name": "openshift-build-test-27850211-wt2kc", "namespace": "", "error": "rolebindings.rbac.authorization.k8s.io \"dedicated-readers-system:serviceaccounts:openshift-backplane-csa\" is forbidden: unable to create new content in namespace openshift-build-test-27850211-wt2kc because it is being terminated"} 
```
By waiting for the rolebindings to be created by `rbac-permissions-operator` in the job, we eliminate this race condition.

### Which Jira/Github issue(s) this PR fixes?

_Fixes https://issues.redhat.com/browse/OSD-14247_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
