### PR TITLE
 created new NS for ACM policies and migrate the current resources over

### DIFF
--- a/deploy/acm-policies/00-openshift-acm-policies.Namespace.yaml
+++ b/deploy/acm-policies/00-openshift-acm-policies.Namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-acm-policies
+

--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cee-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -107,7 +107,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-cee-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -120,7 +120,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-cee-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cee
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -166,7 +166,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-cee
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -179,7 +179,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-cee
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cse-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -80,7 +80,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-cse-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -93,7 +93,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-cse-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cse
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -35,7 +35,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-cse
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -48,7 +48,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-cse
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-csm-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -80,7 +80,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-csm-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -93,7 +93,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-csm-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-csm
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -35,7 +35,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-csm
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -48,7 +48,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-csm
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cssre-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -107,7 +107,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-cssre-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -120,7 +120,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-cssre-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cssre
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -120,7 +120,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-cssre
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -133,7 +133,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-cssre
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-elevated-sre
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -78,7 +78,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-elevated-sre
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -91,7 +91,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-elevated-sre
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mobb-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -80,7 +80,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-mobb-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -93,7 +93,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-mobb-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mobb
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -35,7 +35,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-mobb
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -48,7 +48,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-mobb
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -144,7 +144,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-srep-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -157,7 +157,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-srep-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -408,7 +408,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-srep
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -421,7 +421,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-srep
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-tam-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -80,7 +80,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-tam-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -93,7 +93,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-tam-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-tam
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -35,7 +35,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane-tam
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -48,7 +48,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane-tam
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -49,7 +49,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-backplane
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -62,7 +62,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-backplane
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: ccs-dedicated-admins-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -76,7 +76,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-ccs-dedicated-admins-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -89,7 +89,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-ccs-dedicated-admins-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: ccs-dedicated-admins
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -44,7 +44,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-ccs-dedicated-admins
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -57,7 +57,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-ccs-dedicated-admins
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: customer-registry-cas
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -103,7 +103,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-customer-registry-cas
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -116,7 +116,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-customer-registry-cas
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-cluster-admin
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -43,7 +43,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-osd-cluster-admin
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -56,7 +56,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-osd-cluster-admin
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-must-gather-operator
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -40,7 +40,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-osd-must-gather-operator
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -53,7 +53,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-osd-must-gather-operator
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-openshift-operators-redhat
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -95,7 +95,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-osd-openshift-operators-redhat
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -108,7 +108,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-osd-openshift-operators-redhat
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-pcap-collector
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -72,7 +72,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-osd-pcap-collector
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -85,7 +85,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-osd-pcap-collector
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rbac-permissions-operator-config-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -342,7 +342,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-rbac-permissions-operator-config-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -355,7 +355,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-rbac-permissions-operator-config-sp
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -7,7 +7,7 @@ metadata:
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rbac-permissions-operator-config
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     disabled: false
     policy-templates:
@@ -1009,7 +1009,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
     name: placement-rbac-permissions-operator-config
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -1022,7 +1022,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
     name: binding-rbac-permissions-operator-config
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -624,6 +624,10 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
+        name: openshift-acm-policies
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
         name: openshift-rbac-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
@@ -633,7 +637,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -732,7 +736,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -744,7 +748,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -761,7 +765,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -919,7 +923,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -931,7 +935,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -948,7 +952,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1020,7 +1024,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1032,7 +1036,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1049,7 +1053,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1076,7 +1080,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1088,7 +1092,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1105,7 +1109,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1177,7 +1181,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1189,7 +1193,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1206,7 +1210,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1233,7 +1237,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1245,7 +1249,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1262,7 +1266,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1361,7 +1365,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1373,7 +1377,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1390,7 +1394,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1502,7 +1506,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1514,7 +1518,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1531,7 +1535,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1601,7 +1605,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1613,7 +1617,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1630,7 +1634,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1702,7 +1706,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1714,7 +1718,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1731,7 +1735,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1758,7 +1762,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1770,7 +1774,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1787,7 +1791,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1923,7 +1927,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1935,7 +1939,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1952,7 +1956,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2352,7 +2356,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2364,7 +2368,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2381,7 +2385,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2453,7 +2457,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2465,7 +2469,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2482,7 +2486,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2509,7 +2513,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2521,7 +2525,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2538,7 +2542,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2579,7 +2583,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2591,7 +2595,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2608,7 +2612,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2676,7 +2680,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2688,7 +2692,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2705,7 +2709,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2741,7 +2745,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2753,7 +2757,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2770,7 +2774,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2865,7 +2869,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2877,7 +2881,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2894,7 +2898,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2929,7 +2933,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2941,7 +2945,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2958,7 +2962,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2990,7 +2994,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3002,7 +3006,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3019,7 +3023,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3106,7 +3110,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3118,7 +3122,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3135,7 +3139,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3199,7 +3203,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3211,7 +3215,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3228,7 +3232,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3562,7 +3566,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3574,7 +3578,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3591,7 +3595,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -4592,7 +4596,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -4604,7 +4608,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -624,6 +624,10 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
+        name: openshift-acm-policies
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
         name: openshift-rbac-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
