### PR TITLE
 Integration timeout fix for Hypershift SC and MC

### DIFF
--- a/deploy/osd-oauth-templates/ohss-2561/config.yaml
+++ b/deploy/osd-oauth-templates/ohss-2561/config.yaml
@@ -7,3 +7,6 @@ selectorSyncSet:
   - key: ext-managed.openshift.io/hive-shard
     operator: In
     values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["service-cluster", "management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27128,6 +27128,11 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+        - management-cluster
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27128,6 +27128,11 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+        - management-cluster
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27128,6 +27128,11 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+        - management-cluster
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1


### PR DESCRIPTION
… standard clusters

### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug

### What this PR does / why we need it?
- Switching applyBehaviour to be able to use similar syntax for HCP and standard cluster for https://github.com/openshift/managed-cluster-config/tree/master/deploy/osd-oauth-templates/ohss-2561
- Added a policy of the above fix for management and service cluster in integration
- Had to remove the repo name from the list in generate-policy-config.py because the policy needs to be place in a sub dir in acm-policies with a separate config.yaml. 
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15168
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
