### PR TITLE
OSD-16574 Heighten MOBB, TAM and CSM permissions

### DIFF
--- a/deploy/backplane/csm/01-csm-cluster-readers-ClusterRole.yml
+++ b/deploy/backplane/csm/01-csm-cluster-readers-ClusterRole.yml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-csm-readers-cluster
+rules:
+# CSM can view machineconfigs, machineconfigpools, kubeletconfigs,controllerconfigs
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# CSM can view machines, machinehealthchecks, machinesets
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# CSM can view api request counts
+- apiGroups:
+  - apiserver.openshift.io
+  resources:
+  - apirequestcounts
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/csm/01-csm-monitoring-role.yml
+++ b/deploy/backplane/csm/01-csm-monitoring-role.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-csm
+  namespace: openshift-monitoring
+rules:
+# CSM can portforward monitoring pods
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create

--- a/deploy/backplane/csm/02-csm-monitoring-rolebinding.yml
+++ b/deploy/backplane/csm/02-csm-monitoring-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-csm
+  namespace: openshift-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-csm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-csm

--- a/deploy/backplane/csm/20-csm-mustgather.Role.yml
+++ b/deploy/backplane/csm/20-csm-mustgather.Role.yml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-csm-mustgather
+  namespace: openshift-must-gather-operator
+rules:
+# can create cred secret for mustgathers
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create 
+# can create mustgathers CR
+- apiGroups:
+  - managed.openshift.io
+  resources:
+  - mustgathers
+  verbs:
+  - create
+  - delete
+### END

--- a/deploy/backplane/csm/30-csm-mustgather.RoleBinding.yml
+++ b/deploy/backplane/csm/30-csm-mustgather.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-csm-mustgather
+  namespace: openshift-must-gather-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-csm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-csm-mustgather

--- a/deploy/backplane/csm/30-csm-pcap-collector.Role.yml
+++ b/deploy/backplane/csm/30-csm-pcap-collector.Role.yml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-csm-pcap-collector
+  namespace: openshift-backplane-managed-scripts
+rules:
+# can create cred secret for mustgathers
+# Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
+- verbs:
+    - "create"
+    - "delete"
+  apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  resourceNames:
+    - "pcap-collector-creds"
+### END

--- a/deploy/backplane/csm/40-csm.SubjectPermission.yml
+++ b/deploy/backplane/csm/40-csm.SubjectPermission.yml
@@ -1,14 +1,15 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-tam
+  name: backplane-csm
   namespace: openshift-rbac-permissions
 spec:
   clusterPermissions:
+  - backplane-csm-readers-cluster
   - backplane-readers-cluster
   permissions:
   - clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
-  subjectName: system:serviceaccounts:openshift-backplane-tam
+  subjectName: system:serviceaccounts:openshift-backplane-csm

--- a/deploy/backplane/csm/60-csm-pcap-collector.RoleBinding.yml
+++ b/deploy/backplane/csm/60-csm-pcap-collector.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-csm-mustgather
+  namespace: openshift-backplane-managed-scripts
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-csm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-csm-pcap-collector

--- a/deploy/backplane/mobb/01-mobb-cluster-readers-ClusterRole.yml
+++ b/deploy/backplane/mobb/01-mobb-cluster-readers-ClusterRole.yml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-mobb-readers-cluster
+rules:
+# MOBB can view machineconfigs, machineconfigpools, kubeletconfigs,controllerconfigs
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# MOBB can view machines, machinehealthchecks, machinesets
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# MOBB can view api request counts
+- apiGroups:
+  - apiserver.openshift.io
+  resources:
+  - apirequestcounts
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/mobb/01-mobb-monitoring-role.yml
+++ b/deploy/backplane/mobb/01-mobb-monitoring-role.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-mobb
+  namespace: openshift-monitoring
+rules:
+# MOBB can portforward monitoring pods
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create

--- a/deploy/backplane/mobb/02-mobb-monitoring-rolebinding.yml
+++ b/deploy/backplane/mobb/02-mobb-monitoring-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-mobb
+  namespace: openshift-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-mobb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-mobb

--- a/deploy/backplane/mobb/20-mobb-mustgather.Role.yml
+++ b/deploy/backplane/mobb/20-mobb-mustgather.Role.yml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-mobb-mustgather
+  namespace: openshift-must-gather-operator
+rules:
+# can create cred secret for mustgathers
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create 
+# can create mustgathers CR
+- apiGroups:
+  - managed.openshift.io
+  resources:
+  - mustgathers
+  verbs:
+  - create
+  - delete
+### END

--- a/deploy/backplane/mobb/30-mobb-mustgather.RoleBinding.yml
+++ b/deploy/backplane/mobb/30-mobb-mustgather.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-mobb-mustgather
+  namespace: openshift-must-gather-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-mobb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-mobb-mustgather