@@ -633,7 +637,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -732,7 +736,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -744,7 +748,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -761,7 +765,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -919,7 +923,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -931,7 +935,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -948,7 +952,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1020,7 +1024,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1032,7 +1036,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1049,7 +1053,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1076,7 +1080,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1088,7 +1092,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1105,7 +1109,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1177,7 +1181,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1189,7 +1193,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1206,7 +1210,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1233,7 +1237,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1245,7 +1249,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1262,7 +1266,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1361,7 +1365,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1373,7 +1377,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1390,7 +1394,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1502,7 +1506,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1514,7 +1518,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1531,7 +1535,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1601,7 +1605,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1613,7 +1617,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1630,7 +1634,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1702,7 +1706,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1714,7 +1718,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1731,7 +1735,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1758,7 +1762,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1770,7 +1774,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1787,7 +1791,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1923,7 +1927,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1935,7 +1939,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1952,7 +1956,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2352,7 +2356,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2364,7 +2368,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2381,7 +2385,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2453,7 +2457,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2465,7 +2469,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2482,7 +2486,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2509,7 +2513,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2521,7 +2525,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2538,7 +2542,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2579,7 +2583,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2591,7 +2595,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2608,7 +2612,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2676,7 +2680,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2688,7 +2692,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2705,7 +2709,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2741,7 +2745,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2753,7 +2757,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2770,7 +2774,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2865,7 +2869,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2877,7 +2881,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2894,7 +2898,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2929,7 +2933,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2941,7 +2945,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2958,7 +2962,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2990,7 +2994,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3002,7 +3006,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3019,7 +3023,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3106,7 +3110,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3118,7 +3122,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3135,7 +3139,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3199,7 +3203,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3211,7 +3215,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3228,7 +3232,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3562,7 +3566,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3574,7 +3578,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3591,7 +3595,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -4592,7 +4596,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -4604,7 +4608,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -624,6 +624,10 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
+        name: openshift-acm-policies
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
         name: openshift-rbac-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
@@ -633,7 +637,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -732,7 +736,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -744,7 +748,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -761,7 +765,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -919,7 +923,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -931,7 +935,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cee
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -948,7 +952,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1020,7 +1024,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1032,7 +1036,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1049,7 +1053,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1076,7 +1080,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1088,7 +1092,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cse
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1105,7 +1109,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1177,7 +1181,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1189,7 +1193,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1206,7 +1210,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1233,7 +1237,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1245,7 +1249,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-csm
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1262,7 +1266,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1361,7 +1365,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1373,7 +1377,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cssre-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1390,7 +1394,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1502,7 +1506,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1514,7 +1518,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-cssre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1531,7 +1535,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1601,7 +1605,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1613,7 +1617,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-elevated-sre
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1630,7 +1634,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1702,7 +1706,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1714,7 +1718,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1731,7 +1735,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1758,7 +1762,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1770,7 +1774,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-mobb
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1787,7 +1791,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -1923,7 +1927,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -1935,7 +1939,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -1952,7 +1956,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2352,7 +2356,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2364,7 +2368,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-srep
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2381,7 +2385,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2453,7 +2457,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2465,7 +2469,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2482,7 +2486,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2509,7 +2513,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2521,7 +2525,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane-tam
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2538,7 +2542,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2579,7 +2583,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2591,7 +2595,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-backplane
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2608,7 +2612,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2676,7 +2680,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2688,7 +2692,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2705,7 +2709,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2741,7 +2745,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2753,7 +2757,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-ccs-dedicated-admins
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2770,7 +2774,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2865,7 +2869,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2877,7 +2881,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-customer-registry-cas
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2894,7 +2898,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2929,7 +2933,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -2941,7 +2945,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-cluster-admin
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -2958,7 +2962,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -2990,7 +2994,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3002,7 +3006,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-must-gather-operator
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3019,7 +3023,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3106,7 +3110,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3118,7 +3122,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-openshift-operators-redhat
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3135,7 +3139,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3199,7 +3203,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3211,7 +3215,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-osd-pcap-collector
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3228,7 +3232,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -3562,7 +3566,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -3574,7 +3578,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config-sp
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
@@ -3591,7 +3595,7 @@ objects:
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         disabled: false
         policy-templates:
@@ -4592,7 +4596,7 @@ objects:
       kind: PlacementRule
       metadata:
         name: placement-rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -4604,7 +4608,7 @@ objects:
       kind: PlacementBinding
       metadata:
         name: binding-rbac-permissions-operator-config
-        namespace: openshift-rbac-policies
+        namespace: openshift-acm-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -3,7 +3,7 @@ kind: PolicyGenerator
 metadata:
     name: #Filled by script
 policyDefaults:
-    namespace: openshift-rbac-policies
+    namespace: openshift-acm-policies
     placement:
         clusterSelectors:
             hypershift.open-cluster-management.io/hosted-cluster: "true"


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug/cleanup
### What this PR does / why we need it?
The current ACM policy namespace is specific to openshift-rbac-policies. we want a more generic name to hold different types of policies and not just rbac. this PR create the new ns and migrate the resources over. Clean up of the old ns will be done after the migration.
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-14562
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
