### PR TITLE
Add context keys to CP policy SG authorization

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
@@ -52,7 +52,12 @@
             ],
             "Resource": [
                 "arn:aws:ec2:*:*:security-group*/*"
-            ]
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
         },
         {
             "Sid": "CreateSecurityGroupsVPCNoCondition",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds condition keys to the SecurityGroup Ingress/Egress authorization actions 



### Which Jira/Github issue(s) this PR fixes?

Builds on what was added in #1519 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
