### PR TITLE
OSD-14754 probe_success recording rules should more accurately match routes

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
@@ -10,9 +10,9 @@ spec:
   groups:
     - name: sre-slo.rules
       rules:
-        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"}, "sre", "true", "", "")
+        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"}, "sre", "true", "", "")
           record: sre:slo:probe_success_api
-        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"}, "sre", "true", "", "")
+        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"}, "sre", "true", "", "")
           record: sre:slo:probe_success_console
         - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total), "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version) sre:telemetry:managed_labels
           record: sre:slo:imageregistry_http_requests_total

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32889,10 +32889,10 @@ objects:
         groups:
         - name: sre-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"},
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_api
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_console
           - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32889,10 +32889,10 @@ objects:
         groups:
         - name: sre-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"},
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_api
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_console
           - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32889,10 +32889,10 @@ objects:
         groups:
         - name: sre-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+api.+"},
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_api
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~".+console.+"},
+          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"},
               "sre", "true", "", "")
             record: sre:slo:probe_success_console
           - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?

The `probe_success_api` and `probe_success_console` recording rules are problematic in that if a cluster has the word `api` or `console` in its name, it's going to result in duplicate series on the RHS of the expression, which in turn results in `PrometheusRuleFailure` alerts being thrown and no SLO being reported for that cluster.

This makes the regex match of the `probe_success` metric a bit tighter to prevent that from happening.

### Which Jira/Github issue(s) this PR fixes?

[OSD-14754](https://issues.redhat.com//browse/OSD-14754)

