### PR TITLE
Revert "Add global tag restriction to VPC actions"

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -74,9 +74,7 @@
         "ec2:ModifyNetworkInterfaceAttribute"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:instance/*",
-        "arn:aws:ec2:*:*:network-interface/*",
-        "arn:aws:ec2:*:*:security-group/*"
+        "arn:aws:ec2:*:*:instance/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -91,6 +89,8 @@
         "ec2:ModifyNetworkInterfaceAttribute"
       ],
       "Resource": [
+        "arn:aws:ec2:*:*:network-interface/*",
+        "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:vpc/*"
       ]
     },


### PR DESCRIPTION
Reverts openshift/managed-cluster-config#1661

Testing shows the ENI is not tagged correctly by the CAPA controller.