### PR TITLE
Add Managednotification and Prometheus rule for multiple ingress controllers

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -6,6 +6,14 @@ metadata:
 spec:
   notifications:
     - activeBody: |-
+        Your cluster requires you to take action as there are multiple ingress controllers detected. Red Hat SRE strongly recommends using Openshift-managed Custom Domains instead, as multiple ingress controllers, if improperly configured, can lead to problems with internal and external networking.
+      name: MultipleIngressControllersDetected
+      resendWait: 24
+      resolvedBody: |-
+        Your cluster no longer has multiple Ingress Controllers installed. No additional action on this issue is required.
+      severity: Info
+      summary: "Multiple ingress controllers detected"
+    - activeBody: |-
         Your cluster requires you to take action as its ElasticSearch cluster logging deployment has been detected as reaching a high disk usage threshold. Red Hat SRE strongly recommends reducing application logging on your cluster to ensure logging continues to function. If logging disk consumption exceeds 95%, data will be at risk of becoming unavailable or lost and the stability of your ElasticSearch deployment may be impacted.
       name: LoggingVolumeFillingUp
       resendWait: 24

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -10,6 +10,16 @@ spec:
   groups:
   - name: sre-managed-notification-alerts
     rules:
+    - alert: MultipleIngressControllersDetectedNotificationSRE
+      expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m] offset 5m) or vector(0)) > 0
+      for: 30m
+      labels:
+        severity: Info
+        namespace: openshift-logging
+        send_managed_notification: "true"
+        managed_notification_template: "MultipleIngressControllersDetected"
+  - name: sre-managed-notification-alerts
+    rules:
     - alert: LoggingVolumeFillingUpNotificationSRE
     # KubePersistentVolumeFillingUp alert firing in openshift-logging Namespace.
       expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-logging"}) >= 1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -19663,6 +19663,16 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
+        - activeBody: Your cluster requires you to take action as there are multiple
+            ingress controllers detected. Red Hat SRE strongly recommends using Openshift-managed
+            Custom Domains instead, as multiple ingress controllers, if improperly
+            configured, can lead to problems with internal and external networking.
+          name: MultipleIngressControllersDetected
+          resendWait: 24
+          resolvedBody: Your cluster no longer has multiple Ingress Controllers installed.
+            No additional action on this issue is required.
+          severity: Info
+          summary: Multiple ingress controllers detected
         - activeBody: Your cluster requires you to take action as its ElasticSearch
             cluster logging deployment has been detected as reaching a high disk usage
             threshold. Red Hat SRE strongly recommends reducing application logging
@@ -29723,6 +29733,18 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
+        - name: sre-managed-notification-alerts
+          rules:
+          - alert: MultipleIngressControllersDetectedNotificationSRE
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
+              offset 5m) or vector(0)) > 0
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-logging
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleIngressControllersDetected
         - name: sre-managed-notification-alerts
           rules:
           - alert: LoggingVolumeFillingUpNotificationSRE

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -19663,6 +19663,16 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
+        - activeBody: Your cluster requires you to take action as there are multiple
+            ingress controllers detected. Red Hat SRE strongly recommends using Openshift-managed
+            Custom Domains instead, as multiple ingress controllers, if improperly
+            configured, can lead to problems with internal and external networking.
+          name: MultipleIngressControllersDetected
+          resendWait: 24
+          resolvedBody: Your cluster no longer has multiple Ingress Controllers installed.
+            No additional action on this issue is required.
+          severity: Info
+          summary: Multiple ingress controllers detected
         - activeBody: Your cluster requires you to take action as its ElasticSearch
             cluster logging deployment has been detected as reaching a high disk usage
             threshold. Red Hat SRE strongly recommends reducing application logging
@@ -29723,6 +29733,18 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
+        - name: sre-managed-notification-alerts
+          rules:
+          - alert: MultipleIngressControllersDetectedNotificationSRE
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
+              offset 5m) or vector(0)) > 0
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-logging
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleIngressControllersDetected
         - name: sre-managed-notification-alerts
           rules:
           - alert: LoggingVolumeFillingUpNotificationSRE

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -19663,6 +19663,16 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
+        - activeBody: Your cluster requires you to take action as there are multiple
+            ingress controllers detected. Red Hat SRE strongly recommends using Openshift-managed
+            Custom Domains instead, as multiple ingress controllers, if improperly
+            configured, can lead to problems with internal and external networking.
+          name: MultipleIngressControllersDetected
+          resendWait: 24
+          resolvedBody: Your cluster no longer has multiple Ingress Controllers installed.
+            No additional action on this issue is required.
+          severity: Info
+          summary: Multiple ingress controllers detected
         - activeBody: Your cluster requires you to take action as its ElasticSearch
             cluster logging deployment has been detected as reaching a high disk usage
             threshold. Red Hat SRE strongly recommends reducing application logging
@@ -29723,6 +29733,18 @@ objects:
         namespace: openshift-monitoring
       spec:
         groups:
+        - name: sre-managed-notification-alerts
+          rules:
+          - alert: MultipleIngressControllersDetectedNotificationSRE
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
+              offset 5m) or vector(0)) > 0
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-logging
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleIngressControllersDetected
         - name: sre-managed-notification-alerts
           rules:
           - alert: LoggingVolumeFillingUpNotificationSRE


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This pull request sends a service log to the customer if we get an alert that they have manually created an ingress controller outside of the `custom-domains-operator`. It uses the `splunk-audit-exporter` to pick up the non-system `create` verb, and follows the metric example set out in https://docs.google.com/presentation/d/1SEPCs9zOjy9KjgTXwznnJ9hCNMBOWpbz0vir5iCl_H8/edit#slide=id.g1a09e448a9b_0_139. 
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-12599
### Special notes for your reviewer:
Depends on https://github.com/openshift/splunk-forwarder-operator/pull/167
### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] Wording needs to be confirmed by the BU - as mentioned in the PR. (have corresponded with a PM about wording, waiting for approval).
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:
- [x] Depends on https://github.com/openshift/splunk-forwarder-operator/pull/167 being merged

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
