### PR TITLE
Remove Create and Delete LoadBalancer from HCP Installer Policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -27,14 +27,6 @@
             "Resource": "*"
         },
         {
-            "Sid": "DeleteLoadBalancer",
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:DeleteLoadBalancer"
-            ],
-            "Resource": "*"
-        },
-        {
             "Sid": "PassRoleToEC2",
             "Action": [
                 "iam:PassRole"
@@ -63,19 +55,6 @@
             "Condition": {
                 "StringEquals": {
                     "aws:ResourceTag/red-hat-managed": "true"
-                }
-            }
-        },
-        {
-            "Sid": "CreateLoadBalancer",
-            "Effect": "Allow",
-            "Action": "elasticloadbalancing:CreateLoadBalancer",
-            "Resource": [
-                "*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "aws:RequestTag/red-hat-managed": "true"
                 }
             }
         },


### PR DESCRIPTION
In HCP, the installer doesn't use the CreateLoadBalancer or DeleteLoadBalancer policies. 

/hold 
Needs verification that the statement above is true. 