### PR TITLE
Add delete/patch permissions to cpms for SREs

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -134,6 +134,13 @@ spec:
                               verbs:
                                 - delete
                             - apiGroups:
+                                - machine.openshift.io
+                              resources:
+                                - controlplanemachinesets
+                              verbs:
+                                - delete
+                                - patch
+                            - apiGroups:
                                 - apiserver.openshift.io
                               resources:
                                 - apirequestcounts

--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -115,6 +115,7 @@ rules:
   - machines
   verbs:
   - delete
+# SRE can delete and patch ControlPlaneMachineSet https://issues.redhat.com/browse/OSD-14581 
 - apiGroups:
   - machine.openshift.io
   resources:

--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -119,7 +119,7 @@ rules:
 - apiGroups:
   - machine.openshift.io
   resources:
-  - controlplanemachineset
+  - controlplanemachinesets
   verbs:
   - delete
   - patch

--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -115,6 +115,13 @@ rules:
   - machines
   verbs:
   - delete
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - controlplanemachineset
+  verbs:
+  - delete
+  - patch
 # SRE can view api request counts
 - apiGroups:
   - apiserver.openshift.io

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2079,6 +2079,13 @@ objects:
                     verbs:
                     - delete
                   - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - controlplanemachinesets
+                    verbs:
+                    - delete
+                    - patch
+                  - apiGroups:
                     - apiserver.openshift.io
                     resources:
                     - apirequestcounts
@@ -10533,6 +10540,13 @@ objects:
         - machines
         verbs:
         - delete
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - controlplanemachinesets
+        verbs:
+        - delete
+        - patch
       - apiGroups:
         - apiserver.openshift.io
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2079,6 +2079,13 @@ objects:
                     verbs:
                     - delete
                   - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - controlplanemachinesets
+                    verbs:
+                    - delete
+                    - patch
+                  - apiGroups:
                     - apiserver.openshift.io
                     resources:
                     - apirequestcounts
@@ -10533,6 +10540,13 @@ objects:
         - machines
         verbs:
         - delete
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - controlplanemachinesets
+        verbs:
+        - delete
+        - patch
       - apiGroups:
         - apiserver.openshift.io
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2079,6 +2079,13 @@ objects:
                     verbs:
                     - delete
                   - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - controlplanemachinesets
+                    verbs:
+                    - delete
+                    - patch
+                  - apiGroups:
                     - apiserver.openshift.io
                     resources:
                     - apirequestcounts
@@ -10533,6 +10540,13 @@ objects:
         - machines
         verbs:
         - delete
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - controlplanemachinesets
+        verbs:
+        - delete
+        - patch
       - apiGroups:
         - apiserver.openshift.io
         resources:


### PR DESCRIPTION
As part of OCP 4.12, ControlPlaneMachineSet (CPMS) was added as a new custom resource in openshift-machine-api. SREs need these added permissions to properly service this CR in new clusters.

Linked JIRA:
https://issues.redhat.com/browse/OSD-14591