### PR TITLE
Create RBAC For SD-CICD Role

### DIFF
--- a/deploy/backplane/sdcicd/00-sdcicd.namespace.yml
+++ b/deploy/backplane/sdcicd/00-sdcicd.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane-sdcicd

--- a/deploy/backplane/sdcicd/01-sdcicd-read-only-cluster.ClusterRole.yml
+++ b/deploy/backplane/sdcicd/01-sdcicd-read-only-cluster.ClusterRole.yml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-sdcicd-readers-cluster
+rules:
+# SDCICD can read namespaces
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+# SDCICD can read OLM objects
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  - clusterserviceversions
+  - installplans
+  - subscriptions
+  - operatorconditions
+  - operatorgroups
+  - operators
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/sdcicd/40-sdcicd.SubjectPermission.yml
+++ b/deploy/backplane/sdcicd/40-sdcicd.SubjectPermission.yml
@@ -1,0 +1,15 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-sdcicd
+  namespace: openshift-rbac-permissions
+spec:
+  clusterPermissions:
+  - backplane-sdcicd-readers-cluster
+  - backplane-readers-cluster
+  permissions:
+  - clusterRoleName: dedicated-readers
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-sdcicd

--- a/deploy/backplane/sdcicd/config.yaml
+++ b/deploy/backplane/sdcicd/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet: 
+  resourceApplyMode: "Sync"

--- a/generated_deploy/backplane/sdcicd/00-sdcicd.namespace.yml
+++ b/generated_deploy/backplane/sdcicd/00-sdcicd.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane-sdcicd

--- a/generated_deploy/backplane/sdcicd/01-sdcicd-read-only-cluster.ClusterRole.yml
+++ b/generated_deploy/backplane/sdcicd/01-sdcicd-read-only-cluster.ClusterRole.yml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-sdcicd-readers-cluster
+rules:
+# SDCICD can read namespaces
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+# SDCICD can read OLM objects
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  - clusterserviceversions
+  - installplans
+  - subscriptions
+  - operatorconditions
+  - operatorgroups
+  - operators
+  verbs:
+  - get
+  - list
+  - watch

--- a/generated_deploy/backplane/sdcicd/10-sdcicd-read-only-cluster.ClusterRole.yml
+++ b/generated_deploy/backplane/sdcicd/10-sdcicd-read-only-cluster.ClusterRole.yml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: backplane-sdcicd-readers-cluster
+rules:
+# SDCICD can read namespaces
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+# SDCICD can read CSR objects
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  - clusterserviceversions
+  - installplans
+  - subscriptions
+  - operatorconditions
+  - operatorgroups
+  - operators
+  verbs:
+  - get
+  - list
+  - watch

--- a/generated_deploy/backplane/sdcicd/20-sdcicd.SubjectPermission.yml
+++ b/generated_deploy/backplane/sdcicd/20-sdcicd.SubjectPermission.yml
@@ -1,0 +1,18 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-sdcicd
+  namespace: openshift-rbac-permissions
+spec:
+  clusterPermissions:
+  - backplane-sdcicd-readers-cluster
+  - backplane-readers-cluster
+  permissions:
+  - clusterRoleName: backplane-sdcicd-admins-project
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
+  - clusterRoleName: dedicated-readers
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-sdcicd

--- a/generated_deploy/backplane/sdcicd/40-sdcicd.SubjectPermission.yml
+++ b/generated_deploy/backplane/sdcicd/40-sdcicd.SubjectPermission.yml
@@ -1,0 +1,15 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-sdcicd
+  namespace: openshift-rbac-permissions
+spec:
+  clusterPermissions:
+  - backplane-sdcicd-readers-cluster
+  - backplane-readers-cluster
+  permissions:
+  - clusterRoleName: dedicated-readers
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-sdcicd

--- a/generated_deploy/backplane/sdcicd/config.yaml
+++ b/generated_deploy/backplane/sdcicd/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet: 
+  resourceApplyMode: "Sync"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23244,6 +23244,111 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-sdcicd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-sdcicd
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-sdcicd-readers-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        - operatorconditions
+        - operatorgroups
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-sdcicd-readers-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        - operatorconditions
+        - operatorgroups
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-sdcicd
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-sdcicd-readers-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: backplane-sdcicd-admins-project
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-sdcicd
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-sdcicd
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-sdcicd-readers-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-sdcicd
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-srep
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23244,6 +23244,111 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-sdcicd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-sdcicd
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-sdcicd-readers-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        - operatorconditions
+        - operatorgroups
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-sdcicd-readers-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        - operatorconditions
+        - operatorgroups
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-sdcicd
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-sdcicd-readers-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: backplane-sdcicd-admins-project
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-sdcicd
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-sdcicd
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-sdcicd-readers-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-sdcicd
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-srep
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23244,6 +23244,111 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-sdcicd
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-sdcicd
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-sdcicd-readers-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        - operatorconditions
+        - operatorgroups
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-sdcicd-readers-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - catalogsources
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        - operatorconditions
+        - operatorgroups
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-sdcicd
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-sdcicd-readers-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: backplane-sdcicd-admins-project
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-sdcicd
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-sdcicd
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-sdcicd-readers-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-sdcicd
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-srep
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Feature PR 

Follows https://source.redhat.com/groups/public/sre/wiki/backplane_new_team_on_boarding
SDCICD is adding backplane access to check arbitrary clusters post deployment for an acceptance test in the Tekton environment for Progressive Delivery of Operators. 
We need to rewrite the logic of the acceptance test we wrote over here:
https://github.com/openshift/aws-vpce-operator/blob/main/hack/tests/avo-acceptance-test.yaml#L59-L128
To not pull Kubeconfigs directly from Hives and instead use RBACs to authenticate into clusters. 

Jira:
[SDCICD-993](https://issues.redhat.com//browse/SDCICD-993)

### Special notes for your reviewer:
This is my first time creating RBACs in this style. My thought process was to look at SRE's permissions and pull the access to be mostly read only since we don't want to alter clusters. 
Our goal is to use the RBACs in this case to do zero touch testing in higher level environments. Meaning we will not be modifying clusters but validating values. 
IE: A SSS upgrade can be found in a cluster managed by hive through regions. 
