### PR TITLE
Update route-monitor-operator package and routeMonitor configurations

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
@@ -34,6 +34,7 @@ spec:
                             route:
                                 name: console
                                 namespace: openshift-console
+                            skipPrometheusRule: true
                             slo:
                                 targetAvailabilityPercent: "99.5"
                 pruneObjectBehavior: DeleteIfCreated

--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -46,7 +46,7 @@ spec:
                         metadata:
                             name: route-monitor-operator
                         spec:
-                            image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                            image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.500-6152b76
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/hs-hosted-route-monitor-operator/console.RouteMonitor.yaml
+++ b/deploy/hs-hosted-route-monitor-operator/console.RouteMonitor.yaml
@@ -10,3 +10,4 @@ spec:
     namespace: openshift-console
   slo:
     targetAvailabilityPercent: "99.5"
+  skipPrometheusRule: true

--- a/deploy/hs-mgmt-route-monitor-operator/package.yaml
+++ b/deploy/hs-mgmt-route-monitor-operator/package.yaml
@@ -3,4 +3,4 @@ kind: Package
 metadata:
   name: route-monitor-operator
 spec:
-  image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+  image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.500-6152b76

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3053,7 +3053,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.500-6152b76
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2976,6 +2976,7 @@ objects:
                     route:
                       name: console
                       namespace: openshift-console
+                    skipPrometheusRule: true
                     slo:
                       targetAvailabilityPercent: '99.5'
               pruneObjectBehavior: DeleteIfCreated

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3053,7 +3053,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.500-6152b76
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2976,6 +2976,7 @@ objects:
                     route:
                       name: console
                       namespace: openshift-console
+                    skipPrometheusRule: true
                     slo:
                       targetAvailabilityPercent: '99.5'
               pruneObjectBehavior: DeleteIfCreated

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3053,7 +3053,7 @@ objects:
                   metadata:
                     name: route-monitor-operator
                   spec:
-                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.487-f6fa14d
+                    image: quay.io/app-sre/route-monitor-operator-hs-package:v0.1.500-6152b76
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2976,6 +2976,7 @@ objects:
                     route:
                       name: console
                       namespace: openshift-console
+                    skipPrometheusRule: true
                     slo:
                       targetAvailabilityPercent: '99.5'
               pruneObjectBehavior: DeleteIfCreated


### PR DESCRIPTION
### What this PR does / why we need it?

https://github.com/openshift/route-monitor-operator/pull/207 has been merged and should allow RMO to:

1. Use the latest package hash in https://quay.io/repository/app-sre/route-monitor-operator-hs-package?tab=tags
2. Updates routeMonitor CRs deployed to hosted clusters to skip creating console-errorBudgetBurn alert as this will be deployed on RHOBS - https://gitlab.cee.redhat.com/service/rhobs-rules-and-dashboards/-/merge_requests/168 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-16127
https://issues.redhat.com/browse/OSD-15737

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
