### PR TITLE
Add permission for  klusterlet namespaces in Management and Service clusters

### DIFF
--- a/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
@@ -7,7 +7,7 @@ spec:
   permissions:
   - allowFirst: true
     clusterRoleName: backplane-srep-management-cluster-project
-    namespacesAllowedRegex: "(^uhc.*|^ocm.*)"
+    namespacesAllowedRegex: "(^uhc.*|^ocm.*|^klusterlet.*)"
   - allowFirst: true
     clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"

--- a/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
@@ -7,7 +7,7 @@ spec:
   permissions:
   - allowFirst: true
     clusterRoleName: backplane-srep-service-cluster-project
-    namespacesAllowedRegex: "(^uhc.*|^ocm.*)"
+    namespacesAllowedRegex: "(^uhc.*|^ocm.*|^klusterlet.*)"
   - allowFirst: true
     clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21208,7 +21208,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-management-cluster-project
-          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+          namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - allowFirst: true
           clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
@@ -21342,7 +21342,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-service-cluster-project
-          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+          namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - allowFirst: true
           clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21208,7 +21208,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-management-cluster-project
-          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+          namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - allowFirst: true
           clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
@@ -21342,7 +21342,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-service-cluster-project
-          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+          namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - allowFirst: true
           clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21208,7 +21208,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-management-cluster-project
-          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+          namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - allowFirst: true
           clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
@@ -21342,7 +21342,7 @@ objects:
         permissions:
         - allowFirst: true
           clusterRoleName: backplane-srep-service-cluster-project
-          namespacesAllowedRegex: (^uhc.*|^ocm.*)
+          namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - allowFirst: true
           clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)


### PR DESCRIPTION
### What type of PR is this?
This PR add permission to get/list/watch for klusterlet namespaces.

### What this PR does / why we need it?
SRE-P on-call for hypershift needed permission to troubleshoots issues related to klusterlet like deploy, sts, ds,  pvcs, and events for klusterlet namespaces , for which we got forbidden error. 

### Which Jira/Github issue(s) this PR fixes?
Issue will be fixed by this [OSD-15249](https://issues.redhat.com//browse/OSD-15249)

### Special notes for your reviewer:
 We used to get permissions previously from this https://github.com/openshift/managed-cluster-config/blob/master/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml, that is restricted  to specific namespace patterns.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
