### PR TITLE
OSD-15442 Add KCMCrashLooping alert

### DIFF
--- a/deploy/sre-prometheus/100-kube-controller-manager-crashlooping.yaml
+++ b/deploy/sre-prometheus/100-kube-controller-manager-crashlooping.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-kube-controller-manager-crashlooping
+    role: alert-rules
+  name: sre-managed-kube-controller-manager-crashlooping
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-kube-controller-manager-crashlooping
+    rules:
+    - alert: KubeControllerManagerCrashloopingSRE
+      # This is a stop-gap alert until OCPBUGS-10761 is investigated and fixed
+      # There has been cases where the KCM operator does not enter Down state and results in a few other issues
+      # This is an attempt to catch that before it causes more problems
+      # https://issues.redhat.com/browse/OCPBUGS-10761
+      expr: |
+        sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace="openshift-kube-controller-manager",pod=~"kube-controller-manager-.*",job="kube-state-metrics"}) >= 2
+      for: 60m
+      labels:
+        severity: warning
+        maturity: "immature"
+        source: "https://issues.redhat.com/browse/OSD-15442"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md"
+      annotations:
+        message: Static pod kube-controller-manager pods have been crashlooping for 60 minutes.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31980,6 +31980,33 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-kube-controller-manager-crashlooping
+          role: alert-rules
+        name: sre-managed-kube-controller-manager-crashlooping
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-controller-manager-crashlooping
+          rules:
+          - alert: KubeControllerManagerCrashloopingSRE
+            expr: 'sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+              namespace="openshift-kube-controller-manager",pod=~"kube-controller-manager-.*",job="kube-state-metrics"})
+              >= 2
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-15442
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md
+            annotations:
+              message: Static pod kube-controller-manager pods have been crashlooping
+                for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-kube-controller-manager-missing-on-node
           role: alert-rules
         name: sre-managed-kube-controller-manager-missing-on-node

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31980,6 +31980,33 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-kube-controller-manager-crashlooping
+          role: alert-rules
+        name: sre-managed-kube-controller-manager-crashlooping
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-controller-manager-crashlooping
+          rules:
+          - alert: KubeControllerManagerCrashloopingSRE
+            expr: 'sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+              namespace="openshift-kube-controller-manager",pod=~"kube-controller-manager-.*",job="kube-state-metrics"})
+              >= 2
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-15442
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md
+            annotations:
+              message: Static pod kube-controller-manager pods have been crashlooping
+                for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-kube-controller-manager-missing-on-node
           role: alert-rules
         name: sre-managed-kube-controller-manager-missing-on-node

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31980,6 +31980,33 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-kube-controller-manager-crashlooping
+          role: alert-rules
+        name: sre-managed-kube-controller-manager-crashlooping
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-kube-controller-manager-crashlooping
+          rules:
+          - alert: KubeControllerManagerCrashloopingSRE
+            expr: 'sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+              namespace="openshift-kube-controller-manager",pod=~"kube-controller-manager-.*",job="kube-state-metrics"})
+              >= 2
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              maturity: immature
+              source: https://issues.redhat.com/browse/OSD-15442
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md
+            annotations:
+              message: Static pod kube-controller-manager pods have been crashlooping
+                for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-kube-controller-manager-missing-on-node
           role: alert-rules
         name: sre-managed-kube-controller-manager-missing-on-node


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Currently the KubeControllerManagerDown alert does not fire if the KCM pods are CrashLooping
This adds an alert for that.
OCPBUGS-10761 has been opened to track the reasons for the KCMDown alert not firing

### Which Jira/Github issue(s) this PR fixes?

[OSD-15442](https://issues.redhat.com//browse/OSD-15442)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
