### PR TITLE
remove a duplicate prometheusrule group name

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -18,8 +18,6 @@ spec:
         namespace: openshift-logging
         send_managed_notification: "true"
         managed_notification_template: "MultipleIngressControllersDetected"
-  - name: sre-managed-notification-alerts
-    rules:
     - alert: LoggingVolumeFillingUpNotificationSRE
     # KubePersistentVolumeFillingUp alert firing in openshift-logging Namespace.
       expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-logging"}) >= 1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29824,8 +29824,6 @@ objects:
               namespace: openshift-logging
               send_managed_notification: 'true'
               managed_notification_template: MultipleIngressControllersDetected
-        - name: sre-managed-notification-alerts
-          rules:
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29824,8 +29824,6 @@ objects:
               namespace: openshift-logging
               send_managed_notification: 'true'
               managed_notification_template: MultipleIngressControllersDetected
-        - name: sre-managed-notification-alerts
-          rules:
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29824,8 +29824,6 @@ objects:
               namespace: openshift-logging
               send_managed_notification: 'true'
               managed_notification_template: MultipleIngressControllersDetected
-        - name: sre-managed-notification-alerts
-          rules:
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1


### PR DESCRIPTION
This is causing prometheus pods to crashloop on a cluster (4.9.54 if it matters), which appears to be causing managed-upgrade-operator not to be able to finish the upgrade process

### What type of PR is this?
bug

### What this PR does / why we need it?
[OHSS-18024](https://issues.redhat.com//browse/OHSS-18024)

Prometheus pods are crashlooping with this error:
```
level=error ts=2023-01-18T19:39:48.673Z caller=manager.go:956 component="rule manager" msg="loading groups failed" err="/etc/prometheus/rules/prometheus-k8s-rulefiles-0/openshift-monitoring-sre-managed-notification-alerts.yaml: 14:3: group name: \"sre-managed-notification-alerts\" is repeated in the same file"
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
