### PR TITLE
Remove redundant action sts:GetCallerIdentity

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -24,8 +24,7 @@
                 "route53:ListHostedZones",
                 "route53:ListResourceRecordSets",
                 "route53:GetAccountLimit",
-                "servicequotas:GetServiceQuota",
-                "sts:GetCallerIdentity"
+                "servicequotas:GetServiceQuota"
             ],
             "Resource": "*"
         },

--- a/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
@@ -24,8 +24,7 @@
                 "route53:ListHostedZones",
                 "route53:ListResourceRecordSets",
                 "route53:GetAccountLimit",
-                "servicequotas:GetServiceQuota",
-                "sts:GetCallerIdentity"
+                "servicequotas:GetServiceQuota"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This PR removes the `sts:GetCallerIdentity` action which can not be Denied in an AWS STS policy, its always allowed.


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
