### PR TITLE
Update token-refresher image to version without security vulns

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -65,7 +65,7 @@ spec:
               key: receiver-url
         - name: ISSUER_URL
           value: "https://sso.redhat.com/auth/realms/redhat-external"
-        image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
+        image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
         name: token-refresher
         ports:
         - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33096,7 +33096,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
+              image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
               name: token-refresher
               ports:
               - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33096,7 +33096,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
+              image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
               name: token-refresher
               ports:
               - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33096,7 +33096,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher@sha256:6ce9b80cd1d907cb6c9ed2a18612f386f7503257772d1d88155a4a2e6773fd00
+              image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
               name: token-refresher
               ports:
               - containerPort: 8080


### PR DESCRIPTION
### What type of PR is this?
security fix. Current version uses alpine.

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-16649

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
