### PR TITLE
CreateVPCEndpoint now specifies a security group 

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
@@ -113,6 +113,21 @@
             }
         },
         {
+            "Sid": "VPCEndpointResourceTagCondition",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateVpcEndpoint"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:security-group*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
+        },
+        {
             "Sid": "VPCEndpointNoCondition",
             "Effect": "Allow",
             "Action": [

--- a/resources/sts/4.13/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
+++ b/resources/sts/4.13/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
@@ -113,6 +113,21 @@
             }
         },
         {
+            "Sid": "VPCEndpointResourceTagCondition",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateVpcEndpoint"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:security-group*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
+        },
+        {
             "Sid": "VPCEndpointNoCondition",
             "Effect": "Allow",
             "Action": [


### PR DESCRIPTION
As part of the fix in https://issues.redhat.com/browse/OCPBUGS-11894, CreateVPCEndpoint now specifies a security group, specifically one that's created for the cluster. In order to allow the Control Plane operator to use the security group, a new SID is added to allow CreateVPCEndpoint with any security group with a `red-hat-managed: true` tag. 