### PR TITLE
Expand SREP read rbac a bit for MC and SC

### DIFF
--- a/deploy/backplane/srep/hypershift/management-cluster/10-srep-management-cluster-cluster.ClusteRole.yml
+++ b/deploy/backplane/srep/hypershift/management-cluster/10-srep-management-cluster-cluster.ClusteRole.yml
@@ -27,3 +27,30 @@ rules:
   - get
   - list
   - watch
+# SRE can view ACM Policy at cluster scope
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# SRE can view HCP resources at cluster scope
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# SRE can view networking resources at cluster scope
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/srep/hypershift/service-cluster/10-srep-service-cluster-cluster.ClusteRole.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/10-srep-service-cluster-cluster.ClusteRole.yml
@@ -27,3 +27,30 @@ rules:
   - get
   - list
   - watch
+# SRE can view ACM Policy at cluster scope
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# SRE can view HCP resources at cluster scope
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# SRE can view networking resources at cluster scope
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21409,6 +21409,30 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -21548,6 +21572,30 @@ objects:
         - operator.open-cluster-management.io
         resources:
         - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - '*'
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21409,6 +21409,30 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -21548,6 +21572,30 @@ objects:
         - operator.open-cluster-management.io
         resources:
         - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - '*'
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21409,6 +21409,30 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -21548,6 +21572,30 @@ objects:
         - operator.open-cluster-management.io
         resources:
         - klusterlets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy.open-cluster-management.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - hypershift.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - '*'
         verbs:
         - get
         - list


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Give SRE more read permissions on SC and MC specifically so we do not need to break glass to query for some key resources at a cluster scope (aka with `oc -A`).

### Which Jira/Github issue(s) this PR fixes?
None

### Special notes for your reviewer:
Born from frustration having to break glass to inspect acm policy, hypershift, and network policy state across a MC or SC.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
