### PR TITLE
OSD-13914 : Renaming policies to ensure namespace.name is shorter then 64

### DIFF
--- a/deploy/rosa-oauth-templates-policies/00-openshift-acm-policies.Namespace.yaml
+++ b/deploy/rosa-oauth-templates-policies/00-openshift-acm-policies.Namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-rosa-oauth-templates-policies
+  name: openshift-rosa-oauth-tpl-policies

--- a/deploy/rosa-oauth-templates-policies/50-rosa-oauth-tpl-errors.Policy.yaml
+++ b/deploy/rosa-oauth-templates-policies/50-rosa-oauth-tpl-errors.Policy.yaml
@@ -6,8 +6,8 @@ metadata:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
-    name: rosa-oauth-templates-errors
-    namespace: openshift-rosa-oauth-templates-policies
+    name: rosa-oauth-tpl-errors
+    namespace: openshift-rosa-oauth-tpl-policies
 spec:
     disabled: false
     policy-templates:
@@ -15,7 +15,7 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-                name: rosa-oauth-templates-errors
+                name: rosa-oauth-tpl-errors
             spec:
                 evaluationInterval:
                     compliant: 2h
@@ -29,7 +29,7 @@ spec:
                         kind: Secret
                         metadata:
                             creationTimestamp: null
-                            name: rosa-oauth-templates-errors
+                            name: rosa-oauth-tpl-errors
                             namespace: openshift-config
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
@@ -38,8 +38,8 @@ spec:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-    name: placement-rosa-oauth-templates-errors
-    namespace: openshift-rosa-oauth-templates-policies
+    name: pr-rosa-oauth-tpl-errors
+    namespace: openshift-rosa-oauth-tpl-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -51,13 +51,13 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rosa-oauth-templates-errors
-    namespace: openshift-rosa-oauth-templates-policies
+    name: br-rosa-oauth-tpl-errors
+    namespace: openshift-rosa-oauth-tpl-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule
-    name: placement-rosa-oauth-templates-errors
+    name: pr-rosa-oauth-tpl-errors
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy
-      name: rosa-oauth-templates-errors
+      name: rosa-oauth-tpl-errors

--- a/deploy/rosa-oauth-templates-policies/50-rosa-oauth-tpl-login.Policy.yaml
+++ b/deploy/rosa-oauth-templates-policies/50-rosa-oauth-tpl-login.Policy.yaml
@@ -6,8 +6,8 @@ metadata:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
-    name: rosa-oauth-templates-login
-    namespace: openshift-rosa-oauth-templates-policies
+    name: rosa-oauth-tpl-login
+    namespace: openshift-rosa-oauth-tpl-policies
 spec:
     disabled: false
     policy-templates:
@@ -15,7 +15,7 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-                name: rosa-oauth-templates-login
+                name: rosa-oauth-tpl-login
             spec:
                 evaluationInterval:
                     compliant: 2h
@@ -29,7 +29,7 @@ spec:
                         kind: Secret
                         metadata:
                             creationTimestamp: null
-                            name: rosa-oauth-templates-login
+                            name: rosa-oauth-tpl-login
                             namespace: openshift-config
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
@@ -38,8 +38,8 @@ spec:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-    name: placement-rosa-oauth-templates-login
-    namespace: openshift-rosa-oauth-templates-policies
+    name: pr-rosa-oauth-tpl-login
+    namespace: openshift-rosa-oauth-tpl-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -51,13 +51,13 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rosa-oauth-templates-login
-    namespace: openshift-rosa-oauth-templates-policies
+    name: br-rosa-oauth-tpl-login
+    namespace: openshift-rosa-oauth-tpl-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule
-    name: placement-rosa-oauth-templates-login
+    name: pr-rosa-oauth-tpl-login
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy
-      name: rosa-oauth-templates-login
+      name: rosa-oauth-tpl-login

--- a/deploy/rosa-oauth-templates-policies/50-rosa-oauth-tpl-providers.Policy.yaml
+++ b/deploy/rosa-oauth-templates-policies/50-rosa-oauth-tpl-providers.Policy.yaml
@@ -6,8 +6,8 @@ metadata:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
-    name: rosa-oauth-templates-providers
-    namespace: openshift-rosa-oauth-templates-policies
+    name: rosa-oauth-tpl-providers
+    namespace: openshift-rosa-oauth-tpl-policies
 spec:
     disabled: false
     policy-templates:
@@ -15,7 +15,7 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-                name: rosa-oauth-templates-providers
+                name: rosa-oauth-tpl-providers
             spec:
                 evaluationInterval:
                     compliant: 2h
@@ -29,7 +29,7 @@ spec:
                         kind: Secret
                         metadata:
                             creationTimestamp: null
-                            name: rosa-oauth-templates-providers
+                            name: rosa-oauth-tpl-providers
                             namespace: openshift-config
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
@@ -38,8 +38,8 @@ spec:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-    name: placement-rosa-oauth-templates-providers
-    namespace: openshift-rosa-oauth-templates-policies
+    name: pr-rosa-oauth-tpl-providers
+    namespace: openshift-rosa-oauth-tpl-policies
 spec:
     clusterSelector:
         matchExpressions:
