### PR TITLE
Add get instance profile to support policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
@@ -354,9 +354,12 @@
       }
     },
     {
-      "Sid": "DescribeInstanceAttribute",
+      "Sid": "DescribeInstance",
       "Effect": "Allow",
-      "Action": "ec2:DescribeInstanceAttribute",
+      "Action": [
+        "ec2:DescribeInstanceAttribute",
+        "iam:GetInstanceProfile"
+      ],
       "Resource": "arn:aws:ec2:*:*:instance/*",
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds ability for SRE to get instance profiles for EC2 instances. To assist diagnosing issues with worker nodes.

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-16071

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
