### PR TITLE
Add MGO reinstall job for OSD-17198

### DIFF
--- a/deploy/osd-17198-reinstall-mgo/README.md
+++ b/deploy/osd-17198-reinstall-mgo/README.md
@@ -1,0 +1,6 @@
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OSD-17198
+
+Once clusters no longer report the issue it should be reverted.

--- a/deploy/osd-17198-reinstall-mgo/config.yaml
+++ b/deploy/osd-17198-reinstall-mgo/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11","4.12","4.13","4.14"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/osd-17198-reinstall-mgo/ohss23921.CronJob.yaml
+++ b/deploy/osd-17198-reinstall-mgo/ohss23921.CronJob.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-must-gather-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-must-gather-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-must-gather-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-must-gather-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-must-gather-operator
+              # Check for the presence of MGO v0.1.181, then we know we're stuck
+              # stuck
+              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found) || true
+              if [[ ! -z "$CSV_FOUND" ]]; then
+                # It is present, so wipe out MGO
+                oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                touch /tmp/sub.yaml
+                oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator -o yaml > /tmp/sub.yaml
+                oc -n "$NAMESPACE" delete -f /tmp/sub.yaml
+                oc -n "$NAMESPACE" apply -f /tmp/sub.yaml
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/deploy/osd-17198-reinstall-mgo/pre-4.11/README.md
+++ b/deploy/osd-17198-reinstall-mgo/pre-4.11/README.md
@@ -1,0 +1,6 @@
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OHSS-23921.
+
+Once clusters no longer report the issue it should be reverted.

--- a/deploy/osd-17198-reinstall-mgo/pre-4.11/config.yaml
+++ b/deploy/osd-17198-reinstall-mgo/pre-4.11/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.6","4.7","4.8","4.9","4.10"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/osd-17198-reinstall-mgo/pre-4.11/ohss23921.CronJob.yaml
+++ b/deploy/osd-17198-reinstall-mgo/pre-4.11/ohss23921.CronJob.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-must-gather-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-must-gather-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-must-gather-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-must-gather-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-must-gather-operator
+              # Check for the presence of MGO v0.1.181, then we know we're stuck
+              # stuck
+              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found) || true
+              if [[ ! -z "$CSV_FOUND" ]]; then
+                # It is present, so wipe out MGO
+                oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                touch /tmp/sub.yaml
+                oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator -o yaml > /tmp/sub.yaml
+                oc -n "$NAMESPACE" delete -f /tmp/sub.yaml
+                oc -n "$NAMESPACE" apply -f /tmp/sub.yaml
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/generated_deploy/osd-17198-reinstall-mgo/README.md
+++ b/generated_deploy/osd-17198-reinstall-mgo/README.md
@@ -1,0 +1,6 @@
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OSD-17198
+
+Once clusters no longer report the issue it should be reverted.

--- a/generated_deploy/osd-17198-reinstall-mgo/config.yaml
+++ b/generated_deploy/osd-17198-reinstall-mgo/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11","4.12","4.13","4.14"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/generated_deploy/osd-17198-reinstall-mgo/ohss23921.CronJob.yaml
+++ b/generated_deploy/osd-17198-reinstall-mgo/ohss23921.CronJob.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-must-gather-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-must-gather-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-must-gather-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-must-gather-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-must-gather-operator
+              # Check for the presence of MGO v0.1.181, then we know we're stuck
+              # stuck
+              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found) || true
+              if [[ ! -z "$CSV_FOUND" ]]; then
+                # It is present, so wipe out MGO
+                oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                touch /tmp/sub.yaml
+                oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator -o yaml > /tmp/sub.yaml
+                oc -n "$NAMESPACE" delete -f /tmp/sub.yaml
+                oc -n "$NAMESPACE" apply -f /tmp/sub.yaml
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/generated_deploy/osd-17198-reinstall-mgo/pre-4.11/README.md
+++ b/generated_deploy/osd-17198-reinstall-mgo/pre-4.11/README.md
@@ -1,0 +1,6 @@
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OHSS-23921.
+
+Once clusters no longer report the issue it should be reverted.

