### PR TITLE
OCM-190: Import ConfigMap support for ingress configuration.

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -15,6 +15,69 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+                name: rosa-ingress-controller-policies
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates-raw: |-
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: operator.openshift.io/v1
+                        kind: IngressController
+                        metadata:
+                          name: default
+                          namespace: openshift-ingress-operator
+                          annotations:
+                            ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
+                        spec:
+                          defaultCertificate:
+                            name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+                          {{hub- if ne (lookup "v1" "ConfigMap" "openshift-acm-policies" .ManagedClusterName).data nil hub}}
+                          endpointPublishingStrategy:
+                            type: LoadBalancerService
+                            loadBalancer:
+                              providerParameters:
+                                type: AWS
+                                aws:
+                                  type: '{{hub (default "Classic" (fromConfigMap "openshift-acm-policies" .ManagedClusterName "loadbalancer-aws-type")) hub}}'
+                              dnsManagementPolicy: 'Managed'
+                              scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
+                          {{hub- end hub}}
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rosa-ingress-svc-policies
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates-raw: |
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: Service
+                        metadata:
+                          name: router-default
+                          namespace: openshift-ingress
+                          {{hub- if ne (lookup "v1" "ConfigMap" "openshift-acm-policies" .ManagedClusterName).data nil hub}}
+                          {{hub- if ne (fromConfigMap "openshift-acm-policies" .ManagedClusterName "aws-load-balancer-subnets") "" hub}}
+                          annotations:
+                            service.beta.kubernetes.io/aws-load-balancer-subnets: {{hub (fromConfigMap
+                              "openshift-acm-policies" .ManagedClusterName "aws-load-balancer-subnets")
+                              hub}}
+                          {{hub- end hub}}
+                          {{hub- end hub}}
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
                 name: rosa-ingress-certificate-policies
             spec:
                 evaluationInterval:
@@ -32,28 +95,6 @@ spec:
                         metadata:
                             name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
                             namespace: openshift-ingress
-                    - complianceType: musthave
-                      metadataComplianceType: musthave
-                      objectDefinition:
-                        apiVersion: operator.openshift.io/v1
-                        kind: IngressController
-                        metadata:
-                            annotations:
-                                ingress.operator.openshift.io/auto-delete-load-balancer: "true"
-                            name: default
-                            namespace: openshift-ingress-operator
-                        spec:
-                            defaultCertificate:
-                                name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
-                            endpointPublishingStrategy:
-                                loadBalancer:
-                                    dnsManagementPolicy: Managed
-                                    providerParameters:
-                                        aws:
-                                            type: Classic
-                                        type: AWS
-                                    scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
-                                type: LoadBalancerService
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
@@ -1,19 +1,41 @@
-apiVersion: operator.openshift.io/v1
-kind: IngressController
+# IMPORTANT PRECAUTIONS:
+# Any change to how this policy renders will effect all Hosted Control Planes
+# To change only NEW HCP's, use a reference to the HCP's ConfigMap. The ConfigMap
+#  will only have new keys when ClusterService makes a specific change, like provisioning.
+#  If you supply a default for when the key is missing, the existing HCP's will not be effected
+#  by the change.
+# Changing the policy directly, without the ConfigMap reference will apply to ALL HCP's
+#
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
 metadata:
-  name: default
-  namespace: openshift-ingress-operator
-  annotations:
-    ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
+  name: rosa-ingress-controller-policies
 spec:
-  defaultCertificate:
-    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
-  endpointPublishingStrategy:
-    type: LoadBalancerService
-    loadBalancer:
-      providerParameters:
-        type: AWS
-        aws:
-          type: 'Classic'
-      dnsManagementPolicy: 'Managed'
-      scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
+  evaluationInterval:
+      compliant: 2h
+      noncompliant: 45s
+  object-templates-raw: |
+    - complianceType: musthave
+      metadataComplianceType: musthave
+      objectDefinition:
+        apiVersion: operator.openshift.io/v1
+        kind: IngressController
+        metadata:
+          name: default
+          namespace: openshift-ingress-operator
+          annotations:
+            ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
+        spec:
+          defaultCertificate:
+            name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+          {{hub- if ne (lookup "v1" "ConfigMap" "openshift-acm-policies" .ManagedClusterName).data nil hub}}
+          endpointPublishingStrategy:
+            type: LoadBalancerService
+            loadBalancer:
+              providerParameters:
+                type: AWS
+                aws:
+                  type: '{{hub (default "Classic" (fromConfigMap "openshift-acm-policies" .ManagedClusterName "loadbalancer-aws-type")) hub}}'
+              dnsManagementPolicy: 'Managed'
+              scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
+          {{hub- end hub}}

