### PR TITLE
OSD-15177 switch to mustonlyhave complianceType by default

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -48,7 +48,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -85,7 +85,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -21,13 +21,13 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-cee
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -58,7 +58,7 @@ spec:
                                 - get
                                 - list
                                 - watch
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -72,7 +72,7 @@ spec:
                                 - pods/portforward
                               verbs:
                                 - create
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -88,7 +88,7 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-cee
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -109,7 +109,7 @@ spec:
                               verbs:
                                 - create
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -125,7 +125,7 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-cee
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -142,7 +142,7 @@ spec:
                               verbs:
                                 - create
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -58,7 +58,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -58,7 +58,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -48,7 +48,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -85,7 +85,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
@@ -21,13 +21,13 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-cssre
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -41,7 +41,7 @@ spec:
                         metadata:
                             name: backplane-cssre-admins-cluster
                         rules: []
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -55,7 +55,7 @@ spec:
                                 - pods/portforward
                               verbs:
                                 - create
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -71,7 +71,7 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-cssre
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -96,7 +96,7 @@ spec:
                                 - list
                                 - get
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -36,7 +36,7 @@ spec:
                                 - users
                               verbs:
                                 - impersonate
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -51,13 +51,13 @@ spec:
                               name: system:serviceaccounts:openshift-backplane-srep
                             - kind: Group
                               name: system:serviceaccounts:openshift-backplane-cssre
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: user.openshift.io/v1
                         kind: User
                         metadata:
                             name: backplane-cluster-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -58,7 +58,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -48,7 +48,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -85,7 +85,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -122,7 +122,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -21,13 +21,13 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-srep
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -159,7 +159,7 @@ spec:
                                 - list
                                 - watch
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -330,7 +330,7 @@ spec:
                                 - get
                                 - list
                                 - watch
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -351,7 +351,7 @@ spec:
                               verbs:
                                 - create
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -367,7 +367,7 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-srep
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -384,7 +384,7 @@ spec:
                               verbs:
                                 - create
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -58,7 +58,7 @@ spec:
                         - default
                         - redhat-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -24,7 +24,7 @@ spec:
                     include:
                         - openshift-customer-monitoring
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -54,7 +54,7 @@ spec:
                     include:
                         - openshift-customer-monitoring
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -40,7 +40,7 @@ spec:
                                 - watch
                                 - patch
                                 - update
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -62,7 +62,7 @@ spec:
                                 - configmaps
                               verbs:
                                 - '*'
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -78,7 +78,7 @@ spec:
                               name: dedicated-admins
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -21,13 +21,13 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-managed-scripts
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -41,7 +41,7 @@ spec:
                         metadata:
                             name: openshift-backplane-managed-scripts-reader
                         rules: []
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
@@ -21,20 +21,20 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-managed-scripts
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: ServiceAccount
                         metadata:
                             name: osd-backplane
                             namespace: openshift-backplane-managed-scripts
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -51,7 +51,7 @@ spec:
                                 - get
                                 - list
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -66,7 +66,7 @@ spec:
                             - kind: ServiceAccount
                               name: osd-backplane
                               namespace: openshift-backplane-managed-scripts
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -84,7 +84,7 @@ spec:
                                 - get
                                 - list
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -98,7 +98,7 @@ spec:
                             - kind: ServiceAccount
                               name: osd-backplane
                               namespace: openshift-backplane-managed-scripts
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: batch/v1
                         kind: CronJob

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -51,7 +51,7 @@ spec:
                     include:
                         - openshift-backplane-*
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
@@ -21,20 +21,20 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: ServiceAccount
                         metadata:
                             name: osd-delete-backplane-serviceaccounts
                             namespace: openshift-backplane
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -49,7 +49,7 @@ spec:
                                 - get
                                 - list
                                 - delete
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -63,7 +63,7 @@ spec:
                               verbs:
                                 - get
                                 - list
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: batch/v1
                         kind: CronJob

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -21,13 +21,13 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-operators-redhat
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -42,7 +42,7 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: dedicated-admins
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -57,7 +57,7 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -72,7 +72,7 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: dedicated-admins
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         allowHostNetwork: false
                         allowPrivilegedContainer: false
