### PR TITLE
Automates Worker Node FileDescriptorLimit Alerts

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -35,3 +35,16 @@ spec:
       resendWait: 1
       severity: Error
       summary: "Platform protections removed by non-Red Hat user"
+    - activeBody: Your cluster requires you to take action. The kernel file descriptor
+        limit for a worker node is currently at or above 90% and is predicted to be
+        fully exhausted soon. This will prevent applications on the node from opening
+        and operating on files. Without action, your cluster's SLA and ability to upgrade
+        may be impacted. Please reduce the number of simultaneously-open files on this
+        node, either by adjusting application configuration or by moving some applications
+        to other nodes.
+      name: WorkerNodeFileDescriptorAtLimit
+      resendWait: 24
+      resolvedBody: Your cluster no longer has worker nodes approaching the kernel file
+        descriptor limit. No additional action on this issue is required.
+      severity: Info
+      summary: Worker node file descriptor limit nearly exhausted

--- a/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
@@ -13,36 +13,12 @@ spec:
     - alert: ControlPlaneNodeFileDescriptorLimitSRE
       # This is the same as the upstream alert, but groups by instance id (which is which node is affected)
       # and then only fires on the control-plane, infra, or master node roles.
+      # See the ocm-agent folder for the WorkerNode version of this alert
       expr: |-
         group by (instance) (
           node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} >= 90
         )
         * on (instance) group_left ()group by (instance) (
-          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
-        )
-      for: 15m
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
-      annotations:
-        message: "Kernel is predicted to exhaust file descriptors limit soon."
-  - name: sre-worker-node-filedescriptor-limit
-    rules:
-    - alert: WorkerNodeFileDescriptorLimitSRE
-      # This is the same as the upstream alert, but groups by instance id (which is which node is affected)
-      # and then only fires on the worker nodes. The `unless` portion is because when getting the node-role
-      # metric it splits on the roles, so infra,worker then gives two results, one with just the infra role
-      # and one with just the worker role.  So we get just the infra/controlplane nodes and then exclude
-      # them from the worker node result, which gives us just the customer worker nodes.
-      expr: |-
-        group by (instance) (
-          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} >= 90
-        )
-        * on (instance) group_left ()group by(instance) (
-          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
-        )
-        unless
-        group by(instance) (
           label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
         )
       for: 15m

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -48,3 +48,28 @@ spec:
         namespace: audit-exporter
         send_managed_notification: "true"
         managed_notification_template: "NonSystemChangeValidationWebhookConfigurations"
