### PR TITLE
Add tag condition to DeleteLoadBalancer in hcp installer

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -32,7 +32,12 @@
             "Action": [
                 "elasticloadbalancing:DeleteLoadBalancer"
             ],
-            "Resource": "*"
+            "Resource": "*",
+            "Condition" : {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
         },
         {
             "Sid": "PassRoleToEC2",


### PR DESCRIPTION
Add condition to require `red-hat-managed: true` tag on LB for DeleteLoadBalancer permission in the HCP installer. 