### PR TITLE
Restrict KMS CreateGrant to EC2

### DIFF
--- a/resources/sts/4.10/sts_support_permission_policy.json
+++ b/resources/sts/4.10/sts_support_permission_policy.json
@@ -140,7 +140,6 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
-                "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
                 "route53:ListHostedZones",
@@ -166,6 +165,21 @@
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": true
+                },
+                "StringLike": {
+                    "kms:ViaService": "ec2.*.amazonaws.com"
+                }
+            }
         }
     ]
 }

--- a/resources/sts/4.11/sts_support_permission_policy.json
+++ b/resources/sts/4.11/sts_support_permission_policy.json
@@ -140,7 +140,6 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
-                "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
                 "route53:ListHostedZones",
@@ -166,6 +165,21 @@
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": true
+                },
+                "StringLike": {
+                    "kms:ViaService": "ec2.*.amazonaws.com"
+                }
+            }
         }
     ]
 }

--- a/resources/sts/4.12/sts_support_permission_policy.json
+++ b/resources/sts/4.12/sts_support_permission_policy.json
@@ -140,7 +140,6 @@
                 "elasticloadbalancing:DescribeTargetHealth",
                 "iam:GetRole",
                 "iam:ListRoles",
-                "kms:CreateGrant",
                 "route53:GetHostedZone",
                 "route53:GetHostedZoneCount",
                 "route53:ListHostedZones",
@@ -166,6 +165,21 @@
                 "arn:aws:s3:::managed-velero*",
                 "arn:aws:s3:::*image-registry*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": true
+                },
+                "StringLike": {
+                    "kms:ViaService": "ec2.*.amazonaws.com"
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This PR restricts the KMS CreateGrant action to the EC2 service only in the SRE support policy. This is used when launching instances for the network verifier.

### Which Jira/Github issue(s) this PR fixes?

[OSD-15604](https://issues.redhat.com/browse/OSD-15604)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
