### PR TITLE
Improve the Ingress Controller Policy to support:

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -38,11 +38,22 @@ spec:
                         apiVersion: operator.openshift.io/v1
                         kind: IngressController
                         metadata:
+                            annotations:
+                                ingress.operator.openshift.io/auto-delete-load-balancer: "true"
                             name: default
                             namespace: openshift-ingress-operator
                         spec:
                             defaultCertificate:
                                 name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+                            endpointPublishingStrategy:
+                                loadBalancer:
+                                    dnsManagementPolicy: Managed
+                                    providerParameters:
+                                        aws:
+                                            type: NLB
+                                        type: AWS
+                                    scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
+                                type: LoadBalancerService
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
@@ -3,6 +3,17 @@ kind: IngressController
 metadata:
   name: default
   namespace: openshift-ingress-operator
+  annotations:
+    ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
 spec:
   defaultCertificate:
     name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+  endpointPublishingStrategy:
+    type: LoadBalancerService
+    loadBalancer:
+      providerParameters:
+        type: AWS
+        aws:
+          type: 'NLB'
+      dnsManagementPolicy: 'Managed'
+      scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6834,12 +6834,25 @@ objects:
                   apiVersion: operator.openshift.io/v1
                   kind: IngressController
                   metadata:
+                    annotations:
+                      ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
                     name: default
                     namespace: openshift-ingress-operator
                   spec:
                     defaultCertificate:
                       name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
                         hub}}'
+                    endpointPublishingStrategy:
+                      loadBalancer:
+                        dnsManagementPolicy: Managed
+                        providerParameters:
+                          aws:
+                            type: NLB
+                          type: AWS
+                        scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
+                          .ManagedClusterName "endpoint-publishing-strategy") "internal"
+                          -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
+                      type: LoadBalancerService
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6834,12 +6834,25 @@ objects:
                   apiVersion: operator.openshift.io/v1
                   kind: IngressController
                   metadata:
+                    annotations:
+                      ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
                     name: default
                     namespace: openshift-ingress-operator
                   spec:
                     defaultCertificate:
                       name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
                         hub}}'
+                    endpointPublishingStrategy:
+                      loadBalancer:
+                        dnsManagementPolicy: Managed
+                        providerParameters:
+                          aws:
+                            type: NLB
+                          type: AWS
+                        scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
+                          .ManagedClusterName "endpoint-publishing-strategy") "internal"
+                          -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
+                      type: LoadBalancerService
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6834,12 +6834,25 @@ objects:
                   apiVersion: operator.openshift.io/v1
                   kind: IngressController
                   metadata:
+                    annotations:
+                      ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
                     name: default
                     namespace: openshift-ingress-operator
                   spec:
                     defaultCertificate:
                       name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
                         hub}}'
+                    endpointPublishingStrategy:
+                      loadBalancer:
+                        dnsManagementPolicy: Managed
+                        providerParameters:
+                          aws:
+                            type: NLB
+                          type: AWS
+                        scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
+                          .ManagedClusterName "endpoint-publishing-strategy") "internal"
+                          -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
+                      type: LoadBalancerService
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low


### PR DESCRIPTION
* Auto-delete-load-balancer
* providerParameters.aws.type: NLB
* loadBalancer.scope: External/Internal # Toggled

### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature
### What this PR does / why we need it?
Missing support for Private Ingress Configuration.
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/SDA-9047
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
