### PR TITLE
OSD-15146 - updates avo vpce endpoints for v1alpha2

### DIFF
--- a/deploy/osd-avo-resources/fedramp-vpc-endpoints/us-gov-east-1/00-osd-avo-VpcEndpoint.yaml
+++ b/deploy/osd-avo-resources/fedramp-vpc-endpoints/us-gov-east-1/00-osd-avo-VpcEndpoint.yaml
@@ -1,15 +1,21 @@
-apiVersion: avo.openshift.io/v1alpha1
+apiVersion: avo.openshift.io/v1alpha2
 kind: VpcEndpoint
 metadata:
   name: splunk
   namespace: openshift-security
 spec:
-  subdomainName: splunk
   serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
   securityGroup:
     ingressRules:
       - fromPort: 9997
         toPort: 9997
         protocol: tcp
-  externalNameService:
-    name: indexer
+  vpc:
+    autoDiscoverSubnets: true
+  customDns:
+    route53PrivateHostedZone:
+      autoDiscoverPrivateHostedZone: true
+      record:
+        hostname: "splunk"
+        externalNameService:
+          name: indexer

--- a/deploy/osd-avo-resources/fedramp-vpc-endpoints/us-gov-west-1/00-osd-avo-VpcEndpoint.yaml
+++ b/deploy/osd-avo-resources/fedramp-vpc-endpoints/us-gov-west-1/00-osd-avo-VpcEndpoint.yaml
@@ -1,15 +1,21 @@
-apiVersion: avo.openshift.io/v1alpha1
+apiVersion: avo.openshift.io/v1alpha2
 kind: VpcEndpoint
 metadata:
   name: splunk
   namespace: openshift-security
 spec:
-  subdomainName: splunk
   serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
   securityGroup:
     ingressRules:
       - fromPort: 9997
         toPort: 9997
         protocol: tcp
-  externalNameService:
-    name: indexer
+  vpc:
+    autoDiscoverSubnets: true
+  customDns:
+    route53PrivateHostedZone:
+      autoDiscoverPrivateHostedZone: true
+      record:
+        hostname: "splunk"
+        externalNameService:
+          name: indexer

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22952,21 +22952,27 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: avo.openshift.io/v1alpha1
+    - apiVersion: avo.openshift.io/v1alpha2
       kind: VpcEndpoint
       metadata:
         name: splunk
         namespace: openshift-security
       spec:
-        subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
         securityGroup:
           ingressRules:
           - fromPort: 9997
             toPort: 9997
             protocol: tcp
-        externalNameService:
-          name: indexer
+        vpc:
+          autoDiscoverSubnets: true
+        customDns:
+          route53PrivateHostedZone:
+            autoDiscoverPrivateHostedZone: true
+            record:
+              hostname: splunk
+              externalNameService:
+                name: indexer
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -22994,21 +23000,27 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: avo.openshift.io/v1alpha1
+    - apiVersion: avo.openshift.io/v1alpha2
       kind: VpcEndpoint
       metadata:
         name: splunk
         namespace: openshift-security
       spec:
-        subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
         securityGroup:
           ingressRules:
           - fromPort: 9997
             toPort: 9997
             protocol: tcp
-        externalNameService:
-          name: indexer
+        vpc:
+          autoDiscoverSubnets: true
+        customDns:
+          route53PrivateHostedZone:
+            autoDiscoverPrivateHostedZone: true
+            record:
+              hostname: splunk
+              externalNameService:
+                name: indexer
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22952,21 +22952,27 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: avo.openshift.io/v1alpha1
+    - apiVersion: avo.openshift.io/v1alpha2
       kind: VpcEndpoint
       metadata:
         name: splunk
         namespace: openshift-security
       spec:
-        subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
         securityGroup:
           ingressRules:
           - fromPort: 9997
             toPort: 9997
             protocol: tcp
-        externalNameService:
-          name: indexer
+        vpc:
+          autoDiscoverSubnets: true
+        customDns:
+          route53PrivateHostedZone:
+            autoDiscoverPrivateHostedZone: true
+            record:
+              hostname: splunk
+              externalNameService:
+                name: indexer
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -22994,21 +23000,27 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: avo.openshift.io/v1alpha1
+    - apiVersion: avo.openshift.io/v1alpha2
       kind: VpcEndpoint
       metadata:
         name: splunk
         namespace: openshift-security
       spec:
-        subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
         securityGroup:
           ingressRules:
           - fromPort: 9997
             toPort: 9997
             protocol: tcp
-        externalNameService:
-          name: indexer
+        vpc:
+          autoDiscoverSubnets: true
+        customDns:
+          route53PrivateHostedZone:
+            autoDiscoverPrivateHostedZone: true
+            record:
+              hostname: splunk
+              externalNameService:
+                name: indexer
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22952,21 +22952,27 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: avo.openshift.io/v1alpha1
+    - apiVersion: avo.openshift.io/v1alpha2
       kind: VpcEndpoint
       metadata:
         name: splunk
         namespace: openshift-security
       spec:
-        subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-east-1.vpce-svc-0838533cd2d6d2b8b
         securityGroup:
           ingressRules:
           - fromPort: 9997
             toPort: 9997
             protocol: tcp
-        externalNameService:
-          name: indexer
+        vpc:
+          autoDiscoverSubnets: true
+        customDns:
+          route53PrivateHostedZone:
+            autoDiscoverPrivateHostedZone: true
+            record:
+              hostname: splunk
+              externalNameService:
+                name: indexer
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -22994,21 +23000,27 @@ objects:
         - 'true'
     resourceApplyMode: Sync
     resources:
-    - apiVersion: avo.openshift.io/v1alpha1
+    - apiVersion: avo.openshift.io/v1alpha2
       kind: VpcEndpoint
       metadata:
         name: splunk
         namespace: openshift-security
       spec:
-        subdomainName: splunk
         serviceName: com.amazonaws.vpce.us-gov-west-1.vpce-svc-06225ed6e3620e8e1
         securityGroup:
           ingressRules:
           - fromPort: 9997
             toPort: 9997
             protocol: tcp
-        externalNameService:
-          name: indexer
+        vpc:
+          autoDiscoverSubnets: true
+        customDns:
+          route53PrivateHostedZone:
+            autoDiscoverPrivateHostedZone: true
+            record:
+              hostname: splunk
+              externalNameService:
+                name: indexer
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

cleanup

### What this PR does / why we need it?

Updates the Splunk VPCE Objects to use the new  v1alpha2 version as the v1alpha1 version no longer works in latest version.

### Which Jira/Github issue(s) this PR fixes?

Part of [OSD-15146](https://issues.redhat.com/browse/OSD-15146)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
