### PR TITLE
Optimize remote write config and disable metadata traffic

### DIFF
--- a/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/cluster-monitoring-config.yaml
@@ -19,12 +19,14 @@ data:
             regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)'
           queueConfig:
             capacity: 2500
-            maxShards: 1000
+            maxShards: 500
             minShards: 1
-            maxSamplesPerSend: 500
+            maxSamplesPerSend: 2000
             batchSendDeadline: 60s
             minBackoff: 30ms
             maxBackoff: 5s
+          metadata_config:
+            send: false
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -20959,12 +20959,12 @@ objects:
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
           \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)'\n\
-          \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
-          \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
-          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
-          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \      queueConfig:\n        capacity: 2500\n        maxShards: 500\n  \
+          \      minShards: 1\n        maxSamplesPerSend: 2000\n        batchSendDeadline:\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n      metadata_config:\n\
+          \        send: false\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -20959,12 +20959,12 @@ objects:
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
           \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)'\n\
-          \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
-          \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
-          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
-          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \      queueConfig:\n        capacity: 2500\n        maxShards: 500\n  \
+          \      minShards: 1\n        maxSamplesPerSend: 2000\n        batchSendDeadline:\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n      metadata_config:\n\
+          \        send: false\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -20959,12 +20959,12 @@ objects:
           \    - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
           \      remoteTimeout: 30s\n      writeRelabelConfigs:\n      - sourceLabels:\
           \ [__name__]\n        action: keep\n        regex: '(addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)'\n\
-          \      queueConfig:\n        capacity: 2500\n        maxShards: 1000\n \
-          \       minShards: 1\n        maxSamplesPerSend: 500\n        batchSendDeadline:\
-          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\
-          \ NoSchedule\n      key: node-role.kubernetes.io/infra\n      operator:\
-          \ Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \      queueConfig:\n        capacity: 2500\n        maxShards: 500\n  \
+          \      minShards: 1\n        maxSamplesPerSend: 2000\n        batchSendDeadline:\
+          \ 60s\n        minBackoff: 30ms\n        maxBackoff: 5s\n      metadata_config:\n\
+          \        send: false\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ \"\"\n  tolerations:\n    - effect: NoSchedule\n      key: node-role.kubernetes.io/infra\n\
+          \      operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: \"\"\n  tolerations:\n    - effect:\


### PR DESCRIPTION
### What type of PR is this?

Enhancement

### What this PR does / why we need it?

This PR does two things. Firstly it optimizes the remote write configuration
to send larger batches to the backend which comfortably fall within the ranges
we can support.

This knowledge was gained during our previous load testing https://issues.redhat.com/browse/RHOBS-181
and the change should be favourable from both a client/server perspective

It also disables sending metadata [which Thanos does not currently handle](https://github.com/thanos-io/thanos/blob/main/pkg/receive/handler.go#L514-L523) in remote write and the outcome
is that there is unnecessary traffic on the network which must be processed before being dropped!

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
