### PR TITLE
Remove ReleaseAddress from HCP NodePool policy as it's not used

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -11,8 +11,7 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
-        "ec2:DescribeVpcs",
-        "ec2:ReleaseAddress"
+        "ec2:DescribeVpcs"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/resources/sts/4.13/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.13/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -11,8 +11,7 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
-        "ec2:DescribeVpcs",
-        "ec2:ReleaseAddress"
+        "ec2:DescribeVpcs"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
ReleaseAddress is used for releasing an Elastic IP, which is not applicable to HCP. 