### PR TITLE
Tune the queueConfig of the remote write of hypershift tenant

### DIFF
--- a/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -48,13 +48,13 @@ data:
           - targetLabel: source
             replacement: HCP
           queueConfig:
-            capacity: 2500
-            maxShards: 1000
+            capacity: 10000
+            maxShards: 500
             minShards: 1
-            maxSamplesPerSend: 500
+            maxSamplesPerSend: 2000
             batchSendDeadline: 60s
             minBackoff: 30ms
-            maxBackoff: 5s
+            maxBackoff: 30s
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11849,10 +11849,10 @@ objects:
           \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
           \        targetLabel: _mc_id\n        action: replace\n      - sourceLabels:\
           \ [__name__]\n        action: keep\n      - targetLabel: source\n      \
-          \  replacement: HCP\n      queueConfig:\n        capacity: 2500\n      \
-          \  maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend: 500\n\
+          \  replacement: HCP\n      queueConfig:\n        capacity: 10000\n     \
+          \   maxShards: 500\n        minShards: 1\n        maxSamplesPerSend: 2000\n\
           \        batchSendDeadline: 60s\n        minBackoff: 30ms\n        maxBackoff:\
-          \ 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \ 30s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
           \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
           \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11849,10 +11849,10 @@ objects:
           \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
           \        targetLabel: _mc_id\n        action: replace\n      - sourceLabels:\
           \ [__name__]\n        action: keep\n      - targetLabel: source\n      \
-          \  replacement: HCP\n      queueConfig:\n        capacity: 2500\n      \
-          \  maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend: 500\n\
+          \  replacement: HCP\n      queueConfig:\n        capacity: 10000\n     \
+          \   maxShards: 500\n        minShards: 1\n        maxSamplesPerSend: 2000\n\
           \        batchSendDeadline: 60s\n        minBackoff: 30ms\n        maxBackoff:\
-          \ 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \ 30s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
           \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
           \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11849,10 +11849,10 @@ objects:
           \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
           \        targetLabel: _mc_id\n        action: replace\n      - sourceLabels:\
           \ [__name__]\n        action: keep\n      - targetLabel: source\n      \
-          \  replacement: HCP\n      queueConfig:\n        capacity: 2500\n      \
-          \  maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend: 500\n\
+          \  replacement: HCP\n      queueConfig:\n        capacity: 10000\n     \
+          \   maxShards: 500\n        minShards: 1\n        maxSamplesPerSend: 2000\n\
           \        batchSendDeadline: 60s\n        minBackoff: 30ms\n        maxBackoff:\
-          \ 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \ 30s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
           \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
           \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?
We need tune the queue config a bit to better align the rhobs tenant performance.
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