@@ -36,7 +36,7 @@ spec:
                             type: RunAsAny
                         seLinuxContext:
                             type: RunAsAny
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -51,7 +51,7 @@ spec:
                                 - securitycontextconstraints
                               verbs:
                                 - use
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -35,7 +35,7 @@ spec:
                                 - templates
                               verbs:
                                 - '*'
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -52,7 +52,7 @@ spec:
                               name: dedicated-admins
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         applyMode: AlwaysApply

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
@@ -32,7 +32,7 @@ spec:
                     include:
                         - '*'
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -38,7 +38,7 @@ spec:
                               name: dedicated-admins
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -52,7 +52,7 @@ spec:
                                 - configmaps
                               verbs:
                                 - '*'
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -69,7 +69,7 @@ spec:
                               name: dedicated-admins
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -89,7 +89,7 @@ spec:
                                 - watch
                                 - update
                                 - patch
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -58,7 +58,7 @@ spec:
                     include:
                         - '*'
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -95,7 +95,7 @@ spec:
                     include:
                         - '*'
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -122,7 +122,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -159,7 +159,7 @@ spec:
                     include:
                         - '*'
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -196,7 +196,7 @@ spec:
                     include:
                         - '*'
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -227,7 +227,7 @@ spec:
                         - openshift-operators
                         - openshift-operators-redhat
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -258,7 +258,7 @@ spec:
                         - openshift-operators
                         - openshift-operators-redhat
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -289,7 +289,7 @@ spec:
                         - openshift-operators
                         - openshift-operators-redhat
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -320,7 +320,7 @@ spec:
                         - openshift-operators
                         - openshift-operators-redhat
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
@@ -29,7 +29,7 @@ spec:
                             annotations:
                                 openshift.io/node-selector: ""
                             name: dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -73,7 +73,7 @@ spec:
                         metadata:
                             name: dedicated-admins-cluster
                         rules: []
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -108,7 +108,7 @@ spec:
                         metadata:
                             name: dedicated-admins-project
                         rules: []
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -398,7 +398,7 @@ spec:
                               verbs:
                                 - patch
                                 - update
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -565,7 +565,7 @@ spec:
                                 - leases
                               verbs:
                                 - '*'
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -586,7 +586,7 @@ spec:
                                 managed.openshift.io/aggregate-to-dedicated-admins: cluster
                             name: dedicated-readers
                         rules: []
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -881,7 +881,7 @@ spec:
                                 - get
                                 - list
                                 - watch
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -896,7 +896,7 @@ spec:
                               name: dedicated-admins
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -920,7 +920,7 @@ spec:
                                 - list
                                 - get
                                 - watch
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -937,7 +937,7 @@ spec:
                               name: dedicated-admins
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -951,7 +951,7 @@ spec:
                                 - catalogsources
                               verbs:
                                 - '*'
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -968,7 +968,7 @@ spec:
                               name: dedicated-admins
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -984,7 +984,7 @@ spec:
                                 - list
                                 - get
                                 - watch
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         data:

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: operator.openshift.io/v1
                         kind: Console

--- a/deploy/acm-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
@@ -21,7 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: config.openshift.io/v1
                         kind: OAuth

--- a/deploy/hypershift-validating-webhook-patching/10-validating-webhook-patching.Policy.yaml
+++ b/deploy/hypershift-validating-webhook-patching/10-validating-webhook-patching.Policy.yaml
@@ -24,13 +24,13 @@ spec:
                     matchLabels:
                         hypershift.openshift.io/hosted-control-plane: "true"
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: v1
                         kind: ServiceAccount
                         metadata:
                             name: validating-webhook-patching-sa
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -44,7 +44,7 @@ spec:
                                 - configmaps
                               verbs:
                                 - get
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -57,7 +57,7 @@ spec:
                         subjects:
                             - kind: ServiceAccount
                               name: validating-webhook-patching-sa
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
                       objectDefinition:
                         apiVersion: batch/v1
                         kind: CronJob

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -647,7 +647,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -674,7 +674,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -711,7 +711,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -775,13 +775,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -812,7 +812,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -826,7 +826,7 @@ objects:
                     - pods/portforward
                     verbs:
                     - create
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -842,7 +842,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -863,7 +863,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -879,7 +879,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -896,7 +896,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -962,7 +962,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -999,7 +999,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1063,7 +1063,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1119,7 +1119,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1156,7 +1156,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1220,7 +1220,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1276,7 +1276,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1303,7 +1303,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1340,7 +1340,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1404,13 +1404,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -1424,7 +1424,7 @@ objects:
                   metadata:
                     name: backplane-cssre-admins-cluster
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1438,7 +1438,7 @@ objects:
                     - pods/portforward
                     verbs:
                     - create
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1454,7 +1454,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1479,7 +1479,7 @@ objects:
                     - list
                     - get
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1545,7 +1545,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -1560,7 +1560,7 @@ objects:
                     - users
                     verbs:
                     - impersonate
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1575,13 +1575,13 @@ objects:
                     name: system:serviceaccounts:openshift-backplane-srep
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1644,7 +1644,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1681,7 +1681,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1745,7 +1745,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1801,7 +1801,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1828,7 +1828,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1865,7 +1865,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1902,7 +1902,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1966,13 +1966,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-srep
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2104,7 +2104,7 @@ objects:
                     - list
                     - watch
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2275,7 +2275,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2296,7 +2296,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2312,7 +2312,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2329,7 +2329,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2395,7 +2395,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2432,7 +2432,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2496,7 +2496,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -2552,7 +2552,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2625,7 +2625,7 @@ objects:
                 include:
                 - openshift-customer-monitoring
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2655,7 +2655,7 @@ objects:
                 include:
                 - openshift-customer-monitoring
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2719,7 +2719,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2784,7 +2784,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2803,7 +2803,7 @@ objects:
                     - watch
                     - patch
                     - update
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2825,7 +2825,7 @@ objects:
                     - configmaps
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2841,7 +2841,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2908,13 +2908,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2928,7 +2928,7 @@ objects:
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2991,7 +2991,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3055,20 +3055,20 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3085,7 +3085,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3100,7 +3100,7 @@ objects:
                   - kind: ServiceAccount
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3118,7 +3118,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3132,7 +3132,7 @@ objects:
                   - kind: ServiceAccount
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3276,7 +3276,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3306,7 +3306,7 @@ objects:
                 include:
                 - openshift-backplane-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3370,20 +3370,20 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: osd-delete-backplane-serviceaccounts
                     namespace: openshift-backplane
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3398,7 +3398,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3412,7 +3412,7 @@ objects:
                     verbs:
                     - get
                     - list
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3511,7 +3511,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -3572,13 +3572,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-operators-redhat
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3593,7 +3593,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: dedicated-admins
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3608,7 +3608,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3623,7 +3623,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: dedicated-admins
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3688,7 +3688,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   allowHostNetwork: false
                   allowPrivilegedContainer: false
@@ -3703,7 +3703,7 @@ objects:
                     type: RunAsAny
                   seLinuxContext:
                     type: RunAsAny
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3718,7 +3718,7 @@ objects:
                     - securitycontextconstraints
                     verbs:
                     - use
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3781,7 +3781,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3795,7 +3795,7 @@ objects:
                     - templates
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3812,7 +3812,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   applyMode: AlwaysApply
@@ -3881,7 +3881,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3945,7 +3945,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3962,7 +3962,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3976,7 +3976,7 @@ objects:
                     - configmaps
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3993,7 +3993,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -4013,7 +4013,7 @@ objects:
                     - watch
                     - update
                     - patch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4080,7 +4080,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4117,7 +4117,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4154,7 +4154,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4181,7 +4181,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4218,7 +4218,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4255,7 +4255,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4286,7 +4286,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4317,7 +4317,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4348,7 +4348,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4379,7 +4379,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4443,7 +4443,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -4451,7 +4451,7 @@ objects:
                     annotations:
                       openshift.io/node-selector: ''
                     name: dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4495,7 +4495,7 @@ objects:
                   metadata:
                     name: dedicated-admins-cluster
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4530,7 +4530,7 @@ objects:
                   metadata:
                     name: dedicated-admins-project
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4820,7 +4820,7 @@ objects:
                     verbs:
                     - patch
                     - update
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4987,7 +4987,7 @@ objects:
                     - leases
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -5008,7 +5008,7 @@ objects:
                       managed.openshift.io/aggregate-to-dedicated-admins: cluster
                     name: dedicated-readers
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -5303,7 +5303,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -5318,7 +5318,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5342,7 +5342,7 @@ objects:
                     - list
                     - get
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5359,7 +5359,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5373,7 +5373,7 @@ objects:
                     - catalogsources
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5390,7 +5390,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5406,7 +5406,7 @@ objects:
                     - list
                     - get
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5473,7 +5473,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   data:
@@ -5632,7 +5632,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
                   kind: Console
