### PR TITLE
OSD-17329 - adjusting 'CannotRetrieveUpdatesSRE' alert to provide generic summary

### DIFF
--- a/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
@@ -16,7 +16,9 @@ spec:
             will need to monitor for available updates on their own or risk falling
             behind on security or other bugfixes. If the failure is expected, you
             can clear spec.channel in the ClusterVersion object to tell the cluster-version
-            operator to not retrieve updates. Failure reason {{ with $cluster_operator_conditions
+            operator to not retrieve updates. 
+            Cluster version operator has not retrieved updates in {{ $value | humanizeDuration }}. 
+            Failure reason {{ with $cluster_operator_conditions
             := "cluster_operator_conditions" | query}}{{range $value := .}}{{if and
             (eq (label "name" $value) "version") (eq (label "condition" $value) "RetrievedUpdates")
             (eq (label "endpoint" $value) "metrics") (eq (value $value) 0.0)}}{{label
@@ -24,8 +26,7 @@ spec:
             | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For
             more information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
             end }}{{ end }}
-          summary: Cluster version operator has not retrieved updates in {{ $value
-            | humanizeDuration }}.
+          summary: Cluster version operator has not retrieved updates.
         expr: '
             (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600 
           and ignoring(condition, name, reason) 

--- a/generated_deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
+++ b/generated_deploy/sre-prometheus/100-sre-cannot-retrieve-updates.PrometheusRule.yaml
@@ -16,7 +16,9 @@ spec:
             will need to monitor for available updates on their own or risk falling
             behind on security or other bugfixes. If the failure is expected, you
             can clear spec.channel in the ClusterVersion object to tell the cluster-version
-            operator to not retrieve updates. Failure reason {{ with $cluster_operator_conditions
+            operator to not retrieve updates. 
+            Cluster version operator has not retrieved updates in {{ $value | humanizeDuration }}. 
+            Failure reason {{ with $cluster_operator_conditions
             := "cluster_operator_conditions" | query}}{{range $value := .}}{{if and
             (eq (label "name" $value) "version") (eq (label "condition" $value) "RetrievedUpdates")
             (eq (label "endpoint" $value) "metrics") (eq (value $value) 0.0)}}{{label
@@ -24,8 +26,7 @@ spec:
             | query }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For
             more information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
             end }}{{ end }}
-          summary: Cluster version operator has not retrieved updates in {{ $value
-            | humanizeDuration }}.
+          summary: Cluster version operator has not retrieved updates.
         expr: '
             (time()-cluster_version_operator_update_retrieval_timestamp_seconds) >= 3600 
           and ignoring(condition, name, reason) 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36341,8 +36341,9 @@ objects:
                 will need to monitor for available updates on their own or risk falling
                 behind on security or other bugfixes. If the failure is expected,
                 you can clear spec.channel in the ClusterVersion object to tell the
-                cluster-version operator to not retrieve updates. Failure reason {{
-                with $cluster_operator_conditions := "cluster_operator_conditions"
+                cluster-version operator to not retrieve updates. Cluster version
+                operator has not retrieved updates in {{ $value | humanizeDuration
+                }}. Failure reason {{ with $cluster_operator_conditions := "cluster_operator_conditions"
                 | query}}{{range $value := .}}{{if and (eq (label "name" $value) "version")
                 (eq (label "condition" $value) "RetrievedUpdates") (eq (label "endpoint"
                 $value) "metrics") (eq (value $value) 0.0)}}{{label "reason" $value}}
@@ -36350,8 +36351,7 @@ objects:
                 }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For more
                 information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
                 end }}{{ end }}
-              summary: Cluster version operator has not retrieved updates in {{ $value
-                | humanizeDuration }}.
+              summary: Cluster version operator has not retrieved updates.
             expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
               endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36341,8 +36341,9 @@ objects:
                 will need to monitor for available updates on their own or risk falling
                 behind on security or other bugfixes. If the failure is expected,
                 you can clear spec.channel in the ClusterVersion object to tell the
-                cluster-version operator to not retrieve updates. Failure reason {{
-                with $cluster_operator_conditions := "cluster_operator_conditions"
+                cluster-version operator to not retrieve updates. Cluster version
+                operator has not retrieved updates in {{ $value | humanizeDuration
+                }}. Failure reason {{ with $cluster_operator_conditions := "cluster_operator_conditions"
                 | query}}{{range $value := .}}{{if and (eq (label "name" $value) "version")
                 (eq (label "condition" $value) "RetrievedUpdates") (eq (label "endpoint"
                 $value) "metrics") (eq (value $value) 0.0)}}{{label "reason" $value}}
@@ -36350,8 +36351,7 @@ objects:
                 }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For more
                 information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
                 end }}{{ end }}
-              summary: Cluster version operator has not retrieved updates in {{ $value
-                | humanizeDuration }}.
+              summary: Cluster version operator has not retrieved updates.
             expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
               endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36341,8 +36341,9 @@ objects:
                 will need to monitor for available updates on their own or risk falling
                 behind on security or other bugfixes. If the failure is expected,
                 you can clear spec.channel in the ClusterVersion object to tell the
-                cluster-version operator to not retrieve updates. Failure reason {{
-                with $cluster_operator_conditions := "cluster_operator_conditions"
+                cluster-version operator to not retrieve updates. Cluster version
+                operator has not retrieved updates in {{ $value | humanizeDuration
+                }}. Failure reason {{ with $cluster_operator_conditions := "cluster_operator_conditions"
                 | query}}{{range $value := .}}{{if and (eq (label "name" $value) "version")
                 (eq (label "condition" $value) "RetrievedUpdates") (eq (label "endpoint"
                 $value) "metrics") (eq (value $value) 0.0)}}{{label "reason" $value}}
@@ -36350,8 +36351,7 @@ objects:
                 }}{{ if ne (len (label "url" (first $console_url ) ) ) 0}} For more
                 information refer to {{ label "url" (first $console_url ) }}/settings/cluster/.{{
                 end }}{{ end }}
-              summary: Cluster version operator has not retrieved updates in {{ $value
-                | humanizeDuration }}.
+              summary: Cluster version operator has not retrieved updates.
             expr: ' (time()-cluster_version_operator_update_retrieval_timestamp_seconds)
               >= 3600 and ignoring(condition, name, reason) (cluster_operator_conditions{name="version",condition="RetrievedUpdates",
               endpoint="metrics", reason!="NoChannel"}) and on(instance, job, namespace,


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug

### What this PR does / why we need it?
Our alerting framework in FedRAMP uses summary is the dedupe key. With each change in the dynamic value we receive a new alert. This PR will set the summary as a static value and provide the time details in the description

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
Dedupe issue in GoAlert

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ X ] Tested latest changes against a cluster
- [ N/A ] Included documentation changes with PR
- [ X ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
