### PR TITLE
OSD-16520 - adding NodeFilesystemAlmostOutOfSpaceSRE alert

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -54,3 +54,12 @@ spec:
       resendWait: 72
       severity: Error
       summary: "Multiple EFS CSI drivers detected"
+    - activeBody: Your cluster requires you to take action. The free space on a worker node
+        filesystem is below 3%. This issue can cause any or all of the applications scheduled
+        to that node to experience anything from degraded performance to becoming fully inoperable.
+      name: WorkerNodeFileSystemOutOfSpace
+      resendWait: 24
+      resolvedBody: Worker node file system on your cluster is no longer running out of free space.
+      severity: Info
+      summary: Worker node file system almost out of space
+

--- a/deploy/sre-prometheus/100-sre-node-spacefillingup.yaml
+++ b/deploy/sre-prometheus/100-sre-node-spacefillingup.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-node-filedescriptor-limit
+    role: alert-rules
+  name: sre-node-filedescriptor-limit
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-controlplane-node-almostoutofspace
+    rules:
+    - alert: ControlPlaneNodeFilesystemAlmostOutOfSpaceSRE
+      # This is the same as the upstream alert, but groups by instance id (which is which node is affected)
+      # and then only fires on the control-plane, infra, or master node roles
+      # See the ocm-agent folder for the WorkerNode version of this alert
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available space left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+        summary: Filesystem has less than 3% space left.
+      expr: |-
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 3
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
+        )
+        * on (instance) group_left () (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 30m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -65,3 +65,31 @@ spec:
         send_managed_notification: "true"
       annotations:
         message: "Kernel is predicted to exhaust file descriptors limit soon."
+    - alert: WorkerNodeFilesystemAlmostOutOfSpaceSRE
+      # This is the same as the upstream alert, but groups by instance id (which is which node is affected)
+      # and then only fires on the worker nodes. The `unless` portion is because when getting the node-role
+      # metric it splits on the roles, so infra,worker then gives two results, one with just the infra role
+      # and one with just the worker role.  So we get just the infra/controlplane nodes and then exclude
+      # them from the worker node result, which gives us just the customer worker nodes.
+      annotations:
+        description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+          has only {{ printf "%.2f" $value }}% available space left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+        summary: Filesystem has less than 3% space left.
+      expr: |-
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!=""} * 100 < 3
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!=""} == 0
+        )
+        * on (instance) group_left () (
+          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+        unless
+        (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 30m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25833,6 +25833,16 @@ objects:
           resendWait: 72
           severity: Error
           summary: Multiple EFS CSI drivers detected
+        - activeBody: Your cluster requires you to take action. The free space on
+            a worker node filesystem is below 3%. This issue can cause any or all
+            of the applications scheduled to that node to experience anything from
+            degraded performance to becoming fully inoperable.
+          name: WorkerNodeFileSystemOutOfSpace
+          resendWait: 24
+          resolvedBody: Worker node file system on your cluster is no longer running
+            out of free space.
+          severity: Info
+          summary: Worker node file system almost out of space
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -36149,6 +36159,34 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-filedescriptor-limit
+          role: alert-rules
+        name: sre-node-filedescriptor-limit
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-controlplane-node-almostoutofspace
+          rules:
+          - alert: ControlPlaneNodeFilesystemAlmostOutOfSpaceSRE
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!=\"\"} / node_filesystem_size_bytes{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!=\"\"} == 0\n)\n* on (instance)\
+              \ group_left () (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pruning
           role: alert-rules
         name: sre-pruning
@@ -37070,6 +37108,24 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+          - alert: WorkerNodeFilesystemAlmostOutOfSpaceSRE
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!=\"\"} / node_filesystem_size_bytes{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!=\"\"} == 0\n)\n* on (instance)\
+              \ group_left () (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\n(\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25833,6 +25833,16 @@ objects:
           resendWait: 72
           severity: Error
           summary: Multiple EFS CSI drivers detected
+        - activeBody: Your cluster requires you to take action. The free space on
+            a worker node filesystem is below 3%. This issue can cause any or all
+            of the applications scheduled to that node to experience anything from
+            degraded performance to becoming fully inoperable.
+          name: WorkerNodeFileSystemOutOfSpace
+          resendWait: 24
+          resolvedBody: Worker node file system on your cluster is no longer running
+            out of free space.
+          severity: Info
+          summary: Worker node file system almost out of space
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -36149,6 +36159,34 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-filedescriptor-limit
+          role: alert-rules
+        name: sre-node-filedescriptor-limit
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-controlplane-node-almostoutofspace
+          rules:
+          - alert: ControlPlaneNodeFilesystemAlmostOutOfSpaceSRE
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!=\"\"} / node_filesystem_size_bytes{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!=\"\"} == 0\n)\n* on (instance)\
+              \ group_left () (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pruning
           role: alert-rules
         name: sre-pruning
@@ -37070,6 +37108,24 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+          - alert: WorkerNodeFilesystemAlmostOutOfSpaceSRE
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!=\"\"} / node_filesystem_size_bytes{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!=\"\"} == 0\n)\n* on (instance)\
+              \ group_left () (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\n(\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25833,6 +25833,16 @@ objects:
           resendWait: 72
           severity: Error
           summary: Multiple EFS CSI drivers detected
+        - activeBody: Your cluster requires you to take action. The free space on
+            a worker node filesystem is below 3%. This issue can cause any or all
+            of the applications scheduled to that node to experience anything from
+            degraded performance to becoming fully inoperable.
+          name: WorkerNodeFileSystemOutOfSpace
+          resendWait: 24
+          resolvedBody: Worker node file system on your cluster is no longer running
+            out of free space.
+          severity: Info
+          summary: Worker node file system almost out of space
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -36149,6 +36159,34 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-node-filedescriptor-limit
+          role: alert-rules
+        name: sre-node-filedescriptor-limit
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-controlplane-node-almostoutofspace
+          rules:
+          - alert: ControlPlaneNodeFilesystemAlmostOutOfSpaceSRE
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!=\"\"} / node_filesystem_size_bytes{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!=\"\"} == 0\n)\n* on (instance)\
+              \ group_left () (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pruning
           role: alert-rules
         name: sre-pruning
@@ -37070,6 +37108,24 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+          - alert: WorkerNodeFilesystemAlmostOutOfSpaceSRE
+            annotations:
+              description: Filesystem on {{ $labels.device }} at {{ $labels.instance
+                }} has only {{ printf "%.2f" $value }}% available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!=\"\"} / node_filesystem_size_bytes{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!=\"\"} * 100 < 3\nand\n  node_filesystem_readonly{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!=\"\"} == 0\n)\n* on (instance)\
+              \ group_left () (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\n(\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
, split for cp+infra and worker nodes

### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR adds SRE versions of the upstream alert NodeFilesystemAlmostOutOfSpace, separate for the control plane + infra, which will be routed to the on-call SRE and worker nodes which will be automatically handled by ocm-agent.

### Which Jira/Github issue(s) this PR fixes?

_[OSD-16520](https://issues.redhat.com//browse/OSD-16520)_

### Special notes for your reviewer:
Similar to https://github.com/openshift/managed-cluster-config/pull/1651 and https://github.com/openshift/managed-cluster-config/pull/1653.

There will be a separate CAMO pull request to disable the upstream alert.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
