### PR TITLE
Remove unused AssumeRole action in HyperShift install policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -46,21 +46,6 @@
             }
         },
         {
-            "Sid": "AssumeRole",
-            "Effect": "Allow",
-            "Action": [
-                "sts:AssumeRole"
-            ],
-            "Resource": [
-                "arn:aws:iam::*:role/*"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "aws:ResourceTag/red-hat-managed": "true"
-                }
-            }
-        },
-        {
             "Sid": "ManageInstanceProfiles",
             "Effect": "Allow",
             "Action": [


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Removes an unused privileged IAM action from the HyperShift installer role. 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/SDA-9055

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
