### PR TITLE
Set Load Balancer type for ingressController to Classic

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -50,7 +50,7 @@ spec:
                                     dnsManagementPolicy: Managed
                                     providerParameters:
                                         aws:
-                                            type: NLB
+                                            type: Classic
                                         type: AWS
                                     scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
                                 type: LoadBalancerService

--- a/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
@@ -14,6 +14,6 @@ spec:
       providerParameters:
         type: AWS
         aws:
-          type: 'NLB'
+          type: 'Classic'
       dnsManagementPolicy: 'Managed'
       scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6847,7 +6847,7 @@ objects:
                         dnsManagementPolicy: Managed
                         providerParameters:
                           aws:
-                            type: NLB
+                            type: Classic
                           type: AWS
                         scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
                           .ManagedClusterName "endpoint-publishing-strategy") "internal"

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6847,7 +6847,7 @@ objects:
                         dnsManagementPolicy: Managed
                         providerParameters:
                           aws:
-                            type: NLB
+                            type: Classic
                           type: AWS
                         scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
                           .ManagedClusterName "endpoint-publishing-strategy") "internal"

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6847,7 +6847,7 @@ objects:
                         dnsManagementPolicy: Managed
                         providerParameters:
                           aws:
-                            type: NLB
+                            type: Classic
                           type: AWS
                         scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
                           .ManagedClusterName "endpoint-publishing-strategy") "internal"


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
BUG, to conform with AWS policies

### What this PR does / why we need it?
Uses a Classic Load Balancer

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/SDA-9047

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
