### PR TITLE
Target hcp namespaces by label instead of regex for route-monitor-operator policy

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -21,8 +21,8 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 namespaceSelector:
-                    include:
-                        - ocm-*-*-*
+                    matchLabels:
+                        hypershift.openshift.io/hosted-control-plane: "true"
                 object-templates:
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave

--- a/deploy/hs-mgmt-route-monitor-operator/config.yaml
+++ b/deploy/hs-mgmt-route-monitor-operator/config.yaml
@@ -2,4 +2,5 @@ deploymentMode: Policy
 clusterSelectors:
   hypershift.open-cluster-management.io/management-cluster: true
 namespaceSelector:
-  include: ["ocm-*-*-*"]
+  matchLabels:
+    hypershift.openshift.io/hosted-control-plane: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2989,8 +2989,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               namespaceSelector:
-                include:
-                - ocm-*-*-*
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2989,8 +2989,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               namespaceSelector:
-                include:
-                - ocm-*-*-*
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2989,8 +2989,8 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               namespaceSelector:
-                include:
-                - ocm-*-*-*
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Targeting hostedcontrolplane namespaces by using the label `hypershift.openshift.io/hosted-control-plane: true` should be easier to understand at a glance and less fragile than using a regex for the namespace's name (should the namespace patter ever change).

### Which Jira/Github issue(s) this PR fixes?
related to [OSD-14462](https://issues.redhat.com/browse/OSD-14462)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