--- a/generated_deploy/osd-17198-reinstall-mgo/pre-4.11/config.yaml
+++ b/generated_deploy/osd-17198-reinstall-mgo/pre-4.11/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.6","4.7","4.8","4.9","4.10"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/generated_deploy/osd-17198-reinstall-mgo/pre-4.11/ohss23921.CronJob.yaml
+++ b/generated_deploy/osd-17198-reinstall-mgo/pre-4.11/ohss23921.CronJob.yaml
@@ -1,0 +1,110 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-must-gather-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-must-gather-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-must-gather-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-must-gather-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-must-gather-operator
+              # Check for the presence of MGO v0.1.181, then we know we're stuck
+              # stuck
+              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found) || true
+              if [[ ! -z "$CSV_FOUND" ]]; then
+                # It is present, so wipe out MGO
+                oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+                touch /tmp/sub.yaml
+                oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator -o yaml > /tmp/sub.yaml
+                oc -n "$NAMESPACE" delete -f /tmp/sub.yaml
+                oc -n "$NAMESPACE" apply -f /tmp/sub.yaml
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26775,6 +26775,265 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-17198-reinstall-mgo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-must-gather-operator\n\
+                    # Check for the presence of MGO v0.1.181, then we know we're stuck\n\
+                    # stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found)\
+                    \ || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n  # It is present,\
+                    \ so wipe out MGO\n  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ must-gather-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-17198-reinstall-mgo-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-must-gather-operator\n\
+                    # Check for the presence of MGO v0.1.181, then we know we're stuck\n\
+                    # stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found)\
+                    \ || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n  # It is present,\
+                    \ so wipe out MGO\n  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ must-gather-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26775,6 +26775,265 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-17198-reinstall-mgo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-must-gather-operator\n\
+                    # Check for the presence of MGO v0.1.181, then we know we're stuck\n\
+                    # stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found)\
+                    \ || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n  # It is present,\
+                    \ so wipe out MGO\n  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ must-gather-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-17198-reinstall-mgo-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-must-gather-operator\n\
+                    # Check for the presence of MGO v0.1.181, then we know we're stuck\n\
+                    # stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found)\
+                    \ || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n  # It is present,\
+                    \ so wipe out MGO\n  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ must-gather-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26775,6 +26775,265 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-17198-reinstall-mgo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-must-gather-operator\n\
+                    # Check for the presence of MGO v0.1.181, then we know we're stuck\n\
+                    # stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found)\
+                    \ || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n  # It is present,\
+                    \ so wipe out MGO\n  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ must-gather-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-17198-reinstall-mgo-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-must-gather-operator\n\
+                    # Check for the presence of MGO v0.1.181, then we know we're stuck\n\
+                    # stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ must-gather-operator.v0.1.181-6af88c8 -o name --ignore-not-found)\
+                    \ || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n  # It is present,\
+                    \ so wipe out MGO\n  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  oc -n \"$NAMESPACE\"\
+                    \ get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=\"\
+                    \" -o name | xargs oc delete -n \"$NAMESPACE\"\n  touch /tmp/sub.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ must-gather-operator -o yaml > /tmp/sub.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ delete -f /tmp/sub.yaml\n  oc -n \"$NAMESPACE\" apply -f /tmp/sub.yaml\n\
+                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
For reasons unknown, `must-gather-operator` is in a bad state on the Production fleet.

They have a v0.1.181 installed, but the current OLM catalog tree does not have that version in it.

Therefore, they are stuck and not upgrading to any newer version, because there is no CSV to tell it how to upgrade from 0.1.181.

This CronJob checks if v0.1.181 is installed, if it does, it is deleted and MGO is reinstalled at the latest version.

This is inspired off the work of #1723 , which did similar for OBO, and which I've personally tested (so I know it works). The main difference is that because `CronJob` graduated to `v1` in 4.11, we need two versions of it.

### Which Jira/Github issue(s) this PR fixes?
[OSD-17198](https://issues.redhat.com//browse/OSD-17198)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
