### PR TITLE
Don't fail osd-disable-cpms if cpms doesn't exist

### DIFF
--- a/deploy/osd-14634-disable-cpms/10-osd-disable-cpms.CronJob.yaml
+++ b/deploy/osd-14634-disable-cpms/10-osd-disable-cpms.CronJob.yaml
@@ -36,4 +36,4 @@ spec:
             - -c
             - |
               # the appropriate way to disable CPMS is to delete the CPMS CR.
-              oc delete controlplanemachineset.machine.openshift.io/cluster -n openshift-machine-api
+              oc delete controlplanemachineset.machine.openshift.io/cluster -n openshift-machine-api --ignore-not-found

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -20275,7 +20275,7 @@ objects:
                   - '# the appropriate way to disable CPMS is to delete the CPMS CR.
 
                     oc delete controlplanemachineset.machine.openshift.io/cluster
-                    -n openshift-machine-api
+                    -n openshift-machine-api --ignore-not-found
 
                     '
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -20275,7 +20275,7 @@ objects:
                   - '# the appropriate way to disable CPMS is to delete the CPMS CR.
 
                     oc delete controlplanemachineset.machine.openshift.io/cluster
-                    -n openshift-machine-api
+                    -n openshift-machine-api --ignore-not-found
 
                     '
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -20275,7 +20275,7 @@ objects:
                   - '# the appropriate way to disable CPMS is to delete the CPMS CR.
 
                     oc delete controlplanemachineset.machine.openshift.io/cluster
-                    -n openshift-machine-api
+                    -n openshift-machine-api --ignore-not-found
 
                     '
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds the `--ignore-not-found` flag to this command so that the cronjob doesn't fail if the CPMS doesn't exist

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
