### PR TITLE
(OSD-14058) feat: Add KubeJobFailingSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-sre-kubejobfailing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-kubejobfailing.PrometheusRule.yaml
@@ -1,0 +1,51 @@
+# Existing KubeJob*Failed* alert fires regardless of successfully finished CronJob resulting in a frequent no-op pages. In case of single job failure, if a more recent job completed, the alert indicates an intermittent failure and requires no further investigation.
+# Whereas KubeJob*Failing* alert fires if the Kubernetes Job is consecutively failing.
+# Original alert will be sent to null receiver in CAM-operator and a custom SREP alert with improved expression will replace it.
+# https://issues.redhat.com/browse/OSD-14058
+# TODO: remove KubeJobFailingSRE after KubeJobFailing is available in upstream (https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/816)
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-kubejobfailing
+    role: alert-rules
+  name: sre-kubejobfailing
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-kubejobfailing-recording.rules
+    rules:
+    - record: job:kube_job_status_failed:sum
+      expr: |
+        clamp_max(job:kube_job_status_start_time:max, 1)
+        * ON(job_name) GROUP_LEFT()
+        (kube_job_status_failed{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"} > 0)
+    - record: job:kube_job_status_start_time:max
+      expr: |
+        max(
+         kube_job_status_start_time{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+         * ON(job_name,namespace) GROUP_RIGHT()
+         kube_job_owner{owner_name!="",owner_name!="<none>"}
+        )   
+        BY (job_name, owner_name, namespace)
+        == ON(owner_name) GROUP_LEFT()
+        max(
+         kube_job_status_start_time{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+         * ON(job_name,namespace) GROUP_RIGHT()
+         kube_job_owner{owner_name!="",owner_name!="<none>"}
+        )   
+        BY (owner_name)
+  - name: sre-kubejobfailing
+    rules:
+    - alert: KubeJobFailingSRE
+      expr: |
+        job:kube_job_status_failed:sum
+      for: 15m
+      labels:
+        severity: warning
+        namespace: '{{ $labels.namespace }}'
+      annotations:
+        description: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is failing to complete.'
+        summary: 'Job is failing to complete.'
+        link: 'https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeJobFailed.md'
+        

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31610,6 +31610,51 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-kubejobfailing
+          role: alert-rules
+        name: sre-kubejobfailing
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-kubejobfailing-recording.rules
+          rules:
+          - record: job:kube_job_status_failed:sum
+            expr: 'clamp_max(job:kube_job_status_start_time:max, 1)
+
+              * ON(job_name) GROUP_LEFT()
+
+              (kube_job_status_failed{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              > 0)
+
+              '
+          - record: job:kube_job_status_start_time:max
+            expr: "max(\n kube_job_status_start_time{namespace=~\"(openshift-.*|kube-.*|default)\"\
+              ,job=\"kube-state-metrics\"}\n * ON(job_name,namespace) GROUP_RIGHT()\n\
+              \ kube_job_owner{owner_name!=\"\",owner_name!=\"<none>\"}\n)   \nBY\
+              \ (job_name, owner_name, namespace)\n== ON(owner_name) GROUP_LEFT()\n\
+              max(\n kube_job_status_start_time{namespace=~\"(openshift-.*|kube-.*|default)\"\
+              ,job=\"kube-state-metrics\"}\n * ON(job_name,namespace) GROUP_RIGHT()\n\
+              \ kube_job_owner{owner_name!=\"\",owner_name!=\"<none>\"}\n)   \nBY\
+              \ (owner_name)\n"
+        - name: sre-kubejobfailing
+          rules:
+          - alert: KubeJobFailingSRE
+            expr: 'job:kube_job_status_failed:sum
+
+              '
+            for: 15m
+            labels:
+              severity: warning
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is failing
+                to complete.
+              summary: Job is failing to complete.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeJobFailed.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubequotaexceeded
           role: alert-rules
         name: sre-kubequotaexceeded

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31610,6 +31610,51 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-kubejobfailing
+          role: alert-rules
+        name: sre-kubejobfailing
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-kubejobfailing-recording.rules
+          rules:
+          - record: job:kube_job_status_failed:sum
+            expr: 'clamp_max(job:kube_job_status_start_time:max, 1)
+
+              * ON(job_name) GROUP_LEFT()
+
+              (kube_job_status_failed{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              > 0)
+
+              '
+          - record: job:kube_job_status_start_time:max
+            expr: "max(\n kube_job_status_start_time{namespace=~\"(openshift-.*|kube-.*|default)\"\
+              ,job=\"kube-state-metrics\"}\n * ON(job_name,namespace) GROUP_RIGHT()\n\
+              \ kube_job_owner{owner_name!=\"\",owner_name!=\"<none>\"}\n)   \nBY\
+              \ (job_name, owner_name, namespace)\n== ON(owner_name) GROUP_LEFT()\n\
+              max(\n kube_job_status_start_time{namespace=~\"(openshift-.*|kube-.*|default)\"\
+              ,job=\"kube-state-metrics\"}\n * ON(job_name,namespace) GROUP_RIGHT()\n\
+              \ kube_job_owner{owner_name!=\"\",owner_name!=\"<none>\"}\n)   \nBY\
+              \ (owner_name)\n"
+        - name: sre-kubejobfailing
+          rules:
+          - alert: KubeJobFailingSRE
+            expr: 'job:kube_job_status_failed:sum
+
+              '
+            for: 15m
+            labels:
+              severity: warning
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is failing
+                to complete.
+              summary: Job is failing to complete.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeJobFailed.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubequotaexceeded
           role: alert-rules
         name: sre-kubequotaexceeded

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31610,6 +31610,51 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-kubejobfailing
+          role: alert-rules
+        name: sre-kubejobfailing
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-kubejobfailing-recording.rules
+          rules:
+          - record: job:kube_job_status_failed:sum
+            expr: 'clamp_max(job:kube_job_status_start_time:max, 1)
+
+              * ON(job_name) GROUP_LEFT()
+
+              (kube_job_status_failed{namespace=~"(openshift-.*|kube-.*|default)",job="kube-state-metrics"}
+              > 0)
+
+              '
+          - record: job:kube_job_status_start_time:max
+            expr: "max(\n kube_job_status_start_time{namespace=~\"(openshift-.*|kube-.*|default)\"\
+              ,job=\"kube-state-metrics\"}\n * ON(job_name,namespace) GROUP_RIGHT()\n\
+              \ kube_job_owner{owner_name!=\"\",owner_name!=\"<none>\"}\n)   \nBY\
+              \ (job_name, owner_name, namespace)\n== ON(owner_name) GROUP_LEFT()\n\
+              max(\n kube_job_status_start_time{namespace=~\"(openshift-.*|kube-.*|default)\"\
+              ,job=\"kube-state-metrics\"}\n * ON(job_name,namespace) GROUP_RIGHT()\n\
+              \ kube_job_owner{owner_name!=\"\",owner_name!=\"<none>\"}\n)   \nBY\
+              \ (owner_name)\n"
+        - name: sre-kubejobfailing
+          rules:
+          - alert: KubeJobFailingSRE
+            expr: 'job:kube_job_status_failed:sum
+
+              '
+            for: 15m
+            labels:
+              severity: warning
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is failing
+                to complete.
+              summary: Job is failing to complete.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeJobFailed.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubequotaexceeded
           role: alert-rules
         name: sre-kubequotaexceeded


### PR DESCRIPTION
### What type of PR is this?
Feature

### What does this PR do / why we need it?
Existing KubeJob*Failed* alert fires regardless of successfully finished CronJob resulting in frequent no-op pages. In case of a single job failure, if a more recent job completed, the alert indicates an intermittent failure and requires no further investigation.

Whereas KubeJob*Failing* alert fires if the Kubernetes Job is consecutively failing.

### Which Jira/Github issue(s) this PR fixes?
Fixes https://issues.redhat.com/browse/OSD-14058

### Special notes for your reviewer:
[PR](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/816#pullrequestreview-1270973165) in the upstream project has been created, but maintainers are taking time to merge it. The kubernetes-mixin project is nowadays mostly inactive.

Performance test of KubeJobFailing (job:kube_job_status_failing:sum) with the use of recording rules:
```
  "stats": {
    "timings": {
      "evalTotalTime": 0.000071755,
      "resultSortTime": 0,
      "queryPreparationTime": 0.000040308,
      "innerEvalTime": 0.000022829,
      "execQueueTime": 0.000007586,
      "execTotalTime": 0.00008497
    },
    "samples": {
      "totalQueryableSamples": 1,
      "peakSamples": 1
    }
  },
```

### Pre-checks (if applicable):
- [X] Tested the latest changes against a cluster (https://issues.redhat.com/browse/OSD-14056)