### PR TITLE
OSD-13914 - Fixing the syntax for resource patch for cluster oauth

### DIFF
--- a/deploy/rosa-oauth-templates-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
+++ b/deploy/rosa-oauth-templates-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
@@ -24,11 +24,15 @@ spec:
                     - complianceType: musthave
                       objectDefinition:
                         apiVersion: config.openshift.io/v1
-                        applyMode: AlwaysApply
                         kind: OAuth
-                        name: cluster
-                        patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection": {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-                        patchType: merge
+                        spec:
+                            templates:
+                                login: 
+                                    name: rosa-oauth-templates-login
+                                providerSelection: 
+                                    name: rosa-oauth-templates-providers
+                                error: 
+                                    name: rosa-oauth-templates-errors
                         metadata:
                             name: cluster
                 pruneObjectBehavior: DeleteIfCreated

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30273,12 +30273,15 @@ objects:
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
-                  applyMode: AlwaysApply
                   kind: OAuth
-                  name: cluster
-                  patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
-                    {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-                  patchType: merge
+                  spec:
+                    templates:
+                      login:
+                        name: rosa-oauth-templates-login
+                      providerSelection:
+                        name: rosa-oauth-templates-providers
+                      error:
+                        name: rosa-oauth-templates-errors
                   metadata:
                     name: cluster
               pruneObjectBehavior: DeleteIfCreated

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30273,12 +30273,15 @@ objects:
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
-                  applyMode: AlwaysApply
                   kind: OAuth
-                  name: cluster
-                  patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
-                    {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-                  patchType: merge
+                  spec:
+                    templates:
+                      login:
+                        name: rosa-oauth-templates-login
+                      providerSelection:
+                        name: rosa-oauth-templates-providers
+                      error:
+                        name: rosa-oauth-templates-errors
                   metadata:
                     name: cluster
               pruneObjectBehavior: DeleteIfCreated

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30273,12 +30273,15 @@ objects:
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
-                  applyMode: AlwaysApply
                   kind: OAuth
-                  name: cluster
-                  patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
-                    {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-                  patchType: merge
+                  spec:
+                    templates:
+                      login:
+                        name: rosa-oauth-templates-login
+                      providerSelection:
+                        name: rosa-oauth-templates-providers
+                      error:
+                        name: rosa-oauth-templates-errors
                   metadata:
                     name: cluster
               pruneObjectBehavior: DeleteIfCreated


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Update syntax for the patching action

### Which Jira/Github issue(s) this PR fixes?
[OSD-13914](https://issues.redhat.com//browse/OSD-13914)

### Special notes for your reviewer:
Tested the patching on a standard OSD cluster which initially showed similar error when trying to apply the 'patch' 

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
