### PR TITLE
OSD-15737 - Fix port for RMO api ClusterURLMonitor for HS

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -33,7 +33,7 @@ spec:
                             name: api
                         spec:
                             domainRef: hcp
-                            port: "6443"
+                            port: "443"
                             prefix: https://api.
                             slo:
                                 targetAvailabilityPercent: "99.0"

--- a/deploy/hs-mgmt-route-monitor-operator/api.ClusterUrlMonitor.yaml
+++ b/deploy/hs-mgmt-route-monitor-operator/api.ClusterUrlMonitor.yaml
@@ -4,7 +4,7 @@ kind: ClusterUrlMonitor
 metadata:
   name: api
 spec:
-  port: "6443"
+  port: "443"
   prefix: https://api.
   slo:
     targetAvailabilityPercent: "99.0"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2941,7 +2941,7 @@ objects:
                     name: api
                   spec:
                     domainRef: hcp
-                    port: '6443'
+                    port: '443'
                     prefix: https://api.
                     slo:
                       targetAvailabilityPercent: '99.0'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2941,7 +2941,7 @@ objects:
                     name: api
                   spec:
                     domainRef: hcp
-                    port: '6443'
+                    port: '443'
                     prefix: https://api.
                     slo:
                       targetAvailabilityPercent: '99.0'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2941,7 +2941,7 @@ objects:
                     name: api
                   spec:
                     domainRef: hcp
-                    port: '6443'
+                    port: '443'
                     prefix: https://api.
                     slo:
                       targetAvailabilityPercent: '99.0'


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Fix port for RMO api ClusterURLMonitor for Hypershift

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-15737](https://issues.redhat.com//browse/OSD-15737)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
