### PR TITLE
Add kms permission to installer for verifier, and correct tag in NodePool controller

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -181,7 +181,7 @@
       "Resource": "*",
       "Condition": {
         "StringLike": {
-          "aws:ResourceTag/red-hat-managed": "true"
+          "aws:ResourceTag/red-hat": "true"
         }
       }
     },

--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -214,6 +214,21 @@
               ]
             }
           }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateGrant"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Bool": {
+                    "kms:GrantIsForAWSResource": true
+                },
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat": "true"
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
Adds KMS CreateGrant to the installer role so OCM can create the osd-network-verifier instance. Also fixes the tag expected on the KMS key in the NodePool controller