### PR TITLE
Add missing node pool KMS permissions

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -143,6 +143,39 @@
         "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:volume/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlainText",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:RevokeGrant",
+        "kms:CreateGrant",
+        "kms:ListGrants"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": true
+        },
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds AWS KMS permissions to the node pool management AWS IAM policy for HyperShift

The node pool controller will need permissions to create EC2 instances with EBS volumes encrypted by KMS. This HyperShift PR also adds the actions to their sorted policies.

This PR contains additional security within the conditions ensuring its AWS EC2 service that uses these permissions. We may need to remove the condition for the `DescribeKey` action.

Once this is in an QE'd I'll open a PR to HyperShift to add the extra condition.

### Which Jira/Github issue(s) this PR fixes?

[SDA-7132](https://issues.redhat.com//browse/SDA-7132)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
