### PR TITLE
Remove redundant CreateInstanceProfile action from installer policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -77,7 +77,6 @@
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
                 "iam:DeleteInstanceProfile",
-                "iam:CreateInstanceProfile",
                 "iam:GetInstanceProfile"
             ],
             "Resource": [

--- a/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
@@ -77,7 +77,6 @@
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
                 "iam:DeleteInstanceProfile",
-                "iam:CreateInstanceProfile",
                 "iam:GetInstanceProfile"
             ],
             "Resource": [


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Removing redundant `CreateInstanceProfile` policy from the installer policy file. It already exists in its own SID block with condition keys set.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:
I tested this on a test hosted cluster which installed ok without any issues

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
