### PR TITLE
Remove duplicate elasticloadbalancing:AddTags permission for the KubeControllerManager HCP Policy

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
@@ -18,7 +18,6 @@
         "elasticloadbalancing:ModifyLoadBalancerAttributes",
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
-        "elasticloadbalancing:AddTags",
         "kms:DescribeKey"
       ],
       "Effect": "Allow",


### PR DESCRIPTION
Remove duplicated permission from the KubeControllerManager HCP policy