--- a/deploy/rosa-ingress-certificate-policies/03-ingress-serice-router-default.yaml
+++ b/deploy/rosa-ingress-certificate-policies/03-ingress-serice-router-default.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: rosa-ingress-svc-policies
+spec:
+  evaluationInterval:
+      compliant: 2h
+      noncompliant: 45s
+  object-templates-raw: |
+    - complianceType: musthave
+      metadataComplianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: router-default
+          namespace: openshift-ingress
+          {{hub- if ne (lookup "v1" "ConfigMap" "openshift-acm-policies" .ManagedClusterName).data nil hub}}
+          {{hub- if ne (fromConfigMap "openshift-acm-policies" .ManagedClusterName "aws-load-balancer-subnets") "" hub}}
+          annotations:
+            service.beta.kubernetes.io/aws-load-balancer-subnets: {{hub (fromConfigMap
+              "openshift-acm-policies" .ManagedClusterName "aws-load-balancer-subnets")
+              hub}}
+          {{hub- end hub}}
+          {{hub- end hub}}
+  pruneObjectBehavior: DeleteIfCreated
+  remediationAction: enforce
+  severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6803,6 +6803,54 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+              name: rosa-ingress-controller-policies
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
+                \    kind: IngressController\n    metadata:\n      name: default\n\
+                \      namespace: openshift-ingress-operator\n      annotations:\n\
+                \        ingress.operator.openshift.io/auto-delete-load-balancer:\
+                \ 'true'\n    spec:\n      defaultCertificate:\n        name: '{{hub\
+                \ (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName) hub}}'\n\
+                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
+                \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
+                \        type: LoadBalancerService\n        loadBalancer:\n      \
+                \    providerParameters:\n            type: AWS\n            aws:\n\
+                \              type: '{{hub (default \"Classic\" (fromConfigMap \"\
+                openshift-acm-policies\" .ManagedClusterName \"loadbalancer-aws-type\"\
+                )) hub}}'\n          dnsManagementPolicy: 'Managed'\n          scope:\
+                \ '{{hub- if eq (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}"
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-svc-policies
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: v1\n    kind: Service\n\
+                \    metadata:\n      name: router-default\n      namespace: openshift-ingress\n\
+                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
+                \ .ManagedClusterName).data nil hub}}\n      {{hub- if ne (fromConfigMap\
+                \ \"openshift-acm-policies\" .ManagedClusterName \"aws-load-balancer-subnets\"\
+                ) \"\" hub}}\n      annotations:\n        service.beta.kubernetes.io/aws-load-balancer-subnets:\
+                \ {{hub (fromConfigMap\n          \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"aws-load-balancer-subnets\")\n          hub}}\n      {{hub- end\
+                \ hub}}\n      {{hub- end hub}}\n"
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
               name: rosa-ingress-certificate-policies
             spec:
               evaluationInterval:
@@ -6823,31 +6871,6 @@ objects:
                     name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
                       hub}}'
                     namespace: openshift-ingress
-              - complianceType: musthave
-                metadataComplianceType: musthave
-                objectDefinition:
-                  apiVersion: operator.openshift.io/v1
-                  kind: IngressController
-                  metadata:
-                    annotations:
-                      ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
-                    name: default
-                    namespace: openshift-ingress-operator
-                  spec:
-                    defaultCertificate:
-                      name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
-                        hub}}'
-                    endpointPublishingStrategy:
-                      loadBalancer:
-                        dnsManagementPolicy: Managed
-                        providerParameters:
-                          aws:
-                            type: Classic
-                          type: AWS
-                        scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
-                          .ManagedClusterName "endpoint-publishing-strategy") "internal"
-                          -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
-                      type: LoadBalancerService
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6803,6 +6803,54 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+              name: rosa-ingress-controller-policies
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
+                \    kind: IngressController\n    metadata:\n      name: default\n\
+                \      namespace: openshift-ingress-operator\n      annotations:\n\
+                \        ingress.operator.openshift.io/auto-delete-load-balancer:\
+                \ 'true'\n    spec:\n      defaultCertificate:\n        name: '{{hub\
+                \ (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName) hub}}'\n\
+                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
+                \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
+                \        type: LoadBalancerService\n        loadBalancer:\n      \
+                \    providerParameters:\n            type: AWS\n            aws:\n\
+                \              type: '{{hub (default \"Classic\" (fromConfigMap \"\
+                openshift-acm-policies\" .ManagedClusterName \"loadbalancer-aws-type\"\
+                )) hub}}'\n          dnsManagementPolicy: 'Managed'\n          scope:\
+                \ '{{hub- if eq (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}"
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-svc-policies
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: v1\n    kind: Service\n\
+                \    metadata:\n      name: router-default\n      namespace: openshift-ingress\n\
+                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
+                \ .ManagedClusterName).data nil hub}}\n      {{hub- if ne (fromConfigMap\
+                \ \"openshift-acm-policies\" .ManagedClusterName \"aws-load-balancer-subnets\"\
+                ) \"\" hub}}\n      annotations:\n        service.beta.kubernetes.io/aws-load-balancer-subnets:\
+                \ {{hub (fromConfigMap\n          \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"aws-load-balancer-subnets\")\n          hub}}\n      {{hub- end\
+                \ hub}}\n      {{hub- end hub}}\n"
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
               name: rosa-ingress-certificate-policies
             spec:
               evaluationInterval:
@@ -6823,31 +6871,6 @@ objects:
                     name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
                       hub}}'
                     namespace: openshift-ingress
-              - complianceType: musthave
-                metadataComplianceType: musthave
-                objectDefinition:
-                  apiVersion: operator.openshift.io/v1
-                  kind: IngressController
-                  metadata:
-                    annotations:
-                      ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
-                    name: default
-                    namespace: openshift-ingress-operator
-                  spec:
-                    defaultCertificate:
-                      name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
-                        hub}}'
-                    endpointPublishingStrategy:
-                      loadBalancer:
-                        dnsManagementPolicy: Managed
-                        providerParameters:
-                          aws:
-                            type: Classic
-                          type: AWS
-                        scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
-                          .ManagedClusterName "endpoint-publishing-strategy") "internal"
-                          -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
-                      type: LoadBalancerService
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6803,6 +6803,54 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+              name: rosa-ingress-controller-policies
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
+                \    kind: IngressController\n    metadata:\n      name: default\n\
+                \      namespace: openshift-ingress-operator\n      annotations:\n\
+                \        ingress.operator.openshift.io/auto-delete-load-balancer:\
+                \ 'true'\n    spec:\n      defaultCertificate:\n        name: '{{hub\
+                \ (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName) hub}}'\n\
+                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
+                \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
+                \        type: LoadBalancerService\n        loadBalancer:\n      \
+                \    providerParameters:\n            type: AWS\n            aws:\n\
+                \              type: '{{hub (default \"Classic\" (fromConfigMap \"\
+                openshift-acm-policies\" .ManagedClusterName \"loadbalancer-aws-type\"\
+                )) hub}}'\n          dnsManagementPolicy: 'Managed'\n          scope:\
+                \ '{{hub- if eq (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}"
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-ingress-svc-policies
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+                \ musthave\n  objectDefinition:\n    apiVersion: v1\n    kind: Service\n\
+                \    metadata:\n      name: router-default\n      namespace: openshift-ingress\n\
+                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
+                \ .ManagedClusterName).data nil hub}}\n      {{hub- if ne (fromConfigMap\
+                \ \"openshift-acm-policies\" .ManagedClusterName \"aws-load-balancer-subnets\"\
+                ) \"\" hub}}\n      annotations:\n        service.beta.kubernetes.io/aws-load-balancer-subnets:\
+                \ {{hub (fromConfigMap\n          \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"aws-load-balancer-subnets\")\n          hub}}\n      {{hub- end\
+                \ hub}}\n      {{hub- end hub}}\n"
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
               name: rosa-ingress-certificate-policies
             spec:
               evaluationInterval:
@@ -6823,31 +6871,6 @@ objects:
                     name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
                       hub}}'
                     namespace: openshift-ingress
-              - complianceType: musthave
-                metadataComplianceType: musthave
-                objectDefinition:
-                  apiVersion: operator.openshift.io/v1
-                  kind: IngressController
-                  metadata:
-                    annotations:
-                      ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
-                    name: default
-                    namespace: openshift-ingress-operator
-                  spec:
-                    defaultCertificate:
-                      name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
-                        hub}}'
-                    endpointPublishingStrategy:
-                      loadBalancer:
-                        dnsManagementPolicy: Managed
-                        providerParameters:
-                          aws:
-                            type: Classic
-                          type: AWS
-                        scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies"
-                          .ManagedClusterName "endpoint-publishing-strategy") "internal"
-                          -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
-                      type: LoadBalancerService
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low


### PR DESCRIPTION
## Scenarios:

1. If ConfigMap is missing:
   * Do not include endpointPublishgStrategy in the IngressController policy
   * Do not add an annotation to the router-default ingress service
2. If the ConfigMap is present
   * Do not add an annotation to the service if aws-load-balancer-subnets if missing, otherwise add it.
   * If endpoint-publishing-strategy = internal, set the scope to Internal, otherwise its set to External
   * If loadbalancer-aws-type is missing, use Classic, otherwise use the value in loadbalancer-aws-type.
3. Add an annotation to the router-default service when the configMap key is present
   * If aws-load-balancer-subnets is present, apply the value to the annotation (comma separated list). If missing, skip modification of annotations on the service

INPUTs:
* ConfigMap in the openshift-acm-policies namespace, its name is the same as the HCP. It support for the following keys
  * aws-load-balancer-subnets: Comma separated list of subnet ID's or names
  * loadbalancer-aws-type: NLB / Classic
  * endpoint-publishing-strategy: internal / external  (resulting values are Internal or External)

### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature

### What this PR does / why we need it?
Adds further configuration to Ingress

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OCM-190

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
