### PR TITLE
label hosted control plane namespaces for monitoring

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -41,6 +41,14 @@ spec:
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:
+                        apiVersion: v1
+                        kind: Namespace
+                        metadata:
+                            labels:
+                                openshift.io/cluster-monitoring: "true"
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
                         apiVersion: package-operator.run/v1alpha1
                         kind: Package
                         metadata:

--- a/deploy/hs-mgmt-route-monitor-operator/namespace.yaml
+++ b/deploy/hs-mgmt-route-monitor-operator/namespace.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2949,6 +2949,14 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    labels:
+                      openshift.io/cluster-monitoring: 'true'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
                   apiVersion: package-operator.run/v1alpha1
                   kind: Package
                   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2949,6 +2949,14 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    labels:
+                      openshift.io/cluster-monitoring: 'true'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
                   apiVersion: package-operator.run/v1alpha1
                   kind: Package
                   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2949,6 +2949,14 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    labels:
+                      openshift.io/cluster-monitoring: 'true'
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
                   apiVersion: package-operator.run/v1alpha1
                   kind: Package
                   metadata:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Patch in the cluster-monitoring label to hosted control plane namespaces to allow the API monitor to be scraped

### Which Jira/Github issue(s) this PR fixes?

for [OSD-15737](https://issues.redhat.com//browse/OSD-15737)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
