### PR TITLE
Fix file ownership bug

### DIFF
--- a/deploy/acm-policies/00-openshift-acm-policies.Namespace.yaml
+++ b/deploy/acm-policies/00-openshift-acm-policies.Namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-acm-policies
+

--- a/deploy/acm-policies/config.yaml
+++ b/deploy/acm-policies/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["service-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/hosted-uwm/05-role.yaml
+++ b/deploy/hosted-uwm/05-role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: dedicated-admins-hostedcluster-uwm
+    namespace: openshift-monitoring
+rules:
+    - apiGroups:
+        - ""
+      resourceNames:
+        - cluster-monitoring-config
+      resources:
+        - configmap
+      verbs:
+        - '*'
+    - apiGroups:
+        - ""
+      resources:
+        - configmap
+      verbs:
+        - create

--- a/deploy/hosted-uwm/06-rolebinding.yaml
+++ b/deploy/hosted-uwm/06-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: dedicated-admins-hostedcluster-uwm
+    namespace: openshift-monitoring
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: dedicated-admins-hostedcluster-uwm
+subjects:
+    - kind: Group
+      name: dedicated-admins

--- a/deploy/hosted-uwm/config.yaml
+++ b/deploy/hosted-uwm/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: Policy
+clusterSelectors:
+  hypershift.open-cluster-management.io/hosted-cluster: true

--- a/generated_deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
+++ b/generated_deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
@@ -21,7 +21,8 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates:
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
@@ -43,7 +44,8 @@ spec:
                                 - configmap
                               verbs:
                                 - create
-                    - complianceType: musthave
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: RoleBinding

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3312,6 +3312,94 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hosted-uwm
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hosted-uwm
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-hostedcluster-uwm
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - cluster-monitoring-config
+                    resources:
+                    - configmap
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmap
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-hostedcluster-uwm
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-hostedcluster-uwm
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hosted-uwm
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hosted-uwm
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hosted-uwm
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hosted-uwm
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-hosted-route-monitor-operator
         namespace: openshift-acm-policies
       spec:
@@ -7242,92 +7330,6 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: rosa-ingress-certificate-policies
-    - apiVersion: policy.open-cluster-management.io/v1
-      kind: Policy
-      metadata:
-        annotations:
-          policy.open-cluster-management.io/categories: CM Configuration Management
-          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-          policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: hosted-uwm
-        namespace: openshift-acm-policies
-      spec:
-        disabled: false
-        policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-              name: hosted-uwm
-            spec:
-              evaluationInterval:
-                compliant: 2h
-                noncompliant: 45s
-              object-templates:
-              - complianceType: musthave
-                objectDefinition:
-                  apiVersion: rbac.authorization.k8s.io/v1
-                  kind: Role
-                  metadata:
-                    name: dedicated-admins-hostedcluster-uwm
-                    namespace: openshift-monitoring
-                  rules:
-                  - apiGroups:
-                    - ''
-                    resourceNames:
-                    - cluster-monitoring-config
-                    resources:
-                    - configmap
-                    verbs:
-                    - '*'
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - configmap
-                    verbs:
-                    - create
-              - complianceType: musthave
-                objectDefinition:
-                  apiVersion: rbac.authorization.k8s.io/v1
-                  kind: RoleBinding
-                  metadata:
-                    name: dedicated-admins-hostedcluster-uwm
-                    namespace: openshift-monitoring
-                  roleRef:
-                    apiGroup: rbac.authorization.k8s.io
-                    kind: Role
-                    name: dedicated-admins-hostedcluster-uwm
-                  subjects:
-                  - kind: Group
-                    name: dedicated-admins
-              pruneObjectBehavior: DeleteIfCreated
-              remediationAction: enforce
-              severity: low
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
-      metadata:
-        name: placement-hosted-uwm
-        namespace: openshift-acm-policies
-      spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-    - apiVersion: policy.open-cluster-management.io/v1
-      kind: PlacementBinding
-      metadata:
-        name: binding-hosted-uwm
-        namespace: openshift-acm-policies
-      placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
-        name: placement-hosted-uwm
-      subjects:
-      - apiGroup: policy.open-cluster-management.io
-        kind: Policy
-        name: hosted-uwm
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3312,6 +3312,94 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hosted-uwm
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hosted-uwm
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-hostedcluster-uwm
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - cluster-monitoring-config
+                    resources:
+                    - configmap
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmap
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-hostedcluster-uwm
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-hostedcluster-uwm
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hosted-uwm
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hosted-uwm
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hosted-uwm
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hosted-uwm
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-hosted-route-monitor-operator
         namespace: openshift-acm-policies
       spec:
@@ -7242,92 +7330,6 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: rosa-ingress-certificate-policies
-    - apiVersion: policy.open-cluster-management.io/v1
-      kind: Policy
-      metadata:
-        annotations:
-          policy.open-cluster-management.io/categories: CM Configuration Management
-          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-          policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: hosted-uwm
-        namespace: openshift-acm-policies
-      spec:
-        disabled: false
-        policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-              name: hosted-uwm
-            spec:
-              evaluationInterval:
-                compliant: 2h
-                noncompliant: 45s
-              object-templates:
-              - complianceType: musthave
-                objectDefinition:
-                  apiVersion: rbac.authorization.k8s.io/v1
-                  kind: Role
-                  metadata:
-                    name: dedicated-admins-hostedcluster-uwm
-                    namespace: openshift-monitoring
-                  rules:
-                  - apiGroups:
-                    - ''
-                    resourceNames:
-                    - cluster-monitoring-config
-                    resources:
-                    - configmap
-                    verbs:
-                    - '*'
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - configmap
-                    verbs:
-                    - create
-              - complianceType: musthave
-                objectDefinition:
-                  apiVersion: rbac.authorization.k8s.io/v1
-                  kind: RoleBinding
-                  metadata:
-                    name: dedicated-admins-hostedcluster-uwm
-                    namespace: openshift-monitoring
-                  roleRef:
-                    apiGroup: rbac.authorization.k8s.io
-                    kind: Role
-                    name: dedicated-admins-hostedcluster-uwm
-                  subjects:
-                  - kind: Group
-                    name: dedicated-admins
-              pruneObjectBehavior: DeleteIfCreated
-              remediationAction: enforce
-              severity: low
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
-      metadata:
-        name: placement-hosted-uwm
-        namespace: openshift-acm-policies
-      spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-    - apiVersion: policy.open-cluster-management.io/v1
-      kind: PlacementBinding
-      metadata:
-        name: binding-hosted-uwm
-        namespace: openshift-acm-policies
-      placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
-        name: placement-hosted-uwm
-      subjects:
-      - apiGroup: policy.open-cluster-management.io
-        kind: Policy
-        name: hosted-uwm
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3312,6 +3312,94 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hosted-uwm
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hosted-uwm
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: dedicated-admins-hostedcluster-uwm
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - cluster-monitoring-config
+                    resources:
+                    - configmap
+                    verbs:
+                    - '*'
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmap
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: dedicated-admins-hostedcluster-uwm
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: dedicated-admins-hostedcluster-uwm
+                  subjects:
+                  - kind: Group
+                    name: dedicated-admins
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hosted-uwm
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hosted-uwm
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hosted-uwm
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hosted-uwm
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: hs-hosted-route-monitor-operator
         namespace: openshift-acm-policies
       spec:
@@ -7242,92 +7330,6 @@ objects:
       - apiGroup: policy.open-cluster-management.io
         kind: Policy
         name: rosa-ingress-certificate-policies
-    - apiVersion: policy.open-cluster-management.io/v1
-      kind: Policy
-      metadata:
-        annotations:
-          policy.open-cluster-management.io/categories: CM Configuration Management
-          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
-          policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: hosted-uwm
-        namespace: openshift-acm-policies
-      spec:
-        disabled: false
-        policy-templates:
-        - objectDefinition:
-            apiVersion: policy.open-cluster-management.io/v1
-            kind: ConfigurationPolicy
-            metadata:
-              name: hosted-uwm
-            spec:
-              evaluationInterval:
-                compliant: 2h
-                noncompliant: 45s
-              object-templates:
-              - complianceType: musthave
-                objectDefinition:
-                  apiVersion: rbac.authorization.k8s.io/v1
-                  kind: Role
-                  metadata:
-                    name: dedicated-admins-hostedcluster-uwm
-                    namespace: openshift-monitoring
-                  rules:
-                  - apiGroups:
-                    - ''
-                    resourceNames:
-                    - cluster-monitoring-config
-                    resources:
-                    - configmap
-                    verbs:
-                    - '*'
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - configmap
-                    verbs:
-                    - create
-              - complianceType: musthave
-                objectDefinition:
-                  apiVersion: rbac.authorization.k8s.io/v1
-                  kind: RoleBinding
-                  metadata:
-                    name: dedicated-admins-hostedcluster-uwm
-                    namespace: openshift-monitoring
-                  roleRef:
-                    apiGroup: rbac.authorization.k8s.io
-                    kind: Role
-                    name: dedicated-admins-hostedcluster-uwm
-                  subjects:
-                  - kind: Group
-                    name: dedicated-admins
-              pruneObjectBehavior: DeleteIfCreated
-              remediationAction: enforce
-              severity: low
-    - apiVersion: apps.open-cluster-management.io/v1
-      kind: PlacementRule
-      metadata:
-        name: placement-hosted-uwm
-        namespace: openshift-acm-policies
-      spec:
-        clusterSelector:
-          matchExpressions:
-          - key: hypershift.open-cluster-management.io/hosted-cluster
-            operator: In
-            values:
-            - 'true'
-    - apiVersion: policy.open-cluster-management.io/v1
-      kind: PlacementBinding
-      metadata:
-        name: binding-hosted-uwm
-        namespace: openshift-acm-policies
-      placementRef:
-        apiGroup: apps.open-cluster-management.io
-        kind: PlacementRule
-        name: placement-hosted-uwm
-      subjects:
-      - apiGroup: policy.open-cluster-management.io
-        kind: Policy
-        name: hosted-uwm
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -5,7 +5,7 @@ set -exv
 trap "rm -rf sorted-before*.yaml.tmpl sorted-after*.yaml.tmpl generated_deploy" EXIT
 
 # all custom alerts must have a namespace label
-echo "As a shot term workaround for OSD-XXXX, generated_deploy is cleared by the job when finishing. If you're running locally, please run `make` afterwards to regenerate the files"
+echo "As a shot term workaround for OSD-17203, generated_deploy is cleared by the job when finishing. If you're running locally, please run `make` afterwards to regenerate the files"
 MISSING_NS="false"
 for F in $(find ./deploy/sre-prometheus -type f -iname '*prometheusrule.yaml')
 do

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -2,9 +2,10 @@
 
 set -exv
 
-trap "rm -f sorted-before*.yaml.tmpl sorted-after*.yaml.tmpl" EXIT
+trap "rm -rf sorted-before*.yaml.tmpl sorted-after*.yaml.tmpl generated_deploy" EXIT
 
 # all custom alerts must have a namespace label
+echo "As a shot term workaround for OSD-XXXX, generated_deploy is cleared by the job when finishing. If you're running locally, please run `make` afterwards to regenerate the files"
 MISSING_NS="false"
 for F in $(find ./deploy/sre-prometheus -type f -iname '*prometheusrule.yaml')
 do

--- a/scripts/generate-policy.sh
+++ b/scripts/generate-policy.sh
@@ -3,6 +3,7 @@
 DIRECTORY="/tmp/*/"
 FILENAME="policy-generator-config.yaml"
 ROOT_DIR=$PWD
+mkdir -p $ROOT_DIR/generated_deploy/acm-policies
 for dir in $DIRECTORY; do
     echo $dir
     cd $dir


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The new generate script is breaking the Workspace cleanup from Jenkins which is resulting to builds to fail eventually (because cleanup from previous job isn't succeeding while unrelated to the PR the job is trying to validate).
As a short-term fix, adding a step to delete the generated-deploy folder to ensure we delete those files while we can. This has a drawback when ran locally so added a message to the script output (just needs to run make to regenerate).
While doing so, I found some issues with some resources which were not generated so had to create hosted-uwm to make the corresponding resources generated (to work after generated_deploy has been deleted) + some small fix to have the generate to work when the folder doesn't exist. 
The policy generated for hosted-uwm is the same (checked the content of the diff) except the complianceType and metadataComplianceType (which are in line with other roles now and prevent issues with risk of incorrect permissions we had previously)

### Which Jira/Github issue(s) this PR fixes?
[OSD-17203](https://issues.redhat.com//browse/OSD-17203) 

### Special notes for your reviewer:
I ran it locally and generate/cleanup in the script are working as expected, but the true validation will be on Jenkins. Please note the build will fail (as all workspaces are blocked on cleanup currently) and so, we would need some cleanup done on Jenkins side to have the PR to pass (it goal being to ensure we don't have the issue in the future, but cannot resolve the current situation).  

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
