### PR TITLE
Detect any non-generated ACM policies

### DIFF
--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -31,6 +31,9 @@ do
     cat hack/00-osd-managed-cluster-config-${environment}.yaml.tmpl | sort > sorted-before-${environment}.yaml.tmpl
 done
 
+# remove all generated acm policies files in order to determine if they have changed
+rm -f deploy/acm-policies/50-GENERATED-*.yaml
+
 make
 
 for environment in integration stage production;


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds a PR check to detect any non-generated ACM policies

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
