### PR TITLE
Remove redundant CreateInstanceProfile action and add missing describeSecurityGroups and describeLoadbalancers action to installer role

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -11,11 +11,13 @@
                 "ec2:DescribeRegions",
                 "ec2:DescribeReservedInstancesOfferings",
                 "ec2:DescribeRouteTables",
+                "ec2:DescribeSecurityGroups",
                 "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeVpcs",
                 "ec2:DescribeInstanceTypeOfferings",
+                "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DeleteLoadBalancer",
                 "kms:DescribeKey",
                 "iam:GetRole",
@@ -77,7 +79,6 @@
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
                 "iam:DeleteInstanceProfile",
-                "iam:CreateInstanceProfile",
                 "iam:GetInstanceProfile"
             ],
             "Resource": [

--- a/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
@@ -11,11 +11,13 @@
                 "ec2:DescribeRegions",
                 "ec2:DescribeReservedInstancesOfferings",
                 "ec2:DescribeRouteTables",
+                "ec2:DescribeSecurityGroups",
                 "ec2:DescribeSecurityGroupRules",
                 "ec2:DescribeSubnets",
                 "ec2:DescribeVpcAttribute",
                 "ec2:DescribeVpcs",
                 "ec2:DescribeInstanceTypeOfferings",
+                "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DeleteLoadBalancer",
                 "kms:DescribeKey",
                 "iam:GetRole",
@@ -77,7 +79,6 @@
                 "iam:AddRoleToInstanceProfile",
                 "iam:RemoveRoleFromInstanceProfile",
                 "iam:DeleteInstanceProfile",
-                "iam:CreateInstanceProfile",
                 "iam:GetInstanceProfile"
             ],
             "Resource": [


### PR DESCRIPTION


### What type of PR is this?
bug

### What this PR does / why we need it?
Removing redundant `CreateInstanceProfile` action which already exists in it own SID with condition keys set
Adding `DescribeLoadBalancers` and `DescribeSecurityGroups` as it is needed by the installer during installation.

### Special notes for your reviewer:
This was tested on a hosted cluster installation and deletion which worked ok.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

