### PR TITLE
Changed policy evaluationInterval

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,11 @@ Alternatively you can enable GitHub Actions on your fork and `make` will be ran 
 the action will create a new commit with the generated files.
 
 To add a Policy
-- If the manifest of the object you want to convert to policy already exists in ./deploy :  Right now the policies are group by their funtionalities (like the rbac-policies that will generate all the policies for rbac related thing.). So if you want to add an rbac manifest, go to /script/generate-policy-template.py and add the directory you want to convert in the directory array. 
-- If the manifest of the object does not exist; add your manifests; then also add the directory of your manifest into the array in /script/generate-policy-template.py 
--Policies requires to be deploy in namespaces, so if the new policies don't belong to `openshift-managed-rbac-config`, create a manifest to create a new namespace. Example: ./deploy/acm-policies/00-openshift-managed-rbac-policies.Namespace.yaml 
-- If the manifest is SubjectPermission, add the directory of the manifest into the array in /script/generate-subjectpermissions-policy-template.py. then run `make` as usually
+- If the manifest of the object you want to convert to policy already exists in `deploy` : go to `script/generate-policy-template.py` and add the directory you want to convert in the directory array. 
+- If the manifest of the object does not exist; add your manifests; then add the directory of your manifest into the array in `script/generate-policy-template.py`. 
+- If the manifest is SubjectPermission, add the directory of the manifest into the array in `script/generate-subjectpermissions-policy-template.py` then run `make` as usually
 
-Then Run `make`
-`make` will look for the `policy-generator-config.yaml` files, runs it with the PolicyGenerator binary and save the output to `./deploy/acm-policies` directory. `make` will then automatically
+`make` will look for the `policy-generator-config.yaml` files, runs it with the PolicyGenerator binary and save the output to `deploy/acm-policies` directory. `make` will then automatically
 add the policy as a new SelectorySyncSet.
 
 # Building

--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-cee-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: backplane-cee-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -65,6 +71,9 @@ spec:
             metadata:
                 name: backplane-cee-sp3
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-cee
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-cse-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: backplane-cse-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-cse
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-csm-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: backplane-csm-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-csm
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-cssre-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: backplane-cssre-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -65,6 +71,9 @@ spec:
             metadata:
                 name: backplane-cssre-sp3
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-cssre
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-elevated-sre
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-mobb-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: backplane-mobb-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-mobb
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-srep-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: backplane-srep-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -65,6 +71,9 @@ spec:
             metadata:
                 name: backplane-srep-sp3
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin
@@ -99,6 +108,9 @@ spec:
             metadata:
                 name: backplane-srep-sp4
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-srep
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-tam-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: backplane-tam-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - openshift-backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane-tam
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: backplane
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: ccs-dedicated-admins-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     include:
                         - openshift-customer-monitoring
@@ -44,6 +47,9 @@ spec:
             metadata:
                 name: ccs-dedicated-admins-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     include:
                         - openshift-customer-monitoring

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: ccs-dedicated-admins
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: customer-registry-cas
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: osd-cluster-admin
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: osd-must-gather-operator
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: osd-openshift-operators-redhat
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: osd-pcap-collector
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -41,6 +44,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp2
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - kube
@@ -75,6 +81,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp3
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - kube
@@ -109,6 +118,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp4
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:
@@ -133,6 +145,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp5
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - kube
@@ -167,6 +182,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp6
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     exclude:
                         - kube
@@ -201,6 +219,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp7
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     include:
                         - openshift-operators
@@ -229,6 +250,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp8
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     include:
                         - openshift-operators
@@ -257,6 +281,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp9
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     include:
                         - openshift-operators
