### PR TITLE
osd-cluster-ready++

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.104-58e4525"
+                managed.openshift.io/version: "v0.1.108-cd4483a"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/app-sre/osd-cluster-ready@sha256:44c9767250ac0acc3b94d6c568e6d9e8dd8e0b272f79bc68be709086ea4a9479"
+              image: "quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24645,11 +24645,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.104-58e4525
+              managed.openshift.io/version: v0.1.108-cd4483a
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:44c9767250ac0acc3b94d6c568e6d9e8dd8e0b272f79bc68be709086ea4a9479
+              image: quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24645,11 +24645,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.104-58e4525
+              managed.openshift.io/version: v0.1.108-cd4483a
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:44c9767250ac0acc3b94d6c568e6d9e8dd8e0b272f79bc68be709086ea4a9479
+              image: quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24645,11 +24645,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.104-58e4525
+              managed.openshift.io/version: v0.1.108-cd4483a
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:44c9767250ac0acc3b94d6c568e6d9e8dd8e0b272f79bc68be709086ea4a9479
+              image: quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
This is the promotion of the dependabot base image update in https://github.com/openshift/osd-cluster-ready/pull/39

https://quay.io/repository/app-sre/osd-cluster-ready?tab=tags&tag=latest