### PR TITLE
Adding custom NodeFilesystemAlmostOutOfSpaceSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-NodeFilesystemAlmostOutOfSpaceSRE.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-NodeFilesystemAlmostOutOfSpaceSRE.PrometheusRule.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-nodefilesystemalmostoutofspace-alert
+    role: alert-rules
+  name: sre-nodefilesystemalmostoutofspace-alert
+  namespace: openshift-monitoring
+spec:
+  groups:
+    # JIRA: https://issues.redhat.com/browse/OSD-14857
+    # Fix: https://github.com/openshift/cluster-monitoring-operator/blob/release-4.13/assets/node-exporter/prometheus-rule.yaml#L68-L82
+    # Note: Temporary custom SRE alert to handle the misconfigured alert. Once backports and new release in place with fix, can remove this alert.
+    - name: sre-nodefilesystemalmostoutofspace-alert
+      rules:
+        - alert: NodeFilesystemAlmostOutOfSpaceSRE
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 3
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+            )
+          for: 30m
+          labels:
+            severity: critical
+            namespace: openshift-monitoring
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} 
+              has only {{ printf "%.2f" $value }}% available space left.
+            runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+            summary: Filesystem has less than 3% space left.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28922,6 +28922,33 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-nodefilesystemalmostoutofspace-alert
+          role: alert-rules
+        name: sre-nodefilesystemalmostoutofspace-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-nodefilesystemalmostoutofspace-alert
+          rules:
+          - alert: NodeFilesystemAlmostOutOfSpaceSRE
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-oauth-server
           role: recording-rules
         name: sre-oauth-server

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28922,6 +28922,33 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-nodefilesystemalmostoutofspace-alert
+          role: alert-rules
+        name: sre-nodefilesystemalmostoutofspace-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-nodefilesystemalmostoutofspace-alert
+          rules:
+          - alert: NodeFilesystemAlmostOutOfSpaceSRE
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-oauth-server
           role: recording-rules
         name: sre-oauth-server

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28922,6 +28922,33 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-nodefilesystemalmostoutofspace-alert
+          role: alert-rules
+        name: sre-nodefilesystemalmostoutofspace-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-nodefilesystemalmostoutofspace-alert
+          rules:
+          - alert: NodeFilesystemAlmostOutOfSpaceSRE
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-oauth-server
           role: recording-rules
         name: sre-oauth-server


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Based on [OSD-14857](https://issues.redhat.com/browse/OSD-14857) and [OCPBUGS-6577](https://issues.redhat.com/browse/OCPBUGS-6577), the NodeFilesystemAlmostOutOfSpace alert wrongly fires if a tmpfs mount even with only 4K size is 100% used. This is not actionable by SRE. This issue is fixed in 4.13 for cluster-monitoring-operator but yet to be fixed in older versions. Meanwhile, introducing NodeFilesystemAlmostOutOfSpaceSRE alert which would help reduce some noise till the backports and new release is released and used by the customer(s).

4.13+ Fix - [Link](https://github.com/openshift/cluster-monitoring-operator/blob/release-4.13/assets/node-exporter/prometheus-rule.yaml#L68-L82)

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-14857](https://issues.redhat.com/browse/OSD-14857)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
