### PR TITLE
Rename Sid for RunInstances restriction based on AWS feedback

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -197,7 +197,7 @@
             }
         },
         {
-          "Sid": "RunInstancesRestrictedAMISources",
+          "Sid": "RunInstancesRedHatOwnedAMIs",
           "Effect": "Allow",
           "Action": [
             "ec2:RunInstances"


### PR DESCRIPTION
This change clarifies that this Statement restricts RunInstances to Red Hat owned AMIs, rather than a generic "restricted" message