@@ -5698,7 +5698,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
                   kind: OAuth

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22481,13 +22481,13 @@ objects:
                 matchLabels:
                   hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: validating-webhook-patching-sa
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -22501,7 +22501,7 @@ objects:
                     - configmaps
                     verbs:
                     - get
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -22514,7 +22514,7 @@ objects:
                   subjects:
                   - kind: ServiceAccount
                     name: validating-webhook-patching-sa
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -647,7 +647,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -674,7 +674,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -711,7 +711,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -775,13 +775,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -812,7 +812,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -826,7 +826,7 @@ objects:
                     - pods/portforward
                     verbs:
                     - create
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -842,7 +842,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -863,7 +863,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -879,7 +879,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -896,7 +896,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -962,7 +962,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -999,7 +999,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1063,7 +1063,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1119,7 +1119,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1156,7 +1156,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1220,7 +1220,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1276,7 +1276,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1303,7 +1303,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1340,7 +1340,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1404,13 +1404,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -1424,7 +1424,7 @@ objects:
                   metadata:
                     name: backplane-cssre-admins-cluster
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1438,7 +1438,7 @@ objects:
                     - pods/portforward
                     verbs:
                     - create
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1454,7 +1454,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1479,7 +1479,7 @@ objects:
                     - list
                     - get
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1545,7 +1545,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -1560,7 +1560,7 @@ objects:
                     - users
                     verbs:
                     - impersonate
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1575,13 +1575,13 @@ objects:
                     name: system:serviceaccounts:openshift-backplane-srep
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1644,7 +1644,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1681,7 +1681,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1745,7 +1745,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1801,7 +1801,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1828,7 +1828,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1865,7 +1865,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1902,7 +1902,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1966,13 +1966,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-srep
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2104,7 +2104,7 @@ objects:
                     - list
                     - watch
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2275,7 +2275,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2296,7 +2296,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2312,7 +2312,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2329,7 +2329,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2395,7 +2395,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2432,7 +2432,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2496,7 +2496,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -2552,7 +2552,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2625,7 +2625,7 @@ objects:
                 include:
                 - openshift-customer-monitoring
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2655,7 +2655,7 @@ objects:
                 include:
                 - openshift-customer-monitoring
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2719,7 +2719,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2784,7 +2784,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2803,7 +2803,7 @@ objects:
                     - watch
                     - patch
                     - update
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2825,7 +2825,7 @@ objects:
                     - configmaps
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2841,7 +2841,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2908,13 +2908,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2928,7 +2928,7 @@ objects:
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2991,7 +2991,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3055,20 +3055,20 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3085,7 +3085,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3100,7 +3100,7 @@ objects:
                   - kind: ServiceAccount
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3118,7 +3118,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3132,7 +3132,7 @@ objects:
                   - kind: ServiceAccount
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3276,7 +3276,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3306,7 +3306,7 @@ objects:
                 include:
                 - openshift-backplane-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3370,20 +3370,20 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: osd-delete-backplane-serviceaccounts
                     namespace: openshift-backplane
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3398,7 +3398,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3412,7 +3412,7 @@ objects:
                     verbs:
                     - get
                     - list
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3511,7 +3511,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -3572,13 +3572,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-operators-redhat
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3593,7 +3593,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: dedicated-admins
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3608,7 +3608,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3623,7 +3623,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: dedicated-admins
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3688,7 +3688,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   allowHostNetwork: false
                   allowPrivilegedContainer: false
