### PR TITLE
OSD-13914 - Adding name metadata for operator handling

### DIFF
--- a/deploy/rosa-oauth-templates-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
+++ b/deploy/rosa-oauth-templates-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
@@ -29,6 +29,8 @@ spec:
                         name: cluster
                         patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection": {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
                         patchType: merge
+                        metadata:
+                            name: cluster
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30279,6 +30279,8 @@ objects:
                   patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
                     {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
                   patchType: merge
+                  metadata:
+                    name: cluster
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30279,6 +30279,8 @@ objects:
                   patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
                     {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
                   patchType: merge
+                  metadata:
+                    name: cluster
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30279,6 +30279,8 @@ objects:
                   patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
                     {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
                   patchType: merge
+                  metadata:
+                    name: cluster
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Adding name metadata in order to ensure the resource name is properly detected by the operator

### Which Jira/Github issue(s) this PR fixes?
[OSD-13914](https://issues.redhat.com//browse/OSD-13914)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
