### PR TITLE
deploy route-monitor-operator to hypershift from app-sre repo

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -45,7 +45,7 @@ spec:
                         metadata:
                             name: route-monitor-operator
                         spec:
-                            image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+                            image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -45,7 +45,7 @@ spec:
                         metadata:
                             name: route-monitor-operator
                         spec:
-                            image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                            image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/hs-mgmt-route-monitor-api/package.yaml
+++ b/deploy/hs-mgmt-route-monitor-api/package.yaml
@@ -3,4 +3,4 @@ kind: Package
 metadata:
   name: route-monitor-operator
 spec:
-  image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+  image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f

--- a/deploy/hs-mgmt-route-monitor-api/package.yaml
+++ b/deploy/hs-mgmt-route-monitor-api/package.yaml
@@ -1,6 +1,0 @@
-apiVersion: package-operator.run/v1alpha1
-kind: Package
-metadata:
-  name: route-monitor-operator
-spec:
-  image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f

--- a/deploy/hs-mgmt-route-monitor-operator/package.yaml
+++ b/deploy/hs-mgmt-route-monitor-operator/package.yaml
@@ -3,4 +3,4 @@ kind: Package
 metadata:
   name: route-monitor-operator
 spec:
-  image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+  image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21377,26 +21377,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: hs-mgmt-route-monitor-api
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: package-operator.run/v1alpha1
-      kind: Package
-      metadata:
-        name: route-monitor-operator
-      spec:
-        image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3013,7 +3013,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3013,7 +3013,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+                    image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -21370,6 +21370,26 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-registry-cas-project
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hs-mgmt-route-monitor-api
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: package-operator.run/v1alpha1
+      kind: Package
+      metadata:
+        name: route-monitor-operator
+      spec:
+        image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21377,26 +21377,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: hs-mgmt-route-monitor-api
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: package-operator.run/v1alpha1
-      kind: Package
-      metadata:
-        name: route-monitor-operator
-      spec:
-        image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3013,7 +3013,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3013,7 +3013,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+                    image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -21370,6 +21370,26 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-registry-cas-project
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hs-mgmt-route-monitor-api
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: package-operator.run/v1alpha1
+      kind: Package
+      metadata:
+        name: route-monitor-operator
+      spec:
+        image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21377,26 +21377,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: hs-mgmt-route-monitor-api
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
-    resources:
-    - apiVersion: package-operator.run/v1alpha1
-      kind: Package
-      metadata:
-        name: route-monitor-operator
-      spec:
-        image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3013,7 +3013,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3013,7 +3013,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
+                    image: quay.io/achvatal/route-monitor-operator-hs-package:v0.1.487-f6fa14d
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -21370,6 +21370,26 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: dedicated-admins-registry-cas-project
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: hs-mgmt-route-monitor-api
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: package-operator.run/v1alpha1
+      kind: Package
+      metadata:
+        name: route-monitor-operator
+      spec:
+        image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.461-dbddf1f
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Deploys the latest route-monitor-operator package image from the app-sre repo, now that it has an image

### Which Jira/Github issue(s) this PR fixes?

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
