### PR TITLE
Update to return latest upgrade result

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-internal-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-internal-slo-recording-rules.PrometheusRule.yaml
@@ -10,5 +10,5 @@ spec:
   groups:
     - name: sre-internal-slo.rules
       rules:
-        - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts, upgradeconfig_name) label_replace(topk(1, upgradeoperator_upgrade_result), "sre", "true", "", "")
+        - expr: sre:telemetry:managed_labels * on (version) group_left(alerts, upgradeconfig_name) label_replace(upgradeoperator_upgrade_result, "sre", "true", "", "")
           record: sre:slo:upgradeoperator_upgrade_result

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29385,9 +29385,8 @@ objects:
         groups:
         - name: sre-internal-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts,
-              upgradeconfig_name) label_replace(topk(1, upgradeoperator_upgrade_result),
-              "sre", "true", "", "")
+          - expr: sre:telemetry:managed_labels * on (version) group_left(alerts, upgradeconfig_name)
+              label_replace(upgradeoperator_upgrade_result, "sre", "true", "", "")
             record: sre:slo:upgradeoperator_upgrade_result
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29385,9 +29385,8 @@ objects:
         groups:
         - name: sre-internal-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts,
-              upgradeconfig_name) label_replace(topk(1, upgradeoperator_upgrade_result),
-              "sre", "true", "", "")
+          - expr: sre:telemetry:managed_labels * on (version) group_left(alerts, upgradeconfig_name)
+              label_replace(upgradeoperator_upgrade_result, "sre", "true", "", "")
             record: sre:slo:upgradeoperator_upgrade_result
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29385,9 +29385,8 @@ objects:
         groups:
         - name: sre-internal-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(version, alerts,
-              upgradeconfig_name) label_replace(topk(1, upgradeoperator_upgrade_result),
-              "sre", "true", "", "")
+          - expr: sre:telemetry:managed_labels * on (version) group_left(alerts, upgradeconfig_name)
+              label_replace(upgradeoperator_upgrade_result, "sre", "true", "", "")
             record: sre:slo:upgradeoperator_upgrade_result
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
To update the query of upgrade_results to return the latest result

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_[OSD-14614](https://issues.redhat.com/browse/OSD-14614)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

