### PR TITLE
Fix manifests with syntax errors that cause generated polices to be noncompliant

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -87,7 +87,6 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-cee
-                            namespace: openshift-monitoring
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
@@ -126,7 +125,6 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-cee-mustgather
-                            namespace: openshift-must-gather-operator
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
@@ -161,7 +159,6 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-cee-pcap-collector
-                            namespace: openshift-backplane-managed-scripts
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
@@ -70,7 +70,6 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-cssre
-                            namespace: openshift-monitoring
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
@@ -113,7 +112,6 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-cssre-mustgather
-                            namespace: openshift-must-gather-operator
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -57,6 +57,7 @@ spec:
                       metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: user.openshift.io/v1
+                        groups: null
                         kind: User
                         metadata:
                             name: backplane-cluster-admin

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -367,7 +367,6 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-srep-mustgather
-                            namespace: openshift-must-gather-operator
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
@@ -402,7 +401,6 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-srep-pcap-collector
-                            namespace: openshift-backplane-managed-scripts
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -24,7 +24,11 @@ spec:
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:
+                        allowHostDirVolumePlugin: false
+                        allowHostIPC: false
                         allowHostNetwork: false
+                        allowHostPID: false
+                        allowHostPorts: false
                         allowPrivilegedContainer: false
                         allowedCapabilities:
                             - NET_ADMIN
@@ -33,6 +37,7 @@ spec:
                         kind: SecurityContextConstraints
                         metadata:
                             name: pcap-dedicated-admins
+                        readOnlyRootFilesystem: false
                         runAsUser:
                             type: RunAsAny
                         seLinuxContext:

--- a/deploy/backplane/cee/02-cee-monitoring-rolebinding.yml
+++ b/deploy/backplane/cee/02-cee-monitoring-rolebinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-cee
-  namespace: openshift-monitoring

--- a/deploy/backplane/cee/30-cee-mustgather.RoleBinding.yml
+++ b/deploy/backplane/cee/30-cee-mustgather.RoleBinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-cee-mustgather
-  namespace: openshift-must-gather-operator

--- a/deploy/backplane/cee/60-cee-pcap-collector.RoleBinding.yml
+++ b/deploy/backplane/cee/60-cee-pcap-collector.RoleBinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-cee-pcap-collector
-  namespace: openshift-backplane-managed-scripts

--- a/deploy/backplane/cssre/02-cssre-monitoring-rolebinding.yml
+++ b/deploy/backplane/cssre/02-cssre-monitoring-rolebinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-cssre
-  namespace: openshift-monitoring

--- a/deploy/backplane/cssre/30-cssre-mustgather.RoleBinding.yml
+++ b/deploy/backplane/cssre/30-cssre-mustgather.RoleBinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-cssre-mustgather
-  namespace: openshift-must-gather-operator

--- a/deploy/backplane/elevated-sre/20-cluster-admin.User.yml
+++ b/deploy/backplane/elevated-sre/20-cluster-admin.User.yml
@@ -2,3 +2,4 @@ apiVersion: user.openshift.io/v1
 kind: User
 metadata:
   name: backplane-cluster-admin
+groups: null

--- a/deploy/backplane/lpsre/02-lpsre-monitoring-rolebinding.yml
+++ b/deploy/backplane/lpsre/02-lpsre-monitoring-rolebinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-lpsre
-  namespace: openshift-monitoring

--- a/deploy/backplane/lpsre/30-lpsre-mustgather.RoleBinding.yml
+++ b/deploy/backplane/lpsre/30-lpsre-mustgather.RoleBinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-lpsre-mustgather
-  namespace: openshift-must-gather-operator

--- a/deploy/backplane/srep/20-srep-mustgather.RoleBinding.yml
+++ b/deploy/backplane/srep/20-srep-mustgather.RoleBinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-srep-mustgather
-  namespace: openshift-must-gather-operator

--- a/deploy/backplane/srep/40-cee-pcap-collector.RoleBinding.yml
+++ b/deploy/backplane/srep/40-cee-pcap-collector.RoleBinding.yml
@@ -11,4 +11,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: backplane-srep-pcap-collector
-  namespace: openshift-backplane-managed-scripts

--- a/deploy/osd-pcap-collector/04-pcap-dedicated-admins-scc.yaml
+++ b/deploy/osd-pcap-collector/04-pcap-dedicated-admins-scc.yaml
@@ -2,11 +2,16 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: pcap-dedicated-admins
-allowPrivilegedContainer: false
+allowHostDirVolumePlugin: false
+allowHostIPC: false
 allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
 allowedCapabilities:
 - 'NET_ADMIN'
 - 'NET_RAW'
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:

