### PR TITLE
OSD-16737 make OCPBUGS-773 work on OVN clusters too

### DIFF
--- a/deploy/ocpbugs-773/no-seccomp/10-OCPBUGS-773.CronJob.yaml
+++ b/deploy/ocpbugs-773/no-seccomp/10-OCPBUGS-773.CronJob.yaml
@@ -47,16 +47,16 @@ spec:
             args:
             - -c
             - |
-              pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)
+              pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l openshift-app=tuned -oname)
 
               if [[ -z "${pods}" ]]; then
-                 # no SDN pods found, this is fine
+                 # no tuned pods found, this is fine
                  exit 0
               fi
 
               while IFS= read -r pod; do
                 echo $pod
-                oc exec -n openshift-sdn $pod -c sdn -- chroot /host podman version
+                oc exec -n openshift-cluster-node-tuning-operator $pod -c tuned -- chroot /host podman version
               done <<< "$pods"            
           serviceAccountName: ocpbugs-773
           automountServiceAccountToken: true

--- a/deploy/ocpbugs-773/seccomp/10-OCPBUGS-773.CronJob.yaml
+++ b/deploy/ocpbugs-773/seccomp/10-OCPBUGS-773.CronJob.yaml
@@ -49,16 +49,16 @@ spec:
             args:
             - -c
             - |
-              pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)
+              pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l openshift-app=tuned -oname)
 
               if [[ -z "${pods}" ]]; then
-                 # no SDN pods found, this is fine
+                 # no tuned pods found, this is fine
                  exit 0
               fi
 
               while IFS= read -r pod; do
                 echo $pod
