### PR TITLE
Splits NodeFilesystemSpaceFillingUp alerts for cp/worker

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -54,3 +54,8 @@ spec:
       resendWait: 72
       severity: Error
       summary: "Multiple EFS CSI drivers detected"
+    - activeBody: |-
+        Your cluster requires you to take action. The file system usage for a worker node is currently at or above 90% and is predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of space used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
+      name: WorkerNodeFilesystemSpaceFillingUp
+      resendWait: 24
+      summary: Worker node is predicted to run out of inodes in 4 hours

--- a/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
@@ -27,3 +27,19 @@ spec:
         namespace: openshift-monitoring
       annotations:
         message: "Kernel is predicted to exhaust file descriptors limit soon."
+  - name: sre-controlplane-node-filesystem-space-filling-upstream
+    rules:
+    - alert: ControlPlaneNodeFilesystemSpaceFillingUp
+      # this is the same as the upstream alert, but groups only for controlplane nodes
+      expr: |-
+        (node_filesystem_files_free{fstype!="",job="node-exporter"} / node_filesystem_files{fstype!="",job="node-exporter"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!="",job="node-exporter"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!="",job="node-exporter"} == 0)
+        * on (instance) group_left ()group by (instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 1h
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up fast.
+        summary: Filesystem is predicted to run out of inodes within the next 4 hours.

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -65,3 +65,22 @@ spec:
         send_managed_notification: "true"
       annotations:
         message: "Kernel is predicted to exhaust file descriptors limit soon."
+    - alert: WorkerNodeFilesystemSpaceFillingUp
+      # This is the same as the upstream alert, but groups by the whether it's a worker node or notification
+      expr: |-
+        (node_filesystem_files_free{fstype!="",job="node-exporter"} / node_filesystem_files{fstype!="",job="node-exporter"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!="",job="node-exporter"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!="",job="node-exporter"} == 0)
+        * on (instance) group_left ()group by(instance) (
+          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+        unless
+        group by(instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 1h
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+        send_managed_notification: "true"
+      annotations:
+        message: "Filesystem is predicted to run out of inodes within the next 4 hours."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25833,6 +25833,15 @@ objects:
           resendWait: 72
           severity: Error
           summary: Multiple EFS CSI drivers detected
+        - activeBody: Your cluster requires you to take action. The file system usage
+            for a worker node is currently at or above 90% and is predicted to be
+            fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of space used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemSpaceFillingUp
+          resendWait: 24
+          summary: Worker node is predicted to run out of inodes in 4 hours
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -35797,6 +35806,26 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+        - name: sre-controlplane-node-filesystem-space-filling-upstream
+          rules:
+          - alert: ControlPlaneNodeFilesystemSpaceFillingUp
+            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
+              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
+              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
+              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
+              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
+              \ by (instance) (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+                has only {{ printf "%.2f" $value }}% available inodes left and is
+                filling up fast.
+              summary: Filesystem is predicted to run out of inodes within the next
+                4 hours.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37070,6 +37099,25 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+          - alert: WorkerNodeFilesystemSpaceFillingUp
+            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
+              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
+              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
+              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
+              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
+              \ by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+              send_managed_notification: 'true'
+            annotations:
+              message: Filesystem is predicted to run out of inodes within the next
+                4 hours.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25833,6 +25833,15 @@ objects:
           resendWait: 72
           severity: Error
           summary: Multiple EFS CSI drivers detected
+        - activeBody: Your cluster requires you to take action. The file system usage
+            for a worker node is currently at or above 90% and is predicted to be
+            fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of space used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemSpaceFillingUp
+          resendWait: 24
+          summary: Worker node is predicted to run out of inodes in 4 hours
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -35797,6 +35806,26 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+        - name: sre-controlplane-node-filesystem-space-filling-upstream
+          rules:
+          - alert: ControlPlaneNodeFilesystemSpaceFillingUp
+            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
+              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
+              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
+              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
+              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
+              \ by (instance) (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+                has only {{ printf "%.2f" $value }}% available inodes left and is
+                filling up fast.
+              summary: Filesystem is predicted to run out of inodes within the next
+                4 hours.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37070,6 +37099,25 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+          - alert: WorkerNodeFilesystemSpaceFillingUp
+            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
+              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
+              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
+              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
+              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
+              \ by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+              send_managed_notification: 'true'
+            annotations:
+              message: Filesystem is predicted to run out of inodes within the next
+                4 hours.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25833,6 +25833,15 @@ objects:
           resendWait: 72
           severity: Error
           summary: Multiple EFS CSI drivers detected
+        - activeBody: Your cluster requires you to take action. The file system usage
+            for a worker node is currently at or above 90% and is predicted to be
+            fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of space used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemSpaceFillingUp
+          resendWait: 24
+          summary: Worker node is predicted to run out of inodes in 4 hours
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -35797,6 +35806,26 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+        - name: sre-controlplane-node-filesystem-space-filling-upstream
+          rules:
+          - alert: ControlPlaneNodeFilesystemSpaceFillingUp
+            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
+              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
+              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
+              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
+              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
+              \ by (instance) (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+                has only {{ printf "%.2f" $value }}% available inodes left and is
+                filling up fast.
+              summary: Filesystem is predicted to run out of inodes within the next
+                4 hours.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37070,6 +37099,25 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
+          - alert: WorkerNodeFilesystemSpaceFillingUp
+            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
+              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
+              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
+              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
+              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
+              \ by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+              send_managed_notification: 'true'
+            annotations:
+              message: Filesystem is predicted to run out of inodes within the next
+                4 hours.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Splits up the NodeFilesystemSpaceFillingUp alert into worker/controlplane-based alerts

### Which Jira/Github issue(s) this PR fixes?
Fixes [OSD-14017](https://issues.redhat.com//browse/OSD-14017)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
