### PR TITLE
Add condition to PassRole to restrict to EC2 service

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -40,7 +40,14 @@
       "Effect": "Allow",
       "Resource": [
         "arn:*:iam::*:role/*-Worker-Role"
-      ]
+      ],
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": [
+              "ec2.amazonaws.com"
+          ]
+        }
+      }
     },
     {
       "Effect": "Allow",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Restrict PassRole for the node pool management policy to EC2 only.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
