### PR TITLE
Configure integration endpoint for insights

### DIFF
--- a/deploy/insights-integration/01-support.Secret.yaml
+++ b/deploy/insights-integration/01-support.Secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: support
+  namespace: openshift-config
+type: Opaque
+data:
+  endpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luZ3Jlc3MvdjEvdXBsb2Fk
+  reportEndpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luc2lnaHRzLXJlc3VsdHMtYWdncmVnYXRvci92MS9jbHVzdGVycy8lcy9yZXBvcnQ=
+  scaEndpoint: aHR0cHM6Ly9hcGkuaW50ZWdyYXRpb24ub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=

--- a/deploy/insights-integration/config.yaml
+++ b/deploy/insights-integration/config.yaml
@@ -4,7 +4,7 @@ selectorSyncSet:
   matchExpressions:
   - key: api.openshift.com/environment
     operator: In
-    values: ["staging"]
+    values: ["integration"]
   - key: api.openshift.com/fedramp
     operator: NotIn
     values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11749,6 +11749,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: insights-integration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: support
+        namespace: openshift-config
+      type: Opaque
+      data:
+        endpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luZ3Jlc3MvdjEvdXBsb2Fk
+        reportEndpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luc2lnaHRzLXJlc3VsdHMtYWdncmVnYXRvci92MS9jbHVzdGVycy8lcy9yZXBvcnQ=
+        scaEndpoint: aHR0cHM6Ly9hcGkuaW50ZWdyYXRpb24ub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:
@@ -11759,7 +11792,6 @@ objects:
         operator: In
         values:
         - staging
-        - integration
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11749,6 +11749,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: insights-integration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: support
+        namespace: openshift-config
+      type: Opaque
+      data:
+        endpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luZ3Jlc3MvdjEvdXBsb2Fk
+        reportEndpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luc2lnaHRzLXJlc3VsdHMtYWdncmVnYXRvci92MS9jbHVzdGVycy8lcy9yZXBvcnQ=
+        scaEndpoint: aHR0cHM6Ly9hcGkuaW50ZWdyYXRpb24ub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:
@@ -11759,7 +11792,6 @@ objects:
         operator: In
         values:
         - staging
-        - integration
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11749,6 +11749,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: insights-integration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Secret
+      metadata:
+        name: support
+        namespace: openshift-config
+      type: Opaque
+      data:
+        endpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luZ3Jlc3MvdjEvdXBsb2Fk
+        reportEndpoint: aHR0cHM6Ly9jb25zb2xlLnN0YWdlLnJlZGhhdC5jb20vYXBpL2luc2lnaHRzLXJlc3VsdHMtYWdncmVnYXRvci92MS9jbHVzdGVycy8lcy9yZXBvcnQ=
+        scaEndpoint: aHR0cHM6Ly9hcGkuaW50ZWdyYXRpb24ub3BlbnNoaWZ0LmNvbS9hcGkvYWNjb3VudHNfbWdtdC92MS9jZXJ0aWZpY2F0ZXM=
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-staging
   spec:
     clusterDeploymentSelector:
@@ -11759,7 +11792,6 @@ objects:
         operator: In
         values:
         - staging
-        - integration
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
as we are improving our integration environment, we should have the insights operator contact the correct OCM instance.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/APPSRE-6567

### Special notes for your reviewer:
this is similar and following #1189 and #1212

based on https://github.com/openshift/insights-operator/blob/master/docs/arch.md#how-the-insights-operator-reads-configuration

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
