### PR TITLE
OSD-14462 and OSD-14588 deploy route-monitor-operator and a console monitor to hosted clusters

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor.Policy.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: hs-hosted-route-monitor
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: hs-hosted-route-monitor
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: monitoring.openshift.io/v1alpha1
+                        kind: RouteMonitor
+                        metadata:
+                            name: console
+                            namespace: openshift-route-monitor-operator
+                        spec:
+                            route:
+                                name: console
+                                namespace: openshift-console
+                            slo:
+                                targetAvailabilityPercent: "99.5"
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: package-operator.run/v1alpha1
+                        kind: ClusterPackage
+                        metadata:
+                            name: route-monitor-operator
+                        spec:
+                            image: quay.io/achvatal/route-monitor-operator:package
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-hs-hosted-route-monitor
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-hs-hosted-route-monitor
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-hs-hosted-route-monitor
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: hs-hosted-route-monitor

--- a/deploy/hs-hosted-route-monitor/config.yaml
+++ b/deploy/hs-hosted-route-monitor/config.yaml
@@ -1,0 +1,2 @@
+---
+deploymentMode: Policy

--- a/deploy/hs-hosted-route-monitor/console.RouteMonitor.yaml
+++ b/deploy/hs-hosted-route-monitor/console.RouteMonitor.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: RouteMonitor
+metadata:
+  name: console
+  namespace: openshift-route-monitor-operator
+spec:
+  route:
+    name: console
+    namespace: openshift-console
+  slo:
+    targetAvailabilityPercent: "99.5"
+

--- a/deploy/hs-hosted-route-monitor/route-monitor-operator.Package.yaml
+++ b/deploy/hs-hosted-route-monitor/route-monitor-operator.Package.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: package-operator.run/v1alpha1
+kind: ClusterPackage
+metadata:
+  name: route-monitor-operator
+spec:
+  image: quay.io/achvatal/route-monitor-operator:package

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2843,6 +2843,79 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-hosted-route-monitor
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: ClusterPackage
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-hosted-route-monitor
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-hosted-route-monitor
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-mgmt-route-monitor-api
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2843,6 +2843,79 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-hosted-route-monitor
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: ClusterPackage
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-hosted-route-monitor
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-hosted-route-monitor
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-mgmt-route-monitor-api
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2843,6 +2843,79 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-hosted-route-monitor
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: ClusterPackage
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/achvatal/route-monitor-operator:package
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-hosted-route-monitor
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-hosted-route-monitor
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-hosted-route-monitor
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-mgmt-route-monitor-api
         namespace: openshift-acm-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -23,6 +23,7 @@ directories = [
         'backplane/tam',
         'ccs-dedicated-admins',
         'customer-registry-cas',
+        'hs-hosted-route-monitor',
         'hs-mgmt-route-monitor-api',
         'osd-cluster-admin',
         'osd-delete-backplane-script-resources',


### PR DESCRIPTION
for [OSD-14462](https://issues.redhat.com//browse/OSD-14462) and [OSD-14588](https://issues.redhat.com//browse/OSD-14588)

### What type of PR is this?
feature

### What this PR does / why we need it?
Deploys route-monitor-operator to hosted clusters via a package-operator package that configures the hosted cluster via the management cluster's package-operator.

Additionally, it configures a routemonitor for the hosted cluster's console.

### Which Jira/Github issue(s) this PR fixes?
[OSD-14462](https://issues.redhat.com//browse/OSD-14462) and [OSD-14588](https://issues.redhat.com//browse/OSD-14588)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
