### PR TITLE
[OSD-16075] Add new SL for audit-events failing delivery.

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/OWNERS
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- mrbarge
+- bmeng
+- ravitri

--- a/deploy/ocm-agent-operator-managedfleetnotifications/README.md
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/README.md
@@ -1,0 +1,22 @@
+# ocm-agent-operator ManagedFleetNotifications-CR
+
+This location manages the distribution of the OCM Agent Operator `ManagedFleetNotification` CR to hypershift-only OCM agent running on `rhobsp02ue1`.
+
+The purpose of the `ManagedFleetNotification` CR is to define Service Log templates that map to AlertManager alerts, allowing the OCM Agent to build and send Service Logs when it is notified about those alerts.
+
+The different to the `ManagedNotification` is that the Fleet alerts are working for hypershift.
+
+## How to make changes
+
+Refer to the [onboard OCM Agent SOP page](https://github.com/openshift/ops-sop/blob/master/v4/howto/onboard-an-ocmagent-alert.md#about-the-managedfleetnotification-custom-resource) for the workflow of making changes to this resource.
+
+## Links
+
+- [OCM Agent Operator codebase](https://github.com/openshift/ocm-agent-operator)
+- [OCM Agent codebase](https://github.com/openshift/ocm-agent)
+- [OCM Agent Operator documentation drive](https://drive.google.com/drive/folders/1TsWeNHGDvyZJTtnmipFPrf8lx3SMhaat?usp=sharing)
+
+## Contact
+
+Contact Team Hulk for any more information.
+`@ocm-agent-operator` or `#sd-sre-team-hulk` Slack channel.

--- a/deploy/ocm-agent-operator-managedfleetnotifications/audit-webhook-error-putting-minimized-cloudwatch-log.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/audit-webhook-error-putting-minimized-cloudwatch-log.yaml
@@ -1,0 +1,13 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedFleetNotification
+metadata:
+  name: audit-webhook-error-putting-minimized-cloudwatch-log
+  namespace: openshift-ocm-agent-operator
+spec:
+  fleetNotification:
+    - summary: Audit-events could not be delivered to your CloudWatch.
+      notificationMessage: |-
+        An audit-event send to your CloudWatch failed delivery, due to the event being too large. The reduced event failed delivery as well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.
+      name: audit-webhook-error-putting-minimized-cloudwatch-log
+      resendWait: 24
+      severity: Info

--- a/deploy/ocm-agent-operator-managedfleetnotifications/config.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23912,6 +23912,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocm-agent-operator-managedfleetnotifications
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
+        name: audit-webhook-error-putting-minimized-cloudwatch-log
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+        - summary: Audit-events could not be delivered to your CloudWatch.
+          notificationMessage: 'An audit-event send to your CloudWatch failed delivery,
+            due to the event being too large. The reduced event failed delivery as
+            well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.'
+          name: audit-webhook-error-putting-minimized-cloudwatch-log
+          resendWait: 24
+          severity: Info
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managednotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23912,6 +23912,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocm-agent-operator-managedfleetnotifications
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
+        name: audit-webhook-error-putting-minimized-cloudwatch-log
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+        - summary: Audit-events could not be delivered to your CloudWatch.
+          notificationMessage: 'An audit-event send to your CloudWatch failed delivery,
+            due to the event being too large. The reduced event failed delivery as
+            well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.'
+          name: audit-webhook-error-putting-minimized-cloudwatch-log
+          resendWait: 24
+          severity: Info
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managednotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23912,6 +23912,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocm-agent-operator-managedfleetnotifications
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
+        name: audit-webhook-error-putting-minimized-cloudwatch-log
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+        - summary: Audit-events could not be delivered to your CloudWatch.
+          notificationMessage: 'An audit-event send to your CloudWatch failed delivery,
+            due to the event being too large. The reduced event failed delivery as
+            well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.'
+          name: audit-webhook-error-putting-minimized-cloudwatch-log
+          resendWait: 24
+          severity: Info
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managednotifications
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This SL will be send, when a hypershift-cluster fails to send audit-events to the customer's configured CloudWatch, because the event was too large (>256kb) *and* the delivery of a smaller event to indicate this failure also failed.

### What type of PR is this?

feature

### What this PR does / why we need it?

Add a new notification to automatically send an SL, when this alert is observed.

### Which Jira/Github issue(s) this PR fixes?

Closes [OSD-16075](https://issues.redhat.com//browse/OSD-16075)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
