### PR TITLE
Add iam:SimulatePrincipalPolicy to SRE support role

### DIFF
--- a/resources/sts/4.10/sts_support_permission_policy.json
+++ b/resources/sts/4.10/sts_support_permission_policy.json
@@ -140,6 +140,7 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
+                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",

--- a/resources/sts/4.10/sts_support_permission_policy.json
+++ b/resources/sts/4.10/sts_support_permission_policy.json
@@ -140,7 +140,6 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
-                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
@@ -156,6 +155,18 @@
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"
             ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:SimulatePrincipalPolicy"
+            ],
+            "Effect": "Allow",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            },
             "Resource": "*"
         },
         {

--- a/resources/sts/4.11/sts_support_permission_policy.json
+++ b/resources/sts/4.11/sts_support_permission_policy.json
@@ -140,6 +140,7 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
+                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",

--- a/resources/sts/4.11/sts_support_permission_policy.json
+++ b/resources/sts/4.11/sts_support_permission_policy.json
@@ -140,7 +140,6 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
-                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
@@ -156,6 +155,18 @@
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"
             ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:SimulatePrincipalPolicy"
+            ],
+            "Effect": "Allow",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            },
             "Resource": "*"
         },
         {

--- a/resources/sts/4.7/sts_support_permission_policy.json
+++ b/resources/sts/4.7/sts_support_permission_policy.json
@@ -138,6 +138,7 @@
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
+                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",

--- a/resources/sts/4.7/sts_support_permission_policy.json
+++ b/resources/sts/4.7/sts_support_permission_policy.json
@@ -138,7 +138,6 @@
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
@@ -154,6 +153,18 @@
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"
             ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:SimulatePrincipalPolicy"
+            ],
+            "Effect": "Allow",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            },
             "Resource": "*"
         },
         {

--- a/resources/sts/4.8/sts_support_permission_policy.json
+++ b/resources/sts/4.8/sts_support_permission_policy.json
@@ -138,6 +138,7 @@
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
+                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",

--- a/resources/sts/4.8/sts_support_permission_policy.json
+++ b/resources/sts/4.8/sts_support_permission_policy.json
@@ -138,7 +138,6 @@
                 "elasticloadbalancing:DescribeTargetGroupAttributes",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
@@ -154,6 +153,18 @@
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"
             ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:SimulatePrincipalPolicy"
+            ],
+            "Effect": "Allow",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            },
             "Resource": "*"
         },
         {

--- a/resources/sts/4.9/sts_support_permission_policy.json
+++ b/resources/sts/4.9/sts_support_permission_policy.json
@@ -140,6 +140,7 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
+                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",

--- a/resources/sts/4.9/sts_support_permission_policy.json
+++ b/resources/sts/4.9/sts_support_permission_policy.json
@@ -140,7 +140,6 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
-                "iam:SimulatePrincipalPolicy",
                 "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
@@ -156,6 +155,18 @@
                 "tiros:GetQueryAnswer",
                 "tiros:GetQueryExplanation"
             ],
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:SimulatePrincipalPolicy"
+            ],
+            "Effect": "Allow",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            },
             "Resource": "*"
         },
         {


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This addition to the SRE support role allows us to simulate API calls against all policies attached to roles. The change will allow us to check if all the needed permissions are available on a STS cluster. 
(Part of https://issues.redhat.com/browse/OSD-11275)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
