### PR TITLE
Change installer PassRole resource ARN to be service specific

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -34,7 +34,7 @@
                 "iam:PassRole"
             ],
             "Resource": [
-                "arn:*:iam::*:role/*-Worker-Role"
+                "arn:*:iam::*:role/*-ROSA-Worker"
             ],
             "Effect": "Allow",
             "Condition": {


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This changes the PassRole action resource identifier to be more service specific to ROSA.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
