### PR TITLE
Check for generated file changes in PR check

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -32,6 +32,7 @@ spec:
                         metadata:
                             name: api
                         spec:
+                            domainRef: hcp
                             port: "6443"
                             prefix: https://api.
                             slo:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Files generated for ACM Policy were not checked in the PR check. Any changes in generated ACM Policy must be updated for any configuration changes to MCC.

### Which Jira/Github issue(s) this PR fixes?
Fixes https://issues.redhat.com/browse/OSD-15739

### Special notes for your reviewer:
There is one policy that is modified right now that may need to have changes committed for this PR to pass validations.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
