### PR TITLE
[OSD-8342] ignore the node unschedulable alerts during node update

### DIFF
--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -11,8 +11,8 @@ spec:
   - name: sre-node-unschedulable
     rules:
     - alert: KubeNodeUnschedulableSRE
-      expr: kube_node_spec_unschedulable > 0
-      for: 80m
+      expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"} and on(node) kube_node_spec_taint{key="UpdateInProgress"})
+      for: 60m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21281,8 +21281,9 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0
-            for: 80m
+            expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"}
+              and on(node) kube_node_spec_taint{key="UpdateInProgress"})
+            for: 60m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21281,8 +21281,9 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0
-            for: 80m
+            expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"}
+              and on(node) kube_node_spec_taint{key="UpdateInProgress"})
+            for: 60m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21281,8 +21281,9 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0
-            for: 80m
+            expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"}
+              and on(node) kube_node_spec_taint{key="UpdateInProgress"})
+            for: 60m
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Fix the un-intended KubeNodeUnschedulableSRE alert during the cluster upgrade

### Which Jira/Github issue(s) this PR fixes?
_Fixes #[OSD-8342](https://issues.redhat.com//browse/OSD-8342)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
