### PR TITLE
OSD-15165 extend acm policy generator / OSD-12884 monitor hosted APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ To add a new SelectorSyncSet, add your yaml manifest to the `deploy` dir, then r
 Alternatively you can enable GitHub Actions on your fork and `make` will be ran automatically. Additionally,
 the action will create a new commit with the generated files.
 
-To add a Policy
-- If the manifest of the object you want to convert to policy already exists in `deploy` : go to `script/generate-policy-template.py` and add the directory you want to convert in the directory array. 
-- If the manifest of the object does not exist; add your manifests; then add the directory of your manifest into the array in `script/generate-policy-template.py`. 
-- If the manifest is SubjectPermission, add the directory of the manifest into the array in `script/generate-subjectpermissions-policy-template.py` then run `make` as usually
+To add an ACM (Governance) Policy
+- If the manifest of the object you want to convert to policy already exists in `deploy` : go to `script/generate-policy-config.py` and add the directory you want to convert in the directory array.
+- If the manifest of the object does not exist; add your manifests; then add the directory of your manifest into the array in `script/generate-policy-config.py`.
+- If the manifest is SubjectPermission, add the directory of the manifest into the array in `script/generate-subjectpermissions-policy-template.py` then run `make` as usual
 
 `make` will look for the `policy-generator-config.yaml` files, runs it with the PolicyGenerator binary and save the output to `deploy/acm-policies` directory. `make` will then automatically
 add the policy as a new SelectorySyncSet.

--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-api.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-api.Policy.yaml
@@ -29,10 +29,6 @@ spec:
                         apiVersion: monitoring.openshift.io/v1alpha1
                         kind: ClusterUrlMonitor
                         metadata:
-                            finalizers:
-                                - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
-                            labels:
-                                hive.openshift.io/managed: "true"
                             name: api
                         spec:
                             port: "6443"

--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-api.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-api.Policy.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: hs-mgmt-route-monitor-api
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: hs-mgmt-route-monitor-api
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                namespaceSelector:
+                    include:
+                        - ocm-*-*-*
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: monitoring.openshift.io/v1alpha1
+                        kind: ClusterUrlMonitor
+                        metadata:
+                            finalizers:
+                                - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+                            labels:
+                                hive.openshift.io/managed: "true"
+                            name: api
+                        spec:
+                            port: "6443"
+                            prefix: https://api.
+                            slo:
+                                targetAvailabilityPercent: "99.0"
+                            suffix: /livez
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-hs-mgmt-route-monitor-api
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/management-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-hs-mgmt-route-monitor-api
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-hs-mgmt-route-monitor-api
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: hs-mgmt-route-monitor-api

--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-api.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-api.Policy.yaml
@@ -24,7 +24,8 @@ spec:
                     include:
                         - ocm-*-*-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: monitoring.openshift.io/v1alpha1
                         kind: ClusterUrlMonitor

--- a/deploy/hs-mgmt-route-monitor-api/api.ClusterUrlMonitor.yaml
+++ b/deploy/hs-mgmt-route-monitor-api/api.ClusterUrlMonitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: ClusterUrlMonitor
+metadata:
+  finalizers:
+  - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+  labels:
+    hive.openshift.io/managed: "true"
+  name: api
+spec:
+  port: "6443"
+  prefix: https://api.  
+  slo:
+    targetAvailabilityPercent: "99.0"
+  suffix: /livez

--- a/deploy/hs-mgmt-route-monitor-api/api.ClusterUrlMonitor.yaml
+++ b/deploy/hs-mgmt-route-monitor-api/api.ClusterUrlMonitor.yaml
@@ -2,14 +2,10 @@
 apiVersion: monitoring.openshift.io/v1alpha1
 kind: ClusterUrlMonitor
 metadata:
-  finalizers:
-  - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
-  labels:
-    hive.openshift.io/managed: "true"
   name: api
 spec:
   port: "6443"
-  prefix: https://api.  
+  prefix: https://api.
   slo:
     targetAvailabilityPercent: "99.0"
   suffix: /livez

