### PR TITLE
Add Sids to all statements in HCP Installer policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -2,6 +2,7 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "ReadPermissions",
             "Effect": "Allow",
             "Action": [
                 "ec2:DescribeAvailabilityZones",
@@ -26,6 +27,7 @@
             "Resource": "*"
         },
         {
+            "Sid": "DeleteLoadBalancer",
             "Effect": "Allow",
             "Action": [
                 "elasticloadbalancing:DeleteLoadBalancer"
@@ -33,6 +35,7 @@
             "Resource": "*"
         },
         {
+            "Sid": "PassRoleToEC2",
             "Action": [
                 "iam:PassRole"
             ],
@@ -49,6 +52,7 @@
             }
         },
         {
+            "Sid": "AssumeRole",
             "Effect": "Allow",
             "Action": [
                 "sts:AssumeRole",
@@ -64,6 +68,7 @@
             }
         },
         {
+            "Sid": "CreateLoadBalancer",
             "Effect": "Allow",
             "Action": "elasticloadbalancing:CreateLoadBalancer",
             "Resource": [
@@ -105,6 +110,7 @@
             }
         },
         {
+            "Sid": "GetSecretValue",
             "Effect": "Allow",
             "Action": [
                 "secretsmanager:GetSecretValue"
@@ -167,6 +173,7 @@
             }
         },
         {
+            "Sid": "RunInstancesNoCondition",
             "Effect": "Allow",
             "Action": "ec2:RunInstances",
             "Resource": [
@@ -177,6 +184,7 @@
             ]
         },
         {
+            "Sid": "RunInstancesRestrictedRequestTag",
             "Effect": "Allow",
             "Action": "ec2:RunInstances",
             "Resource": [


### PR DESCRIPTION
AWS is requiring all statements in policies to have Sids