### PR TITLE
Fix image restriction statement

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -150,22 +150,6 @@
       ]
     },
     {
-      "Effect": "Allow",
-      "Action": [
-        "kms:Decrypt",
-        "kms:Encrypt",
-        "kms:GenerateDataKey",
-        "kms:GenerateDataKeyWithoutPlainText",
-        "kms:DescribeKey"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "StringLike": {
-          "kms:ViaService": "ec2.*.amazonaws.com"
-        }
-      }
-    },
-    {
       "Sid": "RunInstancesRedHatAMI",
       "Effect": "Allow",
       "Action": [
@@ -179,6 +163,22 @@
           "ec2:Owner": [
             "531415883065"
           ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlainText",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
         }
       }
     },

--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -172,7 +172,7 @@
         "ec2:RunInstances"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:instance/*"
+        "arn:aws:ec2:*:*:image/*"
       ],
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
### What type of PR is this?
bug
### What this PR does / why we need it?
Restriction on the running AMI's that belong to a specific owner should be on the `image` AWS resource.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
