### PR TITLE
OSD-15189 - Fix ComplianceType for console and oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,17 @@ direct:
 
 ## SelectorSyncSet Deployment
 
-In the `config.yaml` file you define a top level property `selectorSyncSet`.  Within this configuration is supported for `matchLabels`, `matchExpressions`, `matchLabelsApplyMode`, `resourceApplyMode`, and `applyBehavior`.
+In the `config.yaml` file you define a top level property `selectorSyncSet`.  Within this configuration is supported for `matchLabels`, `matchExpressions`, `matchLabelsApplyMode`, `resourceApplyMode` and `applyBehavior`.
 
 * `matchLabels` (optional, default: `{}`) - adds additional `matchLabels` conditions to the SelectorSyncSet's `clusterDeploymentSelector`
 * `matchExpressions` (optional, default: `[]`) - adds `matchExpressions` conditions to the SelectoSyncSet's `clusterDeploymentSelector`
 * `resourceApplyMode` (optional, default: `"Sync"`) - sets the SelectorSyncSet's `resourceApplyMode`
 * `matchLabelsApplyMode` (optional, default: `"AND"`) - When set as `"OR"` generates a separate SSS per `matchLabels` conditions. Default behavior creates a single SSS with all `matchLabels` conditions.  This is to tackle a situation where we want to apply configuration for one of many label conditions.
 * `applyBehavior` (optional, default: None, [see hive default](https://github.com/openshift/hive/blob/master/config/crds/hive.openshift.io_selectorsyncsets.yaml)) - sets the SelectorSyncSet's `applyBehavior`
+
+You can also define a top level property `policy` to specify the behaviour of `./scripts/generate-policy-config.py` for the resource. Supported sub-properties : 
+* `complianceType` (optional, default: `"mustonlyhave"`, [see operator values](https://github.com/open-cluster-management-io/config-policy-controller/blob/main/api/v1/configurationpolicy_types.go) - select the compliance type for the policy when used by `./scripts/generate-policy-config.py`)
+* `metadataComplianceType` (optional, default: `"musthave"`, [see operator values](https://github.com/open-cluster-management-io/config-policy-controller/blob/main/api/v1/configurationpolicy_types.go) - select the compliance type for metadata for the policy when used by `./scripts/generate-policy-config.py`)
 
 Example to apply a directory for any of a set of label conditions using Upsert:
 ```yaml
@@ -78,6 +82,9 @@ selectorSyncSet:
         someOtherLabel: "something else"
     resourceApplyMode: "Upsert"
     matchLabelsApplyMode: "OR"
+policy:
+    complianceType: "mustonlyhave"
+    metadataComplianceType: "musthave"
 ```
 
 # Selector Sync Sets included in this repo

--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -49,6 +50,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -86,6 +88,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -22,12 +22,14 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-cee
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -59,6 +61,7 @@ spec:
                                 - list
                                 - watch
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -73,6 +76,7 @@ spec:
                               verbs:
                                 - create
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -89,6 +93,7 @@ spec:
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-cee
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -110,6 +115,7 @@ spec:
                                 - create
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -126,6 +132,7 @@ spec:
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-cee
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -143,6 +150,7 @@ spec:
                                 - create
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -59,6 +60,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -59,6 +60,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -49,6 +50,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -86,6 +88,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
@@ -22,12 +22,14 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-cssre
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -42,6 +44,7 @@ spec:
                             name: backplane-cssre-admins-cluster
                         rules: []
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -56,6 +59,7 @@ spec:
                               verbs:
                                 - create
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -72,6 +76,7 @@ spec:
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-cssre
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -97,6 +102,7 @@ spec:
                                 - get
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -37,6 +38,7 @@ spec:
                               verbs:
                                 - impersonate
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -52,12 +54,14 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:openshift-backplane-cssre
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: user.openshift.io/v1
                         kind: User
                         metadata:
                             name: backplane-cluster-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -59,6 +60,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -49,6 +50,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -86,6 +88,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -123,6 +126,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -22,12 +22,14 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-srep
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -160,6 +162,7 @@ spec:
                                 - watch
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -331,6 +334,7 @@ spec:
                                 - list
                                 - watch
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -352,6 +356,7 @@ spec:
                                 - create
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -368,6 +373,7 @@ spec:
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-srep
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -385,6 +391,7 @@ spec:
                                 - create
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -59,6 +60,7 @@ spec:
                         - redhat-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -25,6 +25,7 @@ spec:
                         - openshift-customer-monitoring
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -55,6 +56,7 @@ spec:
                         - openshift-customer-monitoring
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -41,6 +42,7 @@ spec:
                                 - patch
                                 - update
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -63,6 +65,7 @@ spec:
                               verbs:
                                 - '*'
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -79,6 +82,7 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -22,12 +22,14 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-managed-scripts
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -42,6 +44,7 @@ spec:
                             name: openshift-backplane-managed-scripts-reader
                         rules: []
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
@@ -22,12 +22,14 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane-managed-scripts
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: ServiceAccount
@@ -35,6 +37,7 @@ spec:
                             name: osd-backplane
                             namespace: openshift-backplane-managed-scripts
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -52,6 +55,7 @@ spec:
                                 - list
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -67,6 +71,7 @@ spec:
                               name: osd-backplane
                               namespace: openshift-backplane-managed-scripts
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -85,6 +90,7 @@ spec:
                                 - list
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -99,6 +105,7 @@ spec:
                               name: osd-backplane
                               namespace: openshift-backplane-managed-scripts
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: batch/v1
                         kind: CronJob

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -52,6 +53,7 @@ spec:
                         - openshift-backplane-*
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
@@ -22,12 +22,14 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-backplane
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: ServiceAccount
@@ -35,6 +37,7 @@ spec:
                             name: osd-delete-backplane-serviceaccounts
                             namespace: openshift-backplane
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -50,6 +53,7 @@ spec:
                                 - list
                                 - delete
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -64,6 +68,7 @@ spec:
                                 - get
                                 - list
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: batch/v1
                         kind: CronJob

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -22,12 +22,14 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
                         metadata:
                             name: openshift-operators-redhat
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -43,6 +45,7 @@ spec:
                               kind: Group
                               name: dedicated-admins
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -58,6 +61,7 @@ spec:
                               kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -73,6 +77,7 @@ spec:
                               kind: Group
                               name: dedicated-admins
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         allowHostNetwork: false
                         allowPrivilegedContainer: false
@@ -37,6 +38,7 @@ spec:
                         seLinuxContext:
                             type: RunAsAny
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -52,6 +54,7 @@ spec:
                               verbs:
                                 - use
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -36,6 +37,7 @@ spec:
                               verbs:
                                 - '*'
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -53,6 +55,7 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         applyMode: AlwaysApply

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
@@ -33,6 +33,7 @@ spec:
                         - '*'
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -39,6 +40,7 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -53,6 +55,7 @@ spec:
                               verbs:
                                 - '*'
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -70,6 +73,7 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -90,6 +94,7 @@ spec:
                                 - update
                                 - patch
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -59,6 +60,7 @@ spec:
                         - '*'
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -96,6 +98,7 @@ spec:
                         - '*'
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -123,6 +126,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -160,6 +164,7 @@ spec:
                         - '*'
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -197,6 +202,7 @@ spec:
                         - '*'
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -228,6 +234,7 @@ spec:
                         - openshift-operators-redhat
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -259,6 +266,7 @@ spec:
                         - openshift-operators-redhat
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -290,6 +298,7 @@ spec:
                         - openshift-operators-redhat
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -321,6 +330,7 @@ spec:
                         - openshift-operators-redhat
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: Namespace
@@ -30,6 +31,7 @@ spec:
                                 openshift.io/node-selector: ""
                             name: dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -74,6 +76,7 @@ spec:
                             name: dedicated-admins-cluster
                         rules: []
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -109,6 +112,7 @@ spec:
                             name: dedicated-admins-project
                         rules: []
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -399,6 +403,7 @@ spec:
                                 - patch
                                 - update
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -566,6 +571,7 @@ spec:
                               verbs:
                                 - '*'
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         aggregationRule:
                             clusterRoleSelectors:
@@ -587,6 +593,7 @@ spec:
                             name: dedicated-readers
                         rules: []
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -882,6 +889,7 @@ spec:
                                 - list
                                 - watch
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
@@ -897,6 +905,7 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -921,6 +930,7 @@ spec:
                                 - get
                                 - watch
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -938,6 +948,7 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -952,6 +963,7 @@ spec:
                               verbs:
                                 - '*'
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -969,6 +981,7 @@ spec:
                             - kind: Group
                               name: system:serviceaccounts:dedicated-admin
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -985,6 +998,7 @@ spec:
                                 - get
                                 - watch
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
@@ -22,6 +22,7 @@ spec:
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         data:

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
@@ -21,7 +21,8 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: mustonlyhave
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: operator.openshift.io/v1
                         kind: Console

--- a/deploy/acm-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-oauth-templates.Policy.yaml
@@ -21,7 +21,8 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: mustonlyhave
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: config.openshift.io/v1
                         kind: OAuth

--- a/deploy/rosa-console-branding/config.yaml
+++ b/deploy/rosa-console-branding/config.yaml
@@ -7,3 +7,5 @@ selectorSyncSet:
   applyBehavior: "CreateOrUpdate"
   # use Upsert so if this configuration no longer applies it will not delete the resource in cluster . We should never delete console.
   resourceApplyMode: "Upsert"
+policy:
+  complianceType: "musthave"

--- a/deploy/rosa-oauth-templates/config.yaml
+++ b/deploy/rosa-oauth-templates/config.yaml
@@ -7,3 +7,5 @@ selectorSyncSet:
   applyBehavior: "CreateOrUpdate"
   # use Upsert so if this configuration no longer applies it will not delete the OAuth resource in cluster which is a singleton.  We should never delete OAuth.
   resourceApplyMode: "Upsert"
+policy:
+  complianceType: "musthave"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -648,6 +648,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -675,6 +676,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -712,6 +714,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -776,12 +779,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -813,6 +818,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -827,6 +833,7 @@ objects:
                     verbs:
                     - create
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -843,6 +850,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -864,6 +872,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -880,6 +889,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -897,6 +907,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -963,6 +974,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1000,6 +1012,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1064,6 +1077,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1120,6 +1134,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1157,6 +1172,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1221,6 +1237,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1277,6 +1294,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1304,6 +1322,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1341,6 +1360,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1405,12 +1425,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -1425,6 +1447,7 @@ objects:
                     name: backplane-cssre-admins-cluster
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1439,6 +1462,7 @@ objects:
                     verbs:
                     - create
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1455,6 +1479,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1480,6 +1505,7 @@ objects:
                     - get
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1546,6 +1572,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -1561,6 +1588,7 @@ objects:
                     verbs:
                     - impersonate
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1576,12 +1604,14 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1645,6 +1675,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1682,6 +1713,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1746,6 +1778,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1802,6 +1835,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1829,6 +1863,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1866,6 +1901,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1903,6 +1939,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1967,12 +2004,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-srep
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2105,6 +2144,7 @@ objects:
                     - watch
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2276,6 +2316,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2297,6 +2338,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2313,6 +2355,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2330,6 +2373,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2396,6 +2440,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2433,6 +2478,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2497,6 +2543,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -2553,6 +2600,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2626,6 +2674,7 @@ objects:
                 - openshift-customer-monitoring
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2656,6 +2705,7 @@ objects:
                 - openshift-customer-monitoring
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2720,6 +2770,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2785,6 +2836,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2804,6 +2856,7 @@ objects:
                     - patch
                     - update
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2826,6 +2879,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2842,6 +2896,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2909,12 +2964,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2929,6 +2986,7 @@ objects:
                     name: openshift-backplane-managed-scripts-reader
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2992,6 +3050,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3056,12 +3115,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
@@ -3069,6 +3130,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3086,6 +3148,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3101,6 +3164,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3119,6 +3183,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3133,6 +3198,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3277,6 +3343,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3307,6 +3374,7 @@ objects:
                 - openshift-backplane-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3371,12 +3439,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
@@ -3384,6 +3454,7 @@ objects:
                     name: osd-delete-backplane-serviceaccounts
                     namespace: openshift-backplane
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3399,6 +3470,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3413,6 +3485,7 @@ objects:
                     - get
                     - list
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3512,6 +3585,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -3573,12 +3647,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-operators-redhat
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3594,6 +3670,7 @@ objects:
                     kind: Group
                     name: dedicated-admins
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3609,6 +3686,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3624,6 +3702,7 @@ objects:
                     kind: Group
                     name: dedicated-admins
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3689,6 +3768,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   allowHostNetwork: false
                   allowPrivilegedContainer: false
@@ -3704,6 +3784,7 @@ objects:
                   seLinuxContext:
                     type: RunAsAny
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3719,6 +3800,7 @@ objects:
                     verbs:
                     - use
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3782,6 +3864,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3796,6 +3879,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3813,6 +3897,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   applyMode: AlwaysApply
@@ -3882,6 +3967,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3946,6 +4032,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3963,6 +4050,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3977,6 +4065,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3994,6 +4083,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -4014,6 +4104,7 @@ objects:
                     - update
                     - patch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4081,6 +4172,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4118,6 +4210,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4155,6 +4248,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4182,6 +4276,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4219,6 +4314,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4256,6 +4352,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4287,6 +4384,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4318,6 +4416,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4349,6 +4448,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4380,6 +4480,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4444,6 +4545,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -4452,6 +4554,7 @@ objects:
                       openshift.io/node-selector: ''
                     name: dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4496,6 +4599,7 @@ objects:
                     name: dedicated-admins-cluster
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4531,6 +4635,7 @@ objects:
                     name: dedicated-admins-project
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4821,6 +4926,7 @@ objects:
                     - patch
                     - update
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4988,6 +5094,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -5009,6 +5116,7 @@ objects:
                     name: dedicated-readers
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -5304,6 +5412,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -5319,6 +5428,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5343,6 +5453,7 @@ objects:
                     - get
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5360,6 +5471,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5374,6 +5486,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5391,6 +5504,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5407,6 +5521,7 @@ objects:
                     - get
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5474,6 +5589,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   data:
@@ -5632,7 +5748,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
                   kind: Console
@@ -5698,7 +5815,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
                   kind: OAuth

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -648,6 +648,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -675,6 +676,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -712,6 +714,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -776,12 +779,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -813,6 +818,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -827,6 +833,7 @@ objects:
                     verbs:
                     - create
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -843,6 +850,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -864,6 +872,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -880,6 +889,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -897,6 +907,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -963,6 +974,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1000,6 +1012,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1064,6 +1077,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1120,6 +1134,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1157,6 +1172,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1221,6 +1237,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1277,6 +1294,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1304,6 +1322,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1341,6 +1360,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1405,12 +1425,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -1425,6 +1447,7 @@ objects:
                     name: backplane-cssre-admins-cluster
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1439,6 +1462,7 @@ objects:
                     verbs:
                     - create
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1455,6 +1479,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1480,6 +1505,7 @@ objects:
                     - get
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1546,6 +1572,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -1561,6 +1588,7 @@ objects:
                     verbs:
                     - impersonate
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1576,12 +1604,14 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1645,6 +1675,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1682,6 +1713,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1746,6 +1778,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1802,6 +1835,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1829,6 +1863,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1866,6 +1901,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1903,6 +1939,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1967,12 +2004,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-srep
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2105,6 +2144,7 @@ objects:
                     - watch
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2276,6 +2316,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2297,6 +2338,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2313,6 +2355,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2330,6 +2373,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2396,6 +2440,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2433,6 +2478,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2497,6 +2543,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -2553,6 +2600,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2626,6 +2674,7 @@ objects:
                 - openshift-customer-monitoring
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2656,6 +2705,7 @@ objects:
                 - openshift-customer-monitoring
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2720,6 +2770,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2785,6 +2836,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2804,6 +2856,7 @@ objects:
                     - patch
                     - update
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2826,6 +2879,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2842,6 +2896,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2909,12 +2964,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2929,6 +2986,7 @@ objects:
                     name: openshift-backplane-managed-scripts-reader
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2992,6 +3050,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3056,12 +3115,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
@@ -3069,6 +3130,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3086,6 +3148,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3101,6 +3164,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3119,6 +3183,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3133,6 +3198,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3277,6 +3343,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3307,6 +3374,7 @@ objects:
                 - openshift-backplane-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3371,12 +3439,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
@@ -3384,6 +3454,7 @@ objects:
                     name: osd-delete-backplane-serviceaccounts
                     namespace: openshift-backplane
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3399,6 +3470,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3413,6 +3485,7 @@ objects:
                     - get
                     - list
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3512,6 +3585,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -3573,12 +3647,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-operators-redhat
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3594,6 +3670,7 @@ objects:
                     kind: Group
                     name: dedicated-admins
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3609,6 +3686,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3624,6 +3702,7 @@ objects:
                     kind: Group
                     name: dedicated-admins
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3689,6 +3768,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   allowHostNetwork: false
                   allowPrivilegedContainer: false
@@ -3704,6 +3784,7 @@ objects:
                   seLinuxContext:
                     type: RunAsAny
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3719,6 +3800,7 @@ objects:
                     verbs:
                     - use
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3782,6 +3864,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3796,6 +3879,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3813,6 +3897,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   applyMode: AlwaysApply
@@ -3882,6 +3967,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3946,6 +4032,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3963,6 +4050,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3977,6 +4065,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3994,6 +4083,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -4014,6 +4104,7 @@ objects:
                     - update
                     - patch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4081,6 +4172,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4118,6 +4210,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4155,6 +4248,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4182,6 +4276,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4219,6 +4314,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4256,6 +4352,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4287,6 +4384,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4318,6 +4416,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4349,6 +4448,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4380,6 +4480,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4444,6 +4545,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -4452,6 +4554,7 @@ objects:
                       openshift.io/node-selector: ''
                     name: dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4496,6 +4599,7 @@ objects:
                     name: dedicated-admins-cluster
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4531,6 +4635,7 @@ objects:
                     name: dedicated-admins-project
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4821,6 +4926,7 @@ objects:
                     - patch
                     - update
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4988,6 +5094,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -5009,6 +5116,7 @@ objects:
                     name: dedicated-readers
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -5304,6 +5412,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -5319,6 +5428,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5343,6 +5453,7 @@ objects:
                     - get
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5360,6 +5471,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5374,6 +5486,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5391,6 +5504,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5407,6 +5521,7 @@ objects:
                     - get
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5474,6 +5589,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   data:
@@ -5632,7 +5748,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
                   kind: Console
@@ -5698,7 +5815,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
                   kind: OAuth

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -648,6 +648,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -675,6 +676,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -712,6 +714,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -776,12 +779,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -813,6 +818,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -827,6 +833,7 @@ objects:
                     verbs:
                     - create
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -843,6 +850,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -864,6 +872,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -880,6 +889,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cee
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -897,6 +907,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -963,6 +974,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1000,6 +1012,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1064,6 +1077,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1120,6 +1134,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1157,6 +1172,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1221,6 +1237,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1277,6 +1294,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1304,6 +1322,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1341,6 +1360,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1405,12 +1425,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -1425,6 +1447,7 @@ objects:
                     name: backplane-cssre-admins-cluster
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1439,6 +1462,7 @@ objects:
                     verbs:
                     - create
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1455,6 +1479,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -1480,6 +1505,7 @@ objects:
                     - get
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1546,6 +1572,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -1561,6 +1588,7 @@ objects:
                     verbs:
                     - impersonate
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1576,12 +1604,14 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1645,6 +1675,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1682,6 +1713,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1746,6 +1778,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -1802,6 +1835,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1829,6 +1863,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -1866,6 +1901,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1903,6 +1939,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -1967,12 +2004,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-srep
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2105,6 +2144,7 @@ objects:
                     - watch
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2276,6 +2316,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2297,6 +2338,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2313,6 +2355,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2330,6 +2373,7 @@ objects:
                     - create
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2396,6 +2440,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2433,6 +2478,7 @@ objects:
                 - redhat-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2497,6 +2543,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -2553,6 +2600,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2626,6 +2674,7 @@ objects:
                 - openshift-customer-monitoring
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2656,6 +2705,7 @@ objects:
                 - openshift-customer-monitoring
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2720,6 +2770,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2785,6 +2836,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -2804,6 +2856,7 @@ objects:
                     - patch
                     - update
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -2826,6 +2879,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2842,6 +2896,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -2909,12 +2964,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -2929,6 +2986,7 @@ objects:
                     name: openshift-backplane-managed-scripts-reader
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -2992,6 +3050,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3056,12 +3115,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
@@ -3069,6 +3130,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3086,6 +3148,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3101,6 +3164,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3119,6 +3183,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3133,6 +3198,7 @@ objects:
                     name: osd-backplane
                     namespace: openshift-backplane-managed-scripts
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3277,6 +3343,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3307,6 +3374,7 @@ objects:
                 - openshift-backplane-*
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3371,12 +3439,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-backplane
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
@@ -3384,6 +3454,7 @@ objects:
                     name: osd-delete-backplane-serviceaccounts
                     namespace: openshift-backplane
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3399,6 +3470,7 @@ objects:
                     - list
                     - delete
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3413,6 +3485,7 @@ objects:
                     - get
                     - list
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob
@@ -3512,6 +3585,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -3573,12 +3647,14 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
                   metadata:
                     name: openshift-operators-redhat
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3594,6 +3670,7 @@ objects:
                     kind: Group
                     name: dedicated-admins
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3609,6 +3686,7 @@ objects:
                     kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3624,6 +3702,7 @@ objects:
                     kind: Group
                     name: dedicated-admins
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3689,6 +3768,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   allowHostNetwork: false
                   allowPrivilegedContainer: false
@@ -3704,6 +3784,7 @@ objects:
                   seLinuxContext:
                     type: RunAsAny
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -3719,6 +3800,7 @@ objects:
                     verbs:
                     - use
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -3782,6 +3864,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3796,6 +3879,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3813,6 +3897,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   applyMode: AlwaysApply
@@ -3882,6 +3967,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3946,6 +4032,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3963,6 +4050,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -3977,6 +4065,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -3994,6 +4083,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -4014,6 +4104,7 @@ objects:
                     - update
                     - patch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4081,6 +4172,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4118,6 +4210,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4155,6 +4248,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4182,6 +4276,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -4219,6 +4314,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4256,6 +4352,7 @@ objects:
                 - '*'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4287,6 +4384,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4318,6 +4416,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4349,6 +4448,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4380,6 +4480,7 @@ objects:
                 - openshift-operators-redhat
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -4444,6 +4545,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: Namespace
@@ -4452,6 +4554,7 @@ objects:
                       openshift.io/node-selector: ''
                     name: dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4496,6 +4599,7 @@ objects:
                     name: dedicated-admins-cluster
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -4531,6 +4635,7 @@ objects:
                     name: dedicated-admins-project
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4821,6 +4926,7 @@ objects:
                     - patch
                     - update
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -4988,6 +5094,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   aggregationRule:
                     clusterRoleSelectors:
@@ -5009,6 +5116,7 @@ objects:
                     name: dedicated-readers
                   rules: []
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -5304,6 +5412,7 @@ objects:
                     - list
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
@@ -5319,6 +5428,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5343,6 +5453,7 @@ objects:
                     - get
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5360,6 +5471,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5374,6 +5486,7 @@ objects:
                     verbs:
                     - '*'
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5391,6 +5504,7 @@ objects:
                   - kind: Group
                     name: system:serviceaccounts:dedicated-admin
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -5407,6 +5521,7 @@ objects:
                     - get
                     - watch
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -5474,6 +5589,7 @@ objects:
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   data:
@@ -5632,7 +5748,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: operator.openshift.io/v1
                   kind: Console
@@ -5698,7 +5815,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: config.openshift.io/v1
                   kind: OAuth

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -3,6 +3,7 @@
 import oyaml as yaml
 import shutil
 import os
+from pathlib import Path
 
 base_directory = "./deploy/"
 # An array of directories you want to generate policies for.
@@ -59,6 +60,15 @@ for directory in sorted(directories, key=str.casefold):
         policy_template = yaml.safe_load(input_file)
     #fill in the name and path in the policy generator template
     policy_template['metadata']['name'] = 'rbac-policies'
+    if Path(os.path.join(base_directory,directory, config_filename)).is_file():
+        with open(os.path.join(base_directory, directory, config_filename),'r') as input_file:
+            config = yaml.safe_load(input_file)
+        if 'policy' in config.keys():
+            if 'complianceType' in config['policy'].keys() and config['policy']['complianceType'] != '' : 
+                policy_template['policyDefaults']['complianceType'] = config['policy']['complianceType'].lower()
+            if 'metadataComplianceType' in config['policy'].keys() and config['policy']['metadataComplianceType'] != '' : 
+                policy_template['policyDefaults']['metadataComplianceType'] = config['policy']['metadataComplianceType'].lower()
+       
     for p in policy_template['policies']:
         p['name'] = policy_name
         for m in p['manifests']:

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -13,6 +13,7 @@ policyDefaults:
         noncompliant: 45s
     pruneObjectBehavior: "DeleteIfCreated"
     complianceType: "mustonlyhave"
+    metadataComplianceType: "musthave"
 policies:
     - name: #Filled by script
       manifests:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Adding a field in the config.yaml to allow choosing the complianceType for the generated policy (needed for the equivalent of 'patch' where we want only to ensure some of the field are set and we don't want to touch the rest of the resource). 

### Which Jira/Github issue(s) this PR fixes?
[OSD-15189](https://issues.redhat.com//browse/OSD-15189)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
