### PR TITLE
Prevent CPMS from being enabled on 4.12 clusters

### DIFF
--- a/deploy/osd-14634-disable-cpms/config.yaml
+++ b/deploy/osd-14634-disable-cpms/config.yaml
@@ -2,11 +2,7 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: Sync
   matchExpressions:
-  ## This will need to be changed to use version-major-minor-patch when
-  ## we move to enable this feature in the future
-  - key: hive.openshift.io/version-major-minor-patch
+  ## This will be removed once OSD-14568 has been completed
+  - key: hive.openshift.io/version-major-minor
     operator: In
-    values:
-    - 4.12.0
-    - 4.12.1
-    - 4.12.2
+    values: ["4.12"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23619,12 +23619,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor-patch
+      - key: hive.openshift.io/version-major-minor
         operator: In
         values:
-        - 4.12.0
-        - 4.12.1
-        - 4.12.2
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23619,12 +23619,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor-patch
+      - key: hive.openshift.io/version-major-minor
         operator: In
         values:
-        - 4.12.0
-        - 4.12.1
-        - 4.12.2
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23619,12 +23619,10 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: hive.openshift.io/version-major-minor-patch
+      - key: hive.openshift.io/version-major-minor
         operator: In
         values:
-        - 4.12.0
-        - 4.12.1
-        - 4.12.2
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
This prevents CPMS from being enabled on 4.12 clusters until [OSD-14568](https://issues.redhat.com//browse/OSD-14568) can be completed, which addresses the contention between CPMS and CIO attempting to both modify master machines when a cluster is being changed from public -> private or vice versa.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-15861](https://issues.redhat.com/browse/OSD-15861)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