--- a/deploy/osd-rebalance-infra-nodes/02-osd-rebalance-infra-nodes-openshift-dns.RoleBinding.yaml
+++ b/deploy/osd-rebalance-infra-nodes/02-osd-rebalance-infra-nodes-openshift-dns.RoleBinding.yaml
@@ -12,4 +12,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: osd-rebalance-infra-nodes-openshift-dns
-  namespace: openshift-dns

--- a/deploy/osd-rebalance-infra-nodes/03-osd-rebalance-infra-nodes-openshift-monitoring.RoleBinding.yaml
+++ b/deploy/osd-rebalance-infra-nodes/03-osd-rebalance-infra-nodes-openshift-monitoring.RoleBinding.yaml
@@ -12,4 +12,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: osd-rebalance-infra-nodes-openshift-monitoring
-  namespace: openshift-monitoring

--- a/deploy/osd-rebalance-infra-nodes/05-osd-rebalance-infra-nodes-openshift-security.RoleBinding.yaml
+++ b/deploy/osd-rebalance-infra-nodes/05-osd-rebalance-infra-nodes-openshift-security.RoleBinding.yaml
@@ -12,4 +12,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: osd-rebalance-infra-nodes-openshift-security
-  namespace: openshift-security

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3764,7 +3764,11 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
+                  allowHostDirVolumePlugin: false
+                  allowHostIPC: false
                   allowHostNetwork: false
+                  allowHostPID: false
+                  allowHostPorts: false
                   allowPrivilegedContainer: false
                   allowedCapabilities:
                   - NET_ADMIN
@@ -3773,6 +3777,7 @@ objects:
                   kind: SecurityContextConstraints
                   metadata:
                     name: pcap-dedicated-admins
+                  readOnlyRootFilesystem: false
                   runAsUser:
                     type: RunAsAny
                   seLinuxContext:
@@ -28159,11 +28164,16 @@ objects:
       apiVersion: security.openshift.io/v1
       metadata:
         name: pcap-dedicated-admins
-      allowPrivilegedContainer: false
+      allowHostDirVolumePlugin: false
+      allowHostIPC: false
       allowHostNetwork: false
+      allowHostPID: false
+      allowHostPorts: false
+      allowPrivilegedContainer: false
       allowedCapabilities:
       - NET_ADMIN
       - NET_RAW
+      readOnlyRootFilesystem: false
       runAsUser:
         type: RunAsAny
       seLinuxContext:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -844,7 +844,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee
-                    namespace: openshift-monitoring
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -883,7 +882,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -918,7 +916,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee-pcap-collector
-                    namespace: openshift-backplane-managed-scripts
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -1473,7 +1470,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cssre
-                    namespace: openshift-monitoring
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -1516,7 +1512,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cssre-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -2349,7 +2344,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-srep-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -2384,7 +2378,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-srep-pcap-collector
-                    namespace: openshift-backplane-managed-scripts
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -6094,7 +6087,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6127,7 +6119,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6172,7 +6163,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee-pcap-collector
-        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -6328,7 +6318,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6365,7 +6354,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6438,7 +6426,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6475,7 +6462,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6548,7 +6534,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6585,7 +6570,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6658,7 +6642,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6695,7 +6678,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6768,7 +6750,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6805,7 +6786,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6878,7 +6858,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6915,7 +6894,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6988,7 +6966,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7025,7 +7002,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7098,7 +7074,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7135,7 +7110,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7208,7 +7182,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7245,7 +7218,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -8622,7 +8594,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8748,7 +8719,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -8821,7 +8791,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8947,7 +8916,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9020,7 +8988,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9146,7 +9113,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9219,7 +9185,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9345,7 +9310,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9418,7 +9382,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9544,7 +9507,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9617,7 +9579,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9743,7 +9704,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9816,7 +9776,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9942,7 +9901,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10015,7 +9973,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10141,7 +10098,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10214,7 +10170,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10340,7 +10295,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10413,7 +10367,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10539,7 +10492,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10612,7 +10564,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10738,7 +10689,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10811,7 +10761,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10937,7 +10886,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11010,7 +10958,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11136,7 +11083,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11209,7 +11155,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11335,7 +11280,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11408,7 +11352,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11534,7 +11477,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11607,7 +11549,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11733,7 +11674,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11806,7 +11746,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11932,7 +11871,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12005,7 +11943,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12131,7 +12068,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12204,7 +12140,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12330,7 +12265,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12403,7 +12337,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12529,7 +12462,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12602,7 +12534,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12728,7 +12659,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12801,7 +12731,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12927,7 +12856,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13000,7 +12928,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13126,7 +13053,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13199,7 +13125,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13325,7 +13250,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13398,7 +13322,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13524,7 +13447,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13597,7 +13519,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13723,7 +13644,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13796,7 +13716,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13922,7 +13841,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13995,7 +13913,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14121,7 +14038,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -14194,7 +14110,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14320,7 +14235,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -14393,7 +14307,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14519,7 +14432,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -21238,7 +21150,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -21287,7 +21198,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-pcap-collector
-        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -28397,7 +28307,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-dns
-        namespace: openshift-dns
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -28437,7 +28346,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-monitoring
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -28498,7 +28406,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-security
-        namespace: openshift-security
     - kind: RoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1602,6 +1602,7 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
