### PR TITLE
Condition HCP KMS permissions by the red-hat-managed: true tag

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -181,7 +181,7 @@
       "Resource": "*",
       "Condition": {
         "StringLike": {
-          "kms:ViaService": "ec2.*.amazonaws.com"
+          "aws:ResourceTag/red-hat-managed": "true"
         }
       }
     },
@@ -197,8 +197,8 @@
         "Bool": {
           "kms:GrantIsForAWSResource": true
         },
-        "StringLike": {
-          "kms:ViaService": "ec2.*.amazonaws.com"
+        "StringEquals": {
+          "aws:ResourceTag/rosa-key": "true"
         }
       }
     }

--- a/resources/sts/4.12/hypershift/openshift_hcp_kms_provider_credential_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_kms_provider_credential_policy.json
@@ -12,8 +12,8 @@
         ],
         "Resource": "*",
         "Condition": {
-          "StringLike": {
-            "kms:ViaService": "ec2.*.amazonaws.com"
+          "StringEquals": {
+            "aws:ResourceTag/rosa-key": "true"
           }
         }
       }

--- a/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
@@ -291,8 +291,8 @@
                 "Bool": {
                     "kms:GrantIsForAWSResource": true
                 },
-                "StringLike": {
-                    "kms:ViaService": "ec2.*.amazonaws.com"
+                "StringEquals": {
+                    "aws:ResourceTag/rosa-key": "true"
                 }
             }
         }


### PR DESCRIPTION
Conditions the HCP KMS permissions to only allow use of KMS keys with the `red-hat-managed: true` flag.