### PR TITLE
Adding 'secretsmanager:GetSecretValue' permission to installer permissions policy for 4.11

### DIFF
--- a/resources/sts/4.11/sts_installer_core_permission_policy.json
+++ b/resources/sts/4.11/sts_installer_core_permission_policy.json
@@ -168,6 +168,18 @@
 		    "ec2:ModifyVpcEndpointServicePermissions"
             ],
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
         }
     ]
 }

--- a/resources/sts/4.11/sts_installer_permission_policy.json
+++ b/resources/sts/4.11/sts_installer_permission_policy.json
@@ -188,6 +188,18 @@
                 "cloudwatch:GetMetricData"
             ],
             "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Provides `secretsmanager:getsecretvalue` permission in installer role permissions policy

### Which Jira/Github issue(s) this PR fixes?

Fixes # https://issues.redhat.com/browse/SDA-7768

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [✓] Tested latest changes against a local cluster
