### PR TITLE
add policy to push cert to hc

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate.Policy.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: rosa-ingress-certificate
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rosa-ingress-certificate
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        stringData:
+                          tls.crt: |
+                            {{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName ).data "tls.crt" ) | base64dec | autoindent hub}}
+                          tls.key: |
+                            {{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName ).data "tls.key" ) | base64dec | autoindent hub}}
+                        kind: Secret
+                        metadata:
+                          name: ingress-certificate-secret
+                          namespace: openshift-ingress
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              kind: ConfigurationPolicy
+              name: rosa-ingress-certificate
+              namespace: ""
+              compliance: Compliant
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rosa-ingress-replace-default-cert
+            spec:
+                object-templates:
+                    - complianceType: musthave
+                      objectDefinition:
+                        apiVersion: operator.openshift.io/v1
+                        kind: IngressController
+                        metadata:
+                          name: default
+                          namespace: openshift-ingress-operator
+                        spec:
+                          defaultCertificate:
+                            name: ingress-certificate-secret
+                pruneObjectBehavior: DeleteAll
+                remediationAction: inform
+                severity: low
+    remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-rosa-ingress-certificate
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-rosa-ingress-certificate
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-rosa-ingress-certificate
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: rosa-ingress-certificate

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5674,6 +5674,100 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-certificate
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  stringData:
+                    tls.crt: '{{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName
+                      ).data "tls.crt" ) | base64dec | autoindent hub}}
+
+                      '
+                    tls.key: '{{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName
+                      ).data "tls.key" ) | base64dec | autoindent hub}}
+
+                      '
+                  kind: Secret
+                  metadata:
+                    name: ingress-certificate-secret
+                    namespace: openshift-ingress
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            name: rosa-ingress-certificate
+            namespace: ''
+            compliance: Compliant
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-replace-default-cert
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
+                  spec:
+                    defaultCertificate:
+                      name: ingress-certificate-secret
+              pruneObjectBehavior: DeleteAll
+              remediationAction: inform
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-ingress-certificate
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-ingress-certificate
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-oauth-templates
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5674,6 +5674,100 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-certificate
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  stringData:
+                    tls.crt: '{{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName
+                      ).data "tls.crt" ) | base64dec | autoindent hub}}
+
+                      '
+                    tls.key: '{{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName
+                      ).data "tls.key" ) | base64dec | autoindent hub}}
+
+                      '
+                  kind: Secret
+                  metadata:
+                    name: ingress-certificate-secret
+                    namespace: openshift-ingress
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            name: rosa-ingress-certificate
+            namespace: ''
+            compliance: Compliant
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-replace-default-cert
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
+                  spec:
+                    defaultCertificate:
+                      name: ingress-certificate-secret
+              pruneObjectBehavior: DeleteAll
+              remediationAction: inform
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-ingress-certificate
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-ingress-certificate
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-oauth-templates
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5674,6 +5674,100 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-certificate
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  stringData:
+                    tls.crt: '{{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName
+                      ).data "tls.crt" ) | base64dec | autoindent hub}}
+
+                      '
+                    tls.key: '{{hub ( index ( lookup "v1" "Secret" "default" .ManagedClusterName
+                      ).data "tls.key" ) | base64dec | autoindent hub}}
+
+                      '
+                  kind: Secret
+                  metadata:
+                    name: ingress-certificate-secret
+                    namespace: openshift-ingress
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            name: rosa-ingress-certificate
+            namespace: ''
+            compliance: Compliant
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-replace-default-cert
+            spec:
+              object-templates:
+              - complianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
+                  spec:
+                    defaultCertificate:
+                      name: ingress-certificate-secret
+              pruneObjectBehavior: DeleteAll
+              remediationAction: inform
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-ingress-certificate
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-ingress-certificate
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-ingress-certificate
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-oauth-templates
         namespace: openshift-acm-policies
       spec:


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / why we need it?

1. deploy policy to the SC to detect ingress certificate generated by cert-manager
2. push the cert secret into the HC, to be used by ingresscontroller

### Which Jira/Github issue(s) this PR fixes?

Fixes: [SDE-2743](https://issues.redhat.com//browse/SDE-2743)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
