### PR TITLE
Remove AuthorizeSecurityGroupIngress from HCP NodePool controller

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -49,22 +49,6 @@
       }
     },
     {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:TerminateInstances"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:security-group/*",
-        "arn:aws:ec2:*:*:security-group-rule/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:ResourceTag/red-hat-managed": "true"
-        }
-      }
-    },
-    {
       "Sid": "NetworkInterfaces",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
NodePool controller doesn't use AuthorizeSecurityGroupIngress permission, removing from policy. 