### PR TITLE
OSD-15881: fix resources causing non-compliant logging policies

### DIFF
--- a/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
@@ -43,9 +43,6 @@ spec:
                             name: openshift-logging
                             namespace: openshift-logging
                         spec:
-                            serviceAccount:
-                                metadata:
-                                    creationTimestamp: null
                             targetNamespaces:
                                 - openshift-logging
                     - complianceType: mustonlyhave

--- a/deploy/osd-logging/01-operatorgroup.yaml
+++ b/deploy/osd-logging/01-operatorgroup.yaml
@@ -6,8 +6,5 @@ metadata:
   name: openshift-logging
   namespace: openshift-logging
 spec:
-  serviceAccount:
-    metadata:
-      creationTimestamp: null
   targetNamespaces:
   - openshift-logging

--- a/deploy/osd-logging/unsupported/01-operatorgroup.yaml
+++ b/deploy/osd-logging/unsupported/01-operatorgroup.yaml
@@ -7,8 +7,5 @@ metadata:
   name: openshift-logging
   namespace: openshift-logging
 spec:
-  serviceAccount:
-    metadata:
-      creationTimestamp: null
   targetNamespaces:
   - openshift-logging

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4300,9 +4300,6 @@ objects:
                     name: openshift-logging
                     namespace: openshift-logging
                   spec:
-                    serviceAccount:
-                      metadata:
-                        creationTimestamp: null
                     targetNamespaces:
                     - openshift-logging
               - complianceType: mustonlyhave
@@ -27438,9 +27435,6 @@ objects:
         name: openshift-logging
         namespace: openshift-logging
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-logging
     - apiVersion: v1
@@ -27683,9 +27677,6 @@ objects:
         name: openshift-logging
         namespace: openshift-logging
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-logging
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4300,9 +4300,6 @@ objects:
                     name: openshift-logging
                     namespace: openshift-logging
                   spec:
-                    serviceAccount:
-                      metadata:
-                        creationTimestamp: null
                     targetNamespaces:
                     - openshift-logging
               - complianceType: mustonlyhave
@@ -27438,9 +27435,6 @@ objects:
         name: openshift-logging
         namespace: openshift-logging
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-logging
     - apiVersion: v1
@@ -27683,9 +27677,6 @@ objects:
         name: openshift-logging
         namespace: openshift-logging
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-logging
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4300,9 +4300,6 @@ objects:
                     name: openshift-logging
                     namespace: openshift-logging
                   spec:
-                    serviceAccount:
-                      metadata:
-                        creationTimestamp: null
                     targetNamespaces:
                     - openshift-logging
               - complianceType: mustonlyhave
@@ -27438,9 +27435,6 @@ objects:
         name: openshift-logging
         namespace: openshift-logging
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-logging
     - apiVersion: v1
@@ -27683,9 +27677,6 @@ objects:
         name: openshift-logging
         namespace: openshift-logging
       spec:
-        serviceAccount:
-          metadata:
-            creationTimestamp: null
         targetNamespaces:
         - openshift-logging
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Remove the `serviceAccount` properties from OperatorGroup as it isn't a valid property and is causing ACM policy to be non-compliant.

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-15881

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
