### PR TITLE
Creates new FileDescriptorLimit alerts

### DIFF
--- a/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
@@ -1,0 +1,53 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-node-filedescriptor-limit
+    role: alert-rules
+  name: sre-node-filedescriptor-limit
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-controlplane-node-filedescriptor-limit
+    rules:
+    - alert: ControlPlaneNodeFileDescriptorLimitSRE
+      # This is the same as the upstream alert, but groups by instance id (which is which node is affected)
+      # and then only fires on the control-plane, infra, or master node roles.
+      expr: |-
+        group by (instance) (
+          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} >= 90
+        )
+        * on (instance) group_left ()group by (instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 15m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        message: "Kernel is predicted to exhaust file descriptors limit soon."
+  - name: sre-worker-node-filedescriptor-limit
+    rules:
+    - alert: WorkerNodeFileDescriptorLimitSRE
+      # This is the same as the upstream alert, but groups by instance id (which is which node is affected)
+      # and then only fires on the worker nodes. The `unless` portion is because when getting the node-role
+      # metric it splits on the roles, so infra,worker then gives two results, one with just the infra role
+      # and one with just the worker role.  So we get just the infra/controlplane nodes and then exclude
+      # them from the worker node result, which gives us just the customer worker nodes.
+      expr: |-
+        group by (instance) (
+          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} >= 90
+        )
+        * on (instance) group_left ()group by(instance) (
+          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+        unless
+        group by(instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 15m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        message: "Kernel is predicted to exhaust file descriptors limit soon."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33228,6 +33228,46 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-filedescriptor-limit
+          role: alert-rules
+        name: sre-node-filedescriptor-limit
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-controlplane-node-filedescriptor-limit
+          rules:
+          - alert: ControlPlaneNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
+        - name: sre-worker-node-filedescriptor-limit
+          rules:
+          - alert: WorkerNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-unschedulable
           role: alert-rules
         name: sre-node-unschedulable

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33228,6 +33228,46 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-filedescriptor-limit
+          role: alert-rules
+        name: sre-node-filedescriptor-limit
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-controlplane-node-filedescriptor-limit
+          rules:
+          - alert: ControlPlaneNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
+        - name: sre-worker-node-filedescriptor-limit
+          rules:
+          - alert: WorkerNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-unschedulable
           role: alert-rules
         name: sre-node-unschedulable

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33228,6 +33228,46 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-filedescriptor-limit
+          role: alert-rules
+        name: sre-node-filedescriptor-limit
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-controlplane-node-filedescriptor-limit
+          rules:
+          - alert: ControlPlaneNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
+        - name: sre-worker-node-filedescriptor-limit
+          rules:
+          - alert: WorkerNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-unschedulable
           role: alert-rules
         name: sre-node-unschedulable


### PR DESCRIPTION
### What type of PR is this?
Feature/Cleanup

### What this PR does / why we need it?
This creates two new alerts to track the NodeFileDescriptor limit based on what role the instance has. This allows us to continue to handle both of these as is now, but we can then pull the worker-node one into OCM Agent Operator in the future to automatically send the alert to customers.

### Which Jira/Github issue(s) this PR fixes?
[OSD-12379](https://issues.redhat.com//browse/OSD-12379)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
