### PR TITLE
Add action to send public key for serial console

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
@@ -108,7 +108,8 @@
                 "ec2:RebootInstances",
                 "ec2:StartInstances",
                 "ec2:StopInstances",
-                "ec2:TerminateInstances"
+                "ec2:TerminateInstances",
+                "ec2-instance-connect:SendSerialConsoleSSHPublicKey"
             ],
             "Resource": "arn:aws:ec2:*:*:instance/*",
             "Condition": {


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Re introduce SendSerialConsoleSSHPublicKey to the ROSA support policy for HyperShift.


### Which Jira/Github issue(s) this PR fixes?


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
