### PR TITLE
Remove alerting for non-default ingress controllers

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -10,14 +10,6 @@ spec:
   groups:
   - name: sre-managed-notification-alerts
     rules:
-    - alert: MultipleIngressControllersDetectedNotificationSRE
-      expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m] offset 5m) or vector(0)) > 0
-      for: 30m
-      labels:
-        severity: Info
-        namespace: openshift-logging
-        send_managed_notification: "true"
-        managed_notification_template: "MultipleIngressControllersDetected"
     - alert: LoggingVolumeFillingUpNotificationSRE
     # KubePersistentVolumeFillingUp alert firing in openshift-logging Namespace.
       expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-logging"}) >= 1

--- a/deploy/sre-prometheus/ocm-agent/legacy-ingress/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/legacy-ingress/100-ocm-agent.PrometheusRule.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-notification-alerts
+    role: alert-rules 
+  name: sre-ingresscontroller-managed-notification-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-notification-alerts
+    rules:
+    - alert: MultipleIngressControllersDetectedNotificationSRE
+      expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m] offset 5m) or vector(0)) > 0
+      for: 30m
+      labels:
+        severity: Info
+        namespace: openshift-monitoring
+        send_managed_notification: "true"
+        managed_notification_template: "MultipleIngressControllersDetected"

--- a/deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
+++ b/deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: ext-managed.openshift.io/legacy-ingress-support
+    operator: NotIn
+    values: ["false"]

--- a/generated_deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/generated_deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -10,14 +10,6 @@ spec:
   groups:
   - name: sre-managed-notification-alerts
     rules:
-    - alert: MultipleIngressControllersDetectedNotificationSRE
-      expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m] offset 5m) or vector(0)) > 0
-      for: 30m
-      labels:
-        severity: Info
-        namespace: openshift-logging
-        send_managed_notification: "true"
-        managed_notification_template: "MultipleIngressControllersDetected"
     - alert: LoggingVolumeFillingUpNotificationSRE
     # KubePersistentVolumeFillingUp alert firing in openshift-logging Namespace.
       expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-logging"}) >= 1

--- a/generated_deploy/sre-prometheus/ocm-agent/legacy-ingress/100-ocm-agent.PrometheusRule.yaml
+++ b/generated_deploy/sre-prometheus/ocm-agent/legacy-ingress/100-ocm-agent.PrometheusRule.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-notification-alerts
+    role: alert-rules 
+  name: sre-ingresscontroller-managed-notification-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-notification-alerts
+    rules:
+    - alert: MultipleIngressControllersDetectedNotificationSRE
+      expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m] offset 5m) or vector(0)) > 0
+      for: 30m
+      labels:
+        severity: Info
+        namespace: openshift-monitoring
+        send_managed_notification: "true"
+        managed_notification_template: "MultipleIngressControllersDetected"

--- a/generated_deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
+++ b/generated_deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: ext-managed.openshift.io/legacy-ingress-support
+    operator: NotIn
+    values: ["false"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36825,16 +36825,6 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
-          - alert: MultipleIngressControllersDetectedNotificationSRE
-            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
-              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
-              offset 5m) or vector(0)) > 0
-            for: 30m
-            labels:
-              severity: Info
-              namespace: openshift-logging
-              send_managed_notification: 'true'
-              managed_notification_template: MultipleIngressControllersDetected
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1
@@ -36878,6 +36868,47 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-ocm-agent-legacy-ingress
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/legacy-ingress-support
+        operator: NotIn
+        values:
+        - 'false'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-notification-alerts
+          role: alert-rules
+        name: sre-ingresscontroller-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-notification-alerts
+          rules:
+          - alert: MultipleIngressControllersDetectedNotificationSRE
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
+              offset 5m) or vector(0)) > 0
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleIngressControllersDetected
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36825,16 +36825,6 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
-          - alert: MultipleIngressControllersDetectedNotificationSRE
-            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
-              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
-              offset 5m) or vector(0)) > 0
-            for: 30m
-            labels:
-              severity: Info
-              namespace: openshift-logging
-              send_managed_notification: 'true'
-              managed_notification_template: MultipleIngressControllersDetected
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1
@@ -36878,6 +36868,47 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-ocm-agent-legacy-ingress
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/legacy-ingress-support
+        operator: NotIn
+        values:
+        - 'false'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-notification-alerts
+          role: alert-rules
+        name: sre-ingresscontroller-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-notification-alerts
+          rules:
+          - alert: MultipleIngressControllersDetectedNotificationSRE
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
+              offset 5m) or vector(0)) > 0
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleIngressControllersDetected
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36825,16 +36825,6 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
-          - alert: MultipleIngressControllersDetectedNotificationSRE
-            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
-              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
-              offset 5m) or vector(0)) > 0
-            for: 30m
-            labels:
-              severity: Info
-              namespace: openshift-logging
-              send_managed_notification: 'true'
-              managed_notification_template: MultipleIngressControllersDetected
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1
@@ -36878,6 +36868,47 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-ocm-agent-legacy-ingress
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/legacy-ingress-support
+        operator: NotIn
+        values:
+        - 'false'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-managed-notification-alerts
+          role: alert-rules
+        name: sre-ingresscontroller-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-notification-alerts
+          rules:
+          - alert: MultipleIngressControllersDetectedNotificationSRE
+            expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
+              or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
+              offset 5m) or vector(0)) > 0
+            for: 30m
+            labels:
+              severity: Info
+              namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: MultipleIngressControllersDetected
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
For [SDE-1768](https://issues.redhat.com/browse/SDE-1768), we will stop supporting non-default application ingress controllers through the cloud ingress operator and the custom domains operators. 
We will need to silence all alerts relating to multiple ingress controllers being detected. This pull request does that. 

Similar to https://github.com/openshift/custom-domains-operator/pull/108, we gate this behind a feature flag. 

**Explanation:**
All new clusters >4.13 will be deployed with the CD label `ext-managed.openshift.io/legacy-ingress-support: true`, or won't have the label at all (all <4.13 clusters). See https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/6008/diffs

Selector Sync set to enable this: 
```
  matchExpressions:
  - key: ext-managed.openshift.io/legacy-ingress-support
    operator: NotIn
    values: ["false"]
```

If `ext-managed.openshift.io/legacy-ingress-support: true`, or the flag doesn't exist, we deploy the rule in the folder `deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml`.

If `ext-managed.openshift.io/legacy-ingress-support: false`, we do not. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_https://issues.redhat.com/browse/OSD-16014

### Special notes for your reviewer:
### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
