### PR TITLE
[OSD-13637] Fix static pod rules for GCP

### DIFF
--- a/deploy/sre-prometheus/100-kube-apiserver-missing-on-node.yaml
+++ b/deploy/sre-prometheus/100-kube-apiserver-missing-on-node.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: KubeAPIServerMissingOnNode60Minutes
       expr: |
-        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver", pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver", pod=~"kube-apiserver-.*", pod!~".*guard.*"}) by (node) >= 1
       for: 60m
       labels:
         severity: warning

--- a/deploy/sre-prometheus/100-kube-controller-manager-missing-on-node.yaml
+++ b/deploy/sre-prometheus/100-kube-controller-manager-missing-on-node.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: KubeControllerManagerMissingOnNode60Minutes
       expr: |
-        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager", pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager", pod=~"kube-controller-manager-.*", pod!~".*guard.*"}) by (node) >= 1
       for: 60m
       labels:
         severity: warning

--- a/deploy/sre-prometheus/100-kube-scheduler-missing-on-node.yaml
+++ b/deploy/sre-prometheus/100-kube-scheduler-missing-on-node.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: KubeSchedulerMissingOnNode60Minutes
       expr: |
-        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler", pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+        count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler", pod=~"openshift-kube-scheduler-.*", pod!~".*guard.*"}) by (node) >= 1
       for: 60m
       labels:
         severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28695,7 +28695,7 @@ objects:
           rules:
           - alert: KubeAPIServerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver",
-              pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+              pod=~"kube-apiserver-.*", pod!~".*guard.*"}) by (node) >= 1
 
               '
             for: 60m
@@ -28721,7 +28721,7 @@ objects:
           rules:
           - alert: KubeControllerManagerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager",
-              pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+              pod=~"kube-controller-manager-.*", pod!~".*guard.*"}) by (node) >= 1
 
               '
             for: 60m
@@ -28747,7 +28747,8 @@ objects:
           rules:
           - alert: KubeSchedulerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler",
-              pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+              pod=~"openshift-kube-scheduler-.*", pod!~".*guard.*"}) by (node) >=
+              1
 
               '
             for: 60m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28695,7 +28695,7 @@ objects:
           rules:
           - alert: KubeAPIServerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver",
-              pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+              pod=~"kube-apiserver-.*", pod!~".*guard.*"}) by (node) >= 1
 
               '
             for: 60m
@@ -28721,7 +28721,7 @@ objects:
           rules:
           - alert: KubeControllerManagerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager",
-              pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+              pod=~"kube-controller-manager-.*", pod!~".*guard.*"}) by (node) >= 1
 
               '
             for: 60m
@@ -28747,7 +28747,8 @@ objects:
           rules:
           - alert: KubeSchedulerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler",
-              pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+              pod=~"openshift-kube-scheduler-.*", pod!~".*guard.*"}) by (node) >=
+              1
 
               '
             for: 60m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28695,7 +28695,7 @@ objects:
           rules:
           - alert: KubeAPIServerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-apiserver",
-              pod=~"kube-apiserver-ip-.*"}) by (node) >= 1
+              pod=~"kube-apiserver-.*", pod!~".*guard.*"}) by (node) >= 1
 
               '
             for: 60m
@@ -28721,7 +28721,7 @@ objects:
           rules:
           - alert: KubeControllerManagerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager",
-              pod=~"kube-controller-manager-ip-.*"}) by (node) >= 1
+              pod=~"kube-controller-manager-.*", pod!~".*guard.*"}) by (node) >= 1
 
               '
             for: 60m
@@ -28747,7 +28747,8 @@ objects:
           rules:
           - alert: KubeSchedulerMissingOnNode60Minutes
             expr: 'count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-scheduler",
-              pod=~"openshift-kube-scheduler-ip-.*"}) by (node) >= 1
+              pod=~"openshift-kube-scheduler-.*", pod!~".*guard.*"}) by (node) >=
+              1
 
               '
             for: 60m


### PR DESCRIPTION
While checking the alerts, I noticed they fire on GCP - this is because the pods are named slight different between GCP and AWS.

Filter the guard pods differently, so both GCP and AWS can be matched with a more generic expression.

This way the expression now works on AWS and GCP.

### What type of PR is this?
bug

### What this PR does / why we need it?

Fixes the existing alert rules for static pods to work on AWS and GCP.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-13637](https://issues.redhat.com//browse/OSD-13637)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
