### PR TITLE
Related to MCO-457. KubeletConfig workaround.

### DIFF
--- a/deploy/kubelet-config/4.10.51/01-kubelet-config.patch.yaml
+++ b/deploy/kubelet-config/4.10.51/01-kubelet-config.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+applyMode: AlwaysApply
+name: custom-kubelet
+patch: '{"spec":{"kubeletConfig":{"featureGates":{"CSIMigrationOpenStack": "true"}}}}'
+patchType: merge

--- a/deploy/kubelet-config/4.10.51/config.yaml
+++ b/deploy/kubelet-config/4.10.51/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: hive.openshift.io/version-major-minor-patch
+      operator: In
+      values: ["4.10.51"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -19469,6 +19469,31 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: kubelet-config-4.10.51
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.10.51
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      applyMode: AlwaysApply
+      name: custom-kubelet
+      patch: '{"spec":{"kubeletConfig":{"featureGates":{"CSIMigrationOpenStack": "true"}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config-pre-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -19469,6 +19469,31 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: kubelet-config-4.10.51
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.10.51
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      applyMode: AlwaysApply
+      name: custom-kubelet
+      patch: '{"spec":{"kubeletConfig":{"featureGates":{"CSIMigrationOpenStack": "true"}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config-pre-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -19469,6 +19469,31 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: kubelet-config-4.10.51
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - 4.10.51
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      applyMode: AlwaysApply
+      name: custom-kubelet
+      patch: '{"spec":{"kubeletConfig":{"featureGates":{"CSIMigrationOpenStack": "true"}}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config-pre-4.9
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Adding CSIMigrationOpenStack:true override to 4.10.51 which is not listed in candidate-4.10 at this time.

### What type of PR is this?
bug

### What this PR does / why we need it?
Version not available in candidate-4.10 is 4.10.51 https://github.com/openshift/cincinnati-graph-data/blob/dc0546a679bb101e8977cee75b1fac9ee89ff991/channels/candidate-4.10.yaml 

Currently all upgrades from 4.10 to 4.11 are blocked due to https://issues.redhat.com/browse/MCO-457 . This is the first step of the process proposed by @jewzaam  to:
1. Set the problematic feature flag during an upgrade to the next version which is not available in any channel yet. (MCO will cause a kubelet restart)
2. Add an exception in CIS to allow upgrade from this specific 4.10.51 version to 4.11 which shouldn't trigger the issue.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
