### PR TITLE
Add alert CannotRetrieveUpdatesSRE

### DIFF
--- a/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
@@ -1,0 +1,38 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-cannot-retrieve-updates-alerts
+    role: alert-rules
+  name: sre-cannot-retrieve-updates-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-cannot-retrieve-updates
+    rules:
+      - alert: CannotRetrieveUpdatesSRE
+        annotations:
+          description: Failure to retrieve updates means that cluster administrators
+            will need to monitor for available updates on their own or risk falling
+            behind on security or other bugfixes. If the failure is expected, you
+            can clear spec.channel in the ClusterVersion object to tell the cluster-version
+            operator to not retrieve updates. Failure reason {{ with $cluster_operator_conditions
+            := "cluster_operator_conditions" | query}}{{range $value := .}}{{if and
+            (eq (label "name" $value) "version") (eq (label "condition" $value) "RetrievedUpdates")
+            (eq (label "endpoint" $value) "metrics") (eq (value $value) 0.0)}}{{label
+            "reason" $value}} {{end}}{{end}}{{end}}. {{ with $console_url := "console_url"
+            | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For
+            more information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
+            end }}{{ end }}
+          summary: Cluster version operator has not retrieved updates in {{ $value
+            | humanizeDuration }}.
+        expr: '
+            (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600 
+          and ignoring(condition, name, reason) 
+            (cluster_operator_conditions{name="version",condition="RetrievedUpdates", endpoint="metrics", reason!="NoChannel"})
+          and on(instance, job, namespace, pod, service)
+            (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"})
+          '
+        labels:
+          severity: critical
+          namespace: '{{ $labels.namespace }}'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32908,6 +32908,42 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cannot-retrieve-updates-alerts
+          role: alert-rules
+        name: sre-cannot-retrieve-updates-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cannot-retrieve-updates
+          rules:
+          - alert: CannotRetrieveUpdatesSRE
+            annotations:
+              description: Failure to retrieve updates means that cluster administrators
+                will need to monitor for available updates on their own or risk falling
+                behind on security or other bugfixes. If the failure is expected,
+                you can clear spec.channel in the ClusterVersion object to tell the
+                cluster-version operator to not retrieve updates. Failure reason {{
+                with $cluster_operator_conditions := "cluster_operator_conditions"
+                | query}}{{range $value := .}}{{if and (eq (label "name" $value) "version")
+                (eq (label "condition" $value) "RetrievedUpdates") (eq (label "endpoint"
+                $value) "metrics") (eq (value $value) 0.0)}}{{label "reason" $value}}
+                {{end}}{{end}}{{end}}. {{ with $console_url := "console_url" | query
+                }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For more
+                information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
+                end }}{{ end }}
+              summary: Cluster version operator has not retrieved updates in {{ $value
+                | humanizeDuration }}.
+            expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
+              >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
+              endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
+              pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubejobfailing
           role: alert-rules
         name: sre-kubejobfailing

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32908,6 +32908,42 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cannot-retrieve-updates-alerts
+          role: alert-rules
+        name: sre-cannot-retrieve-updates-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cannot-retrieve-updates
+          rules:
+          - alert: CannotRetrieveUpdatesSRE
+            annotations:
+              description: Failure to retrieve updates means that cluster administrators
+                will need to monitor for available updates on their own or risk falling
+                behind on security or other bugfixes. If the failure is expected,
+                you can clear spec.channel in the ClusterVersion object to tell the
+                cluster-version operator to not retrieve updates. Failure reason {{
+                with $cluster_operator_conditions := "cluster_operator_conditions"
+                | query}}{{range $value := .}}{{if and (eq (label "name" $value) "version")
+                (eq (label "condition" $value) "RetrievedUpdates") (eq (label "endpoint"
+                $value) "metrics") (eq (value $value) 0.0)}}{{label "reason" $value}}
+                {{end}}{{end}}{{end}}. {{ with $console_url := "console_url" | query
+                }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For more
+                information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
+                end }}{{ end }}
+              summary: Cluster version operator has not retrieved updates in {{ $value
+                | humanizeDuration }}.
+            expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
+              >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
+              endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
+              pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubejobfailing
           role: alert-rules
         name: sre-kubejobfailing

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32908,6 +32908,42 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cannot-retrieve-updates-alerts
+          role: alert-rules
+        name: sre-cannot-retrieve-updates-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cannot-retrieve-updates
+          rules:
+          - alert: CannotRetrieveUpdatesSRE
+            annotations:
+              description: Failure to retrieve updates means that cluster administrators
+                will need to monitor for available updates on their own or risk falling
+                behind on security or other bugfixes. If the failure is expected,
+                you can clear spec.channel in the ClusterVersion object to tell the
+                cluster-version operator to not retrieve updates. Failure reason {{
+                with $cluster_operator_conditions := "cluster_operator_conditions"
+                | query}}{{range $value := .}}{{if and (eq (label "name" $value) "version")
+                (eq (label "condition" $value) "RetrievedUpdates") (eq (label "endpoint"
+                $value) "metrics") (eq (value $value) 0.0)}}{{label "reason" $value}}
+                {{end}}{{end}}{{end}}. {{ with $console_url := "console_url" | query
+                }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For more
+                information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
+                end }}{{ end }}
+              summary: Cluster version operator has not retrieved updates in {{ $value
+                | humanizeDuration }}.
+            expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
+              >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
+              endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,
+              pod, service) (cluster_version{version!~"(4\\.11\\.36|4\\.12\\.12)"}) '
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubejobfailing
           role: alert-rules
         name: sre-kubejobfailing


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
It is suppressed in CAMO with https://github.com/openshift/configure-alertmanager-operator/pull/278

SOP created in https://github.com/openshift/ops-sop/pull/2515

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15967

### Special notes for your reviewer:
Related to https://issues.redhat.com/browse/OCPBUGS-11636

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
