### PR TITLE
Remove privileged IAM permissions for HCP

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -102,22 +102,6 @@
             }
         },
         {
-            "Sid": "CreateAndManagePolicies",
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreatePolicy",
-                "iam:CreateRole"
-            ],
-            "Resource": [
-                "*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "aws:RequestTag/red-hat-managed": "true"
-                }
-            }
-        },
-        {
             "Effect": "Allow",
             "Action": [
                 "secretsmanager:GetSecretValue"

--- a/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
@@ -102,22 +102,6 @@
             }
         },
         {
-            "Sid": "CreateAndManagePolicies",
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreatePolicy",
-                "iam:CreateRole"
-            ],
-            "Resource": [
-                "*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "aws:RequestTag/red-hat-managed": "true"
-                }
-            }
-        },
-        {
             "Effect": "Allow",
             "Action": [
                 "secretsmanager:GetSecretValue"


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
HCP Installs don't require privileged IAM permissions to create IAM roles or policies, role ARNs are passed to OCM after the ROSA CLI creates them.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
