### PR TITLE
Add ability for SREP to add 'reason' metadata header to api requests

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -37,6 +37,12 @@ spec:
                                 - users
                               verbs:
                                 - impersonate
+                            - apiGroups:
+                                - authentication.k8s.io
+                              resources:
+                                - userextras/reason
+                              verbs:
+                                - impersonate
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/elevated-sre/00-impersonate-cluster-admin.ClusterRole.yml
+++ b/deploy/backplane/elevated-sre/00-impersonate-cluster-admin.ClusterRole.yml
@@ -11,3 +11,10 @@ rules:
       - impersonate
     resourceNames:
       - backplane-cluster-admin
+  # SRE can add Impersonate-Extra-Reason headers to API requests
+  - apiGroups:
+    - authentication.k8s.io
+    verbs:
+    - impersonate
+    resources:
+    - userextras/reason

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1582,6 +1582,12 @@ objects:
                     - users
                     verbs:
                     - impersonate
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - userextras/reason
+                    verbs:
+                    - impersonate
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -8434,6 +8440,12 @@ objects:
         - impersonate
         resourceNames:
         - backplane-cluster-admin
+      - apiGroups:
+        - authentication.k8s.io
+        verbs:
+        - impersonate
+        resources:
+        - userextras/reason
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1582,6 +1582,12 @@ objects:
                     - users
                     verbs:
                     - impersonate
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - userextras/reason
+                    verbs:
+                    - impersonate
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -8434,6 +8440,12 @@ objects:
         - impersonate
         resourceNames:
         - backplane-cluster-admin
+      - apiGroups:
+        - authentication.k8s.io
+        verbs:
+        - impersonate
+        resources:
+        - userextras/reason
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1582,6 +1582,12 @@ objects:
                     - users
                     verbs:
                     - impersonate
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - userextras/reason
+                    verbs:
+                    - impersonate
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -8434,6 +8440,12 @@ objects:
         - impersonate
         resourceNames:
         - backplane-cluster-admin
+      - apiGroups:
+        - authentication.k8s.io
+        verbs:
+        - impersonate
+        resources:
+        - userextras/reason
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Adds the ability for SREP backplane users to add metadata to their impersonation user API requests (see [docs](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) for why this is necessary). 
Allows us to send extra information in Kube API requests for compliance reasons.
Suggested by @wanghaoran1988 here: 
https://github.com/openshift/backplane-cli/pull/38/files#r1136676616
### Which Jira/Github issue(s) this PR fixes?
_Fixes #_
https://github.com/openshift/backplane-cli/pull/38
https://issues.redhat.com/browse/OSD-13235
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
