### PR TITLE
Add RunInstances support for network verifier

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -146,6 +146,67 @@
                 "route53:DeleteHostedZone"
             ],
             "Resource": "*"
+        },
+        {
+            "Sid": "CreateTags",
+            "Effect": "Allow",
+            "Action": [
+              "ec2:CreateTags"
+            ],
+            "Resource": [
+              "arn:aws:ec2:*:*:instance/*",
+              "arn:aws:ec2:*:*:volume/*"
+            ],
+            "Condition": {
+              "StringEquals": {
+                  "ec2:CreateAction": [
+                      "RunInstances",
+                      "CreateVolume"
+                  ]
+              }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:RunInstances",
+            "Resource": [
+                "arn:aws:ec2:*:*:subnet/*",
+                "arn:aws:ec2:*:*:network-interface/*",
+                "arn:aws:ec2:*:*:security-group/*",
+                "arn:aws:ec2:*:*:snapshot/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": "ec2:RunInstances",
+            "Resource": [
+                "arn:aws:ec2:*:*:instance/*",
+                "arn:aws:ec2:*:*:volume/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestTag/red-hat-managed": "true"
+                }
+            }
+        },
+        {
+          "Sid": "RunInstancesRestrictedAMISources",
+          "Effect": "Allow",
+          "Action": [
+            "ec2:RunInstances"
+          ],
+          "Resource": [
+            "arn:aws:ec2:*:*:image/*"
+          ],
+          "Condition": {
+            "StringEquals": {
+              "ec2:Owner": [
+                "531415883065",
+                "251351625822",
+                "210686502322"
+              ]
+            }
+          }
         }
     ]
 }


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
HCP Installer permission policy will need permission to run an EC2 instance for the network verifier. To future proof this i've added the OCP AWS account numbers for both commercial and FedRAMP.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
