### PR TITLE
Add Readme for hyperShift policy files directory

### DIFF
--- a/resources/sts/4.12/hypershift/README.md
+++ b/resources/sts/4.12/hypershift/README.md
@@ -1,0 +1,5 @@
+# HyperShift STS role policies
+
+This directory contains policy files required for HyperShift hosted clusters.
+
+The policies in this directory are under review and should not be used for production environments until [SDE-2386](https://issues.redhat.com/browse/SDE-2386) is complete.


### PR DESCRIPTION
### What type of PR is this?
_documentation_

### What this PR does / why we need it?
To specify that the roles in this directory are a work in progress and should not be used for actual installations unless testing [SDE-2386](https://issues.redhat.com//browse/SDE-2386)

### Which Jira/Github issue(s) this PR fixes?
Related to [SDE-2386](https://issues.redhat.com/browse/SDE-2386)


### Special notes for your reviewer:
Just a small README for HyperShift role policies

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
