### PR TITLE
* Remove ELB type, this will cause the system to default to Classic.

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -21,6 +21,7 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates-raw: |
+                    {{- if eq (lookup "operator.openshift.io/v1" "IngressController" "openshift-ingress-operator" "default").metadata.name "default" }}
                     - complianceType: musthave
                       metadataComplianceType: musthave
                       objectDefinition:
@@ -38,14 +39,11 @@ spec:
                           endpointPublishingStrategy:
                             type: LoadBalancerService
                             loadBalancer:
-                              providerParameters:
-                                type: AWS
-                                aws:
-                                  type: '{{hub (default "Classic" (fromConfigMap "openshift-acm-policies" .ManagedClusterName "loadbalancer-aws-type")) hub}}'
                               dnsManagementPolicy: 'Managed'
                               scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
                           {{hub- end hub}}
-                pruneObjectBehavior: DeleteIfCreated
+                    {{- end }}
+                pruneObjectBehavior: None
                 remediationAction: enforce
                 severity: low
         - objectDefinition:

--- a/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
@@ -15,6 +15,7 @@ spec:
       compliant: 2h
       noncompliant: 45s
   object-templates-raw: |
+    {{- if eq (lookup "operator.openshift.io/v1" "IngressController" "openshift-ingress-operator" "default").metadata.name "default" }}
     - complianceType: musthave
       metadataComplianceType: musthave
       objectDefinition:
@@ -32,13 +33,10 @@ spec:
           endpointPublishingStrategy:
             type: LoadBalancerService
             loadBalancer:
-              providerParameters:
-                type: AWS
-                aws:
-                  type: '{{hub (default "Classic" (fromConfigMap "openshift-acm-policies" .ManagedClusterName "loadbalancer-aws-type")) hub}}'
               dnsManagementPolicy: 'Managed'
               scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
           {{hub- end hub}}
-  pruneObjectBehavior: DeleteIfCreated
+    {{- end }}
+  pruneObjectBehavior: None
   remediationAction: enforce
   severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6777,7 +6777,9 @@ objects:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+              object-templates-raw: "{{- if eq (lookup \"operator.openshift.io/v1\"\
+                \ \"IngressController\" \"openshift-ingress-operator\" \"default\"\
+                ).metadata.name \"default\" }}\n- complianceType: musthave\n  metadataComplianceType:\
                 \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
@@ -6787,14 +6789,12 @@ objects:
                 \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
                 \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
                 \        type: LoadBalancerService\n        loadBalancer:\n      \
-                \    providerParameters:\n            type: AWS\n            aws:\n\
-                \              type: '{{hub (default \"Classic\" (fromConfigMap \"\
-                openshift-acm-policies\" .ManagedClusterName \"loadbalancer-aws-type\"\
-                )) hub}}'\n          dnsManagementPolicy: 'Managed'\n          scope:\
-                \ '{{hub- if eq (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName\
-                \ \"endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
-              pruneObjectBehavior: DeleteIfCreated
+                \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
+                \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
+                endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
+                {{- end }}\n"
+              pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
         - objectDefinition:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6777,7 +6777,9 @@ objects:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+              object-templates-raw: "{{- if eq (lookup \"operator.openshift.io/v1\"\
+                \ \"IngressController\" \"openshift-ingress-operator\" \"default\"\
+                ).metadata.name \"default\" }}\n- complianceType: musthave\n  metadataComplianceType:\
                 \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
@@ -6787,14 +6789,12 @@ objects:
                 \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
                 \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
                 \        type: LoadBalancerService\n        loadBalancer:\n      \
-                \    providerParameters:\n            type: AWS\n            aws:\n\
-                \              type: '{{hub (default \"Classic\" (fromConfigMap \"\
-                openshift-acm-policies\" .ManagedClusterName \"loadbalancer-aws-type\"\
-                )) hub}}'\n          dnsManagementPolicy: 'Managed'\n          scope:\
-                \ '{{hub- if eq (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName\
-                \ \"endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
-              pruneObjectBehavior: DeleteIfCreated
+                \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
+                \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
+                endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
+                {{- end }}\n"
+              pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
         - objectDefinition:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6777,7 +6777,9 @@ objects:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
+              object-templates-raw: "{{- if eq (lookup \"operator.openshift.io/v1\"\
+                \ \"IngressController\" \"openshift-ingress-operator\" \"default\"\
+                ).metadata.name \"default\" }}\n- complianceType: musthave\n  metadataComplianceType:\
                 \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
@@ -6787,14 +6789,12 @@ objects:
                 \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
                 \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
                 \        type: LoadBalancerService\n        loadBalancer:\n      \
-                \    providerParameters:\n            type: AWS\n            aws:\n\
-                \              type: '{{hub (default \"Classic\" (fromConfigMap \"\
-                openshift-acm-policies\" .ManagedClusterName \"loadbalancer-aws-type\"\
-                )) hub}}'\n          dnsManagementPolicy: 'Managed'\n          scope:\
-                \ '{{hub- if eq (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName\
-                \ \"endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
-              pruneObjectBehavior: DeleteIfCreated
+                \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
+                \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
+                endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
+                {{- end }}\n"
+              pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
         - objectDefinition:


### PR DESCRIPTION
* OCP-HyperShift will start to provide the type value
* Make it so the Policy will only apply if the IngressController default resource is present
* If the policy is removed, we DO NOT remove the resource Testing
* Validated the policy on ACM 2.7.4 and ACM 2.8.0

### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug

### What this PR does / why we need it?
* It allows for the HostedCluster to eventually control the ELB type.
* For now the ELB will default to Classic

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/ACM-5858
_Fixes #_

### Special notes for your reviewer:
NA

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster. (ACM 2.7.4 & ACM 2.8)
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:
