### PR TITLE
SDA-8595 fix ingress policy

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -21,72 +21,28 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: mustonlyhave
+                    - complianceType: musthave
                       metadataComplianceType: musthave
                       objectDefinition:
-                        apiVersion: policy.open-cluster-management.io/v1
-                        kind: Policy
+                        apiVersion: v1
+                        data:
+                            tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
+                            tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
+                        kind: Secret
                         metadata:
-                            annotations:
-                                policy.open-cluster-management.io/categories: CM Configuration Management
-                                policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-                                policy.open-cluster-management.io/standards: NIST SP 800-53
-                            name: rosa-ingress-certificate
-                            namespace: openshift-acm-policies
+                            name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+                            namespace: openshift-ingress
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: operator.openshift.io/v1
+                        kind: IngressController
+                        metadata:
+                            name: default
+                            namespace: openshift-ingress-operator
                         spec:
-                            disabled: false
-                            policy-templates:
-                                - objectDefinition:
-                                    apiVersion: policy.open-cluster-management.io/v1
-                                    kind: ConfigurationPolicy
-                                    metadata:
-                                        name: rosa-ingress-certificate
-                                    spec:
-                                        evaluationInterval:
-                                            compliant: 2h
-                                            noncompliant: 45s
-                                        object-templates:
-                                            - complianceType: musthave
-                                              metadataComplianceType: musthave
-                                              objectDefinition:
-                                                apiVersion: v1
-                                                data:
-                                                    tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
-                                                    tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
-                                                kind: Secret
-                                                metadata:
-                                                    name: ingress-certificate-secret
-                                                    namespace: openshift-ingress
-                                        pruneObjectBehavior: DeleteIfCreated
-                                        remediationAction: enforce
-                                        severity: low
-                                - extraDependencies:
-                                    - apiVersion: policy.open-cluster-management.io/v1
-                                      compliance: Compliant
-                                      kind: ConfigurationPolicy
-                                      name: rosa-ingress-certificate
-                                      namespace: ""
-                                  objectDefinition:
-                                    apiVersion: policy.open-cluster-management.io/v1
-                                    kind: ConfigurationPolicy
-                                    metadata:
-                                        name: rosa-ingress-replace-default-cert
-                                    spec:
-                                        object-templates:
-                                            - complianceType: musthave
-                                              objectDefinition:
-                                                apiVersion: operator.openshift.io/v1
-                                                kind: IngressController
-                                                metadata:
-                                                    name: default
-                                                    namespace: openshift-ingress-operator
-                                                spec:
-                                                    defaultCertificate:
-                                                        name: ingress-certificate-secret
-                                        pruneObjectBehavior: DeleteAll
-                                        remediationAction: inform
-                                        severity: low
-                            remediationAction: enforce
+                            defaultCertificate:
+                                name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/rosa-ingress-certificate-policies/01-rosa-ingress-certificate.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/01-rosa-ingress-certificate.Policy.yaml
@@ -1,64 +1,8 @@
----
-apiVersion: policy.open-cluster-management.io/v1
-kind: Policy
+apiVersion: v1
+data:
+  tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
+  tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
+kind: Secret
 metadata:
-    annotations:
-        policy.open-cluster-management.io/categories: CM Configuration Management
-        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-        policy.open-cluster-management.io/standards: NIST SP 800-53
-    name: rosa-ingress-certificate
-    namespace: openshift-acm-policies
-spec:
-    disabled: false
-    policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-                name: rosa-ingress-certificate
-            spec:
-                evaluationInterval:
-                    compliant: 2h
-                    noncompliant: 45s
-                object-templates:
-                    - complianceType: musthave
-                      metadataComplianceType: musthave
-                      objectDefinition:
-                        apiVersion: v1
-                        data:
-                          tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
-                          tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
-                        kind: Secret
-                        metadata:
-                          name: ingress-certificate-secret
-                          namespace: openshift-ingress
-                pruneObjectBehavior: DeleteIfCreated
-                remediationAction: enforce
-                severity: low
-        - extraDependencies:
-            - apiVersion: policy.open-cluster-management.io/v1
-              kind: ConfigurationPolicy
-              name: rosa-ingress-certificate
-              namespace: ""
-              compliance: Compliant
-          objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-                name: rosa-ingress-replace-default-cert
-            spec:
-                object-templates:
-                    - complianceType: musthave
-                      objectDefinition:
-                        apiVersion: operator.openshift.io/v1
-                        kind: IngressController
-                        metadata:
-                          name: default
-                          namespace: openshift-ingress-operator
-                        spec:
-                          defaultCertificate:
-                            name: ingress-certificate-secret
-                pruneObjectBehavior: DeleteAll
-                remediationAction: inform
-                severity: low
-    remediationAction: enforce
+  name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+  namespace: openshift-ingress

--- a/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'

--- a/deploy/rosa-ingress-certificate-policies/config.yaml
+++ b/deploy/rosa-ingress-certificate-policies/config.yaml
@@ -1,3 +1,5 @@
 deploymentMode: Policy
 clusterSelectors:
   hypershift.open-cluster-management.io/hosted-cluster: true
+policy:
+  complianceType: "musthave"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6491,75 +6491,32 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
                 metadataComplianceType: musthave
                 objectDefinition:
-                  apiVersion: policy.open-cluster-management.io/v1
-                  kind: Policy
+                  apiVersion: v1
+                  data:
+                    tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
+                      "tls.crt" hub}}'
+                    tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
+                      "tls.key" hub}}'
+                  kind: Secret
                   metadata:
-                    annotations:
-                      policy.open-cluster-management.io/categories: CM Configuration
-                        Management
-                      policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-                      policy.open-cluster-management.io/standards: NIST SP 800-53
-                    name: rosa-ingress-certificate
-                    namespace: openshift-acm-policies
+                    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
+                      hub}}'
+                    namespace: openshift-ingress
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
                   spec:
-                    disabled: false
-                    policy-templates:
-                    - objectDefinition:
-                        apiVersion: policy.open-cluster-management.io/v1
-                        kind: ConfigurationPolicy
-                        metadata:
-                          name: rosa-ingress-certificate
-                        spec:
-                          evaluationInterval:
-                            compliant: 2h
-                            noncompliant: 45s
-                          object-templates:
-                          - complianceType: musthave
-                            metadataComplianceType: musthave
-                            objectDefinition:
-                              apiVersion: v1
-                              data:
-                                tls.crt: '{{hub fromSecret "openshift-acm-policies"
-                                  .ManagedClusterName "tls.crt" hub}}'
-                                tls.key: '{{hub fromSecret "openshift-acm-policies"
-                                  .ManagedClusterName "tls.key" hub}}'
-                              kind: Secret
-                              metadata:
-                                name: ingress-certificate-secret
-                                namespace: openshift-ingress
-                          pruneObjectBehavior: DeleteIfCreated
-                          remediationAction: enforce
-                          severity: low
-                    - extraDependencies:
-                      - apiVersion: policy.open-cluster-management.io/v1
-                        compliance: Compliant
-                        kind: ConfigurationPolicy
-                        name: rosa-ingress-certificate
-                        namespace: ''
-                      objectDefinition:
-                        apiVersion: policy.open-cluster-management.io/v1
-                        kind: ConfigurationPolicy
-                        metadata:
-                          name: rosa-ingress-replace-default-cert
-                        spec:
-                          object-templates:
-                          - complianceType: musthave
-                            objectDefinition:
-                              apiVersion: operator.openshift.io/v1
-                              kind: IngressController
-                              metadata:
-                                name: default
-                                namespace: openshift-ingress-operator
-                              spec:
-                                defaultCertificate:
-                                  name: ingress-certificate-secret
-                          pruneObjectBehavior: DeleteAll
-                          remediationAction: inform
-                          severity: low
-                    remediationAction: enforce
+                    defaultCertificate:
+                      name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
+                        hub}}'
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6491,75 +6491,32 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
                 metadataComplianceType: musthave
                 objectDefinition:
-                  apiVersion: policy.open-cluster-management.io/v1
-                  kind: Policy
+                  apiVersion: v1
+                  data:
+                    tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
+                      "tls.crt" hub}}'
+                    tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
+                      "tls.key" hub}}'
+                  kind: Secret
                   metadata:
-                    annotations:
-                      policy.open-cluster-management.io/categories: CM Configuration
-                        Management
-                      policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-                      policy.open-cluster-management.io/standards: NIST SP 800-53
-                    name: rosa-ingress-certificate
-                    namespace: openshift-acm-policies
+                    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
+                      hub}}'
+                    namespace: openshift-ingress
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
                   spec:
