### PR TITLE
Adding a new label to identify metrics origin on RHOBS

### DIFF
--- a/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/hypershift-cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -45,6 +45,8 @@ data:
             action: replace
           - sourceLabels: [__name__]
             action: keep
+          - targetLabel: source
+            replacement: HCP
           queueConfig:
             capacity: 2500
             maxShards: 1000

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -11688,12 +11688,13 @@ objects:
           \ rhobs-hypershift-credential\n        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
           \        targetLabel: _mc_id\n        action: replace\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n      queueConfig:\n        capacity:\
-          \ 2500\n        maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend:\
-          \ 500\n        batchSendDeadline: 60s\n        minBackoff: 30ms\n      \
-          \  maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
-          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \ [__name__]\n        action: keep\n      - targetLabel: source\n      \
+          \  replacement: HCP\n      queueConfig:\n        capacity: 2500\n      \
+          \  maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend: 500\n\
+          \        batchSendDeadline: 60s\n        minBackoff: 30ms\n        maxBackoff:\
+          \ 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -11688,12 +11688,13 @@ objects:
           \ rhobs-hypershift-credential\n        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
           \        targetLabel: _mc_id\n        action: replace\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n      queueConfig:\n        capacity:\
-          \ 2500\n        maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend:\
-          \ 500\n        batchSendDeadline: 60s\n        minBackoff: 30ms\n      \
-          \  maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
-          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \ [__name__]\n        action: keep\n      - targetLabel: source\n      \
+          \  replacement: HCP\n      queueConfig:\n        capacity: 2500\n      \
+          \  maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend: 500\n\
+          \        batchSendDeadline: 60s\n        minBackoff: 30ms\n        maxBackoff:\
+          \ 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -11688,12 +11688,13 @@ objects:
           \ rhobs-hypershift-credential\n        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \      writeRelabelConfigs:\n      - sourceLabels:\n        - __tmp_openshift_cluster_id__\n\
           \        targetLabel: _mc_id\n        action: replace\n      - sourceLabels:\
-          \ [__name__]\n        action: keep\n      queueConfig:\n        capacity:\
-          \ 2500\n        maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend:\
-          \ 500\n        batchSendDeadline: 60s\n        minBackoff: 30ms\n      \
-          \  maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\
-          \"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
-          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \ [__name__]\n        action: keep\n      - targetLabel: source\n      \
+          \  replacement: HCP\n      queueConfig:\n        capacity: 2500\n      \
+          \  maxShards: 1000\n        minShards: 1\n        maxSamplesPerSend: 500\n\
+          \        batchSendDeadline: 60s\n        minBackoff: 30ms\n        maxBackoff:\
+          \ 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n\
+          \    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n  \
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\


### PR DESCRIPTION
### What type of PR is this?
_Feature_

### What this PR does / why we need it?
Metrics shipped by Hypershift to RHOBS will come from 3 distincts sources:
- From the Prometheus handled by the CMO operator running in the Management Cluster.
- From the Prometheus handled by the OO operator running in the Management Cluster.
- From the Prometheus handled by the CMO operator running in the Data Plane.

The 2 first sources do not need to be distinguished one from the other and will be `source` labelled to value `HCP` for Hosted Control Plane. Value for the last source will be set to `DP` (Dala Plane). 
Be able to clearly identify the source of each metric will avoid confusion and potential conflicts.

### Which Jira/Github issue(s) this PR fixes?
This change is needed to properly support the alerts defined there:
https://gitlab.cee.redhat.com/service/rhobs-rules-and-dashboards/-/tree/main/rules/hypershift-platform
Those rules were defined while implementing the following tickets; they already assume that a `source` label is set to `HCP`:
- [OSD-12616](https://issues.redhat.com/browse/OSD-12616)
- [OSD-13687](https://issues.redhat.com/browse/OSD-13687)

Please tell me if a dedicated ticket is needed for that.

### Special notes for your reviewer:
Change is very similar to this one also done with the same context in mind (Hypershift): https://github.com/openshift/managed-cluster-config/pull/1373

However, here we are adding the label at a lower level (through some `writeRelabelConfig`)

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
