### PR TITLE
Update control-plane-operator policy

### DIFF
--- a/resources/sts/4.12/hypershift/ControlPlaneOperatorPolicy.json
+++ b/resources/sts/4.12/hypershift/ControlPlaneOperatorPolicy.json
@@ -9,7 +9,15 @@
                 "ec2:ModifyVpcEndpoint",
                 "ec2:DeleteVpcEndpoints",
                 "ec2:CreateTags",
-                "route53:ListHostedZones"
+                "route53:ListHostedZones",
+                "ec2:CreateSecurityGroup",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:DeleteSecurityGroup",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeVpcs"
             ],
             "Resource": "*"
         },

--- a/resources/sts/4.12/openshift_control_plane_operator_credentials_policy.json
+++ b/resources/sts/4.12/openshift_control_plane_operator_credentials_policy.json
@@ -9,7 +9,15 @@
                             "ec2:ModifyVpcEndpoint",
                             "ec2:DeleteVpcEndpoints",
                             "ec2:CreateTags",
-                            "route53:ListHostedZones"
+                            "route53:ListHostedZones",
+                            "ec2:CreateSecurityGroup",
+                            "ec2:AuthorizeSecurityGroupIngress",
+                            "ec2:AuthorizeSecurityGroupEgress",
+                            "ec2:DeleteSecurityGroup",
+                            "ec2:RevokeSecurityGroupIngress",
+                            "ec2:RevokeSecurityGroupEgress",
+                            "ec2:DescribeSecurityGroups",
+                            "ec2:DescribeVpcs"
                     ],
                     "Resource": "*"
             },


### PR DESCRIPTION


### What type of PR is this?
feature

### What this PR does / why we need it?
The control-plane-opertor needs additional permissions in order to create and destroy a default security group for NodePools where no security group is specified.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [HOSTEDCP-789](https://issues.redhat.com//browse/HOSTEDCP-789)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
