### PR TITLE
Delete OSD FM managed CMO config SyncSet

### DIFF
--- a/deploy/hs-delete-custom-cmo-config/00-hs-delete-custom-cmo.Namespace.yaml
+++ b/deploy/hs-delete-custom-cmo-config/00-hs-delete-custom-cmo.Namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-delete-custom-cmo-config

--- a/deploy/hs-delete-custom-cmo-config/01-hs-delete-custom-cmo.ServiceAccount.yaml
+++ b/deploy/hs-delete-custom-cmo-config/01-hs-delete-custom-cmo.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hs-delete-custom-cmo-config
+  namespace: openshift-delete-custom-cmo-config

--- a/deploy/hs-delete-custom-cmo-config/02-hs-delete-custom-cmo.ClusterRole.yaml
+++ b/deploy/hs-delete-custom-cmo-config/02-hs-delete-custom-cmo.ClusterRole.yaml
@@ -5,9 +5,9 @@ metadata:
   name: hs-delete-custom-cmo-config
 rules:
 - apiGroups:
-  - ""
+  - "hive.openshift.io/v1"
   resources:
-  - configmaps
+  - syncsets
   resourceNames:
   - "ext-cluster-monitoring-operator-config"
   verbs:

--- a/deploy/hs-delete-custom-cmo-config/02-hs-delete-custom-cmo.ClusterRole.yaml
+++ b/deploy/hs-delete-custom-cmo-config/02-hs-delete-custom-cmo.ClusterRole.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hs-delete-custom-cmo-config
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - "ext-cluster-monitoring-operator-config"
+  verbs:
+  - "*"

--- a/deploy/hs-delete-custom-cmo-config/03-hs-delete-custom-cmo.ClusterRoleBinding.yaml
+++ b/deploy/hs-delete-custom-cmo-config/03-hs-delete-custom-cmo.ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hs-delete-custom-cmo-config
+subjects:
+- kind: ServiceAccount
+  name: hs-delete-custom-cmo-config
+  namespace: openshift-delete-custom-cmo-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hs-delete-custom-cmo-config

--- a/deploy/hs-delete-custom-cmo-config/10-hs-delete-custom-cmo.Job.yaml
+++ b/deploy/hs-delete-custom-cmo-config/10-hs-delete-custom-cmo.Job.yaml
@@ -1,23 +1,23 @@
 ---
-- apiVersion: batch/v1
-  kind: Job
-  metadata:
-    name: hs-delete-custom-cmo-config
-    namespace: openshift-delete-custom-cmo-config
-  spec:
-    template:
-      spec:
-        containers:
-        - name: hs-delete-custom-cmo-config
-          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
-          command:
-          - bash
-          - -c
-          - |
-            readarray -t namespaces < <(oc get cd -l ext-hypershift.openshift.io/cluster-type=management-cluster -A -o go-template='{{range .items}}{{.metadata.namespace}}{{"\n"}}{{end}}');
-            for ns in "${namespaces[@]}"; do
-              oc patch syncset ext-cluster-monitoring-operator-config -n "${ns}" --type merge -p '{"spec":{"resourceApplyMode":"Upsert"}}';
-              oc delete syncset ext-cluster-monitoring-operator-config -n "${ns}";
-            done;
-        serviceAccountName: hs-delete-custom-cmo-config
-        restartPolicy: Never
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hs-delete-custom-cmo-config
+  namespace: openshift-delete-custom-cmo-config
+spec:
+  template:
+    spec:
+      containers:
+      - name: hs-delete-custom-cmo-config
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        command:
+        - bash
+        - -c
+        - |
+          readarray -t namespaces < <(oc get cd -l ext-hypershift.openshift.io/cluster-type=management-cluster -A -o go-template='{{range .items}}{{.metadata.namespace}}{{"\n"}}{{end}}');
+          for ns in "${namespaces[@]}"; do
+            oc patch syncset ext-cluster-monitoring-operator-config -n "${ns}" --type merge -p '{"spec":{"resourceApplyMode":"Upsert"}}';
+            oc delete syncset ext-cluster-monitoring-operator-config -n "${ns}";
+          done;
+      serviceAccountName: hs-delete-custom-cmo-config
+      restartPolicy: Never

--- a/deploy/hs-delete-custom-cmo-config/10-hs-delete-custom-cmo.Job.yaml
+++ b/deploy/hs-delete-custom-cmo-config/10-hs-delete-custom-cmo.Job.yaml
@@ -1,0 +1,23 @@
+---
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: hs-delete-custom-cmo-config
+    namespace: openshift-delete-custom-cmo-config
+  spec:
+    template:
+      spec:
+        containers:
+        - name: hs-delete-custom-cmo-config
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+          command:
+          - bash
+          - -c
+          - |
+            readarray -t namespaces < <(oc get cd -l ext-hypershift.openshift.io/cluster-type=management-cluster -A -o go-template='{{range .items}}{{.metadata.namespace}}{{"\n"}}{{end}}');
+            for ns in "${namespaces[@]}"; do
+              oc patch syncset ext-cluster-monitoring-operator-config -n "${ns}" --type merge -p '{"spec":{"resourceApplyMode":"Upsert"}}';
+              oc delete syncset ext-cluster-monitoring-operator-config -n "${ns}";
+            done;
+        serviceAccountName: hs-delete-custom-cmo-config
+        restartPolicy: Never

