### PR TITLE
Add list cluster deployments rule to delete-cmo-config cluster role

### DIFF
--- a/deploy/hs-delete-custom-cmo-config/02-hs-delete-custom-cmo.ClusterRole.yaml
+++ b/deploy/hs-delete-custom-cmo-config/02-hs-delete-custom-cmo.ClusterRole.yaml
@@ -5,10 +5,17 @@ metadata:
   name: hs-delete-custom-cmo-config
 rules:
 - apiGroups:
-  - "hive.openshift.io/v1"
+  - hive.openshift.io
   resources:
   - syncsets
   resourceNames:
   - "ext-cluster-monitoring-operator-config"
   verbs:
   - "*"
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - get
+  - list

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22948,13 +22948,20 @@ objects:
         name: hs-delete-custom-cmo-config
       rules:
       - apiGroups:
-        - hive.openshift.io/v1
+        - hive.openshift.io
         resources:
         - syncsets
         resourceNames:
         - ext-cluster-monitoring-operator-config
         verbs:
         - '*'
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22948,13 +22948,20 @@ objects:
         name: hs-delete-custom-cmo-config
       rules:
       - apiGroups:
-        - hive.openshift.io/v1
+        - hive.openshift.io
         resources:
         - syncsets
         resourceNames:
         - ext-cluster-monitoring-operator-config
         verbs:
         - '*'
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22948,13 +22948,20 @@ objects:
         name: hs-delete-custom-cmo-config
       rules:
       - apiGroups:
-        - hive.openshift.io/v1
+        - hive.openshift.io
         resources:
         - syncsets
         resourceNames:
         - ext-cluster-monitoring-operator-config
         verbs:
         - '*'
+      - apiGroups:
+        - hive.openshift.io
+        resources:
+        - clusterdeployments
+        verbs:
+        - get
+        - list
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
This PR adds a new rule which allows the `hs-delete-cmo-config` cluster role to list all cluster deployments on a cluster.

### Which Jira/Github issue(s) this PR fixes?
Relates to: [OSD-16179](https://issues.redhat.com/browse/OSD-16179)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
