### PR TITLE
Allow CEE to view Addons

### DIFF
--- a/deploy/backplane/cee/01-cee-cluster-readers-ClusterRole.yml
+++ b/deploy/backplane/cee/01-cee-cluster-readers-ClusterRole.yml
@@ -30,3 +30,12 @@ rules:
   - get
   - list
   - watch
+# CEE can view Addon, AddonInstance, AddonOperator
+- apiGroups:
+  - addons.managed.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This PR is for the CEE team and allows us to view and list child objects of Addons. The change consists of displaying any resource that is a child of the "addons.managed.openshift.io" apiGroup. With this new feature, CEE will be able to easily view and enumerate the various resources associated with Addons, and improve our overall workflow.

This request originated from https://issues.redhat.com/browse/OSD-14426

Thanks.
gbravi