### PR TITLE
fix the incorrect jq placement

### DIFF
--- a/deploy/hypershift-validating-webhook-patching/validating-webhook-patching.Policy.yaml
+++ b/deploy/hypershift-validating-webhook-patching/validating-webhook-patching.Policy.yaml
@@ -92,7 +92,7 @@ spec:
 
                                                       # Get that kubeconfig
                                                       TMPDIR=$(mktemp -d)
-                                                      oc get secret admin-kubeconfig -o json | jq -r '.data.kubeconfig' --ignore-not-found | base64 -d >> ${TMPDIR}/kubeconfig
+                                                      oc get secret admin-kubeconfig -o json --ignore-not-found | jq -r '.data.kubeconfig' | base64 -d >> ${TMPDIR}/kubeconfig
 
                                                       # patch the CA
                                                       for WEBHOOK in namespace regular-user scc techpreviewnoupgrade

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21535,7 +21535,7 @@ objects:
                                 \ not found, might be due to the MCVW has not been\
                                 \ deployed, skipping...\"\n  exit 0\nfi\n\n# Get that\
                                 \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
-                                \ -o json | jq -r '.data.kubeconfig' --ignore-not-found\
+                                \ -o json --ignore-not-found | jq -r '.data.kubeconfig'\
                                 \ | base64 -d >> ${TMPDIR}/kubeconfig\n\n# patch the\
                                 \ CA\nfor WEBHOOK in namespace regular-user scc techpreviewnoupgrade\n\
                                 do\n  oc patch --kubeconfig ${TMPDIR}/kubeconfig validatingwebhookconfiguration\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21535,7 +21535,7 @@ objects:
                                 \ not found, might be due to the MCVW has not been\
                                 \ deployed, skipping...\"\n  exit 0\nfi\n\n# Get that\
                                 \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
-                                \ -o json | jq -r '.data.kubeconfig' --ignore-not-found\
+                                \ -o json --ignore-not-found | jq -r '.data.kubeconfig'\
                                 \ | base64 -d >> ${TMPDIR}/kubeconfig\n\n# patch the\
                                 \ CA\nfor WEBHOOK in namespace regular-user scc techpreviewnoupgrade\n\
                                 do\n  oc patch --kubeconfig ${TMPDIR}/kubeconfig validatingwebhookconfiguration\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21535,7 +21535,7 @@ objects:
                                 \ not found, might be due to the MCVW has not been\
                                 \ deployed, skipping...\"\n  exit 0\nfi\n\n# Get that\
                                 \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
-                                \ -o json | jq -r '.data.kubeconfig' --ignore-not-found\
+                                \ -o json --ignore-not-found | jq -r '.data.kubeconfig'\
                                 \ | base64 -d >> ${TMPDIR}/kubeconfig\n\n# patch the\
                                 \ CA\nfor WEBHOOK in namespace regular-user scc techpreviewnoupgrade\n\
                                 do\n  oc patch --kubeconfig ${TMPDIR}/kubeconfig validatingwebhookconfiguration\


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Fix the incorrect jq place for the cronjob in https://github.com/openshift/managed-cluster-config/pull/1475

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
