### PR TITLE
Add KMS CreateGrant restriction, combine EC2 statement for policy length for HyperShift

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
@@ -24,7 +24,6 @@
         "elasticloadbalancing:Describe*",
         "iam:GetRole",
         "iam:ListRoles",
-        "kms:CreateGrant",
         "route53:GetHosted*",
         "route53:List*",
         "s3:GetBucketTagging",
@@ -143,6 +142,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:RebootInstances",
         "ec2:StartInstances",
         "ec2:StopInstances",
         "ec2:TerminateInstances"
@@ -329,12 +329,17 @@
     },
     {
       "Effect": "Allow",
-      "Action": "ec2:RebootInstances",
-      "Resource": "arn:aws:ec2:*:*:instance/*",
+      "Action": [
+          "kms:CreateGrant"
+      ],
+      "Resource": "*",
       "Condition": {
-        "StringEquals": {
-          "aws:ResourceTag/red-hat-managed": "true"
-        }
+          "Bool": {
+              "kms:GrantIsForAWSResource": true
+          },
+          "StringLike": {
+              "kms:ViaService": "ec2.*.amazonaws.com"
+          }
       }
     }
   ]


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

This PR restricts the KMS CreateGrant action to the EC2 service only in the SRE HyperShift support policy. This is used when launching instances for the network verifier.

The condition keys and resource for the two combined IAM policy statements are the same there should be no issues with combining them.

### Which Jira/Github issue(s) this PR fixes?

[OSD-15604](https://issues.redhat.com/browse/OSD-15604)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