@@ -3703,7 +3703,7 @@ objects:
                     type: RunAsAny
                   seLinuxContext:
                     type: RunAsAny
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3718,7 +3718,7 @@ objects:
                     - securitycontextconstraints
                     verbs:
                     - use
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3781,7 +3781,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3795,7 +3795,7 @@ objects:
                     - templates
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3812,7 +3812,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   applyMode: AlwaysApply
@@ -3881,7 +3881,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3945,7 +3945,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3962,7 +3962,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3976,7 +3976,7 @@ objects:
                     - configmaps
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3993,7 +3993,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -4013,7 +4013,7 @@ objects:
                     - watch
                     - update
                     - patch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4080,7 +4080,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4117,7 +4117,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4154,7 +4154,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4181,7 +4181,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4218,7 +4218,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4255,7 +4255,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4286,7 +4286,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4317,7 +4317,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4348,7 +4348,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4379,7 +4379,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4443,7 +4443,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -4451,7 +4451,7 @@ objects:
                     annotations:
                       openshift.io/node-selector: ''
                     name: dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4495,7 +4495,7 @@ objects:
                   metadata:
                     name: dedicated-admins-cluster
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4530,7 +4530,7 @@ objects:
                   metadata:
                     name: dedicated-admins-project
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4820,7 +4820,7 @@ objects:
                     verbs:
                     - patch
                     - update
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4987,7 +4987,7 @@ objects:
                     - leases
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -5008,7 +5008,7 @@ objects:
                       managed.openshift.io/aggregate-to-dedicated-admins: cluster
                     name: dedicated-readers
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -5303,7 +5303,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -5318,7 +5318,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5342,7 +5342,7 @@ objects:
                     - list
                     - get
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5359,7 +5359,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5373,7 +5373,7 @@ objects:
                     - catalogsources
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5390,7 +5390,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5406,7 +5406,7 @@ objects:
                     - list
                     - get
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5473,7 +5473,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   data:
@@ -5632,7 +5632,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
                   kind: Console
@@ -5698,7 +5698,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
                   kind: OAuth

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22481,13 +22481,13 @@ objects:
                 matchLabels:
                   hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: validating-webhook-patching-sa
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -22501,7 +22501,7 @@ objects:
                     - configmaps
                     verbs:
                     - get
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -22514,7 +22514,7 @@ objects:
                   subjects:
                   - kind: ServiceAccount
                     name: validating-webhook-patching-sa
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -647,7 +647,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -674,7 +674,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -711,7 +711,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -775,13 +775,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -812,7 +812,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -826,7 +826,7 @@ objects:
                     - pods/portforward
                     verbs:
                     - create
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -842,7 +842,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -863,7 +863,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -879,7 +879,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -896,7 +896,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -962,7 +962,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -999,7 +999,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1063,7 +1063,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1119,7 +1119,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1156,7 +1156,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1220,7 +1220,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1276,7 +1276,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1303,7 +1303,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1340,7 +1340,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1404,13 +1404,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -1424,7 +1424,7 @@ objects:
                   metadata:
                     name: backplane-cssre-admins-cluster
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1438,7 +1438,7 @@ objects:
                     - pods/portforward
                     verbs:
                     - create
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1454,7 +1454,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1479,7 +1479,7 @@ objects:
                     - list
                     - get
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1545,7 +1545,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -1560,7 +1560,7 @@ objects:
                     - users
                     verbs:
                     - impersonate
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1575,13 +1575,13 @@ objects:
                     name: system:serviceaccounts:openshift-backplane-srep
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1644,7 +1644,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1681,7 +1681,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1745,7 +1745,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1801,7 +1801,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1828,7 +1828,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1865,7 +1865,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1902,7 +1902,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1966,13 +1966,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-srep
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2104,7 +2104,7 @@ objects:
                     - list
                     - watch
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2275,7 +2275,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2296,7 +2296,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2312,7 +2312,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2329,7 +2329,7 @@ objects:
                     verbs:
                     - create
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2395,7 +2395,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2432,7 +2432,7 @@ objects:
                 - default
                 - redhat-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2496,7 +2496,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -2552,7 +2552,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2625,7 +2625,7 @@ objects:
                 include:
                 - openshift-customer-monitoring
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2655,7 +2655,7 @@ objects:
                 include:
                 - openshift-customer-monitoring
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2719,7 +2719,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2784,7 +2784,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2803,7 +2803,7 @@ objects:
                     - watch
                     - patch
                     - update
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2825,7 +2825,7 @@ objects:
                     - configmaps
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2841,7 +2841,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2908,13 +2908,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2928,7 +2928,7 @@ objects:
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2991,7 +2991,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3055,20 +3055,20 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3085,7 +3085,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3100,7 +3100,7 @@ objects:
                   - kind: ServiceAccount
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3118,7 +3118,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3132,7 +3132,7 @@ objects:
                   - kind: ServiceAccount
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3276,7 +3276,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3306,7 +3306,7 @@ objects:
                 include:
                 - openshift-backplane-*
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3370,20 +3370,20 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: osd-delete-backplane-serviceaccounts
                     namespace: openshift-backplane
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3398,7 +3398,7 @@ objects:
                     - get
                     - list
                     - delete
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3412,7 +3412,7 @@ objects:
                     verbs:
                     - get
                     - list
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3511,7 +3511,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -3572,13 +3572,13 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-operators-redhat
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3593,7 +3593,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: dedicated-admins
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3608,7 +3608,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3623,7 +3623,7 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: dedicated-admins
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3688,7 +3688,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   allowHostNetwork: false
                   allowPrivilegedContainer: false
