### PR TITLE
Refine installer policy for hyperShift hosted clusters

### DIFF
--- a/resources/sts/4.12/hypershift/InstallerPolicy.json
+++ b/resources/sts/4.12/hypershift/InstallerPolicy.json
@@ -4,70 +4,136 @@
         {
             "Effect": "Allow",
             "Action": [
-                "ec2:CreateSubnet",
-                "ec2:CreateVolume",
-                "ec2:CreateVpc",
-                "ec2:DeleteSubnet",
-                "ec2:DeleteVolume",
-                "ec2:DeleteVpc",
-                "ec2:DescribeAddresses",
+                "ec2:CreateTags",
+                "ec2:DeleteTags",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeInternetGateways",
-                "ec2:DescribeNetworkInterfaces",
                 "ec2:DescribeRegions",
                 "ec2:DescribeReservedInstancesOfferings",
                 "ec2:DescribeRouteTables",
-                "ec2:DescribeSecurityGroups",
                 "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeVpcs",
-                "ec2:RunInstances",
-                "elasticloadbalancing:CreateLoadBalancer",
+                "ec2:DescribeInstanceTypeOfferings",
                 "elasticloadbalancing:DeleteLoadBalancer",
-                "iam:AddRoleToInstanceProfile",
-                "iam:AttachRolePolicy",
-                "iam:CreateInstanceProfile",
-                "iam:CreateOpenIDConnectProvider",
-                "iam:CreatePolicy",
-                "iam:CreatePolicyVersion",
-                "iam:CreateRole",
-                "iam:DeleteOpenIDConnectProvider",
-                "iam:DeletePolicyVersion",
-                "iam:DeleteRole",
-                "iam:DeleteRolePermissionsBoundary",
-                "iam:DetachRolePolicy",
-                "iam:GetOpenIDConnectProvider",
-                "iam:GetPolicy",
-                "iam:GetRole",
-                "iam:GetUser",
-                "iam:ListAttachedRolePolicies",
-                "iam:ListPolicyTags",
-                "iam:ListPolicyVersions",
-                "iam:ListRoleTags",
-                "iam:PutRolePermissionsBoundary",
-                "iam:TagInstanceProfile",
-                "iam:TagPolicy",
                 "kms:DescribeKey",
                 "route53:ChangeResourceRecordSets",
                 "route53:DeleteHostedZone",
                 "route53:GetAccountLimit",
                 "route53:GetHostedZone",
                 "route53:ListHostedZones",
-                "route53:ListHostedZonesByName",
                 "route53:ListResourceRecordSets",
-                "s3:CreateBucket",
-                "s3:DeleteBucket",
-                "s3:DeleteObject",
-                "s3:ListObjects",
-                "s3:PutObject",
-                "secretsmanager:GetSecretValue",
                 "servicequotas:GetServiceQuota",
-                "sts:AssumeRole",
-                "sts:AssumeRoleWithWebIdentity",
-                "sts:GetCallerIdentity"
+                "sts:GetCallerIdentity",
+                "iam:TagInstanceProfile"
             ],
-        "Resource": "*"
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:*:iam::*:role/*-Worker-Role"
+            ],
+            "Effect": "Allow"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+              "sts:AssumeRole",
+              "sts:AssumeRoleWithWebIdentity"
+            ],
+            "Resource": [
+              "arn:aws:iam::*:role/*"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:ResourceTag/red-hat-managed": "true"
+              }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "elasticloadbalancing:CreateLoadBalancer",
+            "Resource": [
+              "*"
+            ],
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/red-hat-managed": "true"
+              }
+            }
+        },
+        {
+            "Sid": "BucketActions",
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:DeleteBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*-oidc"
+            ]
+        },
+        {
+            "Sid": "CreateAndManageInstanceProfiles",
+            "Effect": "Allow",
+            "Action": [
+                "iam:AddRoleToInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:CreateInstanceProfile",
+                "iam:GetInstanceProfile"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:instance-profile/*-worker"
+            ]
+        },
+        {
+            "Sid": "CreateAndManagePolicies",
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreatePolicy",
+                "iam:CreateRole"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                  "aws:RequestTag/red-hat-managed": "true"
+                }
+              }
+        },
+        {
+            "Sid": "Route53ManageRecords",
+            "Effect": "Allow",
+            "Action": [
+              "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": "*",
+            "Condition": {
+              "ForAllValues:StringLike": {
+                "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+                  "*.openshiftapps.com",
+                  "*.devshift.org",
+                  "*.hypershift.local"
+                ]
+              }
+            }
+        },
+        {
+            "Sid": "Route53Manage",
+            "Effect": "Allow",
+            "Action": [
+              "route53:ChangeTagsForResource",
+              "route53:CreateHostedZone",
+              "route53:DeleteHostedZone"
+            ],
+            "Resource": "*"
         }
     ]
 }
+

--- a/resources/sts/4.12/hypershift/InstallerPolicy.json
+++ b/resources/sts/4.12/hypershift/InstallerPolicy.json
@@ -18,12 +18,10 @@
                 "ec2:DescribeInstanceTypeOfferings",
                 "elasticloadbalancing:DeleteLoadBalancer",
                 "kms:DescribeKey",
-                "route53:ChangeResourceRecordSets",
-                "route53:DeleteHostedZone",
-                "route53:GetAccountLimit",
-                "route53:GetHostedZone",
+                "iam:GetRole",
                 "route53:ListHostedZones",
                 "route53:ListResourceRecordSets",
+                "route53:GetAccountLimit",
                 "servicequotas:GetServiceQuota",
                 "sts:GetCallerIdentity",
                 "iam:TagInstanceProfile"
@@ -37,7 +35,14 @@
             "Resource": [
                 "arn:*:iam::*:role/*-Worker-Role"
             ],
-            "Effect": "Allow"
+            "Effect": "Allow",
+            "Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": [
+                        "ec2.amazonaws.com"
+                    ]
+                }
+            }
         },
         {
             "Effect": "Allow",
@@ -65,17 +70,6 @@
                 "aws:RequestTag/red-hat-managed": "true"
               }
             }
-        },
-        {
-            "Sid": "BucketActions",
-            "Effect": "Allow",
-            "Action": [
-                "s3:CreateBucket",
-                "s3:DeleteBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::*-oidc"
-            ]
         },
         {
             "Sid": "CreateAndManageInstanceProfiles",
@@ -108,6 +102,20 @@
               }
         },
         {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": [
+                "*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+              }
+        },
+        {
             "Sid": "Route53ManageRecords",
             "Effect": "Allow",
             "Action": [
@@ -119,7 +127,9 @@
                 "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
                   "*.openshiftapps.com",
                   "*.devshift.org",
-                  "*.hypershift.local"
+                  "*.hypershift.local",
+                  "*.openshiftusgov.com",
+                  "*.devshiftusgov.com"
                 ]
               }
             }


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR refines the installer role for hosted clusters by removing actions that are not required and adding condition keys to the actions that are applicable

### Which Jira/Github issue(s) this PR fixes?


_Fixes #_  https://issues.redhat.com/browse/OSD-14611

### Special notes for your reviewer:
This is the part of the work to review and refine all hyperShift role policies and make sure they follow the principle of least privilege with condition keys set, where applicable.

Hosted cluster creation, deletion and normal function (like operators working ) has been tested on both prod and stage environments with this installer policy.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
