### PR TITLE
Add resource tag condition context key

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -182,6 +182,9 @@
       "Condition": {
         "StringLike": {
           "kms:ViaService": "ec2.*.amazonaws.com"
+        },
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
         }
       }
     },

--- a/resources/sts/4.12/hypershift/openshift_hcp_kms_provider_credential_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_kms_provider_credential_policy.json
@@ -14,6 +14,9 @@
         "Condition": {
           "StringLike": {
             "kms:ViaService": "ec2.*.amazonaws.com"
+          },
+          "StringEquals": {
+            "aws:ResourceTag/red-hat-managed": "true"
           }
         }
       }

--- a/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
@@ -293,6 +293,9 @@
                 },
                 "StringLike": {
                     "kms:ViaService": "ec2.*.amazonaws.com"
+                },
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
                 }
             }
         }


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Although AWS [documentation](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awskeymanagementservice.html) doesn't show that `${aws:ResourceTag/${TagKey}` isn't supported for these actions documentation listed is actually representing additional context keys other than the global context keys that are by KMS.

Global keys do support  `${aws:ResourceTag/${TagKey}` on all resources.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
