### PR TITLE
Adds 4.13.z to the CPMS disabling cron job

### DIFF
--- a/deploy/osd-14634-disable-cpms/config.yaml
+++ b/deploy/osd-14634-disable-cpms/config.yaml
@@ -3,6 +3,9 @@ selectorSyncSet:
   resourceApplyMode: Sync
   matchExpressions:
   ## This will be removed once OSD-14568 has been completed
+  ## Issue exists in 4.13 as well
   - key: hive.openshift.io/version-major-minor
     operator: In
-    values: ["4.12"]
+    values: 
+      - "4.12"
+      - "4.13"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26000,6 +26000,7 @@ objects:
         operator: In
         values:
         - '4.12'
+        - '4.13'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26000,6 +26000,7 @@ objects:
         operator: In
         values:
         - '4.12'
+        - '4.13'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26000,6 +26000,7 @@ objects:
         operator: In
         values:
         - '4.12'
+        - '4.13'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
Related to:

[OSD-14568](https://issues.redhat.com/browse/OSD-14568) - CIO needs to change to modify the CPMS object instead of the machines directly in 4.12+ clusters

This issue continues to exist in 4.13, so this PR adds 4.13 to the
SelectorSyncSet for the cron job which disables CPMS in OSD/ROSA
clusters until the issue is resolved.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
