### PR TITLE
Correct syntax error in ManagedFleetNotification

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/audit-webhook-error-putting-minimized-cloudwatch-log.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/audit-webhook-error-putting-minimized-cloudwatch-log.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: openshift-ocm-agent-operator
 spec:
   fleetNotification:
-    - summary: Audit-events could not be delivered to your CloudWatch.
-      notificationMessage: |-
-        An audit-event send to your CloudWatch failed delivery, due to the event being too large. The reduced event failed delivery as well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.
-      name: audit-webhook-error-putting-minimized-cloudwatch-log
-      resendWait: 24
-      severity: Info
+    summary: Audit-events could not be delivered to your CloudWatch.
+    notificationMessage: |-
+      An audit-event send to your CloudWatch failed delivery, due to the event being too large. The reduced event failed delivery as well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.
+    name: audit-webhook-error-putting-minimized-cloudwatch-log
+    resendWait: 24
+    severity: Info

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25171,7 +25171,7 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         fleetNotification:
-        - summary: Audit-events could not be delivered to your CloudWatch.
+          summary: Audit-events could not be delivered to your CloudWatch.
           notificationMessage: 'An audit-event send to your CloudWatch failed delivery,
             due to the event being too large. The reduced event failed delivery as
             well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25171,7 +25171,7 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         fleetNotification:
-        - summary: Audit-events could not be delivered to your CloudWatch.
+          summary: Audit-events could not be delivered to your CloudWatch.
           notificationMessage: 'An audit-event send to your CloudWatch failed delivery,
             due to the event being too large. The reduced event failed delivery as
             well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25171,7 +25171,7 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         fleetNotification:
-        - summary: Audit-events could not be delivered to your CloudWatch.
+          summary: Audit-events could not be delivered to your CloudWatch.
           notificationMessage: 'An audit-event send to your CloudWatch failed delivery,
             due to the event being too large. The reduced event failed delivery as
             well. Please verify your CloudWatch configuration for this cluster: https://access.redhat.com/solutions/7002219.'


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?

Corrects a small syntax error in the `ManagedFleetNotification` added by [OSD-16075](https://issues.redhat.com//browse/OSD-16075) which was preventing its correct application on-cluster.

### Which Jira/Github issue(s) this PR fixes?

[OSD-16075](https://issues.redhat.com//browse/OSD-16075)

