### PR TITLE
Add Sids to all statements in HCP Control Plane policy

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
@@ -2,6 +2,7 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "ReadPermissions",
             "Action": [
                 "ec2:DescribeVpcEndpoints",
                 "ec2:DescribeVpcs",
@@ -65,6 +66,7 @@
             ]
         },
         {
+            "Sid": "ListResourceRecordSets",
             "Action": [
                 "route53:ListResourceRecordSets"
             ],
@@ -74,6 +76,7 @@
             ]
         },
         {
+            "Sid": "ChangeResourceRecordSetsRestrictedRecordNames",
             "Action": [
                 "route53:ChangeResourceRecordSets"
             ],
@@ -143,6 +146,7 @@
             ]
         },
         {
+            "Sid": "CreateTagsRestrictedActions",
             "Effect": "Allow",
             "Action": [
                 "ec2:CreateTags"


### PR DESCRIPTION


AWS is requiring all statements in policies to have Sids. This PR adds a Sid to every statement in the HCP control plane policy that doesn't already have one