@@ -51,13 +51,13 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-rosa-oauth-templates-providers
-    namespace: openshift-rosa-oauth-templates-policies
+    name: pb-rosa-oauth-tpl-providers
+    namespace: openshift-rosa-oauth-tpl-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule
-    name: placement-rosa-oauth-templates-providers
+    name: pr-rosa-oauth-tpl-providers
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy
-      name: rosa-oauth-templates-providers
+      name: rosa-oauth-tpl-providers

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30265,7 +30265,7 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
-        name: openshift-rosa-oauth-templates-policies
+        name: openshift-rosa-oauth-tpl-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30273,8 +30273,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30282,7 +30282,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-errors
+              name: rosa-oauth-tpl-errors
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30296,7 +30296,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-errors
+                    name: rosa-oauth-tpl-errors
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30304,8 +30304,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30316,16 +30316,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: br-rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-errors
+        name: pr-rosa-oauth-tpl-errors
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-errors
+        name: rosa-oauth-tpl-errors
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30333,8 +30333,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30342,7 +30342,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-login
+              name: rosa-oauth-tpl-login
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30356,7 +30356,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-login
+                    name: rosa-oauth-tpl-login
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30364,8 +30364,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30376,16 +30376,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: br-rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-login
+        name: pr-rosa-oauth-tpl-login
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-login
+        name: rosa-oauth-tpl-login
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30393,8 +30393,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30402,7 +30402,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-providers
+              name: rosa-oauth-tpl-providers
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30416,7 +30416,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-providers
+                    name: rosa-oauth-tpl-providers
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30424,8 +30424,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30436,16 +30436,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pb-rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-providers
+        name: pr-rosa-oauth-tpl-providers
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-providers
+        name: rosa-oauth-tpl-providers
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30265,7 +30265,7 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
-        name: openshift-rosa-oauth-templates-policies
+        name: openshift-rosa-oauth-tpl-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30273,8 +30273,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30282,7 +30282,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-errors
+              name: rosa-oauth-tpl-errors
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30296,7 +30296,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-errors
+                    name: rosa-oauth-tpl-errors
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30304,8 +30304,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30316,16 +30316,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: br-rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-errors
+        name: pr-rosa-oauth-tpl-errors
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-errors
+        name: rosa-oauth-tpl-errors
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30333,8 +30333,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30342,7 +30342,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-login
+              name: rosa-oauth-tpl-login
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30356,7 +30356,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-login
+                    name: rosa-oauth-tpl-login
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30364,8 +30364,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30376,16 +30376,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: br-rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-login
+        name: pr-rosa-oauth-tpl-login
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-login
+        name: rosa-oauth-tpl-login
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30393,8 +30393,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30402,7 +30402,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-providers
+              name: rosa-oauth-tpl-providers
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30416,7 +30416,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-providers
+                    name: rosa-oauth-tpl-providers
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30424,8 +30424,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30436,16 +30436,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pb-rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-providers
+        name: pr-rosa-oauth-tpl-providers
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-providers
+        name: rosa-oauth-tpl-providers
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30265,7 +30265,7 @@ objects:
     - apiVersion: v1
       kind: Namespace
       metadata:
-        name: openshift-rosa-oauth-templates-policies
+        name: openshift-rosa-oauth-tpl-policies
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30273,8 +30273,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30282,7 +30282,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-errors
+              name: rosa-oauth-tpl-errors
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30296,7 +30296,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-errors
+                    name: rosa-oauth-tpl-errors
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30304,8 +30304,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30316,16 +30316,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-errors
-        namespace: openshift-rosa-oauth-templates-policies
+        name: br-rosa-oauth-tpl-errors
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-errors
+        name: pr-rosa-oauth-tpl-errors
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-errors
+        name: rosa-oauth-tpl-errors
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30333,8 +30333,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30342,7 +30342,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-login
+              name: rosa-oauth-tpl-login
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30356,7 +30356,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-login
+                    name: rosa-oauth-tpl-login
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30364,8 +30364,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30376,16 +30376,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-login
-        namespace: openshift-rosa-oauth-templates-policies
+        name: br-rosa-oauth-tpl-login
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-login
+        name: pr-rosa-oauth-tpl-login
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-login
+        name: rosa-oauth-tpl-login
     - apiVersion: policy.open-cluster-management.io/v1
       kind: Policy
       metadata:
@@ -30393,8 +30393,8 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         disabled: false
         policy-templates:
@@ -30402,7 +30402,7 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-              name: rosa-oauth-templates-providers
+              name: rosa-oauth-tpl-providers
             spec:
               evaluationInterval:
                 compliant: 2h
@@ -30416,7 +30416,7 @@ objects:
                   kind: Secret
                   metadata:
                     creationTimestamp: null
-                    name: rosa-oauth-templates-providers
+                    name: rosa-oauth-tpl-providers
                     namespace: openshift-config
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
@@ -30424,8 +30424,8 @@ objects:
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
-        name: placement-rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pr-rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       spec:
         clusterSelector:
           matchExpressions:
@@ -30436,16 +30436,16 @@ objects:
     - apiVersion: policy.open-cluster-management.io/v1
       kind: PlacementBinding
       metadata:
-        name: binding-rosa-oauth-templates-providers
-        namespace: openshift-rosa-oauth-templates-policies
+        name: pb-rosa-oauth-tpl-providers
+        namespace: openshift-rosa-oauth-tpl-policies
       placementRef:
         apiGroup: apps.open-cluster-management.io
         kind: PlacementRule
-        name: placement-rosa-oauth-templates-providers
+        name: pr-rosa-oauth-tpl-providers
       subjects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
-        name: rosa-oauth-templates-providers
+        name: rosa-oauth-tpl-providers
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Renaming namespace and policies to ensure the length of namespaced resource (namespace+name) is shorter than 64 to allow proper propagation

### Which Jira/Github issue(s) this PR fixes?
[OSD-13914](https://issues.redhat.com//browse/OSD-13914)


### Special notes for your reviewer:
This first drop isn't generated, once end-to-end validated, [OSD-15086](https://issues.redhat.com/browse/OSD-15086) will take care of the generation to ensure sync'.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
