### PR TITLE
[OSD-14739]add acm policy to deploy the webhook patching cronjob to management cluster

### DIFF
--- a/deploy/hypershift-validating-webhook-patching/OWNERS
+++ b/deploy/hypershift-validating-webhook-patching/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- bmeng
+- mrbarge
+- ravitri
+- shitaljante
+- a7vicky

--- a/deploy/hypershift-validating-webhook-patching/README.md
+++ b/deploy/hypershift-validating-webhook-patching/README.md
@@ -1,0 +1,38 @@
+# About the validating-webhook-patching-job
+
+This policy used to deploy a cronjob to the hosted control plane namespaces
+on management cluster.
+
+The cronjob is going to patch the validatingWebhookConfiguration custom resources
+which intended to be deployed to the hosted clusters.
+
+As the caBundle is a required field for the validatingwebhook and the validation admission
+happened on the management cluster API server. We need to use the caBundle from the management
+cluster in the hosted cluster validatingwebhook CR.
+
+This is a temporary solution before we can handle the cabundle replacement within the cluster
+deployment by hypershift.
+
+## WebhookConfigurations
+The following webhook configurations will be updated by this job.
+- sre-regular-user-validation
+- sre-namespace-validation
+- sre-scc-validation
+- sre-techpreviewnoupgrade-validation
+
+## Resources included in the policy
+
+A policy to deploy the required resources to the hosted control plane namespaces.
+
+A placementrule to target the management cluster for the policy deployment.
+
+A placementbinding to map the policy and the placementrule.
+
+## Resources included in the policy
+- service account
+- role
+- rolebinding
+- cronjob
+
+# About the managed-cluster-validating-webhooks
+https://github.com/openshift/managed-cluster-validating-webhooks

