### PR TITLE
Add prune job to recreate velero-operator metrics service

### DIFF
--- a/deploy/sre-pruning/osd-14743/00-pruning.rbac.Role.yaml
+++ b/deploy/sre-pruning/osd-14743/00-pruning.rbac.Role.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-prune-velero-service-osd-14743
+  namespace: openshift-velero
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors                                                                                                                                                                                                   
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/sre-pruning/osd-14743/00-pruning.rbac.RoleBinding.yaml
+++ b/deploy/sre-pruning/osd-14743/00-pruning.rbac.RoleBinding.yaml
@@ -1,0 +1,15 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-prune-velero-service-osd-14743
+  namespace: openshift-velero
+subjects:
+- kind: ServiceAccount
+  name: osd-prune-velero-service-osd-14743
+  namespace: openshift-sre-pruning
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-prune-velero-service-osd-14743
+  namespace: openshift-velero

--- a/deploy/sre-pruning/osd-14743/00-pruning.rbac.ServiceAccount.yaml
+++ b/deploy/sre-pruning/osd-14743/00-pruning.rbac.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-prune-velero-service-osd-14743
+  namespace: openshift-sre-pruning

--- a/deploy/sre-pruning/osd-14743/01-pruning.CronJob.yaml
+++ b/deploy/sre-pruning/osd-14743/01-pruning.CronJob.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-prune-velero-service-osd-14743
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
+  schedule: "30 0 * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: osd-prune-velero-service-osd-14743
+          restartPolicy: Never
+          containers:
+          - name: osd-prune-velero-service-osd-14743
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - |
+              oc delete service --ignore-not-found -n openshift-velero managed-velero-operator-metrics
+              oc delete servicemonitor --ignore-not-found -n openshift-velero managed-velero-operator-metrics
+              oc delete pod --ignore-not-found -n openshift-velero -l name=managed-velero-operator

--- a/deploy/sre-pruning/osd-14743/OWNERS
+++ b/deploy/sre-pruning/osd-14743/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- mrbarge

--- a/deploy/sre-pruning/osd-14743/config.yaml
+++ b/deploy/sre-pruning/osd-14743/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/sts
+    operator: NotIn
+    values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30348,6 +30348,115 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-14743
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - services
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: 30 0 * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-prune-velero-service-osd-14743
+                restartPolicy: Never
+                containers:
+                - name: osd-prune-velero-service-osd-14743
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete service --ignore-not-found -n openshift-velero managed-velero-operator-metrics
+
+                    oc delete servicemonitor --ignore-not-found -n openshift-velero
+                    managed-velero-operator-metrics
+
+                    oc delete pod --ignore-not-found -n openshift-velero -l name=managed-velero-operator
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: velero-configuration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30348,6 +30348,115 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-14743
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - services
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: 30 0 * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-prune-velero-service-osd-14743
+                restartPolicy: Never
+                containers:
+                - name: osd-prune-velero-service-osd-14743
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete service --ignore-not-found -n openshift-velero managed-velero-operator-metrics
+
+                    oc delete servicemonitor --ignore-not-found -n openshift-velero
+                    managed-velero-operator-metrics
+
+                    oc delete pod --ignore-not-found -n openshift-velero -l name=managed-velero-operator
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: velero-configuration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30348,6 +30348,115 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-14743
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - services
+        verbs:
+        - get
+        - list
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+      subjects:
+      - kind: ServiceAccount
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-prune-velero-service-osd-14743
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: 30 0 * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-prune-velero-service-osd-14743
+                restartPolicy: Never
+                containers:
+                - name: osd-prune-velero-service-osd-14743
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete service --ignore-not-found -n openshift-velero managed-velero-operator-metrics
+
+                    oc delete servicemonitor --ignore-not-found -n openshift-velero
+                    managed-velero-operator-metrics
+
+                    oc delete pod --ignore-not-found -n openshift-velero -l name=managed-velero-operator
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: velero-configuration
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
- Creates a new pruning cronjob/SA/RBAC `osd-prune-velero-service-osd-14743` that performs a daily deletion of the `managed-velero-operator-metrics` Service and ServiceMonitor, followed by the operator pod itself. 

This is in order to force the recreation of the Service and ServiceMonitor without the presence of a now-unused port `8686` which was removed as part of the operator's SDKv1 migration. Presently, on clusters which had the operator installed prior to the SDKv1 migration, that port still remains in the Service/ServiceMonitor and results in a `TargetDown` alert now that there is nothing listening on that port.

### Which Jira/Github issue(s) this PR fixes?
[OSD-14743](https://issues.redhat.com//browse/OSD-14743)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
