### PR TITLE
Added alert for OCMAgentResponseFailureServiceLogsSRE

### DIFF
--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-ocm-agent-operator-alerts
+    role: alert-rules
+  name: sre-ocm-agent-operator-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-ocm-agent-operator-alerts
+    rules:
+    - alert: OCMAgentResponseFailureServiceLogsSRE
+      # Alert if the OCM agent response failure metric has been set for a ten-minute average window
+      expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m]) == 1
+      for: 60m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md"
+
+      annotations:
+        message: OCM Agent has failed to receive a response from the service_logs service for 60 minutes.

--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   - name: sre-ocm-agent-operator-alerts
     rules:
     - alert: OCMAgentResponseFailureServiceLogsSRE
-      # Alert if the OCM agent response failure metric has been set for a ten-minute average window
+      # Alert if the OCM agent response failure metric has been set for an hour average window
       expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m]) == 1
       for: 60m
       labels:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32769,6 +32769,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-ocm-agent-operator-alerts
+          role: alert-rules
+        name: sre-ocm-agent-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-ocm-agent-operator-alerts
+          rules:
+          - alert: OCMAgentResponseFailureServiceLogsSRE
+            expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m])
+              == 1
+            for: 60m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md
+            annotations:
+              message: OCM Agent has failed to receive a response from the service_logs
+                service for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pending-csr-alert
           role: alert-rules
         name: sre-pending-csr-alert

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32769,6 +32769,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-ocm-agent-operator-alerts
+          role: alert-rules
+        name: sre-ocm-agent-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-ocm-agent-operator-alerts
+          rules:
+          - alert: OCMAgentResponseFailureServiceLogsSRE
+            expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m])
+              == 1
+            for: 60m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md
+            annotations:
+              message: OCM Agent has failed to receive a response from the service_logs
+                service for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pending-csr-alert
           role: alert-rules
         name: sre-pending-csr-alert

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32769,6 +32769,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-ocm-agent-operator-alerts
+          role: alert-rules
+        name: sre-ocm-agent-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-ocm-agent-operator-alerts
+          rules:
+          - alert: OCMAgentResponseFailureServiceLogsSRE
+            expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m])
+              == 1
+            for: 60m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md
+            annotations:
+              message: OCM Agent has failed to receive a response from the service_logs
+                service for 60 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pending-csr-alert
           role: alert-rules
         name: sre-pending-csr-alert


### PR DESCRIPTION
### What type of PR is this?
Alert

### What this PR does / why we need it?
Adds new alert for when OCM Agent is unable to send a service log for 60 minutes

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-12238