### PR TITLE
Add private link policy for 4.12

### DIFF
--- a/resources/sts/4.12/sts_installer_privatelink_permission_policy.json
+++ b/resources/sts/4.12/sts_installer_privatelink_permission_policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyVpcEndpointServiceConfiguration",
+        "route53:ListHostedZonesByVPC",
+        "route53:CreateVPCAssociationAuthorization",
+        "route53:AssociateVPCWithHostedZone",
+        "route53:DeleteVPCAssociationAuthorization",
+        "route53:DisassociateVPCFromHostedZone",
+        "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Adds private link policy required by Hive to 4.12. This matches our 4.11 policy see #1396

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