-                oc exec -n openshift-sdn $pod -c sdn -- chroot /host podman version
+                oc exec -n openshift-cluster-node-tuning-operator $pod -c tuned -- chroot /host podman version
               done <<< "$pods"            
           serviceAccountName: ocpbugs-773
           automountServiceAccountToken: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25486,11 +25486,12 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)\n\nif [[\
-                    \ -z \"${pods}\" ]]; then\n   # no SDN pods found, this is fine\n\
-                    \   exit 0\nfi\n\nwhile IFS= read -r pod; do\n  echo $pod\n  oc\
-                    \ exec -n openshift-sdn $pod -c sdn -- chroot /host podman version\n\
-                    done <<< \"$pods\"            \n"
+                  - "pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l\
+                    \ openshift-app=tuned -oname)\n\nif [[ -z \"${pods}\" ]]; then\n\
+                    \   # no tuned pods found, this is fine\n   exit 0\nfi\n\nwhile\
+                    \ IFS= read -r pod; do\n  echo $pod\n  oc exec -n openshift-cluster-node-tuning-operator\
+                    \ $pod -c tuned -- chroot /host podman version\ndone <<< \"$pods\"\
+                    \            \n"
                 serviceAccountName: ocpbugs-773
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -25582,11 +25583,12 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)\n\nif [[\
-                    \ -z \"${pods}\" ]]; then\n   # no SDN pods found, this is fine\n\
-                    \   exit 0\nfi\n\nwhile IFS= read -r pod; do\n  echo $pod\n  oc\
-                    \ exec -n openshift-sdn $pod -c sdn -- chroot /host podman version\n\
-                    done <<< \"$pods\"            \n"
+                  - "pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l\
+                    \ openshift-app=tuned -oname)\n\nif [[ -z \"${pods}\" ]]; then\n\
+                    \   # no tuned pods found, this is fine\n   exit 0\nfi\n\nwhile\
+                    \ IFS= read -r pod; do\n  echo $pod\n  oc exec -n openshift-cluster-node-tuning-operator\
+                    \ $pod -c tuned -- chroot /host podman version\ndone <<< \"$pods\"\
+                    \            \n"
                 serviceAccountName: ocpbugs-773
                 automountServiceAccountToken: true
                 restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25486,11 +25486,12 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)\n\nif [[\
-                    \ -z \"${pods}\" ]]; then\n   # no SDN pods found, this is fine\n\
-                    \   exit 0\nfi\n\nwhile IFS= read -r pod; do\n  echo $pod\n  oc\
-                    \ exec -n openshift-sdn $pod -c sdn -- chroot /host podman version\n\
-                    done <<< \"$pods\"            \n"
+                  - "pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l\
+                    \ openshift-app=tuned -oname)\n\nif [[ -z \"${pods}\" ]]; then\n\
+                    \   # no tuned pods found, this is fine\n   exit 0\nfi\n\nwhile\
+                    \ IFS= read -r pod; do\n  echo $pod\n  oc exec -n openshift-cluster-node-tuning-operator\
+                    \ $pod -c tuned -- chroot /host podman version\ndone <<< \"$pods\"\
+                    \            \n"
                 serviceAccountName: ocpbugs-773
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -25582,11 +25583,12 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)\n\nif [[\
-                    \ -z \"${pods}\" ]]; then\n   # no SDN pods found, this is fine\n\
-                    \   exit 0\nfi\n\nwhile IFS= read -r pod; do\n  echo $pod\n  oc\
-                    \ exec -n openshift-sdn $pod -c sdn -- chroot /host podman version\n\
-                    done <<< \"$pods\"            \n"
+                  - "pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l\
+                    \ openshift-app=tuned -oname)\n\nif [[ -z \"${pods}\" ]]; then\n\
+                    \   # no tuned pods found, this is fine\n   exit 0\nfi\n\nwhile\
+                    \ IFS= read -r pod; do\n  echo $pod\n  oc exec -n openshift-cluster-node-tuning-operator\
+                    \ $pod -c tuned -- chroot /host podman version\ndone <<< \"$pods\"\
+                    \            \n"
                 serviceAccountName: ocpbugs-773
                 automountServiceAccountToken: true
                 restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25486,11 +25486,12 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)\n\nif [[\
-                    \ -z \"${pods}\" ]]; then\n   # no SDN pods found, this is fine\n\
-                    \   exit 0\nfi\n\nwhile IFS= read -r pod; do\n  echo $pod\n  oc\
-                    \ exec -n openshift-sdn $pod -c sdn -- chroot /host podman version\n\
-                    done <<< \"$pods\"            \n"
+                  - "pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l\
+                    \ openshift-app=tuned -oname)\n\nif [[ -z \"${pods}\" ]]; then\n\
+                    \   # no tuned pods found, this is fine\n   exit 0\nfi\n\nwhile\
+                    \ IFS= read -r pod; do\n  echo $pod\n  oc exec -n openshift-cluster-node-tuning-operator\
+                    \ $pod -c tuned -- chroot /host podman version\ndone <<< \"$pods\"\
+                    \            \n"
                 serviceAccountName: ocpbugs-773
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -25582,11 +25583,12 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "pods=$(oc get pod -n openshift-sdn -l app=sdn -oname)\n\nif [[\
-                    \ -z \"${pods}\" ]]; then\n   # no SDN pods found, this is fine\n\
-                    \   exit 0\nfi\n\nwhile IFS= read -r pod; do\n  echo $pod\n  oc\
-                    \ exec -n openshift-sdn $pod -c sdn -- chroot /host podman version\n\
-                    done <<< \"$pods\"            \n"
+                  - "pods=$(oc get pod -n openshift-cluster-node-tuning-operator -l\
+                    \ openshift-app=tuned -oname)\n\nif [[ -z \"${pods}\" ]]; then\n\
+                    \   # no tuned pods found, this is fine\n   exit 0\nfi\n\nwhile\
+                    \ IFS= read -r pod; do\n  echo $pod\n  oc exec -n openshift-cluster-node-tuning-operator\
+                    \ $pod -c tuned -- chroot /host podman version\ndone <<< \"$pods\"\
+                    \            \n"
                 serviceAccountName: ocpbugs-773
                 automountServiceAccountToken: true
                 restartPolicy: Never


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
Switches the OCPBUGS-773 workaround (#1633) to use the `openshift-cluster-node-tuning-operator` pods for carrying out the workaround, rather than the SDN pods, so that OVN clusters can also benefit from the fix.

The CronJob to remediate clusters impacted by OCPBUGS-773 (#1633) previously only operated on SDN clusters, because that was what the workaround was geared around. However, we have observed OVN clusters experiencing the same issue and they're subsequently not benefiting from this 

However, the main reason for using the SDN pods seems to be in order to run a `chroot /host && podman version` on the underlying node. We can do that from a workload which is universal to both SDN and OVN clusters, the `openshift-cluster-node-tuning-operator` `tuned` pods.

### Which Jira/Github issue(s) this PR fixes?
[OSD-16737](https://issues.redhat.com//browse/OSD-16737)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