--- a/deploy/hypershift-validating-webhook-patching/config.yaml
+++ b/deploy/hypershift-validating-webhook-patching/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["service-cluster"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/deploy/hypershift-validating-webhook-patching/validating-webhook-patching.Policy.yaml
+++ b/deploy/hypershift-validating-webhook-patching/validating-webhook-patching.Policy.yaml
@@ -1,0 +1,140 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: validating-webhook-patching
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: validating-webhook-patching
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                namespaceSelector:
+                    matchLabels:
+                        hypershift.openshift.io/hosted-control-plane: "true"
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ServiceAccount
+                        metadata:
+                            name: validating-webhook-patching-sa
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: validating-webhook-patching-role
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                                - configmaps
+                              verbs:
+                                - get
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: validating-webhook-patching-rolebinding
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: validating-webhook-patching-role
+                        subjects:
+                            - kind: ServiceAccount
+                              name: validating-webhook-patching-sa
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: batch/v1
+                        kind: CronJob
+                        metadata:
+                            name: validating-webhook-patching-job
+                        spec:
+                            jobTemplate:
+                                spec:
+                                    template:
+                                        spec:
+                                            containers:
+                                                - args:
+                                                    - /bin/bash
+                                                    - -c
+                                                    - |-
+                                                      set -e
+                                                      set -o nounset
+                                                      set -o pipefail
+
+                                                      if [[ -z "${JOB_NS}" ]]; then
+                                                         echo "Missing namespace JOB_NS var"
+                                                         exit 1
+                                                      fi
+
+                                                      # Get that CA
+                                                      CABundle=$(oc get configmap webhook-cert -o json | jq -r '.data."service-ca.crt"' | base64 -w 0)
+
+                                                      # Get that kubeconfig
+                                                      TMPDIR=$(mktemp -d)
+                                                      oc get secret admin-kubeconfig -o json | jq -r '.data.kubeconfig' | base64 -d >> ${TMPDIR}/kubeconfig
+
+                                                      # patch the CA
+                                                      for WEBHOOK in namespace regular-user scc techpreviewnoupgrade
+                                                      do
+                                                        oc patch --kubeconfig ${TMPDIR}/kubeconfig validatingwebhookconfiguration sre-${WEBHOOK}-validation --type=json -p "[{'op':'replace', 'path': '/webhooks/0/clientConfig/caBundle', 'value': '${CABundle}'}]" || true
+                                                      done
+
+                                                      # clean up
+                                                      rm -f ${TMPDIR}/kubeconfig
+                                                  env:
+                                                    - name: JOB_NS
+                                                      valueFrom:
+                                                        fieldRef:
+                                                            fieldPath: metadata.namespace
+                                                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                                                  name: validating-webhook-patching
+                                            restartPolicy: Never
+                                            serviceAccountName: validating-webhook-patching-sa
+                            schedule: "*/30 * * * *"
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-validating-webhook-patching
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/management-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-validating-webhook-patching
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-validating-webhook-patching
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: validating-webhook-patching
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21373,6 +21373,154 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-validating-webhook-patching
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: validating-webhook-patching
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: validating-webhook-patching
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              namespaceSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ServiceAccount
+                  metadata:
+                    name: validating-webhook-patching-sa
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: validating-webhook-patching-role
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    - configmaps
+                    verbs:
+                    - get
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: validating-webhook-patching-rolebinding
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: validating-webhook-patching-role
+                  subjects:
+                  - kind: ServiceAccount
+                    name: validating-webhook-patching-sa
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: batch/v1
+                  kind: CronJob
+                  metadata:
+                    name: validating-webhook-patching-job
+                  spec:
+                    jobTemplate:
+                      spec:
+                        template:
+                          spec:
+                            containers:
+                            - args:
+                              - /bin/bash
+                              - -c
+                              - "set -e\nset -o nounset\nset -o pipefail\n\nif [[\
+                                \ -z \"${JOB_NS}\" ]]; then\n   echo \"Missing namespace\
+                                \ JOB_NS var\"\n   exit 1\nfi\n\n# Get that CA\nCABundle=$(oc\
+                                \ get configmap webhook-cert -o json | jq -r '.data.\"\
+                                service-ca.crt\"' | base64 -w 0)\n\n# Get that kubeconfig\n\
+                                TMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
+                                \ -o json | jq -r '.data.kubeconfig' | base64 -d >>\
+                                \ ${TMPDIR}/kubeconfig\n\n# patch the CA\nfor WEBHOOK\
+                                \ in namespace regular-user scc techpreviewnoupgrade\n\
+                                do\n  oc patch --kubeconfig ${TMPDIR}/kubeconfig validatingwebhookconfiguration\
+                                \ sre-${WEBHOOK}-validation --type=json -p \"[{'op':'replace',\
+                                \ 'path': '/webhooks/0/clientConfig/caBundle', 'value':\
+                                \ '${CABundle}'}]\" || true\ndone\n\n# clean up\n\
+                                rm -f ${TMPDIR}/kubeconfig"
+                              env:
+                              - name: JOB_NS
+                                valueFrom:
+                                  fieldRef:
+                                    fieldPath: metadata.namespace
+                              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                              name: validating-webhook-patching
+                            restartPolicy: Never
+                            serviceAccountName: validating-webhook-patching-sa
+                    schedule: 05 * * * *
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-validating-webhook-patching
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-validating-webhook-patching
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-validating-webhook-patching
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: validating-webhook-patching
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-integration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21485,7 +21485,7 @@ objects:
                               name: validating-webhook-patching
                             restartPolicy: Never
                             serviceAccountName: validating-webhook-patching-sa
-                    schedule: 05 * * * *
+                    schedule: '*/30 * * * *'
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21373,6 +21373,154 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-validating-webhook-patching
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: validating-webhook-patching
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: validating-webhook-patching
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              namespaceSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ServiceAccount
+                  metadata:
+                    name: validating-webhook-patching-sa
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: validating-webhook-patching-role
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    - configmaps
+                    verbs:
+                    - get
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: validating-webhook-patching-rolebinding
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: validating-webhook-patching-role
+                  subjects:
+                  - kind: ServiceAccount
+                    name: validating-webhook-patching-sa
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: batch/v1
+                  kind: CronJob
+                  metadata:
+                    name: validating-webhook-patching-job
+                  spec:
+                    jobTemplate:
+                      spec:
+                        template:
+                          spec:
+                            containers:
+                            - args:
+                              - /bin/bash
+                              - -c
+                              - "set -e\nset -o nounset\nset -o pipefail\n\nif [[\
+                                \ -z \"${JOB_NS}\" ]]; then\n   echo \"Missing namespace\
+                                \ JOB_NS var\"\n   exit 1\nfi\n\n# Get that CA\nCABundle=$(oc\
+                                \ get configmap webhook-cert -o json | jq -r '.data.\"\
+                                service-ca.crt\"' | base64 -w 0)\n\n# Get that kubeconfig\n\
+                                TMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
+                                \ -o json | jq -r '.data.kubeconfig' | base64 -d >>\
+                                \ ${TMPDIR}/kubeconfig\n\n# patch the CA\nfor WEBHOOK\
+                                \ in namespace regular-user scc techpreviewnoupgrade\n\
+                                do\n  oc patch --kubeconfig ${TMPDIR}/kubeconfig validatingwebhookconfiguration\
+                                \ sre-${WEBHOOK}-validation --type=json -p \"[{'op':'replace',\
+                                \ 'path': '/webhooks/0/clientConfig/caBundle', 'value':\
+                                \ '${CABundle}'}]\" || true\ndone\n\n# clean up\n\
+                                rm -f ${TMPDIR}/kubeconfig"
+                              env:
+                              - name: JOB_NS
+                                valueFrom:
+                                  fieldRef:
+                                    fieldPath: metadata.namespace
+                              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                              name: validating-webhook-patching
+                            restartPolicy: Never
+                            serviceAccountName: validating-webhook-patching-sa
+                    schedule: 05 * * * *
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-validating-webhook-patching
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-validating-webhook-patching
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-validating-webhook-patching
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: validating-webhook-patching
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-integration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21485,7 +21485,7 @@ objects:
                               name: validating-webhook-patching
                             restartPolicy: Never
                             serviceAccountName: validating-webhook-patching-sa
-                    schedule: 05 * * * *
+                    schedule: '*/30 * * * *'
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21373,6 +21373,154 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-validating-webhook-patching
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: validating-webhook-patching
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: validating-webhook-patching
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              namespaceSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ServiceAccount
+                  metadata:
+                    name: validating-webhook-patching-sa
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: validating-webhook-patching-role
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    - configmaps
+                    verbs:
+                    - get
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: validating-webhook-patching-rolebinding
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: validating-webhook-patching-role
+                  subjects:
+                  - kind: ServiceAccount
+                    name: validating-webhook-patching-sa
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: batch/v1
+                  kind: CronJob
+                  metadata:
+                    name: validating-webhook-patching-job
+                  spec:
+                    jobTemplate:
+                      spec:
+                        template:
+                          spec:
+                            containers:
+                            - args:
+                              - /bin/bash
+                              - -c
+                              - "set -e\nset -o nounset\nset -o pipefail\n\nif [[\
+                                \ -z \"${JOB_NS}\" ]]; then\n   echo \"Missing namespace\
+                                \ JOB_NS var\"\n   exit 1\nfi\n\n# Get that CA\nCABundle=$(oc\
+                                \ get configmap webhook-cert -o json | jq -r '.data.\"\
+                                service-ca.crt\"' | base64 -w 0)\n\n# Get that kubeconfig\n\
+                                TMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
+                                \ -o json | jq -r '.data.kubeconfig' | base64 -d >>\
+                                \ ${TMPDIR}/kubeconfig\n\n# patch the CA\nfor WEBHOOK\
+                                \ in namespace regular-user scc techpreviewnoupgrade\n\
+                                do\n  oc patch --kubeconfig ${TMPDIR}/kubeconfig validatingwebhookconfiguration\
+                                \ sre-${WEBHOOK}-validation --type=json -p \"[{'op':'replace',\
+                                \ 'path': '/webhooks/0/clientConfig/caBundle', 'value':\
+                                \ '${CABundle}'}]\" || true\ndone\n\n# clean up\n\
+                                rm -f ${TMPDIR}/kubeconfig"
+                              env:
+                              - name: JOB_NS
+                                valueFrom:
+                                  fieldRef:
+                                    fieldPath: metadata.namespace
+                              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                              name: validating-webhook-patching
+                            restartPolicy: Never
+                            serviceAccountName: validating-webhook-patching-sa
+                    schedule: 05 * * * *
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-validating-webhook-patching
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-validating-webhook-patching
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-validating-webhook-patching
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: validating-webhook-patching
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-integration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21485,7 +21485,7 @@ objects:
                               name: validating-webhook-patching
                             restartPolicy: Never
                             serviceAccountName: validating-webhook-patching-sa
-                    schedule: 05 * * * *
+                    schedule: '*/30 * * * *'
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
With deploying the validatingwebhook to the hosted cluster, it needs the cabundle from the management cluster to be injected into the webhook configuration.
As of now, we do not have a mechanism to consume the resources on management cluster for hosted cluster yet.
This will be a temporary solution before we can manage that within the hypershift.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-14739](https://issues.redhat.com//browse/OSD-14739)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
