### PR TITLE
MTSRE-878 | chore: augment ado permissions with addoninstances and delete addon cr permissions

### DIFF
--- a/deploy/backplane/mtsre/10-mtsre-addon-operator-apis.ClusterRole.yml
+++ b/deploy/backplane/mtsre/10-mtsre-addon-operator-apis.ClusterRole.yml
@@ -8,10 +8,11 @@ rules:
     resources:
       - "addonoperators"
       - "addons"
+      - "addoninstances"
     verbs:
       - get
       - list
       - watch
       - patch
       - update
-
+      - delete

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7135,12 +7135,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7235,12 +7237,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7335,12 +7339,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7435,12 +7441,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7535,12 +7543,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7635,12 +7645,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7735,12 +7747,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7835,12 +7849,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7935,12 +7951,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8035,12 +8053,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8135,12 +8155,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8235,12 +8257,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8335,12 +8359,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8435,12 +8461,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8535,12 +8563,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8635,12 +8665,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8735,12 +8767,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8835,12 +8869,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8935,12 +8971,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9035,12 +9073,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9135,12 +9175,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9235,12 +9277,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9335,12 +9379,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9435,12 +9481,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9535,12 +9583,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9635,12 +9685,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9735,12 +9787,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9835,12 +9889,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7135,12 +7135,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7235,12 +7237,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7335,12 +7339,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7435,12 +7441,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7535,12 +7543,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7635,12 +7645,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7735,12 +7747,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7835,12 +7849,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7935,12 +7951,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8035,12 +8053,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8135,12 +8155,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8235,12 +8257,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8335,12 +8359,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8435,12 +8461,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8535,12 +8563,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8635,12 +8665,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8735,12 +8767,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8835,12 +8869,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8935,12 +8971,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9035,12 +9073,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9135,12 +9175,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9235,12 +9277,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9335,12 +9379,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9435,12 +9481,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9535,12 +9583,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9635,12 +9685,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9735,12 +9787,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9835,12 +9889,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7135,12 +7135,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7235,12 +7237,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7335,12 +7339,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7435,12 +7441,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7535,12 +7543,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7635,12 +7645,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7735,12 +7747,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7835,12 +7849,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -7935,12 +7951,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8035,12 +8053,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8135,12 +8155,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8235,12 +8257,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8335,12 +8359,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8435,12 +8461,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8535,12 +8563,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8635,12 +8665,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8735,12 +8767,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8835,12 +8869,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8935,12 +8971,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9035,12 +9073,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9135,12 +9175,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9235,12 +9277,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9335,12 +9379,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9435,12 +9481,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9535,12 +9583,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9635,12 +9685,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9735,12 +9787,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9835,12 +9889,14 @@ objects:
         resources:
         - addonoperators
         - addons
+        - addoninstances
         verbs:
         - get
         - list
         - watch
         - patch
         - update
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yash.kukreja.98@gmail.com>

### What type of PR is this?
_chore_

### What this PR does / why we need it?
This is a PR for giving the MT-SRE crucial permissions to perform addon migrations where detachment of addons from the addons flow is required. One example is ODF (ocs-consumer and ocs-provider addons) going through the current IBM migration where they require the above two addons to be non-destructibly detached and safely migrated from the addons flow to the IBM.

These things require Addon CR deletion permissions as well as addonInstance permissions as well.

### Linked Jira ticket

https://issues.redhat.com/browse/MTSRE-878