### PR TITLE
[OSD-8342] update to not alerting for worker node during upgrade

### DIFF
--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -11,8 +11,8 @@ spec:
   - name: sre-node-unschedulable
     rules:
     - alert: KubeNodeUnschedulableSRE
-      expr: kube_node_spec_unschedulable > 0
-      for: 80m
+      expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+      for: 60m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30562,8 +30562,10 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0
-            for: 80m
+            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+            for: 60m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30562,8 +30562,10 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0
-            for: 80m
+            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+            for: 60m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30562,8 +30562,10 @@ objects:
         - name: sre-node-unschedulable
           rules:
           - alert: KubeNodeUnschedulableSRE
-            expr: kube_node_spec_unschedulable > 0
-            for: 80m
+            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+            for: 60m
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
I will try to explain the the PromQL, it consist of two parts and connected with `or`

For the first part `kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}` it will be alerted for master node which is unschedulable all the time, 

For the second part `kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade.*"}) > 0`,  it will ignore the kubeNodeUnschedule alert during the upgrade period.

The `ignoring(node,container,endpoint,job,namespace,service)` is there due to the `kube_node_spec_unschedulable` and `mapi_machine_set_status_replicas` are having different set of labels, and I just want to use the `mapi_machine_set_status_replicas` as an indicator that the upgrade is in progress.

Make it in a table, when a node is unscheduleable:

| Is it a master or worker? | Is in the middle of upgrade? | Alerting? | Caught by |
| ---- | ---- | ---- | ---- |
| master | yes | yes | kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"} |
| master | no | yes | kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"} |
| worker | yes | no | n/a |
| worker | no | yes | kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade.*"}) > 0 |

### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
It is another implementation for https://github.com/openshift/managed-cluster-config/pull/1418 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-8342](https://issues.redhat.com//browse/OSD-8342)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
