### PR TITLE
Define Hybrid SRE backplane role for HCP team

### DIFF
--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/00-hybridsre-hcp.namespace.yml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/00-hybridsre-hcp.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane-hybridsre-hcp

--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
@@ -5,9 +5,7 @@ metadata:
   namespace: openshift-rbac-permissions
 spec:
   permissions:
-  - clusterRoleName: hypershift-readers
-    namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"
-  - clusterRoleName: view
+  - clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-hybridsre-hcp

--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
@@ -7,7 +7,7 @@ spec:
   permissions:
   - clusterRoleName: hypershift-readers
     namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"
-  - clusterRoleName: dedicated-readers
+  - clusterRoleName: view
     namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-hybridsre-hcp

--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
@@ -6,6 +6,7 @@ metadata:
 spec:
   permissions:
   - clusterRoleName: dedicated-readers
-    namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"
+    namespacesAllowedRegex: (^hypershift$|^ocm-.*)
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-hybridsre-hcp

--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
@@ -1,0 +1,15 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-hybridsre-hcp
+  namespace: openshift-rbac-permissions
+spec:
+  clusterPermissions:
+  - backplane-readers-cluster
+  permissions:
+  - clusterRoleName: hypershift-readers
+    namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"
+  - clusterRoleName: dedicated-readers
+    namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-hybridsre-hcp

--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/20-hybridsre-hcp.SubjectPermission.yml
@@ -4,8 +4,6 @@ metadata:
   name: backplane-hybridsre-hcp
   namespace: openshift-rbac-permissions
 spec:
-  clusterPermissions:
-  - backplane-readers-cluster
   permissions:
   - clusterRoleName: hypershift-readers
     namespacesAllowedRegex: "(^hypershift$|^ocm-.*)"

--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/config.yaml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
+++ b/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
@@ -6,10 +6,6 @@ label selectors:
 
 Applies only to ROSA HCP Management Clusters.
 
-## backplane-readers-cluster: `cluster`
-
-TODO: needed an "entry-level" cluster-wide role. This one looks promising, though might be too permissive.
-
 ## dedicated-readers: `(^hypershift$|^ocm-.*)`
 
 HCP team needs read/list/watch access to a standard "base" set of k8s objects within their namespaces.

--- a/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
+++ b/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
@@ -1,0 +1,28 @@
+# HCP team on management-cluster
+
+label selectors:
+* ext-hypershift.openshift.io/cluster-type == "management-cluster"
+* api.openshift.com/fedramp != "true"
+
+Applies only to ROSA HCP Management Clusters.
+
+## backplane-readers-cluster: `cluster`
+
+TODO: needed an "entry-level" cluster-wide role. This one looks promising, though might be too permissive.
+
+## dedicated-readers: `(^hypershift$|^ocm-.*)`
+
+HCP team needs read/list/watch access to a standard "base" set of k8s objects within their namespaces.
+
+`dedicated-readers` was chosen as it provides access to objects like pods, configmaps, services, etc.
+
+## hypershift-readers: `(^hypershift$|^ocm-.*)`
+
+HCP team needs access to objects used by hypershift internally. This role provides that access.
+
+Role itself is owned by the hypershift-operator itself and provides read/list/watch access to the following api groups:
+- hypershift.openshift.io – objects like HostedCluster, HostedControlPlane, NodePool
+- cluster.x-k8s.io – objects like MachinePool, MachineSet
+- infrastructure.cluster.x-k8s.io – objects like AWSMachine, AWSCluster
+- work.open-cluster-management.io – AppliedManifestWork
+

--- a/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
+++ b/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
@@ -6,11 +6,9 @@ label selectors:
 
 Applies only to ROSA HCP Management Clusters.
 
-## dedicated-readers: `(^hypershift$|^ocm-.*)`
+## view: `(^hypershift$|^ocm-.*)`
 
-HCP team needs read/list/watch access to a standard "base" set of k8s objects within their namespaces.
-
-`dedicated-readers` was chosen as it provides access to objects like pods, configmaps, services, etc.
+HCP team needs read/list/watch access to core k8s and ocp objects within their namespaces and the guidelines point ot the `view` role as the default.
 
 ## hypershift-readers: `(^hypershift$|^ocm-.*)`
 

--- a/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
+++ b/docs/backplane/requirements/hybridsre-hcp/20-hypershift-management-cluster.md
@@ -6,15 +6,13 @@ label selectors:
 
 Applies only to ROSA HCP Management Clusters.
 
-## view: `(^hypershift$|^ocm-.*)`
+## dedicated-readers: `(^hypershift$|^ocm-.*)`
 
-HCP team needs read/list/watch access to core k8s and ocp objects within their namespaces and the guidelines point ot the `view` role as the default.
+HCP team needs read/list/watch access to core k8s and ocp objects within their namespaces.
 
-## hypershift-readers: `(^hypershift$|^ocm-.*)`
+HCP team also needs access to objects used by hypershift internally, which is provided by `hypershift-readers`, a role that's aggregated into `dedicated-readers`.
 
-HCP team needs access to objects used by hypershift internally. This role provides that access.
-
-Role itself is owned by the hypershift-operator itself and provides read/list/watch access to the following api groups:
+The hypershift role is owned by the hypershift-operator itself and provides read/list/watch access to the following api groups:
 - hypershift.openshift.io – objects like HostedCluster, HostedControlPlane, NodePool
 - cluster.x-k8s.io – objects like MachinePool, MachineSet
 - infrastructure.cluster.x-k8s.io – objects like AWSMachine, AWSCluster

--- a/docs/backplane/requirements/hybridsre-hcp/OWNERS
+++ b/docs/backplane/requirements/hybridsre-hcp/OWNERS
@@ -2,3 +2,5 @@ reviewers:
 - celebdor
 approvers:
 - srep-architects
+options:
+  no_parent_owners: true

--- a/docs/backplane/requirements/hybridsre-hcp/OWNERS
+++ b/docs/backplane/requirements/hybridsre-hcp/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- celebdor
+approvers:
+- srep-architects

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8427,6 +8427,45 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-hybridsre-hcp-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-hybridsre-hcp
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-hybridsre-hcp
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift$|^ocm-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-hybridsre-hcp
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-addon-rhmi-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8427,6 +8427,45 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-hybridsre-hcp-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-hybridsre-hcp
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-hybridsre-hcp
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift$|^ocm-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-hybridsre-hcp
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-addon-rhmi-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8427,6 +8427,45 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-hybridsre-hcp-hypershift-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-hybridsre-hcp
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-hybridsre-hcp
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^hypershift$|^ocm-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-hybridsre-hcp
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-addon-rhmi-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Give the HCP team access to HCP components on prod clusters.

### Which Jira/Github issue(s) this PR fixes?
Implements [HOSTEDCP-891](https://issues.redhat.com/browse/HOSTEDCP-891)
Depends on https://gitlab.cee.redhat.com/service/backplane-api/-/merge_requests/273  


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
