### PR TITLE
Restrict RunInstances to Red Hat AMIs

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -146,7 +146,6 @@
       "Resource": [
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:subnet/*",
-        "arn:aws:ec2:*::image/*",
         "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:volume/*"
       ]
@@ -164,6 +163,23 @@
       "Condition": {
         "StringLike": {
           "kms:ViaService": "ec2.*.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "RunInstancesRedHatAMI",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:RunInstances"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:Owner": [
+            "531415883065"
+          ]
         }
       }
     },


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Ensure HyperShift can only run AMIs created from Red Hat

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
