### PR TITLE
Add request region name to image registry ARN

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
@@ -40,7 +40,7 @@
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws:s3:::*-image-registry-*/*"
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}-*/*"
       ]
     }
   ]


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Further restrict image registry ARN with AWS request region name.

The image registry operator [adds](https://github.com/openshift/cluster-image-registry-operator/blob/master/pkg/storage/s3/s3.go#L648) the region name when constructing the bucket name so this should be safe.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