--- a/deploy/hs-mgmt-route-monitor-api/config.yaml
+++ b/deploy/hs-mgmt-route-monitor-api/config.yaml
@@ -1,0 +1,5 @@
+deploymentMode: Policy
+clusterSelectors:
+  hypershift.open-cluster-management.io/management-cluster: true
+namespaceSelector:
+  include: ["ocm-*-*-*"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2843,6 +2843,75 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-mgmt-route-monitor-api
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              namespaceSelector:
+                include:
+                - ocm-*-*-*
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: ClusterUrlMonitor
+                  metadata:
+                    finalizers:
+                    - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+                    labels:
+                      hive.openshift.io/managed: 'true'
+                    name: api
+                  spec:
+                    port: '6443'
+                    prefix: https://api.
+                    slo:
+                      targetAvailabilityPercent: '99.0'
+                    suffix: /livez
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-mgmt-route-monitor-api
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-mgmt-route-monitor-api
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2861,7 +2861,8 @@ objects:
                 include:
                 - ocm-*-*-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: monitoring.openshift.io/v1alpha1
                   kind: ClusterUrlMonitor

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2866,10 +2866,6 @@ objects:
                   apiVersion: monitoring.openshift.io/v1alpha1
                   kind: ClusterUrlMonitor
                   metadata:
-                    finalizers:
-                    - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
-                    labels:
-                      hive.openshift.io/managed: 'true'
                     name: api
                   spec:
                     port: '6443'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2843,6 +2843,75 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-mgmt-route-monitor-api
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              namespaceSelector:
+                include:
+                - ocm-*-*-*
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: ClusterUrlMonitor
+                  metadata:
+                    finalizers:
+                    - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+                    labels:
+                      hive.openshift.io/managed: 'true'
+                    name: api
+                  spec:
+                    port: '6443'
+                    prefix: https://api.
+                    slo:
+                      targetAvailabilityPercent: '99.0'
+                    suffix: /livez
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-mgmt-route-monitor-api
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-mgmt-route-monitor-api
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2861,7 +2861,8 @@ objects:
                 include:
                 - ocm-*-*-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: monitoring.openshift.io/v1alpha1
                   kind: ClusterUrlMonitor

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2866,10 +2866,6 @@ objects:
                   apiVersion: monitoring.openshift.io/v1alpha1
                   kind: ClusterUrlMonitor
                   metadata:
-                    finalizers:
-                    - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
-                    labels:
-                      hive.openshift.io/managed: 'true'
                     name: api
                   spec:
                     port: '6443'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2843,6 +2843,75 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-mgmt-route-monitor-api
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              namespaceSelector:
+                include:
+                - ocm-*-*-*
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: ClusterUrlMonitor
+                  metadata:
+                    finalizers:
+                    - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
+                    labels:
+                      hive.openshift.io/managed: 'true'
+                    name: api
+                  spec:
+                    port: '6443'
+                    prefix: https://api.
+                    slo:
+                      targetAvailabilityPercent: '99.0'
+                    suffix: /livez
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-mgmt-route-monitor-api
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-mgmt-route-monitor-api
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-mgmt-route-monitor-api
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2861,7 +2861,8 @@ objects:
                 include:
                 - ocm-*-*-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: monitoring.openshift.io/v1alpha1
                   kind: ClusterUrlMonitor

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2866,10 +2866,6 @@ objects:
                   apiVersion: monitoring.openshift.io/v1alpha1
                   kind: ClusterUrlMonitor
                   metadata:
-                    finalizers:
-                    - clusterurlmonitor.routemonitoroperator.monitoring.openshift.io/finalizer
-                    labels:
-                      hive.openshift.io/managed: 'true'
                     name: api
                   spec:
                     port: '6443'

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -131,6 +131,10 @@ if __name__ == '__main__':
         if "deploymentMode" in config:
             deploymentMode = config["deploymentMode"]
 
+        # skip any directory only containing governance policies, as they are only for hypershift
+        if deploymentMode == "Policy":
+            continue
+
         if deploymentMode == "Direct":
             add_resources_for(dirpath, config["direct"])
 

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -6,7 +6,7 @@ policyDefaults:
     namespace: openshift-acm-policies
     placement:
         clusterSelectors:
-            hypershift.open-cluster-management.io/hosted-cluster: "true"
+          hypershift.open-cluster-management.io/hosted-cluster: "true" # Can be overridden by script
     remediationAction: enforce
     evaluationInterval:
         compliant: 2h
@@ -17,5 +17,4 @@ policyDefaults:
 policies:
     - name: #Filled by script
       manifests:
-          # NOTE to use a path, the target directory must NOT have a `config.yaml` else it is included in the policy
           - path: #Filled by script


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

The clusterurlmonitor deploys to the hosted control plane on management
clusters.

This also extends the policy generator tooling to support policies
targeting management clusters and specifying namespaces


### Which Jira/Github issue(s) this PR fixes?

Addresses both [OSD-15165](https://issues.redhat.com//browse/OSD-15165) and [OSD-12884](https://issues.redhat.com//browse/OSD-12884)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
