### PR TITLE
[OSD-16029] Add sre-metric-set to hypershift management clusters

### DIFF
--- a/deploy/hypershift-sre-metric-set/config.yaml
+++ b/deploy/hypershift-sre-metric-set/config.yaml
@@ -1,0 +1,7 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]

--- a/deploy/hypershift-sre-metric-set/sre-metric-set.yaml
+++ b/deploy/hypershift-sre-metric-set/sre-metric-set.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sre-metric-set
+  namespace: hypershift
+data:
+  config: |
+    kubeAPIServer:
+      - action:       "keep"
+        regex:        "apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\+Inf)"
+        sourceLabels: ["__name__", "le"]
+    openshiftAPIServer:
+      - action:       "keep"
+        regex:        "apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\+Inf)"
+        sourceLabels: ["__name__", "le"]

--- a/generated_deploy/hypershift-sre-metric-set/config.yaml
+++ b/generated_deploy/hypershift-sre-metric-set/config.yaml
@@ -1,0 +1,7 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]

--- a/generated_deploy/hypershift-sre-metric-set/sre-metric-set.yaml
+++ b/generated_deploy/hypershift-sre-metric-set/sre-metric-set.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sre-metric-set
+  namespace: hypershift
+data:
+  config: |
+    kubeAPIServer:
+      - action:       "keep"
+        regex:        "apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\+Inf)"
+        sourceLabels: ["__name__", "le"]
+    openshiftAPIServer:
+      - action:       "keep"
+        regex:        "apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\+Inf)"
+        sourceLabels: ["__name__", "le"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25242,6 +25242,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-sre-metric-set
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: sre-metric-set
+        namespace: hypershift
+      data:
+        config: "kubeAPIServer:\n  - action:       \"keep\"\n    regex:        \"\
+          apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nopenshiftAPIServer:\n\
+          \  - action:       \"keep\"\n    regex:        \"apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-integration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25242,6 +25242,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-sre-metric-set
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: sre-metric-set
+        namespace: hypershift
+      data:
+        config: "kubeAPIServer:\n  - action:       \"keep\"\n    regex:        \"\
+          apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nopenshiftAPIServer:\n\
+          \  - action:       \"keep\"\n    regex:        \"apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-integration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25242,6 +25242,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-sre-metric-set
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: sre-metric-set
+        namespace: hypershift
+      data:
+        config: "kubeAPIServer:\n  - action:       \"keep\"\n    regex:        \"\
+          apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nopenshiftAPIServer:\n\
+          \  - action:       \"keep\"\n    regex:        \"apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: insights-integration
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Adds the sre-metric-set configmap to all management clusters

### Which Jira/Github issue(s) this PR fixes?
[OSD-16029](https://issues.redhat.com/browse/OSD-16029)

### Special notes for your reviewer:
Documentation for the configmap in question is [here](https://github.com/openshift/hypershift/blob/2a2dd829bc561ae1cb3997b7f51fd07d62aa341e/docs/content/how-to/metrics-sets.md)

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
