### PR TITLE
Bump KubeControllerManagerCrashloopingSRE to critical

### DIFF
--- a/deploy/sre-prometheus/100-kube-controller-manager-crashlooping.yaml
+++ b/deploy/sre-prometheus/100-kube-controller-manager-crashlooping.yaml
@@ -19,8 +19,7 @@ spec:
         sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace="openshift-kube-controller-manager",pod=~"kube-controller-manager-.*",job="kube-state-metrics"}) >= 2
       for: 60m
       labels:
-        severity: warning
-        maturity: "immature"
+        severity: critical
         source: "https://issues.redhat.com/browse/OSD-15442"
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md"
       annotations:

--- a/deploy/sre-prometheus/100-kube-controller-manager-missing-on-node.yaml
+++ b/deploy/sre-prometheus/100-kube-controller-manager-missing-on-node.yaml
@@ -15,8 +15,7 @@ spec:
         count(cluster:master_nodes{}) by (node) unless count(kube_pod_info{namespace="openshift-kube-controller-manager", pod=~"kube-controller-manager-.*", pod!~".*guard.*"}) by (node) >= 1
       for: 60m
       labels:
-        severity: warning
-        maturity: "immature"
+        severity: critical
         source: "https://issues.redhat.com/browse/OSD-13647"
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md"
       annotations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32475,8 +32475,7 @@ objects:
               '
             for: 60m
             labels:
-              severity: warning
-              maturity: immature
+              severity: critical
               source: https://issues.redhat.com/browse/OSD-15442
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md
             annotations:
@@ -32501,8 +32500,7 @@ objects:
               '
             for: 60m
             labels:
-              severity: warning
-              maturity: immature
+              severity: critical
               source: https://issues.redhat.com/browse/OSD-13647
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
             annotations:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32475,8 +32475,7 @@ objects:
               '
             for: 60m
             labels:
-              severity: warning
-              maturity: immature
+              severity: critical
               source: https://issues.redhat.com/browse/OSD-15442
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md
             annotations:
@@ -32501,8 +32500,7 @@ objects:
               '
             for: 60m
             labels:
-              severity: warning
-              maturity: immature
+              severity: critical
               source: https://issues.redhat.com/browse/OSD-13647
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
             annotations:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32475,8 +32475,7 @@ objects:
               '
             for: 60m
             labels:
-              severity: warning
-              maturity: immature
+              severity: critical
               source: https://issues.redhat.com/browse/OSD-15442
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeControllerManagerCrashloopingSRE.md
             annotations:
@@ -32501,8 +32500,7 @@ objects:
               '
             for: 60m
             labels:
-              severity: warning
-              maturity: immature
+              severity: critical
               source: https://issues.redhat.com/browse/OSD-13647
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/StaticPodMissing.md
             annotations:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Bumps the severity of alert `KubeControllerManagerCrashloopingSRE` to critical.

### Which Jira/Github issue(s) this PR fixes?
[OSD-15736](https://issues.redhat.com//browse/OSD-15736)

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
