### PR TITLE
Change instance profile ARN resource to be serivce specific

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -70,7 +70,7 @@
                 "iam:GetInstanceProfile"
             ],
             "Resource": [
-                "arn:aws:iam::*:instance-profile/*-worker"
+                "arn:aws:iam::*:instance-profile/rosa-*"
             ]
         },
         {
@@ -81,7 +81,7 @@
                 "iam:TagInstanceProfile"
             ],
             "Resource": [
-                "arn:aws:iam::*:instance-profile/*-worker"
+                "arn:aws:iam::*:instance-profile/rosa-*"
             ],
             "Condition": {
                 "StringEquals": {


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Changes the instance profile ARN resource restriction to be service specific. The change is in conjunction with the below CS change.

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/SDA-9052

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
