### PR TITLE
adds bounds for disabling CPMS to only be for a few certain OSD versions

### DIFF
--- a/deploy/osd-14634-disable-cpms/config.yaml
+++ b/deploy/osd-14634-disable-cpms/config.yaml
@@ -4,6 +4,9 @@ selectorSyncSet:
   matchExpressions:
   ## This will need to be changed to use version-major-minor-patch when
   ## we move to enable this feature in the future
-  - key: hive.openshift.io/version-major-minor
+  - key: hive.openshift.io/version-major-minor-patch
     operator: In
-    values: ["4.12"]
+    values:
+    - 4.12.0
+    - 4.12.1
+    - 4.12.2

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22513,10 +22513,12 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor
+      - key: hive.openshift.io/version-major-minor-patch
         operator: In
         values:
-        - '4.12'
+        - 4.12.0
+        - 4.12.1
+        - 4.12.2
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22513,10 +22513,12 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor
+      - key: hive.openshift.io/version-major-minor-patch
         operator: In
         values:
-        - '4.12'
+        - 4.12.0
+        - 4.12.1
+        - 4.12.2
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22513,10 +22513,12 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor
+      - key: hive.openshift.io/version-major-minor-patch
         operator: In
         values:
-        - '4.12'
+        - 4.12.0
+        - 4.12.1
+        - 4.12.2
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
Now that the OVN bug that caused this is fixed (OCPBUGS-6494, OCPBUGS-5306) in 4.12.3, let's bound this job to only be present in 4.12.0 - 4.12.2 z-streams.

If we ever pull those z-streams we should just remove this entire folder.

### Which Jira/Github issue(s) this PR fixes?

[OSD-14634](https://issues.redhat.com//browse/OSD-14634)

### Special notes for your reviewer:

This should be able to be tested in staging by creating both a 4.12.2 cluster and seeing the cronjob present as well as in a 4.12.3 cluster (can use fast channel) and NOT seeing this cronjob present.

### Pre-checks (if applicable):
- [ NA ] Tested latest changes against a cluster
- [ NA ] Included documentation changes with PR
- [ NA ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
