### PR TITLE
OSD-14462 deploy route-monitor-operator to hosted clusters and monitor the console

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: hs-hosted-route-monitor-operator
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: hs-hosted-route-monitor-operator
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: monitoring.openshift.io/v1alpha1
+                        kind: RouteMonitor
+                        metadata:
+                            annotations: null
+                            name: console
+                            namespace: openshift-route-monitor-operator
+                        spec:
+                            route:
+                                name: console
+                                namespace: openshift-console
+                            slo:
+                                targetAvailabilityPercent: "99.5"
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: package-operator.run/v1alpha1
+                        kind: Package
+                        metadata:
+                            name: route-monitor-operator
+                        spec:
+                            image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-hs-hosted-route-monitor-operator
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-hs-hosted-route-monitor-operator
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-hs-hosted-route-monitor-operator
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: hs-hosted-route-monitor-operator

--- a/deploy/hs-hosted-route-monitor-operator/config.yaml
+++ b/deploy/hs-hosted-route-monitor-operator/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: Policy
+clusterSelectors:
+  hypershift.open-cluster-management.io/hosted-cluster: true

--- a/deploy/hs-hosted-route-monitor-operator/console.RouteMonitor.yaml
+++ b/deploy/hs-hosted-route-monitor-operator/console.RouteMonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: RouteMonitor
+metadata:
+  annotations:
+  name: console
+  namespace: openshift-route-monitor-operator
+spec:
+  route:
+    name: console
+    namespace: openshift-console
+  slo:
+    targetAvailabilityPercent: "99.5"

--- a/deploy/hs-hosted-route-monitor-operator/package.yaml
+++ b/deploy/hs-hosted-route-monitor-operator/package.yaml
@@ -1,0 +1,6 @@
+apiVersion: package-operator.run/v1alpha1
+kind: Package
+metadata:
+  name: route-monitor-operator
+spec:
+  image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2843,6 +2843,80 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-hosted-route-monitor-operator
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    annotations: null
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: Package
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-hosted-route-monitor-operator
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-hosted-route-monitor-operator
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-mgmt-route-monitor-api
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2843,6 +2843,80 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-hosted-route-monitor-operator
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    annotations: null
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: Package
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-hosted-route-monitor-operator
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-hosted-route-monitor-operator
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-mgmt-route-monitor-api
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2843,6 +2843,80 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hs-hosted-route-monitor-operator
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: RouteMonitor
+                  metadata:
+                    annotations: null
+                    name: console
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    route:
+                      name: console
+                      namespace: openshift-console
+                    slo:
+                      targetAvailabilityPercent: '99.5'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: package-operator.run/v1alpha1
+                  kind: Package
+                  metadata:
+                    name: route-monitor-operator
+                  spec:
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hs-hosted-route-monitor-operator
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hs-hosted-route-monitor-operator
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hs-hosted-route-monitor-operator
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-mgmt-route-monitor-api
         namespace: openshift-acm-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -23,6 +23,7 @@ directories = [
         'backplane/tam',
         'ccs-dedicated-admins',
         'customer-registry-cas',
+        'hs-hosted-route-monitor-operator',
         'hs-mgmt-route-monitor-api',
         'osd-cluster-admin',
         'osd-delete-backplane-script-resources',


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Installs a route-monitor-operator package and console routemonitor to hosted clusters so that we have monitoring on hosted clusters' console availability.

### Which Jira/Github issue(s) this PR fixes?
Fixes [OSD-14462](https://issues.redhat.com//browse/OSD-14462)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
