### PR TITLE
setting groups to []

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -57,7 +57,7 @@ spec:
                       metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: user.openshift.io/v1
-                        groups: null
+                        groups: []
                         kind: User
                         metadata:
                             name: backplane-cluster-admin

--- a/deploy/backplane/elevated-sre/20-cluster-admin.User.yml
+++ b/deploy/backplane/elevated-sre/20-cluster-admin.User.yml
@@ -2,4 +2,4 @@ apiVersion: user.openshift.io/v1
 kind: User
 metadata:
   name: backplane-cluster-admin
-groups: null
+groups: []

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1602,7 +1602,7 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
-                  groups: null
+                  groups: []
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
@@ -8342,7 +8342,7 @@ objects:
       kind: User
       metadata:
         name: backplane-cluster-admin
-      groups: null
+      groups: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1602,7 +1602,7 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
-                  groups: null
+                  groups: []
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
@@ -8342,7 +8342,7 @@ objects:
       kind: User
       metadata:
         name: backplane-cluster-admin
-      groups: null
+      groups: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1602,7 +1602,7 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: user.openshift.io/v1
-                  groups: null
+                  groups: []
                   kind: User
                   metadata:
                     name: backplane-cluster-admin
@@ -8342,7 +8342,7 @@ objects:
       kind: User
       metadata:
         name: backplane-cluster-admin
-      groups: null
+      groups: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug
### What this PR does / why we need it?
getting the groups [] because groups: null gets dropped by ACM policies.
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15257
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
