### PR TITLE
[osd-15092] Add missing permissions to control plane operator and node pool management operator

### DIFF
--- a/resources/sts/4.12/hypershift/ControlPlaneOperatorPolicy.json
+++ b/resources/sts/4.12/hypershift/ControlPlaneOperatorPolicy.json
@@ -4,10 +4,65 @@
         {
             "Action": [
                 "ec2:DescribeVpcEndpoints",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSecurityGroups",
                 "route53:ListHostedZones"
             ],
             "Effect": "Allow",
             "Resource": "*"
+        },
+        {
+            "Sid": "CreateSecurityGroups",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:security-group*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestTag/red-hat-managed": "true"
+                }
+            }
+        },
+        {
+            "Sid": "DeleteSecurityGroup",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:security-group*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
+        },
+        {
+            "Sid": "SecurityGroupIngressEgress",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupEgress"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:security-group*/*"
+            ]
+        },
+        {
+            "Sid": "CreateSecurityGroupsVPCNoCondition",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:vpc/*"
+            ]
         },
         {
             "Action": [
@@ -93,11 +148,15 @@
                 "ec2:CreateTags"
             ],
             "Resource": [
-                "arn:aws:ec2:*:*:vpc-endpoint/*"
+                "arn:aws:ec2:*:*:vpc-endpoint/*",
+                "arn:aws:ec2:*:*:security-group/*"
             ],
             "Condition": {
                 "StringEquals": {
-                    "ec2:CreateAction": "CreateVpcEndpoint"
+                    "ec2:CreateAction": [
+                        "CreateVpcEndpoint",
+                        "CreateSecurityGroup"
+                    ]
                 }
             }
         }

--- a/resources/sts/4.12/hypershift/NodePoolManagementPolicy.json
+++ b/resources/sts/4.12/hypershift/NodePoolManagementPolicy.json
@@ -59,6 +59,33 @@
       }
     },
     {
+      "Sid": "NetworkInterfaces",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyNetworkInterfaceAttribute"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "NetworkInterfacesNoCondition",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyNetworkInterfaceAttribute"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:network-interface/*",
+        "arn:aws:ec2:*:*:security-group/*",
+        "arn:aws:ec2:*:*:vpc/*"
+      ]
+    },
+    {
       "Effect": "Allow",
       "Action": [
         "ec2:TerminateInstances"


### PR DESCRIPTION


### What type of PR is this?
feature

### What this PR does / why we need it?
Adding missing permissiong to the control plane operator and node pool management operator which were missing earlier. These now contain condition keys set where appropriate.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15092

### Special notes for your reviewer:
@mjlshen spotted the missing permissions in the control plane operator from a recent hyperShift on call troubleshooting thread. Link in the jira card. But while testing I found a couple of missing permissions in the node pool management operator role which has been fixed up in this PR too. It looks like these permissions were needed in one of the newer OCP hosted cluster version (tested in 4.12.4)

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
