### PR TITLE
Add SREP architects alias and restrict approvals for STS policy changes

### DIFF
--- a/resources/sts/OWNERS
+++ b/resources/sts/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- srep-functional-leads
+- srep-team-leads
+approvers:
+- srep-team-leads
+- srep-architects
+options:
+  no_parent_owners: true


### PR DESCRIPTION
### What type of PR is this?

cleanup

### What this PR does / why we need it?

This PR restricts approvals for AWS STS policies changes to SREP team leads and SREP architects only.

