### PR TITLE
Remove configure health check action from support policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_support_permission_policy.json
@@ -102,7 +102,6 @@
       "Sid": "DescribeLoadBalancers",
       "Effect": "Allow",
       "Action": [
-        "elasticloadbalancing:ConfigureHealthCheck",
         "elasticloadbalancing:DescribeAccountLimits",
         "elasticloadbalancing:DescribeInstanceHealth",
         "elasticloadbalancing:DescribeListenerCertificates",


### PR DESCRIPTION
### What type of PR is this?
cleanup 

### What this PR does / why we need it?
Removes the "elasticloadbalancing:ConfigureHealthCheck" action from the support policy. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
