### PR TITLE
[OHSS-23921] Add new reinstall cronjob.

### DIFF
--- a/deploy/ohss-23921-reinstall-obo/README.md
+++ b/deploy/ohss-23921-reinstall-obo/README.md
@@ -1,0 +1,6 @@
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OHSS-23921.
+
+Once clusters no longer report the issue it should be reverted.

--- a/deploy/ohss-23921-reinstall-obo/config.yaml
+++ b/deploy/ohss-23921-reinstall-obo/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.10"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/ohss-23921-reinstall-obo/ohss23921.CronJob.yaml
+++ b/deploy/ohss-23921-reinstall-obo/ohss23921.CronJob.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-observability-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-observability-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-observability-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-observability-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-observability-operator
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-observability-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-observability-operator
+              COUNT_CSV=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator="" -o name | wc -l) || true
+              if [[ $COUNT_CSV -ge 2 ]]; then
+                oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                touch /tmp/sub.yaml
+                oc -n "$NAMESPACE" get subscriptions.operators.coreos.com observability-operator -o yaml > /tmp/sub.yaml
+                oc -n "$NAMESPACE" delete -f /tmp/sub.yaml
+                oc -n "$NAMESPACE" apply -f /tmp/sub.yaml
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/generated_deploy/ohss-23921-reinstall-obo/README.md
+++ b/generated_deploy/ohss-23921-reinstall-obo/README.md
@@ -1,0 +1,6 @@
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OHSS-23921.
+
+Once clusters no longer report the issue it should be reverted.

--- a/generated_deploy/ohss-23921-reinstall-obo/config.yaml
+++ b/generated_deploy/ohss-23921-reinstall-obo/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.10"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/generated_deploy/ohss-23921-reinstall-obo/ohss23921.CronJob.yaml
+++ b/generated_deploy/ohss-23921-reinstall-obo/ohss23921.CronJob.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-observability-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-observability-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-observability-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-observability-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-observability-operator
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-observability-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-observability-operator
+              COUNT_CSV=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator="" -o name | wc -l) || true
+              if [[ $COUNT_CSV -ge 2 ]]; then
+                oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                touch /tmp/sub.yaml
+                oc -n "$NAMESPACE" get subscriptions.operators.coreos.com observability-operator -o yaml > /tmp/sub.yaml
+                oc -n "$NAMESPACE" delete -f /tmp/sub.yaml
+                oc -n "$NAMESPACE" apply -f /tmp/sub.yaml
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26558,6 +26558,131 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ohss-23921-reinstall-obo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-observability-operator\n\
+                    COUNT_CSV=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
+                    \  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ observability-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-14634-disable-cpms
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26558,6 +26558,131 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ohss-23921-reinstall-obo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-observability-operator\n\
+                    COUNT_CSV=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
+                    \  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ observability-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-14634-disable-cpms
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26558,6 +26558,131 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ohss-23921-reinstall-obo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-observability-operator\n\
+                    COUNT_CSV=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | wc -l) || true\nif [[ $COUNT_CSV -ge 2 ]]; then\n\
+                    \  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/observability-operator.openshift-observability-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ observability-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-14634-disable-cpms
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This is only required for 4.10 clusters.

### What type of PR is this?
cleanup - during an operator upgrade a breaking change was introduced.

The obo operator now must be reinstalled in 4.10 clusters.

Script is based on https://github.com/openshift/ops-sop/blob/master/v4/knowledge_base/reinstall-operator.md

### What this PR does / why we need it?

Creates a cronjob to reinstall obo on 4.10 clusters.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OHSS-23921](https://issues.redhat.com//browse/OHSS-23921)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
