### PR TITLE
Remove AssumeRoleWithWebIdentity from the HCP installer policy as it'…

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -55,8 +55,7 @@
             "Sid": "AssumeRole",
             "Effect": "Allow",
             "Action": [
-                "sts:AssumeRole",
-                "sts:AssumeRoleWithWebIdentity"
+                "sts:AssumeRole"
             ],
             "Resource": [
                 "arn:aws:iam::*:role/*"


### PR DESCRIPTION
According to https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html 

`Calling AssumeRoleWithWebIdentity does not require the use of AWS security credentials.`
I installed an HCP cluster successfully without this permission explicitly in the HCP Installer policy, as it's presence in the role is not required for OCM to use it. 