-                    disabled: false
-                    policy-templates:
-                    - objectDefinition:
-                        apiVersion: policy.open-cluster-management.io/v1
-                        kind: ConfigurationPolicy
-                        metadata:
-                          name: rosa-ingress-certificate
-                        spec:
-                          evaluationInterval:
-                            compliant: 2h
-                            noncompliant: 45s
-                          object-templates:
-                          - complianceType: musthave
-                            metadataComplianceType: musthave
-                            objectDefinition:
-                              apiVersion: v1
-                              data:
-                                tls.crt: '{{hub fromSecret "openshift-acm-policies"
-                                  .ManagedClusterName "tls.crt" hub}}'
-                                tls.key: '{{hub fromSecret "openshift-acm-policies"
-                                  .ManagedClusterName "tls.key" hub}}'
-                              kind: Secret
-                              metadata:
-                                name: ingress-certificate-secret
-                                namespace: openshift-ingress
-                          pruneObjectBehavior: DeleteIfCreated
-                          remediationAction: enforce
-                          severity: low
-                    - extraDependencies:
-                      - apiVersion: policy.open-cluster-management.io/v1
-                        compliance: Compliant
-                        kind: ConfigurationPolicy
-                        name: rosa-ingress-certificate
-                        namespace: ''
-                      objectDefinition:
-                        apiVersion: policy.open-cluster-management.io/v1
-                        kind: ConfigurationPolicy
-                        metadata:
-                          name: rosa-ingress-replace-default-cert
-                        spec:
-                          object-templates:
-                          - complianceType: musthave
-                            objectDefinition:
-                              apiVersion: operator.openshift.io/v1
-                              kind: IngressController
-                              metadata:
-                                name: default
-                                namespace: openshift-ingress-operator
-                              spec:
-                                defaultCertificate:
-                                  name: ingress-certificate-secret
-                          pruneObjectBehavior: DeleteAll
-                          remediationAction: inform
-                          severity: low
-                    remediationAction: enforce
+                    defaultCertificate:
+                      name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
+                        hub}}'
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6491,75 +6491,32 @@ objects:
                 compliant: 2h
                 noncompliant: 45s
               object-templates:
-              - complianceType: mustonlyhave
+              - complianceType: musthave
                 metadataComplianceType: musthave
                 objectDefinition:
-                  apiVersion: policy.open-cluster-management.io/v1
-                  kind: Policy
+                  apiVersion: v1
+                  data:
+                    tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
+                      "tls.crt" hub}}'
+                    tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
+                      "tls.key" hub}}'
+                  kind: Secret
                   metadata:
-                    annotations:
-                      policy.open-cluster-management.io/categories: CM Configuration
-                        Management
-                      policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-                      policy.open-cluster-management.io/standards: NIST SP 800-53
-                    name: rosa-ingress-certificate
-                    namespace: openshift-acm-policies
+                    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
+                      hub}}'
+                    namespace: openshift-ingress
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
                   spec:
-                    disabled: false
-                    policy-templates:
-                    - objectDefinition:
-                        apiVersion: policy.open-cluster-management.io/v1
-                        kind: ConfigurationPolicy
-                        metadata:
-                          name: rosa-ingress-certificate
-                        spec:
-                          evaluationInterval:
-                            compliant: 2h
-                            noncompliant: 45s
-                          object-templates:
-                          - complianceType: musthave
-                            metadataComplianceType: musthave
-                            objectDefinition:
-                              apiVersion: v1
-                              data:
-                                tls.crt: '{{hub fromSecret "openshift-acm-policies"
-                                  .ManagedClusterName "tls.crt" hub}}'
-                                tls.key: '{{hub fromSecret "openshift-acm-policies"
-                                  .ManagedClusterName "tls.key" hub}}'
-                              kind: Secret
-                              metadata:
-                                name: ingress-certificate-secret
-                                namespace: openshift-ingress
-                          pruneObjectBehavior: DeleteIfCreated
-                          remediationAction: enforce
-                          severity: low
-                    - extraDependencies:
-                      - apiVersion: policy.open-cluster-management.io/v1
-                        compliance: Compliant
-                        kind: ConfigurationPolicy
-                        name: rosa-ingress-certificate
-                        namespace: ''
-                      objectDefinition:
-                        apiVersion: policy.open-cluster-management.io/v1
-                        kind: ConfigurationPolicy
-                        metadata:
-                          name: rosa-ingress-replace-default-cert
-                        spec:
-                          object-templates:
-                          - complianceType: musthave
-                            objectDefinition:
-                              apiVersion: operator.openshift.io/v1
-                              kind: IngressController
-                              metadata:
-                                name: default
-                                namespace: openshift-ingress-operator
-                              spec:
-                                defaultCertificate:
-                                  name: ingress-certificate-secret
-                          pruneObjectBehavior: DeleteAll
-                          remediationAction: inform
-                          severity: low
-                    remediationAction: enforce
+                    defaultCertificate:
+                      name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
+                        hub}}'
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
* fix the ingress policy, there was a duplicate configurationpolicy defined and the policy did not deploy right

### Which Jira/Github issue(s) this PR fixes?

[SDA-8595](https://issues.redhat.com//browse/SDA-8595)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
