### PR TITLE
Remove unused permissions for KMS cluster API provider

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -174,8 +174,7 @@
       "Effect": "Allow",
       "Action": [
         "kms:Decrypt",
-        "kms:Encrypt",
-        "kms:GenerateDataKey",
+        "kms:ReEncrypt*",
         "kms:GenerateDataKeyWithoutPlainText",
         "kms:DescribeKey"
       ],
@@ -189,9 +188,7 @@
     {
       "Effect": "Allow",
       "Action": [
-        "kms:RevokeGrant",
-        "kms:CreateGrant",
-        "kms:ListGrants"
+        "kms:CreateGrant"
       ],
       "Resource": "*",
       "Condition": {

--- a/resources/sts/4.12/hypershift/openshift_hcp_kms_provider_credential_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_kms_provider_credential_policy.json
@@ -7,7 +7,7 @@
           "kms:Encrypt",
           "kms:Decrypt",
           "kms:ReEncrypt*",
-          "kms:GenerateDataKey*",
+          "kms:GenerateDataKeyWithoutPlainText",
           "kms:DescribeKey"
         ],
         "Resource": "*",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Removing permissions not required to encrypt EBS volumes in EC2. Scoping to permissions required in AWS documentation [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html)



### Which Jira/Github issue(s) this PR fixes?

HyperShift will also make the same change https://github.com/openshift/hypershift/pull/2456

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
