### PR TITLE
[MTSRE-1024]: cert-manager backplane permissions for LPSRE

### DIFF
--- a/deploy/backplane/lpsre/cert-manager/01-cert-manager-lpsre-project.SubjectPermission.yaml
+++ b/deploy/backplane/lpsre/cert-manager/01-cert-manager-lpsre-project.SubjectPermission.yaml
@@ -1,0 +1,11 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-lpsre-cert-manager-project
+  namespace: openshift-rbac-permissions
+spec:
+  permissions:
+  - clusterRoleName: view
+    namespacesAllowedRegex: (^redhat-cert-manager-operator$)
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-lpsre

--- a/deploy/backplane/lpsre/cert-manager/config.yaml
+++ b/deploy/backplane/lpsre/cert-manager/config.yaml
@@ -1,0 +1,4 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchLabels:
+    api.openshift.com/addon-cert-manager-operator: "true"

--- a/deploy/backplane/lpsre/config.yaml
+++ b/deploy/backplane/lpsre/config.yaml
@@ -30,7 +30,7 @@ selectorSyncSet:
       api.openshift.com/addon-ocs-converged-qe: "true"
       api.openshift.com/addon-ocs-provider-dev: "true"
       api.openshift.com/addon-ocs-provider-qe: "true"
-      api.openshift.com/addon-managed-api-service: "true"
       api.openshift.com/addon-smart-events-operator: "true"
+      api.openshift.com/addon-cert-manager-operator: "true"
   matchLabelsApplyMode: "OR"
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -15067,6 +15067,199 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-addon-cert-manager-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-cert-manager-operator: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-admins-cluster
+      aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-lpsre-admins
+            operator: In
+            values:
+            - cluster
+      rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-admin
+      rules:
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
+        - addonoperators
+        - addons
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-monitoring
+      rules:
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - monitoringstacks
+        - thanosqueriers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-addon-operator-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-addon-operator-admin
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - clusterRoleName: backplane-lpsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - clusterRoleName: backplane-lpsre-addon-operator-olm-admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - list
+        - get
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre-mustgather
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-admins-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-acm
   spec:
     clusterDeploymentSelector:
@@ -15114,6 +15307,32 @@ objects:
         - get
         - list
         - watch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-cert-manager
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-cert-manager-operator: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-cert-manager-project
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: view
+          namespacesAllowedRegex: (^redhat-cert-manager-operator$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -15067,6 +15067,199 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-addon-cert-manager-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-cert-manager-operator: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-admins-cluster
+      aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-lpsre-admins
+            operator: In
+            values:
+            - cluster
+      rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-admin
+      rules:
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
+        - addonoperators
+        - addons
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-monitoring
+      rules:
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - monitoringstacks
+        - thanosqueriers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-addon-operator-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-addon-operator-admin
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - clusterRoleName: backplane-lpsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - clusterRoleName: backplane-lpsre-addon-operator-olm-admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - list
+        - get
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre-mustgather
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-admins-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-acm
   spec:
     clusterDeploymentSelector:
@@ -15114,6 +15307,32 @@ objects:
         - get
         - list
         - watch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-cert-manager
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-cert-manager-operator: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-cert-manager-project
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: view
+          namespacesAllowedRegex: (^redhat-cert-manager-operator$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -15067,6 +15067,199 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-addon-cert-manager-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-cert-manager-operator: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-admins-cluster
+      aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-lpsre-admins
+            operator: In
+            values:
+            - cluster
+      rules: []
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-admin
+      rules:
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
+        - addonoperators
+        - addons
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-olm-admin
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-monitoring
+      rules:
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - monitoringstacks
+        - thanosqueriers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-addon-operator-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-addon-operator-admin
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - clusterRoleName: backplane-lpsre-monitoring
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        - clusterRoleName: backplane-lpsre-addon-operator-olm-admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - list
+        - get
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre-mustgather
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-admins-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-acm
   spec:
     clusterDeploymentSelector:
@@ -15114,6 +15307,32 @@ objects:
         - get
         - list
         - watch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-cert-manager
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-cert-manager-operator: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-cert-manager-project
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: view
+          namespacesAllowedRegex: (^redhat-cert-manager-operator$)
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/resources/addons-namespaces/main.yaml
+++ b/resources/addons-namespaces/main.yaml
@@ -15,7 +15,8 @@ addon-namespaces:
   kas-fleetshard-operator-qe: redhat-kas-fleetshard-operator-qe
   prow-operator: prow
   cluster-logging-operator: openshift-logging
-  acm-operator: acm
+  advanced-cluster-management: redhat-open-cluster-management
+  cert-manager-operator: redhat-cert-manager-operator
   dba-operator: addon-dba-operator
   reference-addon: redhat-reference-addon
   ocm-addon-test-operator: redhat-ocm-addon-test-operator


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Adds initial backplane permissions for the cert-manager addon.

### Which Jira/Github issue(s) this PR fixes?
[MTSRE-1024](https://issues.redhat.com//browse/MTSRE-1024)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
