### PR TITLE
OSD-16223 - Add alert for detecting multiple version of EFS pods

### DIFF
--- a/deploy/sre-prometheus/100-multiple-efs-operator-PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-multiple-efs-operator-PrometheusRule.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: aws-efs-alerts
+    role: alert-rules
+  name: aws-efs-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: aws-efs-alerts 
+    rules:
+    - alert: MultipleVersionsOfEFSCSIDriverInstalled 
+      expr: count(kube_pod_info{namespace="openshift-operators", pod=~"efs-csi-node-.*"}) > 0 and count(kube_pod_info{namespace="openshift-cluster-csi-drivers", pod=~"aws-efs-csi-driver-operator-.*"}) > 0
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        source: "https://issues.redhat.com/browse/OSD-16223"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md"
+      annotations:
+        message: Multiple versions of EFS CSI Driver installed 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35536,6 +35536,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: aws-efs-alerts
+          role: alert-rules
+        name: aws-efs-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: aws-efs-alerts
+          rules:
+          - alert: MultipleVersionsOfEFSCSIDriverInstalled
+            expr: count(kube_pod_info{namespace="openshift-operators", pod=~"efs-csi-node-.*"})
+              > 0 and count(kube_pod_info{namespace="openshift-cluster-csi-drivers",
+              pod=~"aws-efs-csi-driver-operator-.*"}) > 0
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-16223
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
+            annotations:
+              message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-filedescriptor-limit
           role: alert-rules
         name: sre-node-filedescriptor-limit

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35536,6 +35536,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: aws-efs-alerts
+          role: alert-rules
+        name: aws-efs-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: aws-efs-alerts
+          rules:
+          - alert: MultipleVersionsOfEFSCSIDriverInstalled
+            expr: count(kube_pod_info{namespace="openshift-operators", pod=~"efs-csi-node-.*"})
+              > 0 and count(kube_pod_info{namespace="openshift-cluster-csi-drivers",
+              pod=~"aws-efs-csi-driver-operator-.*"}) > 0
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-16223
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
+            annotations:
+              message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-filedescriptor-limit
           role: alert-rules
         name: sre-node-filedescriptor-limit

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35536,6 +35536,29 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: aws-efs-alerts
+          role: alert-rules
+        name: aws-efs-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: aws-efs-alerts
+          rules:
+          - alert: MultipleVersionsOfEFSCSIDriverInstalled
+            expr: count(kube_pod_info{namespace="openshift-operators", pod=~"efs-csi-node-.*"})
+              > 0 and count(kube_pod_info{namespace="openshift-cluster-csi-drivers",
+              pod=~"aws-efs-csi-driver-operator-.*"}) > 0
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-16223
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
+            annotations:
+              message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-filedescriptor-limit
           role: alert-rules
         name: sre-node-filedescriptor-limit


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This PR adds Prometheus Rule to detect if multiple version of EFS operator exists

### Which Jira/Github issue(s) this PR fixes?
[OSD-16223](https://issues.redhat.com//browse/OSD-16223)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
