### PR TITLE
Add iam:TagInstanceProfile permission to Installer role

### DIFF
--- a/resources/sts/4.12/hypershift/InstallerPolicy.json
+++ b/resources/sts/4.12/hypershift/InstallerPolicy.json
@@ -45,6 +45,7 @@
                 "iam:ListPolicyVersions",
                 "iam:ListRoleTags",
                 "iam:PutRolePermissionsBoundary",
+                "iam:TagInstanceProfile",
                 "iam:TagPolicy",
                 "kms:DescribeKey",
                 "route53:ChangeResourceRecordSets",


### PR DESCRIPTION
OCM creates InstanceProfile resources but so far they were not tagged. 

### What type of PR is this?
Feature

### What this PR does / why we need it?
This adds the necessary permission to allow tagging and align with all the other AWS resources.

### Which Jira/Github issue(s) this PR fixes?
Related: [SDA-7934](https://issues.redhat.com//browse/SDA-7934)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