--- a/deploy/hs-delete-custom-cmo-config/config.yaml
+++ b/deploy/hs-delete-custom-cmo-config/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-managed.openshift.io/hive-shard
+    operator: In
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22967,6 +22967,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hs-delete-custom-cmo-config
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-delete-custom-cmo-config
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hs-delete-custom-cmo-config
+      rules:
+      - apiGroups:
+        - hive.openshift.io/v1
+        resources:
+        - syncsets
+        resourceNames:
+        - ext-cluster-monitoring-operator-config
+        verbs:
+        - '*'
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: hs-delete-custom-cmo-config
+      subjects:
+      - kind: ServiceAccount
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hs-delete-custom-cmo-config
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+      spec:
+        template:
+          spec:
+            containers:
+            - name: hs-delete-custom-cmo-config
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              command:
+              - bash
+              - -c
+              - "readarray -t namespaces < <(oc get cd -l ext-hypershift.openshift.io/cluster-type=management-cluster\
+                \ -A -o go-template='{{range .items}}{{.metadata.namespace}}{{\"\\\
+                n\"}}{{end}}');\nfor ns in \"${namespaces[@]}\"; do\n  oc patch syncset\
+                \ ext-cluster-monitoring-operator-config -n \"${ns}\" --type merge\
+                \ -p '{\"spec\":{\"resourceApplyMode\":\"Upsert\"}}';\n  oc delete\
+                \ syncset ext-cluster-monitoring-operator-config -n \"${ns}\";\ndone;\n"
+            serviceAccountName: hs-delete-custom-cmo-config
+            restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22967,6 +22967,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hs-delete-custom-cmo-config
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-delete-custom-cmo-config
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hs-delete-custom-cmo-config
+      rules:
+      - apiGroups:
+        - hive.openshift.io/v1
+        resources:
+        - syncsets
+        resourceNames:
+        - ext-cluster-monitoring-operator-config
+        verbs:
+        - '*'
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: hs-delete-custom-cmo-config
+      subjects:
+      - kind: ServiceAccount
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hs-delete-custom-cmo-config
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+      spec:
+        template:
+          spec:
+            containers:
+            - name: hs-delete-custom-cmo-config
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              command:
+              - bash
+              - -c
+              - "readarray -t namespaces < <(oc get cd -l ext-hypershift.openshift.io/cluster-type=management-cluster\
+                \ -A -o go-template='{{range .items}}{{.metadata.namespace}}{{\"\\\
+                n\"}}{{end}}');\nfor ns in \"${namespaces[@]}\"; do\n  oc patch syncset\
+                \ ext-cluster-monitoring-operator-config -n \"${ns}\" --type merge\
+                \ -p '{\"spec\":{\"resourceApplyMode\":\"Upsert\"}}';\n  oc delete\
+                \ syncset ext-cluster-monitoring-operator-config -n \"${ns}\";\ndone;\n"
+            serviceAccountName: hs-delete-custom-cmo-config
+            restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22967,6 +22967,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hs-delete-custom-cmo-config
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-delete-custom-cmo-config
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hs-delete-custom-cmo-config
+      rules:
+      - apiGroups:
+        - hive.openshift.io/v1
+        resources:
+        - syncsets
+        resourceNames:
+        - ext-cluster-monitoring-operator-config
+        verbs:
+        - '*'
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: hs-delete-custom-cmo-config
+      subjects:
+      - kind: ServiceAccount
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hs-delete-custom-cmo-config
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: hs-delete-custom-cmo-config
+        namespace: openshift-delete-custom-cmo-config
+      spec:
+        template:
+          spec:
+            containers:
+            - name: hs-delete-custom-cmo-config
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              command:
+              - bash
+              - -c
+              - "readarray -t namespaces < <(oc get cd -l ext-hypershift.openshift.io/cluster-type=management-cluster\
+                \ -A -o go-template='{{range .items}}{{.metadata.namespace}}{{\"\\\
+                n\"}}{{end}}');\nfor ns in \"${namespaces[@]}\"; do\n  oc patch syncset\
+                \ ext-cluster-monitoring-operator-config -n \"${ns}\" --type merge\
+                \ -p '{\"spec\":{\"resourceApplyMode\":\"Upsert\"}}';\n  oc delete\
+                \ syncset ext-cluster-monitoring-operator-config -n \"${ns}\";\ndone;\n"
+            serviceAccountName: hs-delete-custom-cmo-config
+            restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
**Background:-**
 - SRE-P is trying to deprecate the custom CMO config deployed by Fleet Manager and fall back to the default CMO config via MCC. This was addressed with [OSD-15900](https://issues.redhat.com/browse/OSD-15900) and Fleet Manager no longer creates/reconciles the SyncSet (ext-cluster-monitoring-operator-config) for Management Clusters.
- But it turns out that fleet manager cannot clean up existing terraformed resources yet. The suggested approach by the OSD FM team was to delete the resources manually.

**Solution:-**
- This PR creates a job that deletes the left-over `ext-cluster-monitoring-operator-config` SyncSet from Hive.
- It is only deployed on Hive shards.
- First, it fetches all management clusters' clusterdeployment namespaces; retrieve cluster deployments with the label `ext-hypershift.openshift.io/cluster-type=management-cluster`.
- Then the target SyncSet's `resourceApplyMopde` is patched to `Upsert` which means that the on-cluster config map is not deleted if this SyncSet on Hive is deleted. This makes sure that the monitoring CO isn't degraded until we deploy the stock/default CMO config (https://github.com/openshift/managed-cluster-config/pull/1663).
- The SyncSet is then deleted.


### Which Jira/Github issue(s) this PR fixes?
Resolves: https://issues.redhat.com/browse/OSD-16179
Follows up on: https://issues.redhat.com/browse/OSD-15900
Is followed up by: https://github.com/openshift/managed-cluster-config/pull/1663

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
