### PR TITLE
Add label to toggle debugging handlers off

### DIFF
--- a/deploy/kubelet-config/config.yaml
+++ b/deploy/kubelet-config/config.yaml
@@ -1,11 +1,11 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: Upsert
-  matchLabelsApplyMode: "OR"
+  matchLabelsApplyMode: "AND"
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
       values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"]
-    - key: api.openshift.com/legal-entity-id
-      operator: In
-      values: ["${{DPTP_LEGAL_ENTITY_ID}}"]
+    - key: ext-managed.openshift.io/disable-debugging-handlers
+      operator: NotIn
+      values: ["true"]

--- a/deploy/kubelet-config/post-4.9-disable-debugging-handlers/01-kubelet-config.yaml
+++ b/deploy/kubelet-config/post-4.9-disable-debugging-handlers/01-kubelet-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: custom-kubelet
+spec:
+  kubeletConfig:
+    enableDebuggingHandlers: false
+  machineConfigPoolSelector:
+    matchExpressions:
+    - key: machineconfiguration.openshift.io/mco-built-in
+      operator: Exists
+  autoSizingReserved: true

--- a/deploy/kubelet-config/post-4.9-disable-debugging-handlers/config.yaml
+++ b/deploy/kubelet-config/post-4.9-disable-debugging-handlers/config.yaml
@@ -1,7 +1,11 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: Upsert
+  matchLabelsApplyMode: "AND"
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
-      operator: In
+      operator: NotIn
       values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"]
+    - key: ext-managed.openshift.io/disable-debugging-handlers
+      operator: In
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25264,7 +25264,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-version-major-minor
+    name: kubelet-config
   spec:
     clusterDeploymentSelector:
       matchLabels:
@@ -25281,6 +25281,10 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -25300,16 +25304,27 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-legal-entity-id
+    name: kubelet-config-post-4.9-disable-debugging-handlers
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/legal-entity-id
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers
         operator: In
         values:
-        - ${{DPTP_LEGAL_ENTITY_ID}}
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -25317,6 +25332,8 @@ objects:
       metadata:
         name: custom-kubelet
       spec:
+        kubeletConfig:
+          enableDebuggingHandlers: false
         machineConfigPoolSelector:
           matchExpressions:
           - key: machineconfiguration.openshift.io/mco-built-in
@@ -25346,10 +25363,6 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: api.openshift.com/legal-entity-id
-        operator: NotIn
-        values:
-        - ${{DPTP_LEGAL_ENTITY_ID}}
     resourceApplyMode: Upsert
     patches:
     - kind: MachineConfigPool

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25264,7 +25264,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-version-major-minor
+    name: kubelet-config
   spec:
     clusterDeploymentSelector:
       matchLabels:
@@ -25281,6 +25281,10 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -25300,16 +25304,27 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-legal-entity-id
+    name: kubelet-config-post-4.9-disable-debugging-handlers
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/legal-entity-id
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers
         operator: In
         values:
-        - ${{DPTP_LEGAL_ENTITY_ID}}
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -25317,6 +25332,8 @@ objects:
       metadata:
         name: custom-kubelet
       spec:
+        kubeletConfig:
+          enableDebuggingHandlers: false
         machineConfigPoolSelector:
           matchExpressions:
           - key: machineconfiguration.openshift.io/mco-built-in
@@ -25346,10 +25363,6 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: api.openshift.com/legal-entity-id
-        operator: NotIn
-        values:
-        - ${{DPTP_LEGAL_ENTITY_ID}}
     resourceApplyMode: Upsert
     patches:
     - kind: MachineConfigPool

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25264,7 +25264,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-version-major-minor
+    name: kubelet-config
   spec:
     clusterDeploymentSelector:
       matchLabels:
@@ -25281,6 +25281,10 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -25300,16 +25304,27 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-legal-entity-id
+    name: kubelet-config-post-4.9-disable-debugging-handlers
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: api.openshift.com/legal-entity-id
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers
         operator: In
         values:
-        - ${{DPTP_LEGAL_ENTITY_ID}}
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -25317,6 +25332,8 @@ objects:
       metadata:
         name: custom-kubelet
       spec:
+        kubeletConfig:
+          enableDebuggingHandlers: false
         machineConfigPoolSelector:
           matchExpressions:
           - key: machineconfiguration.openshift.io/mco-built-in
@@ -25346,10 +25363,6 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: api.openshift.com/legal-entity-id
-        operator: NotIn
-        values:
-        - ${{DPTP_LEGAL_ENTITY_ID}}
     resourceApplyMode: Upsert
     patches:
     - kind: MachineConfigPool


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Instead of trying to fight hive reconcile or pause syncing from hive, this PR allows disabling debugging handlers via external labels API.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-16901

### Special notes for your reviewer:
Careful sanity check of the changes so we know it won't impact existing clusters, please.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
