### PR TITLE
Add global tag restriction to VPC actions

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -74,7 +74,9 @@
         "ec2:ModifyNetworkInterfaceAttribute"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:instance/*"
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:network-interface/*",
+        "arn:aws:ec2:*:*:security-group/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -89,8 +91,6 @@
         "ec2:ModifyNetworkInterfaceAttribute"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*",
-        "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:vpc/*"
       ]
     },


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds global condition tag to VPC actions

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
