### PR TITLE
OSD-15020 Adding prune job for RPO service and servicemonitor

### DIFF
--- a/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
+++ b/deploy/sre-pruning/105-pruning.rbac.ClusterRole.yaml
@@ -3,40 +3,57 @@ kind: ClusterRole
 metadata:
   name: sre-pruner-buildsdeploys-cr
 rules:
-# deployment pruning
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - replicationcontrollers
-  verbs:
-  - list
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - replicationcontrollers
-  verbs:
-  - delete
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs:
-  - get
-  - list
-# builds pruning
-- apiGroups:
-  - build.openshift.io
-  resources:
-  - buildconfigs
-  - builds
-  verbs:
-  - list
-  - get
-- apiGroups:
-  - build.openshift.io
-  resources:
-  - builds
-  verbs:
-  - delete
+  # deployment pruning
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - replicationcontrollers
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - replicationcontrollers
+    verbs:
+      - delete
+  - apiGroups:
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+    verbs:
+      - get
+      - list
+  # builds pruning
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - buildconfigs
+      - builds
+    verbs:
+      - list
+      - get
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - builds
+    verbs:
+      - delete
+  # service and servicemonitor pruning
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - list
+      - get
+      - delete

--- a/deploy/sre-pruning/osd-15020-rpo-412/115-pruning-servicemonitors.CronJob.yaml
+++ b/deploy/sre-pruning/osd-15020-rpo-412/115-pruning-servicemonitors.CronJob.yaml
@@ -4,8 +4,8 @@ metadata:
   name: services-pruner
   namespace: openshift-sre-pruning
 spec:
-  failedJobsHistoryLimit: 5
-  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
   concurrencyPolicy: Replace
   schedule: "30 2 * * *"
   jobTemplate:

--- a/deploy/sre-pruning/osd-15020-rpo-412/115-pruning-servicemonitors.CronJob.yaml
+++ b/deploy/sre-pruning/osd-15020-rpo-412/115-pruning-servicemonitors.CronJob.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: services-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/7 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                  weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+            - name: services-pruner
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - >-
+                  oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator --namespace openshift-rbac-permissions --ignore-not-found

--- a/deploy/sre-pruning/osd-15020-rpo-412/115-pruning-servicemonitors.CronJob.yaml
+++ b/deploy/sre-pruning/osd-15020-rpo-412/115-pruning-servicemonitors.CronJob.yaml
@@ -7,7 +7,7 @@ spec:
   failedJobsHistoryLimit: 5
   successfulJobsHistoryLimit: 3
   concurrencyPolicy: Replace
-  schedule: "*/7 * * * *"
+  schedule: "30 2 * * *"
   jobTemplate:
     spec:
       template:

--- a/deploy/sre-pruning/osd-15020-rpo-412/config.yaml
+++ b/deploy/sre-pruning/osd-15020-rpo-412/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.12"]

--- a/deploy/sre-pruning/osd-15020-rpo-pre-412/115-pruning-servicemonitors.CronJob.yaml
+++ b/deploy/sre-pruning/osd-15020-rpo-pre-412/115-pruning-servicemonitors.CronJob.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: services-pruner
+  namespace: openshift-sre-pruning
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/7 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                  weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: sre-pruner-sa
+          restartPolicy: Never
+          containers:
+            - name: services-pruner
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              args:
+                - /bin/bash
+                - -c
+                - >-
+                  oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator --namespace openshift-rbac-permissions --ignore-not-found

--- a/deploy/sre-pruning/osd-15020-rpo-pre-412/config.yaml
+++ b/deploy/sre-pruning/osd-15020-rpo-pre-412/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: NotIn
+    values: ["4.12"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31783,6 +31783,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -31995,6 +32011,118 @@ objects:
                     --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
                     --keep-younger-than=24h --keep-tag-revisions=5 --ignore-invalid-refs=true
                     --confirm
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-15020-rpo-412
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator
+                    --namespace openshift-rbac-permissions --ignore-not-found
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-15020-rpo-pre-412
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator
+                    --namespace openshift-rbac-permissions --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32036,10 +32036,10 @@ objects:
         name: services-pruner
         namespace: openshift-sre-pruning
       spec:
-        failedJobsHistoryLimit: 5
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: '*/7 * * * *'
+        schedule: 30 2 * * *
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31783,6 +31783,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -31995,6 +32011,118 @@ objects:
                     --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
                     --keep-younger-than=24h --keep-tag-revisions=5 --ignore-invalid-refs=true
                     --confirm
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-15020-rpo-412
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator
+                    --namespace openshift-rbac-permissions --ignore-not-found
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-15020-rpo-pre-412
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator
+                    --namespace openshift-rbac-permissions --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32036,10 +32036,10 @@ objects:
         name: services-pruner
         namespace: openshift-sre-pruning
       spec:
-        failedJobsHistoryLimit: 5
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: '*/7 * * * *'
+        schedule: 30 2 * * *
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31783,6 +31783,22 @@ objects:
         - builds
         verbs:
         - delete
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - list
+        - get
+        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -31995,6 +32011,118 @@ objects:
                     --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
                     --keep-younger-than=24h --keep-tag-revisions=5 --ignore-invalid-refs=true
                     --confirm
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-15020-rpo-412
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator
+                    --namespace openshift-rbac-permissions --ignore-not-found
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-pruning-osd-15020-rpo-pre-412
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.12'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: services-pruner
+        namespace: openshift-sre-pruning
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/7 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: sre-pruner-sa
+                restartPolicy: Never
+                containers:
+                - name: services-pruner
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - oc delete service/localmetrics-rbac-permissions-operator servicemonitor.monitoring.coreos.com/localmetrics-rbac-permissions-operator
+                    --namespace openshift-rbac-permissions --ignore-not-found
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32036,10 +32036,10 @@ objects:
         name: services-pruner
         namespace: openshift-sre-pruning
       spec:
-        failedJobsHistoryLimit: 5
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: '*/7 * * * *'
+        schedule: 30 2 * * *
         jobTemplate:
           spec:
             template:


### PR DESCRIPTION
### What type of PR is this?
_(cleanup)_

### What this PR does / why we need it?

In [OSD-12370](https://issues.redhat.com/browse/OSD-12370) the bug of mismatch in the labels of pod, service and servicemonitor for rbac-permissions-operator(RPO) was fixed, merged and promoted. However, this has caused the service and servicemonitor with old label to still be present on some of the clusters.

Therefore, with the help of this PR the old service and servicemonitor is deleted via a Job. Once it's run, the PR will be reverted after cleanup is done. To track this change, [OSD-15020](https://issues.redhat.com/browse/OSD-15020) jira is created.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-15020](https://issues.redhat.com/browse/OSD-15020) 

### Special notes for your reviewer:
- Have created two separate directories with different `config.yaml` since the CronJob group version in OpenShift 4.12 only supports v1 version but in versions older than that, v1beta1 is supported.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
