### PR TITLE
Add 'operators.coreos.com' api permissions to backplane lpsre

### DIFF
--- a/deploy/backplane/lpsre/10-lpsre-addon-operator-olm-apis.ClusterRole.yml
+++ b/deploy/backplane/lpsre/10-lpsre-addon-operator-olm-apis.ClusterRole.yml
@@ -16,3 +16,11 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - operators
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/backplane/mtsre/10-mtsre-addon-operator-olm-apis.ClusterRole.yml
+++ b/deploy/backplane/mtsre/10-mtsre-addon-operator-olm-apis.ClusterRole.yml
@@ -16,3 +16,11 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - operators
+    verbs:
+      - get
+      - list
+      - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8382,6 +8382,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8573,6 +8581,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8764,6 +8780,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8955,6 +8979,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9146,6 +9178,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9337,6 +9377,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9528,6 +9576,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9719,6 +9775,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9910,6 +9974,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10101,6 +10173,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10292,6 +10372,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10483,6 +10571,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10674,6 +10770,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10865,6 +10969,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11056,6 +11168,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11247,6 +11367,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11438,6 +11566,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11629,6 +11765,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11820,6 +11964,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12011,6 +12163,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12202,6 +12362,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12393,6 +12561,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12584,6 +12760,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12775,6 +12959,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12966,6 +13158,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13157,6 +13357,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13348,6 +13556,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13539,6 +13755,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13730,6 +13954,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13921,6 +14153,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15722,6 +15962,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15824,6 +16072,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15926,6 +16182,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16028,6 +16292,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16130,6 +16402,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16232,6 +16512,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16334,6 +16622,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16436,6 +16732,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16538,6 +16842,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16640,6 +16952,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16742,6 +17062,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16844,6 +17172,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16946,6 +17282,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17048,6 +17392,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17150,6 +17502,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17252,6 +17612,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17354,6 +17722,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17456,6 +17832,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17558,6 +17942,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17660,6 +18052,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17762,6 +18162,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17864,6 +18272,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17966,6 +18382,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18068,6 +18492,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18170,6 +18602,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18272,6 +18712,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18374,6 +18822,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18476,6 +18932,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8382,6 +8382,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8573,6 +8581,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8764,6 +8780,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8955,6 +8979,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9146,6 +9178,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9337,6 +9377,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9528,6 +9576,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9719,6 +9775,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9910,6 +9974,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10101,6 +10173,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10292,6 +10372,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10483,6 +10571,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10674,6 +10770,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10865,6 +10969,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11056,6 +11168,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11247,6 +11367,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11438,6 +11566,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11629,6 +11765,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11820,6 +11964,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12011,6 +12163,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12202,6 +12362,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12393,6 +12561,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12584,6 +12760,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12775,6 +12959,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12966,6 +13158,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13157,6 +13357,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13348,6 +13556,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13539,6 +13755,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13730,6 +13954,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13921,6 +14153,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15722,6 +15962,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15824,6 +16072,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15926,6 +16182,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16028,6 +16292,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16130,6 +16402,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16232,6 +16512,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16334,6 +16622,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16436,6 +16732,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16538,6 +16842,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16640,6 +16952,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16742,6 +17062,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16844,6 +17172,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16946,6 +17282,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17048,6 +17392,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17150,6 +17502,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17252,6 +17612,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17354,6 +17722,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17456,6 +17832,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17558,6 +17942,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17660,6 +18052,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17762,6 +18162,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17864,6 +18272,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17966,6 +18382,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18068,6 +18492,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18170,6 +18602,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18272,6 +18712,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18374,6 +18822,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18476,6 +18932,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8382,6 +8382,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8573,6 +8581,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8764,6 +8780,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8955,6 +8979,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9146,6 +9178,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9337,6 +9377,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9528,6 +9576,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9719,6 +9775,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9910,6 +9974,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10101,6 +10173,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10292,6 +10372,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10483,6 +10571,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10674,6 +10770,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10865,6 +10969,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11056,6 +11168,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11247,6 +11367,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11438,6 +11566,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11629,6 +11765,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11820,6 +11964,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12011,6 +12163,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12202,6 +12362,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12393,6 +12561,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12584,6 +12760,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12775,6 +12959,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12966,6 +13158,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13157,6 +13357,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13348,6 +13556,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13539,6 +13755,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13730,6 +13954,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13921,6 +14153,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15722,6 +15962,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15824,6 +16072,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -15926,6 +16182,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16028,6 +16292,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16130,6 +16402,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16232,6 +16512,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16334,6 +16622,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16436,6 +16732,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16538,6 +16842,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16640,6 +16952,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16742,6 +17062,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16844,6 +17172,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -16946,6 +17282,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17048,6 +17392,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17150,6 +17502,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17252,6 +17612,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17354,6 +17722,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17456,6 +17832,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17558,6 +17942,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17660,6 +18052,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17762,6 +18162,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17864,6 +18272,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -17966,6 +18382,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18068,6 +18492,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18170,6 +18602,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18272,6 +18712,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18374,6 +18822,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -18476,6 +18932,14 @@ objects:
         - patch
         - update
         - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>


Add permissions for 'operators.coreos.com' to lpsre and mtsre olm api roles

**jira**

- https://issues.redhat.com/browse/MTSRE-933
- https://issues.redhat.com/browse/MTSRE-834