--- a/deploy/backplane/mobb/30-mobb-pcap-collector.Role.yml
+++ b/deploy/backplane/mobb/30-mobb-pcap-collector.Role.yml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-mobb-pcap-collector
+  namespace: openshift-backplane-managed-scripts
+rules:
+# can create cred secret for mustgathers
+# Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
+- verbs:
+    - "create"
+    - "delete"
+  apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  resourceNames:
+    - "pcap-collector-creds"
+### END

--- a/deploy/backplane/mobb/40-mobb.SubjectPermission.yml
+++ b/deploy/backplane/mobb/40-mobb.SubjectPermission.yml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-rbac-permissions
 spec:
   clusterPermissions:
+  - backplane-mobb-readers-cluster
   - backplane-readers-cluster
   permissions:
   - clusterRoleName: dedicated-readers

--- a/deploy/backplane/mobb/60-mobb-pcap-collector.RoleBinding.yml
+++ b/deploy/backplane/mobb/60-mobb-pcap-collector.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-mobb-mustgather
+  namespace: openshift-backplane-managed-scripts
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-mobb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-mobb-pcap-collector

--- a/deploy/backplane/tam/01-tam-cluster-readers-ClusterRole.yml
+++ b/deploy/backplane/tam/01-tam-cluster-readers-ClusterRole.yml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-tam-readers-cluster
+rules:
+# TAM can view machineconfigs, machineconfigpools, kubeletconfigs,controllerconfigs
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# TAM can view machines, machinehealthchecks, machinesets
+- apiGroups:
+  - machine.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+# TAM can view api request counts
+- apiGroups:
+  - apiserver.openshift.io
+  resources:
+  - apirequestcounts
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/tam/01-tam-monitoring-role.yml
+++ b/deploy/backplane/tam/01-tam-monitoring-role.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-tam
+  namespace: openshift-monitoring
+rules:
+# TAM can portforward monitoring pods
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create

--- a/deploy/backplane/tam/02-tam-monitoring-rolebinding.yml
+++ b/deploy/backplane/tam/02-tam-monitoring-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-tam
+  namespace: openshift-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-tam
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-tam

--- a/deploy/backplane/tam/20-tam-mustgather.Role.yml
+++ b/deploy/backplane/tam/20-tam-mustgather.Role.yml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-tam-mustgather
+  namespace: openshift-must-gather-operator
+rules:
+# can create cred secret for mustgathers
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create 
+# can create mustgathers CR
+- apiGroups:
+  - managed.openshift.io
+  resources:
+  - mustgathers
+  verbs:
+  - create
+  - delete
+### END

--- a/deploy/backplane/tam/30-tam-mustgather.RoleBinding.yml
+++ b/deploy/backplane/tam/30-tam-mustgather.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-tam-mustgather
+  namespace: openshift-must-gather-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-tam
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-tam-mustgather

--- a/deploy/backplane/tam/30-tam-pcap-collector.Role.yml
+++ b/deploy/backplane/tam/30-tam-pcap-collector.Role.yml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-tam-pcap-collector
+  namespace: openshift-backplane-managed-scripts
+rules:
+# can create cred secret for mustgathers
+# Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
+- verbs:
+    - "create"
+    - "delete"
+  apiGroups:
+    - ""
+  resources:
+    - "secrets"
+  resourceNames:
+    - "pcap-collector-creds"
+### END

--- a/deploy/backplane/tam/40-tam.SubjectPermission.yml
+++ b/deploy/backplane/tam/40-tam.SubjectPermission.yml
@@ -1,14 +1,15 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-csm
+  name: backplane-tam
   namespace: openshift-rbac-permissions
 spec:
   clusterPermissions:
+  - backplane-tam-readers-cluster
   - backplane-readers-cluster
   permissions:
   - clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
-  subjectName: system:serviceaccounts:openshift-backplane-csm
+  subjectName: system:serviceaccounts:openshift-backplane-tam

--- a/deploy/backplane/tam/60-tam-pcap-collector.RoleBinding.yml
+++ b/deploy/backplane/tam/60-tam-pcap-collector.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-tam-mustgather
+  namespace: openshift-backplane-managed-scripts
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-tam
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-tam-pcap-collector


### PR DESCRIPTION
### What type of PR is this?
Backplane permission extensions for `openshift-backplane-csm`, `openshift-backplane-tam` and `openshift-backplane-mobb` groups.

### What this PR does / why we need it?
Per revised guidelines [0], members in the TAM, MOBB and CSM groups should possess permissions equivalent to that of CEE. CEE's (non-HyperShift) permissions have been reflected in these other groups.

Note: this PR has also included the additional CEE abilities such as port-forwarding, pcap collection and creating must-gathers.

[0] https://source.redhat.com/groups/public/sre/wiki/security_faq_osdv4_access_control_policy#jive_content_id_Role_Based_Access_Control_Overview

### Which Jira/Github issue(s) this PR fixes?

OSD-16574

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
