### PR TITLE
Set domainRef for api clusterurlmonitor

### DIFF
--- a/deploy/hs-mgmt-route-monitor-operator/api.ClusterUrlMonitor.yaml
+++ b/deploy/hs-mgmt-route-monitor-operator/api.ClusterUrlMonitor.yaml
@@ -9,3 +9,4 @@ spec:
   slo:
     targetAvailabilityPercent: "99.0"
   suffix: /livez
+  domainRef: hcp


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Takes advantage of [recent merge to RMO](https://github.com/openshift/route-monitor-operator/pull/193) allowing us to set the domain reference for clusterurlmonitors.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15399

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
