### PR TITLE
Adds cronjob to disable ControlPlaneMachineSet to 4.12 clusters

### DIFF
--- a/deploy/osd-14634-disable-cpms/00-osd-disable-cmps.ServiceAccount.yaml
+++ b/deploy/osd-14634-disable-cpms/00-osd-disable-cmps.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-disable-cpms
+  namespace: openshift-machine-api

--- a/deploy/osd-14634-disable-cpms/01-osd-disable-cpms.Role.yaml
+++ b/deploy/osd-14634-disable-cpms/01-osd-disable-cpms.Role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-disable-cpms
+  namespace: openshift-machine-api
+rules:
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - controlplanemachinesets
+  verbs:
+  - delete

--- a/deploy/osd-14634-disable-cpms/02-osd-disable-cpms.RoleBinding.yaml
+++ b/deploy/osd-14634-disable-cpms/02-osd-disable-cpms.RoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: osd-disable-cpms
+  namespace: openshift-machine-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-disable-cpms
+subjects:
+- kind: ServiceAccount
+  name: osd-disable-cpms
+  namespace: openshift-machine-api

--- a/deploy/osd-14634-disable-cpms/10-osd-disable-cpms.CronJob.yaml
+++ b/deploy/osd-14634-disable-cpms/10-osd-disable-cpms.CronJob.yaml
@@ -1,0 +1,39 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-disable-cpms
+  namespace: openshift-machine-api
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
+  schedule: "0 */1 * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 180
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: osd-disable-cpms
+          restartPolicy: Never
+          containers:
+          - name: osd-disable-cpms
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - |
+              # the appropriate way to disable CPMS is to delete the CPMS CR.
+              oc delete controlplanemachineset.machine.openshift.io/cluster -n openshift-machine-api

--- a/deploy/osd-14634-disable-cpms/config.yaml
+++ b/deploy/osd-14634-disable-cpms/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  ## This will need to be changed to use version-major-minor-patch when
+  ## we move to enable this feature in the future
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.12"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -12734,6 +12734,97 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-14634-disable-cpms
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      rules:
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - controlplanemachinesets
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-disable-cpms
+      subjects:
+      - kind: ServiceAccount
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: 0 */1 * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 180
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-disable-cpms
+                restartPolicy: Never
+                containers:
+                - name: osd-disable-cpms
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - '# the appropriate way to disable CPMS is to delete the CPMS CR.
+
+                    oc delete controlplanemachineset.machine.openshift.io/cluster
+                    -n openshift-machine-api
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -12734,6 +12734,97 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-14634-disable-cpms
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      rules:
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - controlplanemachinesets
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-disable-cpms
+      subjects:
+      - kind: ServiceAccount
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: 0 */1 * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 180
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-disable-cpms
+                restartPolicy: Never
+                containers:
+                - name: osd-disable-cpms
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - '# the appropriate way to disable CPMS is to delete the CPMS CR.
+
+                    oc delete controlplanemachineset.machine.openshift.io/cluster
+                    -n openshift-machine-api
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -12734,6 +12734,97 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-14634-disable-cpms
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      rules:
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - controlplanemachinesets
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-disable-cpms
+      subjects:
+      - kind: ServiceAccount
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-disable-cpms
+        namespace: openshift-machine-api
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: 0 */1 * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 180
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-disable-cpms
+                restartPolicy: Never
+                containers:
+                - name: osd-disable-cpms
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - '# the appropriate way to disable CPMS is to delete the CPMS CR.
+
+                    oc delete controlplanemachineset.machine.openshift.io/cluster
+                    -n openshift-machine-api
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?

This PR creates a cronjob on 4.12+ clusters that will disable the ControlPlane MachineSet in order to avoid conflicts with Cloud Ingress Operator and until it is decided to enable the feature across the fleet.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-14634_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ x ] Tested latest changes against a cluster
- [ x ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