@@ -3703,7 +3703,7 @@ objects:
                     type: RunAsAny
                   seLinuxContext:
                     type: RunAsAny
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3718,7 +3718,7 @@ objects:
                     - securitycontextconstraints
                     verbs:
                     - use
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3781,7 +3781,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3795,7 +3795,7 @@ objects:
                     - templates
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3812,7 +3812,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   applyMode: AlwaysApply
@@ -3881,7 +3881,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3945,7 +3945,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3962,7 +3962,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3976,7 +3976,7 @@ objects:
                     - configmaps
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3993,7 +3993,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -4013,7 +4013,7 @@ objects:
                     - watch
                     - update
                     - patch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4080,7 +4080,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4117,7 +4117,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4154,7 +4154,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4181,7 +4181,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4218,7 +4218,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4255,7 +4255,7 @@ objects:
                 include:
                 - '*'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4286,7 +4286,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4317,7 +4317,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4348,7 +4348,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4379,7 +4379,7 @@ objects:
                 - openshift-operators
                 - openshift-operators-redhat
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4443,7 +4443,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -4451,7 +4451,7 @@ objects:
                     annotations:
                       openshift.io/node-selector: ''
                     name: dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4495,7 +4495,7 @@ objects:
                   metadata:
                     name: dedicated-admins-cluster
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4530,7 +4530,7 @@ objects:
                   metadata:
                     name: dedicated-admins-project
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4820,7 +4820,7 @@ objects:
                     verbs:
                     - patch
                     - update
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4987,7 +4987,7 @@ objects:
                     - leases
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -5008,7 +5008,7 @@ objects:
                       managed.openshift.io/aggregate-to-dedicated-admins: cluster
                     name: dedicated-readers
                   rules: []
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -5303,7 +5303,7 @@ objects:
                     - get
                     - list
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -5318,7 +5318,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5342,7 +5342,7 @@ objects:
                     - list
                     - get
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5359,7 +5359,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5373,7 +5373,7 @@ objects:
                     - catalogsources
                     verbs:
                     - '*'
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5390,7 +5390,7 @@ objects:
                     name: dedicated-admins
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5406,7 +5406,7 @@ objects:
                     - list
                     - get
                     - watch
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5473,7 +5473,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   data:
@@ -5632,7 +5632,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
                   kind: Console
@@ -5698,7 +5698,7 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
                   kind: OAuth

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22481,13 +22481,13 @@ objects:
                 matchLabels:
                   hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: validating-webhook-patching-sa
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -22501,7 +22501,7 @@ objects:
                     - configmaps
                     verbs:
                     - get
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -22514,7 +22514,7 @@ objects:
                   subjects:
                   - kind: ServiceAccount
                     name: validating-webhook-patching-sa
-              - complianceType: musthave
+              - complianceType: mustonlyhave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -12,6 +12,7 @@ policyDefaults:
         compliant: 2h
         noncompliant: 45s
     pruneObjectBehavior: "DeleteIfCreated"
+    complianceType: "mustonlyhave"
 policies:
     - name: #Filled by script
       manifests:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Switch to a `mustonlyhave` policy compliance type by default.

Using `musthave` policy type can result in lingering data being left in target resources if those resources are changed over time in the Policy. For RBAC, this can lead to leftover permissions left in Roles/ClusterRoles that are no longer present in the policy itself.

### Which Jira/Github issue(s) this PR fixes?

[OSD-15177](https://issues.redhat.com//browse/OSD-15177)

