### PR TITLE
Remove tagging permissions from the HCP installer policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -4,8 +4,6 @@
         {
             "Effect": "Allow",
             "Action": [
-                "ec2:CreateTags",
-                "ec2:DeleteTags",
                 "ec2:DescribeAvailabilityZones",
                 "ec2:DescribeInternetGateways",
                 "ec2:DescribeRegions",


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This PR removes the tagging permissions from the HCP installer that were supporting validation in cluster service. The validation checked and then ensured public subnets passed in from customers were tagged. Such permissions are very privileged so the validation has been removed in [SDA-8759](https://issues.redhat.com/browse/SDA-8759).

A preflight check will take its place to warn customers that their subnet is not tagged.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
