### PR TITLE
SREP backplane updates for SC and MC

### DIFF
--- a/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
@@ -4,10 +4,16 @@ metadata:
   name: backplane-srep-management-cluster
   namespace: openshift-rbac-permissions
 spec:
+  clusterPermissions:
+  - backplane-srep-management-cluster-cluster
+  # permit get at global scope https://issues.redhat.com/browse/OSD-15997
+  - view
   permissions:
   - clusterRoleName: backplane-srep-management-cluster-project
     namespacesAllowedRegex: "(^uhc.*|^ocm.*|^klusterlet.*)"
   - clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"
+  - clusterRoleName: backplane-srep # apply standard srep access to hcp namespaces https://issues.redhat.com/browse/OSD-15997
+    namespaceAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
@@ -6,10 +6,14 @@ metadata:
 spec:
   clusterPermissions:
   - backplane-srep-service-cluster-cluster
+  # permit get at global scope https://issues.redhat.com/browse/OSD-15997
+  - view
   permissions:
   - clusterRoleName: backplane-srep-service-cluster-project
     namespacesAllowedRegex: "(^uhc.*|^ocm.*|^klusterlet.*)"
   - clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"
+  - clusterRoleName: backplane-srep # apply standard srep access to hcp namespaces https://issues.redhat.com/browse/OSD-15997
+    namespaceAllowedRegex: "(^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)"
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21508,11 +21508,16 @@ objects:
         name: backplane-srep-management-cluster
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-srep-management-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-management-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        - clusterRoleName: backplane-srep
+          namespaceAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
@@ -21669,11 +21674,14 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        - clusterRoleName: backplane-srep
+          namespaceAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21508,11 +21508,16 @@ objects:
         name: backplane-srep-management-cluster
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-srep-management-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-management-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        - clusterRoleName: backplane-srep
+          namespaceAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
@@ -21669,11 +21674,14 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        - clusterRoleName: backplane-srep
+          namespaceAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21508,11 +21508,16 @@ objects:
         name: backplane-srep-management-cluster
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-srep-management-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-management-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        - clusterRoleName: backplane-srep
+          namespaceAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
@@ -21669,11 +21674,14 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)
         - clusterRoleName: dedicated-readers
           namespacesAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
+        - clusterRoleName: backplane-srep
+          namespaceAllowedRegex: (^hypershift.*|^uhc.*|^ocm.*|^klusterlet.*|^open-cluster-management.*)
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
SREP member of 'view' at global scope.
SREP has standard permissions in HCP namespaces, i.e. oc delete pod

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15997

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
