### PR TITLE
OSD-16319 - Add OBO nodeSelector/tolerations on MCs

### DIFF
--- a/deploy/hypershift-obo-nodeselector-tolerations/config.yaml
+++ b/deploy/hypershift-obo-nodeselector-tolerations/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/hypershift-obo-nodeselector-tolerations/obo-prometheus.nodeSelector.patch.yaml
+++ b/deploy/hypershift-obo-nodeselector-tolerations/obo-prometheus.nodeSelector.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: monitoring.rhobs/v1
+kind: Prometheus
+name: hypershift-monitoring-stack
+namespace: openshift-observability-operator
+applyMode: Sync
+patch: '{"spec":{"nodeSelector":{"node-role.kubernetes.io/obo":""}}}'
+patchType: merge

--- a/deploy/hypershift-obo-nodeselector-tolerations/obo-prometheus.tolerations.patch.yaml
+++ b/deploy/hypershift-obo-nodeselector-tolerations/obo-prometheus.tolerations.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: monitoring.rhobs/v1
+applyMode: Sync
+kind: Prometheus
+name: hypershift-monitoring-stack
+namespace: openshift-observability-operator
+patch: '{"spec":{"tolerations":[{"effect":"NoSchedule","key":"obo","value":"true"}]}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23255,6 +23255,43 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-obo-nodeselector-tolerations
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: monitoring.rhobs/v1
+      kind: Prometheus
+      name: hypershift-monitoring-stack
+      namespace: openshift-observability-operator
+      applyMode: Sync
+      patch: '{"spec":{"nodeSelector":{"node-role.kubernetes.io/obo":""}}}'
+      patchType: merge
+    - apiVersion: monitoring.rhobs/v1
+      applyMode: Sync
+      kind: Prometheus
+      name: hypershift-monitoring-stack
+      namespace: openshift-observability-operator
+      patch: '{"spec":{"tolerations":[{"effect":"NoSchedule","key":"obo","value":"true"}]}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-validating-webhook-patching
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23255,6 +23255,43 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-obo-nodeselector-tolerations
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: monitoring.rhobs/v1
+      kind: Prometheus
+      name: hypershift-monitoring-stack
+      namespace: openshift-observability-operator
+      applyMode: Sync
+      patch: '{"spec":{"nodeSelector":{"node-role.kubernetes.io/obo":""}}}'
+      patchType: merge
+    - apiVersion: monitoring.rhobs/v1
+      applyMode: Sync
+      kind: Prometheus
+      name: hypershift-monitoring-stack
+      namespace: openshift-observability-operator
+      patch: '{"spec":{"tolerations":[{"effect":"NoSchedule","key":"obo","value":"true"}]}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-validating-webhook-patching
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23255,6 +23255,43 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-obo-nodeselector-tolerations
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: monitoring.rhobs/v1
+      kind: Prometheus
+      name: hypershift-monitoring-stack
+      namespace: openshift-observability-operator
+      applyMode: Sync
+      patch: '{"spec":{"nodeSelector":{"node-role.kubernetes.io/obo":""}}}'
+      patchType: merge
+    - apiVersion: monitoring.rhobs/v1
+      applyMode: Sync
+      kind: Prometheus
+      name: hypershift-monitoring-stack
+      namespace: openshift-observability-operator
+      patch: '{"spec":{"tolerations":[{"effect":"NoSchedule","key":"obo","value":"true"}]}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-validating-webhook-patching
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Hypershift MCs will have dedicated obo machinepools due to performance reasons. This adds the necessary nodeSelector/tolerations to support this.

### Which Jira/Github issue(s) this PR fixes?

[OSD-16319](https://issues.redhat.com/browse/OSD-16319)

### Special notes for your reviewer:
* Tested with a sample SSS patch and verified against an MC