@@ -285,6 +312,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config-sp10
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 namespaceSelector:
                     include:
                         - openshift-operators

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -17,6 +17,9 @@ spec:
             metadata:
                 name: rbac-permissions-operator-config
             spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
                 object-templates:
                     - complianceType: musthave
                       objectDefinition:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -643,6 +643,9 @@ objects:
             metadata:
               name: backplane-cee-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -667,6 +670,9 @@ objects:
             metadata:
               name: backplane-cee-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -691,6 +697,9 @@ objects:
             metadata:
               name: backplane-cee-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -762,6 +771,9 @@ objects:
             metadata:
               name: backplane-cee
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -946,6 +958,9 @@ objects:
             metadata:
               name: backplane-cse-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -970,6 +985,9 @@ objects:
             metadata:
               name: backplane-cse-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1041,6 +1059,9 @@ objects:
             metadata:
               name: backplane-cse
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1094,6 +1115,9 @@ objects:
             metadata:
               name: backplane-csm-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1118,6 +1142,9 @@ objects:
             metadata:
               name: backplane-csm-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1189,6 +1216,9 @@ objects:
             metadata:
               name: backplane-csm
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1242,6 +1272,9 @@ objects:
             metadata:
               name: backplane-cssre-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1266,6 +1299,9 @@ objects:
             metadata:
               name: backplane-cssre-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1290,6 +1326,9 @@ objects:
             metadata:
               name: backplane-cssre-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1361,6 +1400,9 @@ objects:
             metadata:
               name: backplane-cssre
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1499,6 +1541,9 @@ objects:
             metadata:
               name: backplane-elevated-sre
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1595,6 +1640,9 @@ objects:
             metadata:
               name: backplane-mobb-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1619,6 +1667,9 @@ objects:
             metadata:
               name: backplane-mobb-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1690,6 +1741,9 @@ objects:
             metadata:
               name: backplane-mobb
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1743,6 +1797,9 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1767,6 +1824,9 @@ objects:
             metadata:
               name: backplane-srep-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1791,6 +1851,9 @@ objects:
             metadata:
               name: backplane-srep-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1825,6 +1888,9 @@ objects:
             metadata:
               name: backplane-srep-sp4
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1896,6 +1962,9 @@ objects:
             metadata:
               name: backplane-srep
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2322,6 +2391,9 @@ objects:
             metadata:
               name: backplane-tam-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2346,6 +2418,9 @@ objects:
             metadata:
               name: backplane-tam-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -2417,6 +2492,9 @@ objects:
             metadata:
               name: backplane-tam
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2470,6 +2548,9 @@ objects:
             metadata:
               name: backplane
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2537,6 +2618,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-customer-monitoring
@@ -2564,6 +2648,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-customer-monitoring
@@ -2628,6 +2715,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2690,6 +2780,9 @@ objects:
             metadata:
               name: customer-registry-cas
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2811,6 +2904,9 @@ objects:
             metadata:
               name: osd-cluster-admin
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2872,6 +2968,9 @@ objects:
             metadata:
               name: osd-must-gather-operator
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2930,6 +3029,9 @@ objects:
             metadata:
               name: osd-openshift-operators-redhat
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3043,6 +3145,9 @@ objects:
             metadata:
               name: osd-pcap-collector
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3133,6 +3238,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3157,6 +3265,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3191,6 +3302,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3225,6 +3339,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp4
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3249,6 +3366,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp5
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3283,6 +3403,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp6
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3317,6 +3440,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp7
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3345,6 +3471,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp8
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3373,6 +3502,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp9
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3401,6 +3533,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp10
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3466,6 +3601,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -643,6 +643,9 @@ objects:
             metadata:
               name: backplane-cee-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -667,6 +670,9 @@ objects:
             metadata:
               name: backplane-cee-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -691,6 +697,9 @@ objects:
             metadata:
               name: backplane-cee-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -762,6 +771,9 @@ objects:
             metadata:
               name: backplane-cee
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -946,6 +958,9 @@ objects:
             metadata:
               name: backplane-cse-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -970,6 +985,9 @@ objects:
             metadata:
               name: backplane-cse-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1041,6 +1059,9 @@ objects:
             metadata:
               name: backplane-cse
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1094,6 +1115,9 @@ objects:
             metadata:
               name: backplane-csm-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1118,6 +1142,9 @@ objects:
             metadata:
               name: backplane-csm-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1189,6 +1216,9 @@ objects:
             metadata:
               name: backplane-csm
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1242,6 +1272,9 @@ objects:
             metadata:
               name: backplane-cssre-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1266,6 +1299,9 @@ objects:
             metadata:
               name: backplane-cssre-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1290,6 +1326,9 @@ objects:
             metadata:
               name: backplane-cssre-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1361,6 +1400,9 @@ objects:
             metadata:
               name: backplane-cssre
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1499,6 +1541,9 @@ objects:
             metadata:
               name: backplane-elevated-sre
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1595,6 +1640,9 @@ objects:
             metadata:
               name: backplane-mobb-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1619,6 +1667,9 @@ objects:
             metadata:
               name: backplane-mobb-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1690,6 +1741,9 @@ objects:
             metadata:
               name: backplane-mobb
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1743,6 +1797,9 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1767,6 +1824,9 @@ objects:
             metadata:
               name: backplane-srep-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1791,6 +1851,9 @@ objects:
             metadata:
               name: backplane-srep-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1825,6 +1888,9 @@ objects:
             metadata:
               name: backplane-srep-sp4
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1896,6 +1962,9 @@ objects:
             metadata:
               name: backplane-srep
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2322,6 +2391,9 @@ objects:
             metadata:
               name: backplane-tam-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2346,6 +2418,9 @@ objects:
             metadata:
               name: backplane-tam-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -2417,6 +2492,9 @@ objects:
             metadata:
               name: backplane-tam
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2470,6 +2548,9 @@ objects:
             metadata:
               name: backplane
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2537,6 +2618,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-customer-monitoring
@@ -2564,6 +2648,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-customer-monitoring
@@ -2628,6 +2715,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2690,6 +2780,9 @@ objects:
             metadata:
               name: customer-registry-cas
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2811,6 +2904,9 @@ objects:
             metadata:
               name: osd-cluster-admin
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2872,6 +2968,9 @@ objects:
             metadata:
               name: osd-must-gather-operator
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2930,6 +3029,9 @@ objects:
             metadata:
               name: osd-openshift-operators-redhat
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3043,6 +3145,9 @@ objects:
             metadata:
               name: osd-pcap-collector
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3133,6 +3238,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3157,6 +3265,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3191,6 +3302,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3225,6 +3339,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp4
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3249,6 +3366,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp5
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3283,6 +3403,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp6
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3317,6 +3440,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp7
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3345,6 +3471,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp8
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3373,6 +3502,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp9
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3401,6 +3533,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp10
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3466,6 +3601,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -643,6 +643,9 @@ objects:
             metadata:
               name: backplane-cee-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -667,6 +670,9 @@ objects:
             metadata:
               name: backplane-cee-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -691,6 +697,9 @@ objects:
             metadata:
               name: backplane-cee-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -762,6 +771,9 @@ objects:
             metadata:
               name: backplane-cee
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -946,6 +958,9 @@ objects:
             metadata:
               name: backplane-cse-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -970,6 +985,9 @@ objects:
             metadata:
               name: backplane-cse-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1041,6 +1059,9 @@ objects:
             metadata:
               name: backplane-cse
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1094,6 +1115,9 @@ objects:
             metadata:
               name: backplane-csm-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1118,6 +1142,9 @@ objects:
             metadata:
               name: backplane-csm-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1189,6 +1216,9 @@ objects:
             metadata:
               name: backplane-csm
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1242,6 +1272,9 @@ objects:
             metadata:
               name: backplane-cssre-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1266,6 +1299,9 @@ objects:
             metadata:
               name: backplane-cssre-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1290,6 +1326,9 @@ objects:
             metadata:
               name: backplane-cssre-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1361,6 +1400,9 @@ objects:
             metadata:
               name: backplane-cssre
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1499,6 +1541,9 @@ objects:
             metadata:
               name: backplane-elevated-sre
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1595,6 +1640,9 @@ objects:
             metadata:
               name: backplane-mobb-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1619,6 +1667,9 @@ objects:
             metadata:
               name: backplane-mobb-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1690,6 +1741,9 @@ objects:
             metadata:
               name: backplane-mobb
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1743,6 +1797,9 @@ objects:
             metadata:
               name: backplane-srep-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1767,6 +1824,9 @@ objects:
             metadata:
               name: backplane-srep-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -1791,6 +1851,9 @@ objects:
             metadata:
               name: backplane-srep-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1825,6 +1888,9 @@ objects:
             metadata:
               name: backplane-srep-sp4
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -1896,6 +1962,9 @@ objects:
             metadata:
               name: backplane-srep
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2322,6 +2391,9 @@ objects:
             metadata:
               name: backplane-tam-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2346,6 +2418,9 @@ objects:
             metadata:
               name: backplane-tam-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - openshift-backplane-cluster-admin
