### PR TITLE
OSD-15432 use correct secret for HS-MCVW patching

### DIFF
--- a/deploy/hypershift-validating-webhook-patching/10-validating-webhook-patching.Policy.yaml
+++ b/deploy/hypershift-validating-webhook-patching/10-validating-webhook-patching.Policy.yaml
@@ -96,7 +96,7 @@ spec:
 
                                                       # Get that kubeconfig
                                                       TMPDIR=$(mktemp -d)
-                                                      oc get secret admin-kubeconfig -o json --ignore-not-found | jq -r '.data.kubeconfig' | base64 -d >> ${TMPDIR}/kubeconfig
+                                                      oc get secret service-network-admin-kubeconfig -o json --ignore-not-found | jq -r '.data.kubeconfig' | base64 -d >> ${TMPDIR}/kubeconfig
 
                                                       # patch the CA
                                                       for WEBHOOK in namespace regular-user scc techpreviewnoupgrade

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21636,7 +21636,7 @@ objects:
                                 \nif [[ -z $CABUNDLE ]]; then\n  echo \"CA bundle\
                                 \ not found, might be due to the MCVW has not been\
                                 \ deployed, skipping...\"\n  exit 0\nfi\n\n# Get that\
-                                \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
+                                \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret service-network-admin-kubeconfig\
                                 \ -o json --ignore-not-found | jq -r '.data.kubeconfig'\
                                 \ | base64 -d >> ${TMPDIR}/kubeconfig\n\n# patch the\
                                 \ CA\nfor WEBHOOK in namespace regular-user scc techpreviewnoupgrade\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21636,7 +21636,7 @@ objects:
                                 \nif [[ -z $CABUNDLE ]]; then\n  echo \"CA bundle\
                                 \ not found, might be due to the MCVW has not been\
                                 \ deployed, skipping...\"\n  exit 0\nfi\n\n# Get that\
-                                \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
+                                \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret service-network-admin-kubeconfig\
                                 \ -o json --ignore-not-found | jq -r '.data.kubeconfig'\
                                 \ | base64 -d >> ${TMPDIR}/kubeconfig\n\n# patch the\
                                 \ CA\nfor WEBHOOK in namespace regular-user scc techpreviewnoupgrade\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21636,7 +21636,7 @@ objects:
                                 \nif [[ -z $CABUNDLE ]]; then\n  echo \"CA bundle\
                                 \ not found, might be due to the MCVW has not been\
                                 \ deployed, skipping...\"\n  exit 0\nfi\n\n# Get that\
-                                \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret admin-kubeconfig\
+                                \ kubeconfig\nTMPDIR=$(mktemp -d)\noc get secret service-network-admin-kubeconfig\
                                 \ -o json --ignore-not-found | jq -r '.data.kubeconfig'\
                                 \ | base64 -d >> ${TMPDIR}/kubeconfig\n\n# patch the\
                                 \ CA\nfor WEBHOOK in namespace regular-user scc techpreviewnoupgrade\n\


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The validating webhook patching CronJob for the Hypershift deployment of managed-cluster-validating-webhooks should not be using the `admin-kubeconfig` secret when it patches the webhooks on the hosted cluster. It should be using the `service-network-admin-kubeconfig` instead.

### Which Jira/Github issue(s) this PR fixes?
[OSD-15423](https://issues.redhat.com//browse/OSD-15423)
