### PR TITLE
Change node manager  PassRole resource ARN to be service specific

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -41,7 +41,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-Worker-Role"
+        "arn:*:iam::*:role/*-ROSA-Worker"
       ],
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
### What type of PR is this?
cleanup 

### What this PR does / why we need it?
This changes the PassRole action resource identifier to be more service specific to ROSA and match the installer role, ref #1682 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
