### PR TITLE
Add tag instance profile to installer and core installer policies

### DIFF
--- a/resources/sts/4.12/sts_installer_core_permission_policy.json
+++ b/resources/sts/4.12/sts_installer_core_permission_policy.json
@@ -92,6 +92,7 @@
 		    "iam:CreateInstanceProfile",
 		    "iam:DeleteInstanceProfile",
 		    "iam:GetInstanceProfile",
+		    "iam:TagInstanceProfile",
 		    "iam:GetRole",
 		    "iam:GetRolePolicy",
 		    "iam:GetUser",

--- a/resources/sts/4.12/sts_installer_permission_policy.json
+++ b/resources/sts/4.12/sts_installer_permission_policy.json
@@ -116,6 +116,7 @@
                 "iam:CreateInstanceProfile",
                 "iam:DeleteInstanceProfile",
                 "iam:GetInstanceProfile",
+                "iam:TagInstanceProfile",
                 "iam:GetRole",
                 "iam:GetRolePolicy",
                 "iam:GetUser",


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Adding IAM actions from #1472 to the installer core and installer policy. They should be in all until we have a path to install HyperShift only policies [SDA-8155](https://issues.redhat.com/browse/SDA-8155)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
