### PR TITLE
chore: access for egressnetworkpolicy for ocs addons

### DIFF
--- a/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/01-ocs-consumer-cr-admins.ClusterRole.yml
@@ -88,3 +88,14 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+    - network.openshift.io
+    resources:
+    - egressnetworkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+    - patch
+    - update
+    - delete

--- a/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
+++ b/deploy/backplane/mtsre/ocs-provider/01-ocs-provider-cr-admins.ClusterRole.yml
@@ -88,3 +88,14 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+    - network.openshift.io
+    resources:
+    - egressnetworkpolicies
+    verbs:
+    - get
+    - list
+    - watch
+    - patch
+    - update
+    - delete

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9906,6 +9906,17 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - egressnetworkpolicies
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10052,6 +10063,17 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - egressnetworkpolicies
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9906,6 +9906,17 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - egressnetworkpolicies
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10052,6 +10063,17 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - egressnetworkpolicies
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9906,6 +9906,17 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - egressnetworkpolicies
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10052,6 +10063,17 @@ objects:
         - prometheusrules
         - servicemonitors
         - podmonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - egressnetworkpolicies
         verbs:
         - get
         - list


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

### What type of PR is this?
_(chore)_

### What this PR does / why we need it?

Currently, MT-SRE members don't have backplane access to access the egressnetworkpolicy and that has blocked us to perform numerous fixes in the past to flaky problems around fixing the egress network policy created by aws-data-gather in the past.