### PR TITLE
[MTSRE-965] feat: give LPSRE access to restart deployments/statefulsets/deploymentconfigs

### DIFF
--- a/deploy/backplane/lpsre/rhoam/01-rhoam-lpsre-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/lpsre/rhoam/01-rhoam-lpsre-admins-project.ClusterRole.yaml
@@ -130,3 +130,24 @@ rules:
   - deployments/scale
   verbs:
   - patch
+# LP SRE can restart deployments/statefulsets/deploymentconfigs
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - deployments
+  verbs:
+  - patch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - patch
+# LP SRE can patch routes
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - patch  

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -15695,6 +15695,25 @@ objects:
         - deployments/scale
         verbs:
         - patch
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        verbs:
+        - patch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -15907,6 +15926,25 @@ objects:
         - apps
         resources:
         - deployments/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        verbs:
+        - patch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
         verbs:
         - patch
     - apiVersion: managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -15695,6 +15695,25 @@ objects:
         - deployments/scale
         verbs:
         - patch
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        verbs:
+        - patch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -15907,6 +15926,25 @@ objects:
         - apps
         resources:
         - deployments/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        verbs:
+        - patch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
         verbs:
         - patch
     - apiVersion: managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -15695,6 +15695,25 @@ objects:
         - deployments/scale
         verbs:
         - patch
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        verbs:
+        - patch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - patch
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -15907,6 +15926,25 @@ objects:
         - apps
         resources:
         - deployments/scale
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        verbs:
+        - patch
+      - apiGroups:
+        - route.openshift.io
+        resources:
+        - routes
         verbs:
         - patch
     - apiVersion: managed.openshift.io/v1alpha1


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Given impersonation privilege has been removed with the migration from CSSRE to LPSRE for RHOAM this PR adds explicit access to patch `deployments/statefulsets/deploymentconfigs` for the purpose of restarting workloads. Additionally RHOAM requires access to patch `routes`. Resource names are not explicitly defined as this Role is only applied at the namespace scope for `redhat-` prefixed namespaces owned by RHOAM and no process has been defined to identify resource name changes/additions in upstream projects.

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_ https://issues.redhat.com/browse/MTSRE-965

Closes #1492

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
