### PR TITLE
osd-cluster-ready++

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.108-cd4483a"
+                managed.openshift.io/version: "v0.1.112-43308f7"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5"
+              image: "quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28624,11 +28624,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.108-cd4483a
+              managed.openshift.io/version: v0.1.112-43308f7
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28624,11 +28624,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.108-cd4483a
+              managed.openshift.io/version: v0.1.112-43308f7
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28624,11 +28624,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.108-cd4483a
+              managed.openshift.io/version: v0.1.112-43308f7
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:f70aa8033565fc73c006acb9199845242b1f729cb5a407b5174cf22656b4e2d5
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
### What this PR does / why we need it?

Pulling in base image updates for regular maintenance.

https://github.com/openshift/osd-cluster-ready/compare/cd4483a2f30ea3bf8df6f37314912f4d69638aec...43308f77d7b5f47f464d98eeece29cda80ba8363

[OSD-16713](https://issues.redhat.com//browse/OSD-16713)