### PR TITLE
OSD-13914 - Migrate patch of oauth for Hypershift support

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: rosa-oauth-templates
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rosa-oauth-templates
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: config.openshift.io/v1
+                        kind: OAuth
+                        metadata:
+                            name: cluster
+                        spec:
+                            templates:
+                                error:
+                                    name: rosa-oauth-templates-errors
+                                login:
+                                    name: rosa-oauth-templates-login
+                                providerSelection:
+                                    name: rosa-oauth-templates-providers
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-rosa-oauth-templates
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-rosa-oauth-templates
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-rosa-oauth-templates
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: rosa-oauth-templates

--- a/deploy/rosa-oauth-templates/config.yaml
+++ b/deploy/rosa-oauth-templates/config.yaml
@@ -4,3 +4,6 @@ selectorSyncSet:
   - key: api.openshift.com/product
     operator: In
     values: ["rosa"]
+  applyBehavior: "CreateOrUpdate"
+  # use Upsert so if this configuration no longer applies it will not delete the OAuth resource in cluster which is a singleton.  We should never delete OAuth.
+  resourceApplyMode: "Upsert"

--- a/deploy/rosa-oauth-templates/rosa-oauth-templates.OAuth.yaml
+++ b/deploy/rosa-oauth-templates/rosa-oauth-templates.OAuth.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  templates:
+    login:
+      name: rosa-oauth-templates-login
+    providerSelection:
+      name: rosa-oauth-templates-providers
+    error: 
+      name: rosa-oauth-templates-errors

--- a/deploy/rosa-oauth-templates/rosa-oauth-templates.patch.yaml
+++ b/deploy/rosa-oauth-templates/rosa-oauth-templates.patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: config.openshift.io/v1
-applyMode: AlwaysApply
-kind: OAuth
-name: cluster
-patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
-  {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5669,6 +5669,70 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: rosa-console-branding
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-oauth-templates
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-oauth-templates
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: config.openshift.io/v1
+                  kind: OAuth
+                  metadata:
+                    name: cluster
+                  spec:
+                    templates:
+                      error:
+                        name: rosa-oauth-templates-errors
+                      login:
+                        name: rosa-oauth-templates-login
+                      providerSelection:
+                        name: rosa-oauth-templates-providers
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-oauth-templates
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-oauth-templates
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-oauth-templates
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-oauth-templates
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -30173,15 +30237,21 @@ objects:
         operator: In
         values:
         - rosa
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    applyBehavior: CreateOrUpdate
+    resources:
     - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
       kind: OAuth
-      name: cluster
-      patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
-        {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-      patchType: merge
+      metadata:
+        name: cluster
+      spec:
+        templates:
+          login:
+            name: rosa-oauth-templates-login
+          providerSelection:
+            name: rosa-oauth-templates-providers
+          error:
+            name: rosa-oauth-templates-errors
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5669,6 +5669,70 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: rosa-console-branding
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-oauth-templates
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-oauth-templates
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: config.openshift.io/v1
+                  kind: OAuth
+                  metadata:
+                    name: cluster
+                  spec:
+                    templates:
+                      error:
+                        name: rosa-oauth-templates-errors
+                      login:
+                        name: rosa-oauth-templates-login
+                      providerSelection:
+                        name: rosa-oauth-templates-providers
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-oauth-templates
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-oauth-templates
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-oauth-templates
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-oauth-templates
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -30173,15 +30237,21 @@ objects:
         operator: In
         values:
         - rosa
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    applyBehavior: CreateOrUpdate
+    resources:
     - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
       kind: OAuth
-      name: cluster
-      patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
-        {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-      patchType: merge
+      metadata:
+        name: cluster
+      spec:
+        templates:
+          login:
+            name: rosa-oauth-templates-login
+          providerSelection:
+            name: rosa-oauth-templates-providers
+          error:
+            name: rosa-oauth-templates-errors
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5669,6 +5669,70 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: rosa-console-branding
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-oauth-templates
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-oauth-templates
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: config.openshift.io/v1
+                  kind: OAuth
+                  metadata:
+                    name: cluster
+                  spec:
+                    templates:
+                      error:
+                        name: rosa-oauth-templates-errors
+                      login:
+                        name: rosa-oauth-templates-login
+                      providerSelection:
+                        name: rosa-oauth-templates-providers
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-oauth-templates
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-oauth-templates
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-oauth-templates
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-oauth-templates
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -30173,15 +30237,21 @@ objects:
         operator: In
         values:
         - rosa
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    applyBehavior: CreateOrUpdate
+    resources:
     - apiVersion: config.openshift.io/v1
-      applyMode: AlwaysApply
       kind: OAuth
-      name: cluster
-      patch: '{"spec":{"templates": {"login": {"name": "rosa-oauth-templates-login"},"providerSelection":
-        {"name": "rosa-oauth-templates-providers"},"error": {"name": "rosa-oauth-templates-errors"}}}}'
-      patchType: merge
+      metadata:
+        name: cluster
+      spec:
+        templates:
+          login:
+            name: rosa-oauth-templates-login
+          providerSelection:
+            name: rosa-oauth-templates-providers
+          error:
+            name: rosa-oauth-templates-errors
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -32,6 +32,7 @@ directories = [
         'osd-project-request-template',
         'osd-user-workload-monitoring',
         'rbac-permissions-operator-config',
+        'rosa-oauth-templates',
         'rosa-console-branding',
         'rosa-console-branding-configmap',
         ]


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
- Changing the applyMode of the rosa-oauth-templates syncset to support behavior similar de 'MustHave' in Policies (ie update of selected fields) to allow to have the resource for Hosted Clusters generated as the other resources.  
- Adding the SSS to the list of generated resources for Policy generate
 
### Which Jira/Github issue(s) this PR fixes?
[OSD-13914](https://issues.redhat.com//browse/OSD-13914)

### Special notes for your reviewer:
Setting resourceApplyMode to Upsert as in a Patch, we shouldn't delete the resource if we delete the SSS

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
