### PR TITLE
Add global condition context key to S3 arn

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
@@ -153,7 +153,7 @@
       "Action": "s3:ListBucket",
       "Resource": [
         "arn:aws:s3:::managed-velero*",
-        "arn:aws:s3:::*image-registry*"
+        "arn:aws:s3:::*image-registry-${aws:RequestedRegion}-*"
       ]
     },
     {


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Adds global condition context key to S3 ARN for HyperShift support policy

### Which Jira/Github issue(s) this PR fixes?



### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
