### PR TITLE
Revert "Merge pull request #1418 from bmeng/unschedulenode"

### DIFF
--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -11,8 +11,8 @@ spec:
   - name: sre-node-unschedulable
     rules:
     - alert: KubeNodeUnschedulableSRE
-      expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"} and on(node) kube_node_spec_taint{key="UpdateInProgress"})
-      for: 60m
+      expr: kube_node_spec_unschedulable > 0
+      for: 80m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28800,9 +28800,8 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"}
-              and on(node) kube_node_spec_taint{key="UpdateInProgress"})
-            for: 60m
+            expr: kube_node_spec_unschedulable > 0
+            for: 80m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28800,9 +28800,8 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"}
-              and on(node) kube_node_spec_taint{key="UpdateInProgress"})
-            for: 60m
+            expr: kube_node_spec_unschedulable > 0
+            for: 80m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28800,9 +28800,8 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0 unless on(node) (kube_node_role{role!="master"}
-              and on(node) kube_node_spec_taint{key="UpdateInProgress"})
-            for: 60m
+            expr: kube_node_spec_unschedulable > 0
+            for: 80m
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
This reverts commit 0f6dbf844b65a4d1a692fa49d363099b14511980, reversing changes made to 602123491f58d0dd0460ca5a4d7c4098cfce21d1.

The tweak to the alert appears to be having nil effect and the reduction of the alert timeout from 80m to 60m is causing increased alert noise to SRE Primary. 

Reverting the commit so that it can receive further investigation.

Refs [OSD-8342](https://issues.redhat.com//browse/OSD-8342)
