### PR TITLE
OSD-13913 - Rosa branding enablement for Hosted clusters

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
@@ -24,11 +24,19 @@ spec:
                     - complianceType: musthave
                       objectDefinition:
                         apiVersion: operator.openshift.io/v1
-                        applyMode: AlwaysApply
                         kind: Console
-                        name: cluster
-                        patch: '{"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}'
-                        patchType: merge
+                        metadata:
+                            name: cluster
+                        spec:
+                            customization:
+                                brand: null
+                                customLogoFile:
+                                    key: rosa-brand-logo.svg
+                                    name: rosa-brand-logo
+                                customProductName: Red Hat OpenShift Service on AWS
+                                documentationBaseURL: https://docs.openshift.com/rosa/
+                            managementState: Managed
+                            route: null
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/rosa-console-branding/config.yaml
+++ b/deploy/rosa-console-branding/config.yaml
@@ -4,3 +4,6 @@ selectorSyncSet:
   - key: api.openshift.com/product
     operator: In
     values: ["rosa"]
+  applyBehavior: "CreateOrUpdate"
+  # use Upsert so if this configuration no longer applies it will not delete the resource in cluster . We should never delete console.
+  resourceApplyMode: "Upsert"

--- a/deploy/rosa-console-branding/rosa-branding.Console.yaml
+++ b/deploy/rosa-console-branding/rosa-branding.Console.yaml
@@ -1,0 +1,14 @@
+apiVersion: operator.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+spec:
+  managementState: Managed
+  route:
+  customization:
+    brand: 
+    documentationBaseURL: https://docs.openshift.com/rosa/
+    customProductName: "Red Hat OpenShift Service on AWS"
+    customLogoFile:
+      name: rosa-brand-logo
+      key: rosa-brand-logo.svg

--- a/deploy/rosa-console-branding/rosa-branding.console.Patch.yaml
+++ b/deploy/rosa-console-branding/rosa-branding.console.Patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: operator.openshift.io/v1
-applyMode: AlwaysApply
-kind: Console
-name: cluster
-patchType: merge
-patch: >-
-  {"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5635,12 +5635,19 @@ objects:
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
-                  applyMode: AlwaysApply
                   kind: Console
-                  name: cluster
-                  patch: '{"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red
-                    Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}'
-                  patchType: merge
+                  metadata:
+                    name: cluster
+                  spec:
+                    customization:
+                      brand: null
+                      customLogoFile:
+                        key: rosa-brand-logo.svg
+                        name: rosa-brand-logo
+                      customProductName: Red Hat OpenShift Service on AWS
+                      documentationBaseURL: https://docs.openshift.com/rosa/
+                    managementState: Managed
+                    route: null
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -30219,15 +30226,23 @@ objects:
         operator: In
         values:
         - rosa
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    applyBehavior: CreateOrUpdate
+    resources:
     - apiVersion: operator.openshift.io/v1
-      applyMode: AlwaysApply
       kind: Console
-      name: cluster
-      patchType: merge
-      patch: '{"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red
-        Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}'
+      metadata:
+        name: cluster
+      spec:
+        managementState: Managed
+        route: null
+        customization:
+          brand: null
+          documentationBaseURL: https://docs.openshift.com/rosa/
+          customProductName: Red Hat OpenShift Service on AWS
+          customLogoFile:
+            name: rosa-brand-logo
+            key: rosa-brand-logo.svg
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5635,12 +5635,19 @@ objects:
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
-                  applyMode: AlwaysApply
                   kind: Console
-                  name: cluster
-                  patch: '{"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red
-                    Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}'
-                  patchType: merge
+                  metadata:
+                    name: cluster
+                  spec:
+                    customization:
+                      brand: null
+                      customLogoFile:
+                        key: rosa-brand-logo.svg
+                        name: rosa-brand-logo
+                      customProductName: Red Hat OpenShift Service on AWS
+                      documentationBaseURL: https://docs.openshift.com/rosa/
+                    managementState: Managed
+                    route: null
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -30219,15 +30226,23 @@ objects:
         operator: In
         values:
         - rosa
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    applyBehavior: CreateOrUpdate
+    resources:
     - apiVersion: operator.openshift.io/v1
-      applyMode: AlwaysApply
       kind: Console
-      name: cluster
-      patchType: merge
-      patch: '{"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red
-        Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}'
+      metadata:
+        name: cluster
+      spec:
+        managementState: Managed
+        route: null
+        customization:
+          brand: null
+          documentationBaseURL: https://docs.openshift.com/rosa/
+          customProductName: Red Hat OpenShift Service on AWS
+          customLogoFile:
+            name: rosa-brand-logo
+            key: rosa-brand-logo.svg
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5635,12 +5635,19 @@ objects:
               - complianceType: musthave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
-                  applyMode: AlwaysApply
                   kind: Console
-                  name: cluster
-                  patch: '{"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red
-                    Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}'
-                  patchType: merge
+                  metadata:
+                    name: cluster
+                  spec:
+                    customization:
+                      brand: null
+                      customLogoFile:
+                        key: rosa-brand-logo.svg
+                        name: rosa-brand-logo
+                      customProductName: Red Hat OpenShift Service on AWS
+                      documentationBaseURL: https://docs.openshift.com/rosa/
+                    managementState: Managed
+                    route: null
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -30219,15 +30226,23 @@ objects:
         operator: In
         values:
         - rosa
-    resourceApplyMode: Sync
-    patches:
+    resourceApplyMode: Upsert
+    applyBehavior: CreateOrUpdate
+    resources:
     - apiVersion: operator.openshift.io/v1
-      applyMode: AlwaysApply
       kind: Console
-      name: cluster
-      patchType: merge
-      patch: '{"spec":{"managementState":"Managed","route":null,"customization":{"brand":null,"documentationBaseURL":"https://docs.openshift.com/rosa/","customProductName":"Red
-        Hat OpenShift Service on AWS","customLogoFile":{"name":"rosa-brand-logo","key":"rosa-brand-logo.svg"}}}}'
+      metadata:
+        name: cluster
+      spec:
+        managementState: Managed
+        route: null
+        customization:
+          brand: null
+          documentationBaseURL: https://docs.openshift.com/rosa/
+          customProductName: Red Hat OpenShift Service on AWS
+          customLogoFile:
+            name: rosa-brand-logo
+            key: rosa-brand-logo.svg
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Bug
### What this PR does / why we need it?
Switching from 'patch' to 'CreateOrUpdate' the SSS for rosa-branding in order to allow using the same resource for standard cluster and the policy used for Hosted clusters

### Which Jira/Github issue(s) this PR fixes?
[OSD-13913](https://issues.redhat.com//browse/OSD-13913)

### Special notes for your reviewer:
Tested the new SSS on staging for the console - validated existing values don't get overriden/regenerate upon application
Similar change has been implemented and validated for oauth in https://github.com/openshift/managed-cluster-config/pull/1476 

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
