### PR TITLE
Fix conflict between control plane and ACM policies

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
@@ -42,7 +42,6 @@ spec:
                         kind: ClusterRole
                         metadata:
                             name: backplane-cssre-admins-cluster
-                        rules: []
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -42,7 +42,6 @@ spec:
                         kind: ClusterRole
                         metadata:
                             name: openshift-backplane-managed-scripts-reader
-                        rules: []
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -74,7 +74,6 @@ spec:
                         kind: ClusterRole
                         metadata:
                             name: dedicated-admins-cluster
-                        rules: []
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:
@@ -110,7 +109,6 @@ spec:
                         kind: ClusterRole
                         metadata:
                             name: dedicated-admins-project
-                        rules: []
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:
@@ -591,7 +589,6 @@ spec:
                             labels:
                                 managed.openshift.io/aggregate-to-dedicated-admins: cluster
                             name: dedicated-readers
-                        rules: []
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/cssre/01-cssre-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/cssre/01-cssre-admins-cluster.ClusterRole.yaml
@@ -10,4 +10,3 @@ aggregationRule:
         operator: In
         values:
           - "cluster"
-rules: []

--- a/deploy/backplane/lpsre/01-lpsre-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/lpsre/01-lpsre-admins-cluster.ClusterRole.yaml
@@ -10,4 +10,3 @@ aggregationRule:
         operator: In
         values:
           - "cluster"
-rules: []

--- a/deploy/osd-backplane-managed-scripts/10-openshift-backplane-managed-scripts.ClusterRole.yml
+++ b/deploy/osd-backplane-managed-scripts/10-openshift-backplane-managed-scripts.ClusterRole.yml
@@ -10,4 +10,3 @@ aggregationRule:
 kind: ClusterRole
 metadata:
   name: openshift-backplane-managed-scripts-reader
-rules: []

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
@@ -51,4 +51,3 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dedicated-admins-cluster
-rules: []

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
@@ -33,4 +33,3 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dedicated-admins-project
-rules: []

--- a/deploy/rbac-permissions-operator-config/05-dedicated-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-readers.ClusterRole.yaml
@@ -21,4 +21,3 @@ metadata:
   labels:
     managed.openshift.io/aggregate-to-dedicated-admins: "cluster"
   name: dedicated-readers
-rules: []

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1442,7 +1442,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: backplane-cssre-admins-cluster
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -3126,7 +3125,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5596,7 +5594,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: dedicated-admins-cluster
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5632,7 +5629,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: dedicated-admins-project
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -6113,7 +6109,6 @@ objects:
                     labels:
                       managed.openshift.io/aggregate-to-dedicated-admins: cluster
                     name: dedicated-readers
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -7382,7 +7377,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7489,7 +7483,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7596,7 +7589,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7703,7 +7695,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7810,7 +7801,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7917,7 +7907,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8024,7 +8013,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8131,7 +8119,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8238,7 +8225,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -9639,7 +9625,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -9832,7 +9817,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10025,7 +10009,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10218,7 +10201,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10411,7 +10393,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10604,7 +10585,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10797,7 +10777,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10990,7 +10969,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11183,7 +11161,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11376,7 +11353,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11569,7 +11545,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11762,7 +11737,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11955,7 +11929,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12148,7 +12121,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12341,7 +12313,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12534,7 +12505,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12727,7 +12697,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12920,7 +12889,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13113,7 +13081,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13306,7 +13273,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13499,7 +13465,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13692,7 +13657,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13885,7 +13849,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14078,7 +14041,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14271,7 +14233,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14464,7 +14425,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14657,7 +14617,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14850,7 +14809,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15043,7 +15001,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15236,7 +15193,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15429,7 +15385,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15622,7 +15577,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -25214,7 +25168,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: openshift-backplane-managed-scripts-reader
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -31275,7 +31228,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: dedicated-admins-cluster
-      rules: []
     - aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:
