### PR TITLE
Add missing openshift_cluster_csi_drivers_ebs_cloud_credentials permissions

### DIFF
--- a/resources/sts/4.11/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
+++ b/resources/sts/4.11/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
@@ -20,6 +20,31 @@
         "ec2:ModifyVolume"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlainText",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:RevokeGrant",
+        "kms:CreateGrant",
+        "kms:ListGrants"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": true
+        }
+      }
     }
   ]
 }

--- a/resources/sts/4.12/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
+++ b/resources/sts/4.12/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
@@ -20,6 +20,31 @@
         "ec2:ModifyVolume"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlainText",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:RevokeGrant",
+        "kms:CreateGrant",
+        "kms:ListGrants"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": true
+        }
+      }
     }
   ]
 }

--- a/resources/sts/4.13/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
+++ b/resources/sts/4.13/openshift_cluster_csi_drivers_ebs_cloud_credentials_policy.json
@@ -20,6 +20,32 @@
         "ec2:ModifyVolume"
       ],
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:ReEncrypt*",
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey",
+        "kms:GenerateDataKeyWithoutPlainText",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:RevokeGrant",
+        "kms:CreateGrant",
+        "kms:ListGrants"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": true
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Add missing openshift_cluster_csi_drivers_ebs_cloud_credentials permissions for 4.11, 4.12, 4.13.

These permissions were added with https://github.com/openshift/cluster-storage-operator/pull/263 and went unnoticed in the gap analysis for 4.11 and 4.12. 

This PR retroactively adds them for 4.11. and 4.12, and adds the extra "kms:ReEncrypt*" permission top for 4.13. 

### What type of PR is this?
feature

### What this PR does / why we need it?

See credential request of the cluster-storage-operator: https://github.com/openshift/cluster-storage-operator/blob/master/manifests/03_credentials_request_aws.yaml#L40-L51

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
