### PR TITLE
Add HyperShift monitoring label to openshift-monitoring namespace

### DIFF
--- a/deploy/hypershift-namespace-labels/02-openshift-monitoring.patch.yaml
+++ b/deploy/hypershift-namespace-labels/02-openshift-monitoring.patch.yaml
@@ -1,0 +1,7 @@
+kind: Namespace
+apiVersion: v1
+name: openshift-monitoring
+applyMode: AlwaysApply
+patch: |-
+  { "metadata": {"labels": {"hypershift.openshift.io/monitoring":"true"} } }
+patchType: merge

--- a/deploy/hypershift-namespace-labels/README.md
+++ b/deploy/hypershift-namespace-labels/README.md
@@ -1,0 +1,8 @@
+# Overview
+
+For HyperShift, we need to patch certain namespaces to add labels that could help achieve functional goals. We don't do anything else directly with the namespace apart from adding labels. This is a single SSS to patch namespace labels for these use cases in HyperShift.
+
+## Namespaces patched
+
+- `openshift-observability-operator` ([OSD-13931](https://issues.redhat.com/browse/OSD-13931)) - The `network.openshift.io/policy-group: monitoring` network policy label is added to allow ingress traffic.
+- `openshift-monitoring` ([OSD-15906](https://issues.redhat.com/browse/OSD-15906)) - Adds a common label `hypershift.openshift.io/monitoring` that identifies the namespace should be being monitored by Observability Operator.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22631,6 +22631,13 @@ objects:
       patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
         } }'
       patchType: merge
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-monitoring
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"hypershift.openshift.io/monitoring":"true"}
+        } }'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22631,6 +22631,13 @@ objects:
       patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
         } }'
       patchType: merge
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-monitoring
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"hypershift.openshift.io/monitoring":"true"}
+        } }'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22631,6 +22631,13 @@ objects:
       patch: '{ "metadata": {"labels": {"network.openshift.io/policy-group":"monitoring"}
         } }'
       patchType: merge
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-monitoring
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"hypershift.openshift.io/monitoring":"true"}
+        } }'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
With HyperShift Management Clusters metrics to be forwarded to RHOBS via the Observability Operator, we need a common label that acts as an identifier that the namespace should be watched by the operator.
This PR adds the `hypershift.openshift.io/monitoring` label to the `openshift-monitoring` namespace on HyperShift Management to achieve this.

_**Note:** Even though this configuration targets Service Clusters, patching the label on the Service Clusters won't make a difference as Service Clusters will not have `rhobs/v1` service monitors in the `openshift-monitoring` namespace. Thus OBO won't scrape any metrics from the namespace._

### Which Jira/Github issue(s) this PR fixes?

Resolves: [OSD-15906](https://issues.redhat.com/browse/OSD-15906)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
