### PR TITLE
Added new permission [ec2:DescribeSecurityGroupRules] to 4.12 core installer policy

### DIFF
--- a/resources/sts/4.12/hypershift/InstallerPolicy.json
+++ b/resources/sts/4.12/hypershift/InstallerPolicy.json
@@ -18,6 +18,7 @@
                 "ec2:DescribeReservedInstancesOfferings",
                 "ec2:DescribeRouteTables",
                 "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeVpcs",

--- a/resources/sts/4.12/sts_installer_core_permission_policy.json
+++ b/resources/sts/4.12/sts_installer_core_permission_policy.json
@@ -42,6 +42,7 @@
 		    "ec2:DescribeReservedInstancesOfferings",
 		    "ec2:DescribeRouteTables",
 		    "ec2:DescribeSecurityGroups",
+		    "ec2:DescribeSecurityGroupRules",
 		    "ec2:DescribeSubnets",
 		    "ec2:DescribeTags",
 		    "ec2:DescribeVolumes",

--- a/resources/sts/4.12/sts_installer_permission_policy.json
+++ b/resources/sts/4.12/sts_installer_permission_policy.json
@@ -61,6 +61,7 @@
                 "ec2:DescribeReservedInstancesOfferings",
                 "ec2:DescribeRouteTables",
                 "ec2:DescribeSecurityGroups",
+		"ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeTags",
                 "ec2:DescribeVolumes",


### PR DESCRIPTION


### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature

### What this PR does / why we need it?
Adds a new permission, ec2:DescribeSecurityGroupRules, to 4.12 core installer policy file. This allows us to run `DescribeSecurityGroupRules` in the CS preflights for hypershift clusters specifically.

### Which Jira/Github issue(s) this PR fixes?
[SDA-7039](https://issues.redhat.com/browse/SDA-7039)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
