### PR TITLE
OSD-14190 : Review backplane permissions for Management and Service clusters

### DIFF
--- a/deploy/backplane/srep/hypershift/management-cluster/10-srep-management-cluster-project.ClusteRole.yml
+++ b/deploy/backplane/srep/hypershift/management-cluster/10-srep-management-cluster-project.ClusteRole.yml
@@ -1,0 +1,96 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-srep-management-cluster-project
+rules:
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - appliedmanifestworks
+  - operator
+  - work
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - clusterclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.open-cluster-management.io
+  resources:
+  - klusterlets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  - configurationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - awsendpointservices
+  - hostedclusters
+  - hostedcontrolplanes
+  - nodepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  - clusters
+  - machinedeployments
+  - machinehealthchecks
+  - machinepools
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclustercontrolleridentities
+  - awsclusterroleidentities
+  - awsclusters
+  - awsclusterstaticidentities
+  - awsclustertemplates
+  - awsfargateprofiles
+  - awsmachinepools
+  - awsmachines
+  - awsmachinetemplates
+  - awsmanagedmachinepools
+  - azureclusteridentities
+  - azureclusters
+  - azuremachines
+  - azuremachinetemplates
+  - ibmpowervsclusters
+  - ibmpowervsimages
+  - ibmpowervsmachines
+  - ibmpowervsmachinetemplates
+  - ibmvpcclusters
+  - ibmvpcmachines
+  - ibmvpcmachinetemplates
+  - kubevirtclusters
+  - kubevirtmachines
+  - kubevirtmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
@@ -1,0 +1,15 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-srep-management-cluster
+  namespace: openshift-rbac-permissions
+spec:
+  permissions:
+  - allowFirst: true
+    clusterRoleName: backplane-srep-management-cluster-project
+    namespacesAllowedRegex: "(^uhc.*|^ocm.*)"
+  - allowFirst: true
+    clusterRoleName: dedicated-readers
+    namespacesAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/deploy/backplane/srep/hypershift/management-cluster/config.yaml
+++ b/deploy/backplane/srep/hypershift/management-cluster/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/backplane/srep/hypershift/service-cluster/10-srep-service-cluster-project.ClusteRole.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/10-srep-service-cluster-project.ClusteRole.yml
@@ -1,0 +1,96 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-srep-service-cluster-project
+rules:
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - appliedmanifestworks
+  - operator
+  - work
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - clusterclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.open-cluster-management.io
+  resources:
+  - klusterlets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  - configurationpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - awsendpointservices
+  - hostedclusters
+  - hostedcontrolplanes
+  - nodepools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  - clusters
+  - machinedeployments
+  - machinehealthchecks
+  - machinepools
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclustercontrolleridentities
+  - awsclusterroleidentities
+  - awsclusters
+  - awsclusterstaticidentities
+  - awsclustertemplates
+  - awsfargateprofiles
+  - awsmachinepools
+  - awsmachines
+  - awsmachinetemplates
+  - awsmanagedmachinepools
+  - azureclusteridentities
+  - azureclusters
+  - azuremachines
+  - azuremachinetemplates
+  - ibmpowervsclusters
+  - ibmpowervsimages
+  - ibmpowervsmachines
+  - ibmpowervsmachinetemplates
+  - ibmvpcclusters
+  - ibmvpcmachines
+  - ibmvpcmachinetemplates
+  - kubevirtclusters
+  - kubevirtmachines
+  - kubevirtmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
@@ -1,0 +1,15 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-srep-service-cluster
+  namespace: openshift-rbac-permissions
+spec:
+  permissions:
+  - allowFirst: true
+    clusterRoleName: backplane-srep-service-cluster-project
+    namespacesAllowedRegex: "(^uhc.*|^ocm.*)"
+  - allowFirst: true
+    clusterRoleName: dedicated-readers
+    namespacesAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/deploy/backplane/srep/hypershift/service-cluster/config.yaml
+++ b/deploy/backplane/srep/hypershift/service-cluster/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type 
+    operator: In
+    values: ["service-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -18296,6 +18296,274 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-management-cluster-project
+      rules:
+      - apiGroups:
+        - work.open-cluster-management.io
+        resources:
+        - appliedmanifestworks
+        - operator
+        - work
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.open-cluster-management.io
+        resources:
+        - clusterclaims
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.open-cluster-management.io
+        resources:
+        - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - policies
+        - configurationpolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - awsendpointservices
+        - hostedclusters
+        - hostedcontrolplanes
+        - nodepools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - clusterclasses
+        - clusters
+        - machinedeployments
+        - machinehealthchecks
+        - machinepools
+        - machines
+        - machinesets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+        resources:
+        - awsclustercontrolleridentities
+        - awsclusterroleidentities
+        - awsclusters
+        - awsclusterstaticidentities
+        - awsclustertemplates
+        - awsfargateprofiles
+        - awsmachinepools
+        - awsmachines
+        - awsmachinetemplates
+        - awsmanagedmachinepools
+        - azureclusteridentities
+        - azureclusters
+        - azuremachines
+        - azuremachinetemplates
+        - ibmpowervsclusters
+        - ibmpowervsimages
+        - ibmpowervsmachines
+        - ibmpowervsmachinetemplates
+        - ibmvpcclusters
+        - ibmvpcmachines
+        - ibmvpcmachinetemplates
+        - kubevirtclusters
+        - kubevirtmachines
+        - kubevirtmachinetemplates
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-management-cluster
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-management-cluster-project
+          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+        - allowFirst: true
+          clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-srep-hypershift-service-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-service-cluster-project
+      rules:
+      - apiGroups:
+        - work.open-cluster-management.io
+        resources:
+        - appliedmanifestworks
+        - operator
+        - work
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.open-cluster-management.io
+        resources:
+        - clusterclaims
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.open-cluster-management.io
+        resources:
+        - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - policies
+        - configurationpolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - awsendpointservices
+        - hostedclusters
+        - hostedcontrolplanes
+        - nodepools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - clusterclasses
+        - clusters
+        - machinedeployments
+        - machinehealthchecks
+        - machinepools
+        - machines
+        - machinesets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+        resources:
+        - awsclustercontrolleridentities
+        - awsclusterroleidentities
+        - awsclusters
+        - awsclusterstaticidentities
+        - awsclustertemplates
+        - awsfargateprofiles
+        - awsmachinepools
+        - awsmachines
+        - awsmachinetemplates
+        - awsmanagedmachinepools
+        - azureclusteridentities
+        - azureclusters
+        - azuremachines
+        - azuremachinetemplates
+        - ibmpowervsclusters
+        - ibmpowervsimages
+        - ibmpowervsmachines
+        - ibmpowervsmachinetemplates
+        - ibmvpcclusters
+        - ibmvpcmachines
+        - ibmvpcmachinetemplates
+        - kubevirtclusters
+        - kubevirtmachines
+        - kubevirtmachinetemplates
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-service-cluster
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-service-cluster-project
+          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+        - allowFirst: true
+          clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-tam
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -18296,6 +18296,274 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-management-cluster-project
+      rules:
+      - apiGroups:
+        - work.open-cluster-management.io
+        resources:
+        - appliedmanifestworks
+        - operator
+        - work
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.open-cluster-management.io
+        resources:
+        - clusterclaims
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.open-cluster-management.io
+        resources:
+        - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - policies
+        - configurationpolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - awsendpointservices
+        - hostedclusters
+        - hostedcontrolplanes
+        - nodepools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - clusterclasses
+        - clusters
+        - machinedeployments
+        - machinehealthchecks
+        - machinepools
+        - machines
+        - machinesets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+        resources:
+        - awsclustercontrolleridentities
+        - awsclusterroleidentities
+        - awsclusters
+        - awsclusterstaticidentities
+        - awsclustertemplates
+        - awsfargateprofiles
+        - awsmachinepools
+        - awsmachines
+        - awsmachinetemplates
+        - awsmanagedmachinepools
+        - azureclusteridentities
+        - azureclusters
+        - azuremachines
+        - azuremachinetemplates
+        - ibmpowervsclusters
+        - ibmpowervsimages
+        - ibmpowervsmachines
+        - ibmpowervsmachinetemplates
+        - ibmvpcclusters
+        - ibmvpcmachines
+        - ibmvpcmachinetemplates
+        - kubevirtclusters
+        - kubevirtmachines
+        - kubevirtmachinetemplates
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-management-cluster
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-management-cluster-project
+          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+        - allowFirst: true
+          clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-srep-hypershift-service-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-service-cluster-project
+      rules:
+      - apiGroups:
+        - work.open-cluster-management.io
+        resources:
+        - appliedmanifestworks
+        - operator
+        - work
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.open-cluster-management.io
+        resources:
+        - clusterclaims
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.open-cluster-management.io
+        resources:
+        - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - policies
+        - configurationpolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - awsendpointservices
+        - hostedclusters
+        - hostedcontrolplanes
+        - nodepools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - clusterclasses
+        - clusters
+        - machinedeployments
+        - machinehealthchecks
+        - machinepools
+        - machines
+        - machinesets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+        resources:
+        - awsclustercontrolleridentities
+        - awsclusterroleidentities
+        - awsclusters
+        - awsclusterstaticidentities
+        - awsclustertemplates
+        - awsfargateprofiles
+        - awsmachinepools
+        - awsmachines
+        - awsmachinetemplates
+        - awsmanagedmachinepools
+        - azureclusteridentities
+        - azureclusters
+        - azuremachines
+        - azuremachinetemplates
+        - ibmpowervsclusters
+        - ibmpowervsimages
+        - ibmpowervsmachines
+        - ibmpowervsmachinetemplates
+        - ibmvpcclusters
+        - ibmvpcmachines
+        - ibmvpcmachinetemplates
+        - kubevirtclusters
+        - kubevirtmachines
+        - kubevirtmachinetemplates
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-service-cluster
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-service-cluster-project
+          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+        - allowFirst: true
+          clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-tam
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -18296,6 +18296,274 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-management-cluster-project
+      rules:
+      - apiGroups:
+        - work.open-cluster-management.io
+        resources:
+        - appliedmanifestworks
+        - operator
+        - work
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.open-cluster-management.io
+        resources:
+        - clusterclaims
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.open-cluster-management.io
+        resources:
+        - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - policies
+        - configurationpolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - awsendpointservices
+        - hostedclusters
+        - hostedcontrolplanes
+        - nodepools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - clusterclasses
+        - clusters
+        - machinedeployments
+        - machinehealthchecks
+        - machinepools
+        - machines
+        - machinesets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+        resources:
+        - awsclustercontrolleridentities
+        - awsclusterroleidentities
+        - awsclusters
+        - awsclusterstaticidentities
+        - awsclustertemplates
+        - awsfargateprofiles
+        - awsmachinepools
+        - awsmachines
+        - awsmachinetemplates
+        - awsmanagedmachinepools
+        - azureclusteridentities
+        - azureclusters
+        - azuremachines
+        - azuremachinetemplates
+        - ibmpowervsclusters
+        - ibmpowervsimages
+        - ibmpowervsmachines
+        - ibmpowervsmachinetemplates
+        - ibmvpcclusters
+        - ibmvpcmachines
+        - ibmvpcmachinetemplates
+        - kubevirtclusters
+        - kubevirtmachines
+        - kubevirtmachinetemplates
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-management-cluster
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-management-cluster-project
+          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+        - allowFirst: true
+          clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-srep-hypershift-service-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-srep-service-cluster-project
+      rules:
+      - apiGroups:
+        - work.open-cluster-management.io
+        resources:
+        - appliedmanifestworks
+        - operator
+        - work
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.open-cluster-management.io
+        resources:
+        - clusterclaims
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.open-cluster-management.io
+        resources:
+        - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - policies
+        - configurationpolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - awsendpointservices
+        - hostedclusters
+        - hostedcontrolplanes
+        - nodepools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - clusterclasses
+        - clusters
+        - machinedeployments
+        - machinehealthchecks
+        - machinepools
+        - machines
+        - machinesets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - infrastructure.cluster.x-k8s.io
+        resources:
+        - awsclustercontrolleridentities
+        - awsclusterroleidentities
+        - awsclusters
+        - awsclusterstaticidentities
+        - awsclustertemplates
+        - awsfargateprofiles
+        - awsmachinepools
+        - awsmachines
+        - awsmachinetemplates
+        - awsmanagedmachinepools
+        - azureclusteridentities
+        - azureclusters
+        - azuremachines
+        - azuremachinetemplates
+        - ibmpowervsclusters
+        - ibmpowervsimages
+        - ibmpowervsmachines
+        - ibmpowervsmachinetemplates
+        - ibmvpcclusters
+        - ibmvpcmachines
+        - ibmvpcmachinetemplates
+        - kubevirtclusters
+        - kubevirtmachines
+        - kubevirtmachinetemplates
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-service-cluster
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - allowFirst: true
+          clusterRoleName: backplane-srep-service-cluster-project
+          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+        - allowFirst: true
+          clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-tam
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION

### What type of PR is this?
Feature
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?
Reviewing backplane permissions for Management and Service clusters 

### Which Jira/Github issue(s) this PR fixes?
[OSD-14190](https://issues.redhat.com//browse/OSD-14190)
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
