### PR TITLE
OSD-15020 adjust timings of pruning cronjob

### DIFF
--- a/deploy/sre-pruning/osd-15020-rpo-pre-412/115-pruning-servicemonitors.CronJob.yaml
+++ b/deploy/sre-pruning/osd-15020-rpo-pre-412/115-pruning-servicemonitors.CronJob.yaml
@@ -4,10 +4,10 @@ metadata:
   name: services-pruner
   namespace: openshift-sre-pruning
 spec:
-  failedJobsHistoryLimit: 5
-  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
   concurrencyPolicy: Replace
-  schedule: "*/7 * * * *"
+  schedule: "30 2 * * *"
   jobTemplate:
     spec:
       template:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32707,10 +32707,10 @@ objects:
         name: services-pruner
         namespace: openshift-sre-pruning
       spec:
-        failedJobsHistoryLimit: 5
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: '*/7 * * * *'
+        schedule: 30 2 * * *
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32707,10 +32707,10 @@ objects:
         name: services-pruner
         namespace: openshift-sre-pruning
       spec:
-        failedJobsHistoryLimit: 5
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: '*/7 * * * *'
+        schedule: 30 2 * * *
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32707,10 +32707,10 @@ objects:
         name: services-pruner
         namespace: openshift-sre-pruning
       spec:
-        failedJobsHistoryLimit: 5
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
         concurrencyPolicy: Replace
-        schedule: '*/7 * * * *'
+        schedule: 30 2 * * *
         jobTemplate:
           spec:
             template:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The pruning job introduced in [OSD-15020](https://issues.redhat.com//browse/OSD-15020) runs unnecessarily frequently for clusters pre-4.12. This adjusts the timing to once per day and limits the amount of failed/successful jobs.

### Which Jira/Github issue(s) this PR fixes?
[OSD-15020](https://issues.redhat.com//browse/OSD-15020)