@@ -2417,6 +2492,9 @@ objects:
             metadata:
               name: backplane-tam
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2470,6 +2548,9 @@ objects:
             metadata:
               name: backplane
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2537,6 +2618,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-customer-monitoring
@@ -2564,6 +2648,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-customer-monitoring
@@ -2628,6 +2715,9 @@ objects:
             metadata:
               name: ccs-dedicated-admins
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2690,6 +2780,9 @@ objects:
             metadata:
               name: customer-registry-cas
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2811,6 +2904,9 @@ objects:
             metadata:
               name: osd-cluster-admin
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2872,6 +2968,9 @@ objects:
             metadata:
               name: osd-must-gather-operator
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -2930,6 +3029,9 @@ objects:
             metadata:
               name: osd-openshift-operators-redhat
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3043,6 +3145,9 @@ objects:
             metadata:
               name: osd-pcap-collector
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3133,6 +3238,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3157,6 +3265,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp2
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3191,6 +3302,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp3
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3225,6 +3339,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp4
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:
@@ -3249,6 +3366,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp5
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3283,6 +3403,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp6
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 exclude:
                 - kube
@@ -3317,6 +3440,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp7
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3345,6 +3471,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp8
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3373,6 +3502,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp9
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3401,6 +3533,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config-sp10
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               namespaceSelector:
                 include:
                 - openshift-operators
@@ -3466,6 +3601,9 @@ objects:
             metadata:
               name: rbac-permissions-operator-config
             spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
               object-templates:
               - complianceType: musthave
                 objectDefinition:

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -8,6 +8,9 @@ policyDefaults:
         clusterSelectors:
             hypershift.open-cluster-management.io/hosted-cluster: "true"
     remediationAction: enforce
+    evaluationInterval:
+        compliant: 2h
+        noncompliant: 45s
     pruneObjectBehavior: "DeleteIfCreated"
 policies:
     - name: #Filled by script


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

feature/documentation

### What this PR does / why we need it?

Set `evaluationInterval` for the policies to 
evaluationInterval:
      compliant: 2h
      noncompliant: 45s

So the policies don't get evaluated constantly and spam the activities logs.
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-14430
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