@@ -31308,7 +31260,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: dedicated-admins-project
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -31780,7 +31731,6 @@ objects:
         labels:
           managed.openshift.io/aggregate-to-dedicated-admins: cluster
         name: dedicated-readers
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1442,7 +1442,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: backplane-cssre-admins-cluster
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -3126,7 +3125,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5596,7 +5594,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: dedicated-admins-cluster
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5632,7 +5629,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: dedicated-admins-project
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -6113,7 +6109,6 @@ objects:
                     labels:
                       managed.openshift.io/aggregate-to-dedicated-admins: cluster
                     name: dedicated-readers
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -7382,7 +7377,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7489,7 +7483,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7596,7 +7589,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7703,7 +7695,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7810,7 +7801,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7917,7 +7907,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8024,7 +8013,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8131,7 +8119,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8238,7 +8225,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -9639,7 +9625,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -9832,7 +9817,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10025,7 +10009,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10218,7 +10201,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10411,7 +10393,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10604,7 +10585,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10797,7 +10777,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10990,7 +10969,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11183,7 +11161,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11376,7 +11353,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11569,7 +11545,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11762,7 +11737,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11955,7 +11929,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12148,7 +12121,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12341,7 +12313,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12534,7 +12505,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12727,7 +12697,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12920,7 +12889,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13113,7 +13081,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13306,7 +13273,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13499,7 +13465,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13692,7 +13657,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13885,7 +13849,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14078,7 +14041,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14271,7 +14233,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14464,7 +14425,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14657,7 +14617,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14850,7 +14809,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15043,7 +15001,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15236,7 +15193,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15429,7 +15385,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15622,7 +15577,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -25214,7 +25168,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: openshift-backplane-managed-scripts-reader
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -31275,7 +31228,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: dedicated-admins-cluster
-      rules: []
     - aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:
@@ -31308,7 +31260,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: dedicated-admins-project
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -31780,7 +31731,6 @@ objects:
         labels:
           managed.openshift.io/aggregate-to-dedicated-admins: cluster
         name: dedicated-readers
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1442,7 +1442,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: backplane-cssre-admins-cluster
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -3126,7 +3125,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5596,7 +5594,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: dedicated-admins-cluster
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5632,7 +5629,6 @@ objects:
                   kind: ClusterRole
                   metadata:
                     name: dedicated-admins-project
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -6113,7 +6109,6 @@ objects:
                     labels:
                       managed.openshift.io/aggregate-to-dedicated-admins: cluster
                     name: dedicated-readers
-                  rules: []
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -7382,7 +7377,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7489,7 +7483,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7596,7 +7589,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7703,7 +7695,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7810,7 +7801,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -7917,7 +7907,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8024,7 +8013,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8131,7 +8119,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -8238,7 +8225,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -9639,7 +9625,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -9832,7 +9817,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10025,7 +10009,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10218,7 +10201,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10411,7 +10393,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10604,7 +10585,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10797,7 +10777,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -10990,7 +10969,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11183,7 +11161,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11376,7 +11353,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11569,7 +11545,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11762,7 +11737,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -11955,7 +11929,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12148,7 +12121,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12341,7 +12313,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12534,7 +12505,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12727,7 +12697,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -12920,7 +12889,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13113,7 +13081,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13306,7 +13273,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13499,7 +13465,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13692,7 +13657,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -13885,7 +13849,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14078,7 +14041,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14271,7 +14233,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14464,7 +14425,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14657,7 +14617,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -14850,7 +14809,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15043,7 +15001,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15236,7 +15193,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15429,7 +15385,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -15622,7 +15577,6 @@ objects:
             operator: In
             values:
             - cluster
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
@@ -25214,7 +25168,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: openshift-backplane-managed-scripts-reader
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
@@ -31275,7 +31228,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: dedicated-admins-cluster
-      rules: []
     - aggregationRule:
         clusterRoleSelectors:
         - matchExpressions:
@@ -31308,7 +31260,6 @@ objects:
       kind: ClusterRole
       metadata:
         name: dedicated-admins-project
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -31780,7 +31731,6 @@ objects:
         labels:
           managed.openshift.io/aggregate-to-dedicated-admins: cluster
         name: dedicated-readers
-      rules: []
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
ClusterRoles that use aggregation have their rules overwritten by the control plane but since these ConfigurationPolicies are set to `mustonlyhave` and `rules: []`, the aggregated rules will be overwritten on every evaluation and then the control plane will add them back.

Reference:
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
