### PR TITLE
Fix backplane-acm-lpsre-admins-project ClusterRole syntax

### DIFF
--- a/deploy/backplane/lpsre/acm/acm/02-acm-lpsre-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/lpsre/acm/acm/02-acm-lpsre-admins-project.ClusterRole.yaml
@@ -419,7 +419,6 @@ rules:
   - list
   - watch
   serviceAccountName: multiclusterhub-operator
-- rules:
 - apiGroups:
   - ''
   resources:
@@ -679,7 +678,6 @@ rules:
   - list
   - watch
   serviceAccountName: multicluster-observability-operator
-- rules:
 - apiGroups:
   - ''
   resources:
@@ -861,7 +859,6 @@ rules:
   - watch
   serviceAccountName: submariner-addon
   permissions:
-- rules:
 - apiGroups:
   - ''
   resources:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -14715,7 +14715,6 @@ objects:
         - list
         - watch
         serviceAccountName: multiclusterhub-operator
-      - rules: null
       - apiGroups:
         - ''
         resources:
@@ -14975,7 +14974,6 @@ objects:
         - list
         - watch
         serviceAccountName: multicluster-observability-operator
-      - rules: null
       - apiGroups:
         - ''
         resources:
@@ -15157,7 +15155,6 @@ objects:
         - watch
         serviceAccountName: submariner-addon
         permissions: null
-      - rules: null
       - apiGroups:
         - ''
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -14715,7 +14715,6 @@ objects:
         - list
         - watch
         serviceAccountName: multiclusterhub-operator
-      - rules: null
       - apiGroups:
         - ''
         resources:
@@ -14975,7 +14974,6 @@ objects:
         - list
         - watch
         serviceAccountName: multicluster-observability-operator
-      - rules: null
       - apiGroups:
         - ''
         resources:
@@ -15157,7 +15155,6 @@ objects:
         - watch
         serviceAccountName: submariner-addon
         permissions: null
-      - rules: null
       - apiGroups:
         - ''
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -14715,7 +14715,6 @@ objects:
         - list
         - watch
         serviceAccountName: multiclusterhub-operator
-      - rules: null
       - apiGroups:
         - ''
         resources:
@@ -14975,7 +14974,6 @@ objects:
         - list
         - watch
         serviceAccountName: multicluster-observability-operator
-      - rules: null
       - apiGroups:
         - ''
         resources:
@@ -15157,7 +15155,6 @@ objects:
         - watch
         serviceAccountName: submariner-addon
         permissions: null
-      - rules: null
       - apiGroups:
         - ''
         resources:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Fixes backplane-acm-lpsre-admins-project ClusterRole which had some empty `rules` that were causing failures on deployment to SC.

### Which Jira/Github issue(s) this PR fixes?
None, noticed while validating some other things.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
