### PR TITLE
Use stock CMO on management clusters

### DIFF
--- a/deploy/cluster-monitoring-config/config.yaml
+++ b/deploy/cluster-monitoring-config/config.yaml
@@ -7,6 +7,3 @@ selectorSyncSet:
     - key: ext-managed.openshift.io/uwm-disabled
       operator: NotIn
       values: ["true"]
-    - key: ext-hypershift.openshift.io/cluster-type
-      operator: NotIn
-      values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22312,10 +22312,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: ext-hypershift.openshift.io/cluster-type
-        operator: NotIn
-        values:
-        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22312,10 +22312,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: ext-hypershift.openshift.io/cluster-type
-        operator: NotIn
-        values:
-        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22312,10 +22312,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: ext-hypershift.openshift.io/cluster-type
-        operator: NotIn
-        values:
-        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Currently, we are deploying a custom CMO configuration to all Management Clusters via  OSD Fleet Manager. In order to do this, we exclude[1] the standard CMO config from being deployed on Management Clusters. With us moving away from using CMO to ship Management Cluster metrics, this change has to be reverted.
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-15901
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