+                  groups: null
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
@@ -8527,6 +8528,7 @@ objects:
       kind: User
       metadata:
         name: backplane-cluster-admin
+      groups: null
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3764,7 +3764,11 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
+                  allowHostDirVolumePlugin: false
+                  allowHostIPC: false
                   allowHostNetwork: false
+                  allowHostPID: false
+                  allowHostPorts: false
                   allowPrivilegedContainer: false
                   allowedCapabilities:
                   - NET_ADMIN
@@ -3773,6 +3777,7 @@ objects:
                   kind: SecurityContextConstraints
                   metadata:
                     name: pcap-dedicated-admins
+                  readOnlyRootFilesystem: false
                   runAsUser:
                     type: RunAsAny
                   seLinuxContext:
@@ -28159,11 +28164,16 @@ objects:
       apiVersion: security.openshift.io/v1
       metadata:
         name: pcap-dedicated-admins
-      allowPrivilegedContainer: false
+      allowHostDirVolumePlugin: false
+      allowHostIPC: false
       allowHostNetwork: false
+      allowHostPID: false
+      allowHostPorts: false
+      allowPrivilegedContainer: false
       allowedCapabilities:
       - NET_ADMIN
       - NET_RAW
+      readOnlyRootFilesystem: false
       runAsUser:
         type: RunAsAny
       seLinuxContext:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -844,7 +844,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee
-                    namespace: openshift-monitoring
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -883,7 +882,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -918,7 +916,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee-pcap-collector
-                    namespace: openshift-backplane-managed-scripts
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -1473,7 +1470,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cssre
-                    namespace: openshift-monitoring
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -1516,7 +1512,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cssre-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -2349,7 +2344,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-srep-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -2384,7 +2378,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-srep-pcap-collector
-                    namespace: openshift-backplane-managed-scripts
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -6094,7 +6087,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6127,7 +6119,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6172,7 +6163,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee-pcap-collector
-        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -6328,7 +6318,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6365,7 +6354,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6438,7 +6426,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6475,7 +6462,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6548,7 +6534,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6585,7 +6570,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6658,7 +6642,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6695,7 +6678,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6768,7 +6750,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6805,7 +6786,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6878,7 +6858,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6915,7 +6894,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6988,7 +6966,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7025,7 +7002,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7098,7 +7074,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7135,7 +7110,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7208,7 +7182,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7245,7 +7218,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -8622,7 +8594,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8748,7 +8719,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -8821,7 +8791,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8947,7 +8916,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9020,7 +8988,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9146,7 +9113,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9219,7 +9185,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9345,7 +9310,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9418,7 +9382,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9544,7 +9507,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9617,7 +9579,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9743,7 +9704,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9816,7 +9776,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9942,7 +9901,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10015,7 +9973,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10141,7 +10098,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10214,7 +10170,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10340,7 +10295,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10413,7 +10367,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10539,7 +10492,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10612,7 +10564,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10738,7 +10689,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10811,7 +10761,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10937,7 +10886,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11010,7 +10958,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11136,7 +11083,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11209,7 +11155,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11335,7 +11280,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11408,7 +11352,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11534,7 +11477,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11607,7 +11549,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11733,7 +11674,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11806,7 +11746,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11932,7 +11871,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12005,7 +11943,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12131,7 +12068,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12204,7 +12140,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12330,7 +12265,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12403,7 +12337,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12529,7 +12462,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12602,7 +12534,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12728,7 +12659,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12801,7 +12731,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12927,7 +12856,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13000,7 +12928,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13126,7 +13053,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13199,7 +13125,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13325,7 +13250,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13398,7 +13322,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13524,7 +13447,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13597,7 +13519,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13723,7 +13644,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13796,7 +13716,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13922,7 +13841,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13995,7 +13913,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14121,7 +14038,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -14194,7 +14110,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14320,7 +14235,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -14393,7 +14307,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14519,7 +14432,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -21238,7 +21150,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -21287,7 +21198,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-pcap-collector
-        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -28397,7 +28307,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-dns
-        namespace: openshift-dns
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -28437,7 +28346,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-monitoring
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -28498,7 +28406,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-security
-        namespace: openshift-security
     - kind: RoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1602,6 +1602,7 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
+                  groups: null
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
@@ -8527,6 +8528,7 @@ objects:
       kind: User
       metadata:
         name: backplane-cluster-admin