+    - alert: WorkerNodeFileDescriptorLimitSRE
+      # This is the same as the upstream alert, but groups by instance id (which is which node is affected)
+      # and then only fires on the worker nodes. The `unless` portion is because when getting the node-role
+      # metric it splits on the roles, so infra,worker then gives two results, one with just the infra role
+      # and one with just the worker role.  So we get just the infra/controlplane nodes and then exclude
+      # them from the worker node result, which gives us just the customer worker nodes.
+      expr: |-
+        group by (instance) (
+          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} >= 90
+        )
+        * on (instance) group_left ()group by(instance) (
+          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+        unless
+        group by(instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 15m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: WorkerNodeFileDescriptorAtLimit
+        send_managed_notification: "true"
+      annotations:
+        message: "Kernel is predicted to exhaust file descriptors limit soon."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23680,6 +23680,19 @@ objects:
           resendWait: 1
           severity: Error
           summary: Platform protections removed by non-Red Hat user
+        - activeBody: Your cluster requires you to take action. The kernel file descriptor
+            limit for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. This will prevent applications on the node
+            from opening and operating on files. Without action, your cluster's SLA
+            and ability to upgrade may be impacted. Please reduce the number of simultaneously-open
+            files on this node, either by adjusting application configuration or by
+            moving some applications to other nodes.
+          name: WorkerNodeFileDescriptorAtLimit
+          resendWait: 24
+          resolvedBody: Your cluster no longer has worker nodes approaching the kernel
+            file descriptor limit. No additional action on this issue is required.
+          severity: Info
+          summary: Worker node file descriptor limit nearly exhausted
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -33496,22 +33509,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
-        - name: sre-worker-node-filedescriptor-limit
-          rules:
-          - alert: WorkerNodeFileDescriptorLimitSRE
-            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
-              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
-              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
-            for: 15m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: Kernel is predicted to exhaust file descriptors limit soon.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -34700,6 +34697,22 @@ objects:
               namespace: audit-exporter
               send_managed_notification: 'true'
               managed_notification_template: NonSystemChangeValidationWebhookConfigurations
+          - alert: WorkerNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFileDescriptorAtLimit
+              send_managed_notification: 'true'
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23680,6 +23680,19 @@ objects:
           resendWait: 1
           severity: Error
           summary: Platform protections removed by non-Red Hat user
+        - activeBody: Your cluster requires you to take action. The kernel file descriptor
+            limit for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. This will prevent applications on the node
+            from opening and operating on files. Without action, your cluster's SLA
+            and ability to upgrade may be impacted. Please reduce the number of simultaneously-open
+            files on this node, either by adjusting application configuration or by
+            moving some applications to other nodes.
+          name: WorkerNodeFileDescriptorAtLimit
+          resendWait: 24
+          resolvedBody: Your cluster no longer has worker nodes approaching the kernel
+            file descriptor limit. No additional action on this issue is required.
+          severity: Info
+          summary: Worker node file descriptor limit nearly exhausted
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -33496,22 +33509,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
-        - name: sre-worker-node-filedescriptor-limit
-          rules:
-          - alert: WorkerNodeFileDescriptorLimitSRE
-            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
-              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
-              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
-            for: 15m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: Kernel is predicted to exhaust file descriptors limit soon.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -34700,6 +34697,22 @@ objects:
               namespace: audit-exporter
               send_managed_notification: 'true'
               managed_notification_template: NonSystemChangeValidationWebhookConfigurations
+          - alert: WorkerNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFileDescriptorAtLimit
+              send_managed_notification: 'true'
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23680,6 +23680,19 @@ objects:
           resendWait: 1
           severity: Error
           summary: Platform protections removed by non-Red Hat user
+        - activeBody: Your cluster requires you to take action. The kernel file descriptor
+            limit for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. This will prevent applications on the node
+            from opening and operating on files. Without action, your cluster's SLA
+            and ability to upgrade may be impacted. Please reduce the number of simultaneously-open
+            files on this node, either by adjusting application configuration or by
+            moving some applications to other nodes.
+          name: WorkerNodeFileDescriptorAtLimit
+          resendWait: 24
+          resolvedBody: Your cluster no longer has worker nodes approaching the kernel
+            file descriptor limit. No additional action on this issue is required.
+          severity: Info
+          summary: Worker node file descriptor limit nearly exhausted
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -33496,22 +33509,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
-        - name: sre-worker-node-filedescriptor-limit
-          rules:
-          - alert: WorkerNodeFileDescriptorLimitSRE
-            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
-              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
-              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
-            for: 15m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: Kernel is predicted to exhaust file descriptors limit soon.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -34700,6 +34697,22 @@ objects:
               namespace: audit-exporter
               send_managed_notification: 'true'
               managed_notification_template: NonSystemChangeValidationWebhookConfigurations
+          - alert: WorkerNodeFileDescriptorLimitSRE
+            expr: "group by (instance) (\n  node_filefd_allocated{job=\"node-exporter\"\
+              } * 100 / node_filefd_maximum{job=\"node-exporter\"} >= 90\n)\n* on\
+              \ (instance) group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFileDescriptorAtLimit
+              send_managed_notification: 'true'
+            annotations:
+              message: Kernel is predicted to exhaust file descriptors limit soon.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Automates the sending of a SL for Worker node FileDescriptorLimit Alerts

### Which Jira/Github issue(s) this PR fixes?
Resolves [OSD-12379](https://issues.redhat.com//browse/OSD-12379)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ x ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
