### PR TITLE
apply integration timeout fix for sc and mc in hypershift

### DIFF
--- a/deploy/osd-oauth-templates/ohss-2561-hypershift/README.md
+++ b/deploy/osd-oauth-templates/ohss-2561-hypershift/README.md
@@ -1,0 +1,5 @@
+This is a temporary measure undertaken as part of [OHSS-2561](https://issues.redhat.com/browse/OHSS-2561) whilst a longer-term solution is sought to make this configurable by cluster owners.
+
+This change applies an extended login session duration of 7d to Hypershift Management and Service clusters in Integration.
+
+

--- a/deploy/osd-oauth-templates/ohss-2561-hypershift/config.yaml
+++ b/deploy/osd-oauth-templates/ohss-2561-hypershift/config.yaml
@@ -4,6 +4,6 @@ selectorSyncSet:
   - key: environment
     operator: In
     values: ["integration"]
-  - key: ext-managed.openshift.io/hive-shard
+  - key: ext-hypershift.openshift.io/cluster-type
     operator: In
-    values: ["true"]
+    values: ["service-cluster", "management-cluster"]

--- a/deploy/osd-oauth-templates/ohss-2561-hypershift/hive-integration-oauth.patch.yaml
+++ b/deploy/osd-oauth-templates/ohss-2561-hypershift/hive-integration-oauth.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: config.openshift.io/v1
+applyMode: AlwaysApply
+kind: OAuth
+name: cluster
+namespace: default
+patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout": "168h"}}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27016,6 +27016,33 @@ objects:
         operator: In
         values:
         - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: OAuth
+      name: cluster
+      namespace: default
+      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
+        "168h"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-oauth-templates-ohss-2561-hypershift
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - integration
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27016,6 +27016,33 @@ objects:
         operator: In
         values:
         - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: OAuth
+      name: cluster
+      namespace: default
+      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
+        "168h"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-oauth-templates-ohss-2561-hypershift
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - integration
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27016,6 +27016,33 @@ objects:
         operator: In
         values:
         - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: OAuth
+      name: cluster
+      namespace: default
+      patch: '{"spec":{"tokenConfig":{"accessTokenMaxAgeSeconds":604800, "accessTokenInactivityTimeout":
+        "168h"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-oauth-templates-ohss-2561-hypershift
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - integration
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug
### What this PR does / why we need it?
the fix in https://github.com/openshift/managed-cluster-config/pull/1521 didn't work because of the way matchExpressions works that all the expressions must evaluate to true. 
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15168
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
