### PR TITLE
deploy a routemonitor for each hostedcontrolplane

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hypershift-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hypershift-route-monitor-operator.Policy.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: hypershift-route-monitor-operator
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: hypershift-route-monitor-operator
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: monitoring.openshift.io/v1alpha1
+                        kind: RouteMonitor
+                        metadata:
+                            name: console
+                            namespace: openshift-route-monitor-operator
+                        spec:
+                            route:
+                                name: console
+                                namespace: openshift-console
+                            slo:
+                                targetAvailabilityPercent: "99.5"
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: package-operator.run/v1alpha1
+                        kind: ClusterPackage
+                        metadata:
+                            name: route-monitor-operator
+                        spec:
+                            image: quay.io/achvatal/route-monitor-operator:package
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-hypershift-route-monitor-operator
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-hypershift-route-monitor-operator
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-hypershift-route-monitor-operator
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: hypershift-route-monitor-operator

--- a/deploy/hypershift-route-monitor-operator/100-openshift-route-monitor-operator.console.RouteMonitor.yaml
+++ b/deploy/hypershift-route-monitor-operator/100-openshift-route-monitor-operator.console.RouteMonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: RouteMonitor
+metadata:
+  name: console
+  namespace: openshift-route-monitor-operator
+spec:
+  route:
+    name: console
+    namespace: openshift-console
+  slo:
+    targetAvailabilityPercent: "99.5"

--- a/deploy/hypershift-route-monitor-operator/60-hostedcluster-routemonitor-operator.Package.yaml
+++ b/deploy/hypershift-route-monitor-operator/60-hostedcluster-routemonitor-operator.Package.yaml
@@ -1,0 +1,6 @@
+apiVersion: package-operator.run/v1alpha1
+kind: ClusterPackage
+metadata:
+  name: route-monitor-operator
+spec:
+  image: quay.io/achvatal/route-monitor-operator:package

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2948,6 +2948,79 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hypershift-route-monitor-operator
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: ClusterPackage
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hypershift-route-monitor-operator
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hypershift-route-monitor-operator
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:
@@ -22551,6 +22624,37 @@ objects:
       patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
         } }'
       patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hypershift-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: RouteMonitor
+      metadata:
+        name: console
+        namespace: openshift-route-monitor-operator
+      spec:
+        route:
+          name: console
+          namespace: openshift-console
+        slo:
+          targetAvailabilityPercent: '99.5'
+    - apiVersion: package-operator.run/v1alpha1
+      kind: ClusterPackage
+      metadata:
+        name: route-monitor-operator
+      spec:
+        image: quay.io/achvatal/route-monitor-operator:package
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2948,6 +2948,79 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hypershift-route-monitor-operator
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: ClusterPackage
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hypershift-route-monitor-operator
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hypershift-route-monitor-operator
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:
@@ -22551,6 +22624,37 @@ objects:
       patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
         } }'
       patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hypershift-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: RouteMonitor
+      metadata:
+        name: console
+        namespace: openshift-route-monitor-operator
+      spec:
+        route:
+          name: console
+          namespace: openshift-console
+        slo:
+          targetAvailabilityPercent: '99.5'
+    - apiVersion: package-operator.run/v1alpha1
+      kind: ClusterPackage
+      metadata:
+        name: route-monitor-operator
+      spec:
+        image: quay.io/achvatal/route-monitor-operator:package
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2948,6 +2948,79 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hypershift-route-monitor-operator
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: ClusterPackage
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hypershift-route-monitor-operator
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hypershift-route-monitor-operator
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hypershift-route-monitor-operator
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:
@@ -22551,6 +22624,37 @@ objects:
       patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
         } }'
       patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hypershift-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: RouteMonitor
+      metadata:
+        name: console
+        namespace: openshift-route-monitor-operator
+      spec:
+        route:
+          name: console
+          namespace: openshift-console
+        slo:
+          targetAvailabilityPercent: '99.5'
+    - apiVersion: package-operator.run/v1alpha1
+      kind: ClusterPackage
+      metadata:
+        name: route-monitor-operator
+      spec:
+        image: quay.io/achvatal/route-monitor-operator:package
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -36,6 +36,7 @@ directories = [
         'rosa-oauth-templates',
         'rosa-console-branding',
         'rosa-console-branding-configmap',
+        'hypershift-route-monitor-operator',
         ]
 policy_generator_config = './scripts/policy-generator-config.yaml'
 config_filename = "config.yaml"


### PR DESCRIPTION
As RMO watches all namespaces for routeMonitors. Currently, we're using this to monitor the cluster console route in classic OSD, and therefore will need the same functionality on Hypershift. This is related to [OSD-14588](https://issues.redhat.com/browse/OSD-14588) ticket