### PR TITLE
Add openshift-customer-monitoring support to HCP

### DIFF
--- a/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
@@ -1,0 +1,658 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: osd-customer-monitoring
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: osd-customer-monitoring
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: Namespace
+                        metadata:
+                            annotations:
+                                openshift.io/node-selector: ""
+                            labels:
+                                name: openshift-customer-monitoring
+                                openshift.io/cluster-logging: "true"
+                                openshift.io/cluster-monitoring: "false"
+                                openshift.io/workload-monitoring: "true"
+                            name: openshift-customer-monitoring
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: operators.coreos.com/v1
+                        kind: OperatorGroup
+                        metadata:
+                            name: openshift-customer-monitoring
+                            namespace: openshift-customer-monitoring
+                        spec:
+                            serviceAccount:
+                                metadata:
+                                    creationTimestamp: null
+                            targetNamespaces:
+                                - openshift-customer-monitoring
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: prometheus-k8s-openshift-customer-monitoring
+                            namespace: openshift-customer-monitoring
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - '*'
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: dedicated-admins-openshift-customer-monitoring
+                            namespace: openshift-customer-monitoring
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - namespaces
+                                - pods
+                                - pods/log
+                              verbs:
+                                - list
+                                - get
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                              verbs:
+                                - delete
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - subscriptions
+                                - clusterserviceversions
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - prometheuses
+                                - prometheusrules
+                                - servicemonitors
+                                - podmonitors
+                                - thanosrulers
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - alertmanagers
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                                - project.openshift.io
+                              resources:
+                                - projects
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - configmaps
+                                - endpoints
+                                - persistentvolumeclaims
+                                - replicationcontrollers
+                                - replicationcontrollers/scale
+                                - services
+                                - services/proxy
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - patch
+                                - update
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - daemonsets
+                                - deployments
+                                - deployments/rollback
+                                - deployments/scale
+                                - replicasets
+                                - replicasets/scale
+                                - statefulsets
+                                - statefulsets/scale
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - patch
+                                - update
+                            - apiGroups:
+                                - autoscaling
+                              resources:
+                                - horizontalpodautoscalers
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - patch
+                                - update
+                            - apiGroups:
+                                - batch
+                              resources:
+                                - cronjobs
+                                - jobs
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - patch
+                                - update
+                            - apiGroups:
+                                - extensions
+                              resources:
+                                - daemonsets
+                                - deployments
+                                - deployments/rollback
+                                - deployments/scale
+                                - ingresses
+                                - networkpolicies
+                                - replicasets
+                                - replicasets/scale
+                                - replicationcontrollers/scale
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - patch
+                                - update
+                            - apiGroups:
+                                - policy
+                              resources:
+                                - poddisruptionbudgets
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - patch
+                                - update
+                            - apiGroups:
+                                - networking.k8s.io
+                              resources:
+                                - networkpolicies
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - patch
+                                - update
+                            - apiGroups:
+                                - metrics.k8s.io
+                              resources:
+                                - pods
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - builds/details
+                              verbs:
+                                - update
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - builds
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - buildconfigs
+                                - buildconfigs/webhooks
+                                - builds
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - builds/log
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - buildconfigs/instantiate
+                                - buildconfigs/instantiatebinary
+                                - builds/clone
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - jenkins
+                              verbs:
+                                - edit
+                                - view
+                            - apiGroups:
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs
+                                - deploymentconfigs/scale
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigrollbacks
+                                - deploymentconfigs/instantiate
+                                - deploymentconfigs/rollback
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs/log
+                                - deploymentconfigs/status
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - image.openshift.io
+                              resources:
+                                - imagestreams/status
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - quota.openshift.io
+                              resources:
+                                - appliedclusterresourcequotas
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routes
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routes/custom-host
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routes/status
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - template.openshift.io
+                              resources:
+                                - processedtemplates
+                                - templateconfigs
+                                - templateinstances
+                                - templates
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - extensions
+                                - networking.k8s.io
+                              resources:
+                                - networkpolicies
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - buildlogs
+                              verbs:
+                                - create
+                                - delete
+                                - deletecollection
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - resourcequotausages
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - configmaps
+                                - endpoints
+                                - persistentvolumeclaims
+                                - pods
+                                - replicationcontrollers
+                                - replicationcontrollers/scale
+                                - services
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - bindings
+                                - events
+                                - limitranges
+                                - namespaces/status
+                                - pods/log
+                                - pods/status
+                                - replicationcontrollers/status
+                                - resourcequotas
+                                - resourcequotas/status
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - namespaces
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - controllerrevisions
+                                - daemonsets
+                                - deployments
+                                - deployments/scale
+                                - replicasets
+                                - replicasets/scale
+                                - statefulsets
+                                - statefulsets/scale
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - autoscaling
+                              resources:
+                                - horizontalpodautoscalers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - batch
+                              resources:
+                                - cronjobs
+                                - jobs
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - extensions
+                              resources:
+                                - daemonsets
+                                - deployments
+                                - deployments/scale
+                                - ingresses
+                                - networkpolicies
+                                - replicasets
+                                - replicasets/scale
+                                - replicationcontrollers/scale
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - policy
+                              resources:
+                                - poddisruptionbudgets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - networking.k8s.io
+                              resources:
+                                - networkpolicies
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - buildconfigs
+                                - buildconfigs/webhooks
+                                - builds
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - jenkins
+                              verbs:
+                                - view
+                            - apiGroups:
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs
+                                - deploymentconfigs/scale
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - buildlogs
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - packages.operators.coreos.com
+                              resources:
+                                - packagemanifests
+                              verbs:
+                                - '*'
+                            - apiGroups:
+                                - authorization.openshift.io
+                              resources:
+                                - localresourceaccessreviews
+                                - localsubjectaccessreviews
+                                - subjectrulesreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - authorization.k8s.io
+                              resources:
+                                - localsubjectaccessreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - authorization.openshift.io
+                              resources:
+                                - resourceaccessreviews
+                                - subjectaccessreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - security.openshift.io
+                              resources:
+                                - podsecuritypolicyreviews
+                                - podsecuritypolicyselfsubjectreviews
+                                - podsecuritypolicysubjectreviews
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routes/status
+                              verbs:
+                                - update
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/portforward
+                              verbs:
+                                - create
+                                - delete
+                                - get
+                                - list
+                                - patch
+                                - update
+                                - watch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: prometheus-k8s-openshift-customer-monitoring
+                            namespace: openshift-customer-monitoring
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: prometheus-k8s-openshift-customer-monitoring
+                        subjects:
+                            - kind: ServiceAccount
+                              name: prometheus-k8s
+                              namespace: openshift-customer-monitoring
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: dedicated-admins-openshift-customer-monitoring
+                            namespace: openshift-customer-monitoring
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: dedicated-admins-openshift-customer-monitoring
+                        subjects:
+                            - kind: Group
+                              name: dedicated-admins
+                            - kind: Group
+                              name: system:serviceaccounts:dedicated-admin
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-osd-customer-monitoring
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-osd-customer-monitoring
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-osd-customer-monitoring
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: osd-customer-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3200,6 +3200,661 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-customer-monitoring
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-customer-monitoring
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    annotations:
+                      openshift.io/node-selector: ''
+                    labels:
+                      name: openshift-customer-monitoring
+                      openshift.io/cluster-logging: 'true'
+                      openshift.io/cluster-monitoring: 'false'
+                      openshift.io/workload-monitoring: 'true'
+                    name: openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operators.coreos.com/v1
+                  kind: OperatorGroup
+                  metadata:
+                    name: openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  spec:
+                    serviceAccount:
+                      metadata:
+                        creationTimestamp: null
+                    targetNamespaces:
+                    - openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: prometheus-k8s-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - '*'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    - pods
+                    - pods/log
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - subscriptions
+                    - clusterserviceversions
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - podmonitors
+                    - thanosrulers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    - endpoints
+                    - persistentvolumeclaims
+                    - replicationcontrollers
+                    - replicationcontrollers/scale
+                    - services
+                    - services/proxy
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/rollback
+                    - deployments/scale
+                    - replicasets
+                    - replicasets/scale
+                    - statefulsets
+                    - statefulsets/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - cronjobs
+                    - jobs
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - extensions
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/rollback
+                    - deployments/scale
+                    - ingresses
+                    - networkpolicies
+                    - replicasets
+                    - replicasets/scale
+                    - replicationcontrollers/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds/details
+                    verbs:
+                    - update
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs/instantiate
+                    - buildconfigs/instantiatebinary
+                    - builds/clone
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - edit
+                    - view
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigrollbacks
+                    - deploymentconfigs/instantiate
+                    - deploymentconfigs/rollback
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/log
+                    - deploymentconfigs/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/custom-host
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - processedtemplates
+                    - templateconfigs
+                    - templateinstances
+                    - templates
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotausages
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    - endpoints
+                    - persistentvolumeclaims
+                    - pods
+                    - replicationcontrollers
+                    - replicationcontrollers/scale
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - bindings
+                    - events
+                    - limitranges
+                    - namespaces/status
+                    - pods/log
+                    - pods/status
+                    - replicationcontrollers/status
+                    - resourcequotas
+                    - resourcequotas/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - controllerrevisions
+                    - daemonsets
+                    - deployments
+                    - deployments/scale
+                    - replicasets
+                    - replicasets/scale
+                    - statefulsets
+                    - statefulsets/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - cronjobs
+                    - jobs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/scale
+                    - ingresses
+                    - networkpolicies
+                    - replicasets
+                    - replicasets/scale
+                    - replicationcontrollers/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - view
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    - subjectrulesreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - localsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - resourceaccessreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - podsecuritypolicyreviews
+                    - podsecuritypolicyselfsubjectreviews
+                    - podsecuritypolicysubjectreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - update
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: prometheus-k8s-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: prometheus-k8s-openshift-customer-monitoring
+                  subjects:
+                  - kind: ServiceAccount
+                    name: prometheus-k8s
+                    namespace: openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-customer-monitoring
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-customer-monitoring
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-customer-monitoring
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-customer-monitoring
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-customer-monitoring
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3200,6 +3200,661 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-customer-monitoring
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-customer-monitoring
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    annotations:
+                      openshift.io/node-selector: ''
+                    labels:
+                      name: openshift-customer-monitoring
+                      openshift.io/cluster-logging: 'true'
+                      openshift.io/cluster-monitoring: 'false'
+                      openshift.io/workload-monitoring: 'true'
+                    name: openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operators.coreos.com/v1
+                  kind: OperatorGroup
+                  metadata:
+                    name: openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  spec:
+                    serviceAccount:
+                      metadata:
+                        creationTimestamp: null
+                    targetNamespaces:
+                    - openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: prometheus-k8s-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - '*'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    - pods
+                    - pods/log
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - subscriptions
+                    - clusterserviceversions
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - podmonitors
+                    - thanosrulers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    - endpoints
+                    - persistentvolumeclaims
+                    - replicationcontrollers
+                    - replicationcontrollers/scale
+                    - services
+                    - services/proxy
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/rollback
+                    - deployments/scale
+                    - replicasets
+                    - replicasets/scale
+                    - statefulsets
+                    - statefulsets/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - cronjobs
+                    - jobs
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - extensions
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/rollback
+                    - deployments/scale
+                    - ingresses
+                    - networkpolicies
+                    - replicasets
+                    - replicasets/scale
+                    - replicationcontrollers/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds/details
+                    verbs:
+                    - update
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs/instantiate
+                    - buildconfigs/instantiatebinary
+                    - builds/clone
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - edit
+                    - view
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigrollbacks
+                    - deploymentconfigs/instantiate
+                    - deploymentconfigs/rollback
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/log
+                    - deploymentconfigs/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/custom-host
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - processedtemplates
+                    - templateconfigs
+                    - templateinstances
+                    - templates
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotausages
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    - endpoints
+                    - persistentvolumeclaims
+                    - pods
+                    - replicationcontrollers
+                    - replicationcontrollers/scale
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - bindings
+                    - events
+                    - limitranges
+                    - namespaces/status
+                    - pods/log
+                    - pods/status
+                    - replicationcontrollers/status
+                    - resourcequotas
+                    - resourcequotas/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - controllerrevisions
+                    - daemonsets
+                    - deployments
+                    - deployments/scale
+                    - replicasets
+                    - replicasets/scale
+                    - statefulsets
+                    - statefulsets/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - cronjobs
+                    - jobs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/scale
+                    - ingresses
+                    - networkpolicies
+                    - replicasets
+                    - replicasets/scale
+                    - replicationcontrollers/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - view
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    - subjectrulesreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - localsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - resourceaccessreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - podsecuritypolicyreviews
+                    - podsecuritypolicyselfsubjectreviews
+                    - podsecuritypolicysubjectreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - update
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: prometheus-k8s-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: prometheus-k8s-openshift-customer-monitoring
+                  subjects:
+                  - kind: ServiceAccount
+                    name: prometheus-k8s
+                    namespace: openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-customer-monitoring
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-customer-monitoring
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-customer-monitoring
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-customer-monitoring
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-customer-monitoring
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3200,6 +3200,661 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: osd-customer-monitoring
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: osd-customer-monitoring
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    annotations:
+                      openshift.io/node-selector: ''
+                    labels:
+                      name: openshift-customer-monitoring
+                      openshift.io/cluster-logging: 'true'
+                      openshift.io/cluster-monitoring: 'false'
+                      openshift.io/workload-monitoring: 'true'
+                    name: openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operators.coreos.com/v1
+                  kind: OperatorGroup
+                  metadata:
+                    name: openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  spec:
+                    serviceAccount:
+                      metadata:
+                        creationTimestamp: null
+                    targetNamespaces:
+                    - openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: prometheus-k8s-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - '*'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    - pods
+                    - pods/log
+                    verbs:
+                    - list
+                    - get
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - subscriptions
+                    - clusterserviceversions
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - podmonitors
+                    - thanosrulers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagers
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    - endpoints
+                    - persistentvolumeclaims
+                    - replicationcontrollers
+                    - replicationcontrollers/scale
+                    - services
+                    - services/proxy
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/rollback
+                    - deployments/scale
+                    - replicasets
+                    - replicasets/scale
+                    - statefulsets
+                    - statefulsets/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - cronjobs
+                    - jobs
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - extensions
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/rollback
+                    - deployments/scale
+                    - ingresses
+                    - networkpolicies
+                    - replicasets
+                    - replicasets/scale
+                    - replicationcontrollers/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - patch
+                    - update
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds/details
+                    verbs:
+                    - update
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - builds/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs/instantiate
+                    - buildconfigs/instantiatebinary
+                    - builds/clone
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - edit
+                    - view
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigrollbacks
+                    - deploymentconfigs/instantiate
+                    - deploymentconfigs/rollback
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/log
+                    - deploymentconfigs/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/custom-host
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - processedtemplates
+                    - templateconfigs
+                    - templateinstances
+                    - templates
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - create
+                    - delete
+                    - deletecollection
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotausages
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    - endpoints
+                    - persistentvolumeclaims
+                    - pods
+                    - replicationcontrollers
+                    - replicationcontrollers/scale
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - bindings
+                    - events
+                    - limitranges
+                    - namespaces/status
+                    - pods/log
+                    - pods/status
+                    - replicationcontrollers/status
+                    - resourcequotas
+                    - resourcequotas/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - controllerrevisions
+                    - daemonsets
+                    - deployments
+                    - deployments/scale
+                    - replicasets
+                    - replicasets/scale
+                    - statefulsets
+                    - statefulsets/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - cronjobs
+                    - jobs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - extensions
+                    resources:
+                    - daemonsets
+                    - deployments
+                    - deployments/scale
+                    - ingresses
+                    - networkpolicies
+                    - replicasets
+                    - replicasets/scale
+                    - replicationcontrollers/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - view
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - localresourceaccessreviews
+                    - localsubjectaccessreviews
+                    - subjectrulesreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.k8s.io
+                    resources:
+                    - localsubjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - resourceaccessreviews
+                    - subjectaccessreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - podsecuritypolicyreviews
+                    - podsecuritypolicyselfsubjectreviews
+                    - podsecuritypolicysubjectreviews
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - update
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+                    - delete
+                    - get
+                    - list
+                    - patch
+                    - update
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: prometheus-k8s-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: prometheus-k8s-openshift-customer-monitoring
+                  subjects:
+                  - kind: ServiceAccount
+                    name: prometheus-k8s
+                    namespace: openshift-customer-monitoring
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-openshift-customer-monitoring
+                    namespace: openshift-customer-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-openshift-customer-monitoring
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+                  - kind: Group
+                    name: system:serviceaccounts:dedicated-admin
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-osd-customer-monitoring
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-osd-customer-monitoring
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-osd-customer-monitoring
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: osd-customer-monitoring
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-delete-backplane-script-resources
         namespace: openshift-acm-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -26,6 +26,7 @@ directories = [
         'hs-hosted-route-monitor-operator',
         'hs-mgmt-route-monitor-operator',
         'osd-cluster-admin',
+        'osd-customer-monitoring',
         'osd-delete-backplane-script-resources',
         'osd-delete-backplane-serviceaccounts',
         'osd-backplane-managed-scripts',


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Gap with HCP config, openshift-customer-monitoring is currently  deployed fleet-wide today for OSD/ROSA.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15636

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
