### PR TITLE
OSD-15738: Fix OperatorGroup for deploy/osd-customer-monitoring

### DIFF
--- a/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
@@ -44,9 +44,6 @@ spec:
                             name: openshift-customer-monitoring
                             namespace: openshift-customer-monitoring
                         spec:
-                            serviceAccount:
-                                metadata:
-                                    creationTimestamp: null
                             targetNamespaces:
                                 - openshift-customer-monitoring
                     - complianceType: mustonlyhave

--- a/deploy/osd-customer-monitoring/01-operatorgroup.yaml
+++ b/deploy/osd-customer-monitoring/01-operatorgroup.yaml
@@ -4,8 +4,5 @@ metadata:
   name: openshift-customer-monitoring
   namespace: openshift-customer-monitoring
 spec:
-  serviceAccount:
-    metadata:
-      creationTimestamp: null
   targetNamespaces:
   - openshift-customer-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3245,9 +3245,6 @@ objects:
                     name: openshift-customer-monitoring
                     namespace: openshift-customer-monitoring
                   spec:
-                    serviceAccount:
-                      metadata:
-                        creationTimestamp: null
                     targetNamespaces:
                     - openshift-customer-monitoring
               - complianceType: mustonlyhave
@@ -25673,9 +25670,6 @@ objects:
         name: openshift-customer-monitoring
         namespace: openshift-customer-monitoring
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-customer-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3245,9 +3245,6 @@ objects:
                     name: openshift-customer-monitoring
                     namespace: openshift-customer-monitoring
                   spec:
-                    serviceAccount:
-                      metadata:
-                        creationTimestamp: null
                     targetNamespaces:
                     - openshift-customer-monitoring
               - complianceType: mustonlyhave
@@ -25673,9 +25670,6 @@ objects:
         name: openshift-customer-monitoring
         namespace: openshift-customer-monitoring
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-customer-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3245,9 +3245,6 @@ objects:
                     name: openshift-customer-monitoring
                     namespace: openshift-customer-monitoring
                   spec:
-                    serviceAccount:
-                      metadata:
-                        creationTimestamp: null
                     targetNamespaces:
                     - openshift-customer-monitoring
               - complianceType: mustonlyhave
@@ -25673,9 +25670,6 @@ objects:
         name: openshift-customer-monitoring
         namespace: openshift-customer-monitoring
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-customer-monitoring
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Removes invalid properties from osd-customer-monitoring operatorgroup

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-15738

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
