### PR TITLE
OSD-14739 Set MCVW Hypershift cronjob metadata policy type

### DIFF
--- a/deploy/hypershift-validating-webhook-patching/validating-webhook-patching.Policy.yaml
+++ b/deploy/hypershift-validating-webhook-patching/validating-webhook-patching.Policy.yaml
@@ -25,12 +25,14 @@ spec:
                         hypershift.openshift.io/hosted-control-plane: "true"
                 object-templates:
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         kind: ServiceAccount
                         metadata:
                             name: validating-webhook-patching-sa
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -45,6 +47,7 @@ spec:
                               verbs:
                                 - get
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding
@@ -58,6 +61,7 @@ spec:
                             - kind: ServiceAccount
                               name: validating-webhook-patching-sa
                     - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: batch/v1
                         kind: CronJob

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22600,12 +22600,14 @@ objects:
                   hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: validating-webhook-patching-sa
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -22620,6 +22622,7 @@ objects:
                     verbs:
                     - get
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -22633,6 +22636,7 @@ objects:
                   - kind: ServiceAccount
                     name: validating-webhook-patching-sa
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22600,12 +22600,14 @@ objects:
                   hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: validating-webhook-patching-sa
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -22620,6 +22622,7 @@ objects:
                     verbs:
                     - get
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -22633,6 +22636,7 @@ objects:
                   - kind: ServiceAccount
                     name: validating-webhook-patching-sa
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22600,12 +22600,14 @@ objects:
                   hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: v1
                   kind: ServiceAccount
                   metadata:
                     name: validating-webhook-patching-sa
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
@@ -22620,6 +22622,7 @@ objects:
                     verbs:
                     - get
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: RoleBinding
@@ -22633,6 +22636,7 @@ objects:
                   - kind: ServiceAccount
                     name: validating-webhook-patching-sa
               - complianceType: mustonlyhave
+                metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: batch/v1
                   kind: CronJob


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?

The policy used for the temporary `managed-cluster-validating-webhooks` HyperShift CronJob should set a `metadataComplianceType` for its resources.

### Which Jira/Github issue(s) this PR fixes?
[OSD-14739](https://issues.redhat.com//browse/OSD-14739)