+      groups: null
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3764,7 +3764,11 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
+                  allowHostDirVolumePlugin: false
+                  allowHostIPC: false
                   allowHostNetwork: false
+                  allowHostPID: false
+                  allowHostPorts: false
                   allowPrivilegedContainer: false
                   allowedCapabilities:
                   - NET_ADMIN
@@ -3773,6 +3777,7 @@ objects:
                   kind: SecurityContextConstraints
                   metadata:
                     name: pcap-dedicated-admins
+                  readOnlyRootFilesystem: false
                   runAsUser:
                     type: RunAsAny
                   seLinuxContext:
@@ -28159,11 +28164,16 @@ objects:
       apiVersion: security.openshift.io/v1
       metadata:
         name: pcap-dedicated-admins
-      allowPrivilegedContainer: false
+      allowHostDirVolumePlugin: false
+      allowHostIPC: false
       allowHostNetwork: false
+      allowHostPID: false
+      allowHostPorts: false
+      allowPrivilegedContainer: false
       allowedCapabilities:
       - NET_ADMIN
       - NET_RAW
+      readOnlyRootFilesystem: false
       runAsUser:
         type: RunAsAny
       seLinuxContext:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -844,7 +844,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee
-                    namespace: openshift-monitoring
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -883,7 +882,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -918,7 +916,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cee-pcap-collector
-                    namespace: openshift-backplane-managed-scripts
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -1473,7 +1470,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cssre
-                    namespace: openshift-monitoring
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -1516,7 +1512,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-cssre-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -2349,7 +2344,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-srep-mustgather
-                    namespace: openshift-must-gather-operator
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -2384,7 +2378,6 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-srep-pcap-collector
-                    namespace: openshift-backplane-managed-scripts
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -6094,7 +6087,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6127,7 +6119,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6172,7 +6163,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cee-pcap-collector
-        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -6328,7 +6318,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6365,7 +6354,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6438,7 +6426,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6475,7 +6462,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6548,7 +6534,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6585,7 +6570,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6658,7 +6642,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6695,7 +6678,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6768,7 +6750,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6805,7 +6786,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6878,7 +6858,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -6915,7 +6894,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -6988,7 +6966,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7025,7 +7002,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7098,7 +7074,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7135,7 +7110,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7208,7 +7182,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7245,7 +7218,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-cssre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -8622,7 +8594,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8748,7 +8719,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -8821,7 +8791,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -8947,7 +8916,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9020,7 +8988,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9146,7 +9113,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9219,7 +9185,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9345,7 +9310,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9418,7 +9382,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9544,7 +9507,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9617,7 +9579,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9743,7 +9704,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -9816,7 +9776,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9942,7 +9901,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10015,7 +9973,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10141,7 +10098,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10214,7 +10170,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10340,7 +10295,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10413,7 +10367,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10539,7 +10492,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10612,7 +10564,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10738,7 +10689,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -10811,7 +10761,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10937,7 +10886,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11010,7 +10958,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11136,7 +11083,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11209,7 +11155,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11335,7 +11280,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11408,7 +11352,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11534,7 +11477,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11607,7 +11549,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11733,7 +11674,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -11806,7 +11746,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -11932,7 +11871,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12005,7 +11943,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12131,7 +12068,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12204,7 +12140,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12330,7 +12265,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12403,7 +12337,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12529,7 +12462,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12602,7 +12534,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12728,7 +12659,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -12801,7 +12731,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12927,7 +12856,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13000,7 +12928,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13126,7 +13053,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13199,7 +13125,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13325,7 +13250,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13398,7 +13322,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13524,7 +13447,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13597,7 +13519,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13723,7 +13644,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13796,7 +13716,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -13922,7 +13841,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -13995,7 +13913,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14121,7 +14038,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -14194,7 +14110,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14320,7 +14235,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -14393,7 +14307,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -14519,7 +14432,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-lpsre-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -21238,7 +21150,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-mustgather
-        namespace: openshift-must-gather-operator
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -21287,7 +21198,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-pcap-collector
-        namespace: openshift-backplane-managed-scripts
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -28397,7 +28307,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-dns
-        namespace: openshift-dns
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -28437,7 +28346,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-monitoring
-        namespace: openshift-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -28498,7 +28406,6 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: osd-rebalance-infra-nodes-openshift-security
-        namespace: openshift-security
     - kind: RoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1602,6 +1602,7 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
+                  groups: null
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
@@ -8527,6 +8528,7 @@ objects:
       kind: User
       metadata:
         name: backplane-cluster-admin
+      groups: null
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
These commits fix syntax errors in the manifests used to generate policies. This will significantly reduce the churn on the Hub cluster since the current behavior of ACM policies is to send a noncompliant status update every time an invalid object manifest is encountered.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15257

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
