### PR TITLE
Revert "Remove unused create pods/portforward in openshift-monitoring"

### DIFF
--- a/deploy/backplane/cee/01-cee-monitoring-role.yml
+++ b/deploy/backplane/cee/01-cee-monitoring-role.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-cee
+  namespace: openshift-monitoring
+rules:
+# CEE can portforward monitoring pods
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create

--- a/deploy/backplane/cee/02-cee-monitoring-rolebinding.yml
+++ b/deploy/backplane/cee/02-cee-monitoring-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-cee
+  namespace: openshift-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-cee
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-cee

--- a/deploy/backplane/lpsre/02-lpsre-monitoring-role.yml
+++ b/deploy/backplane/lpsre/02-lpsre-monitoring-role.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-lpsre
+  namespace: openshift-monitoring
+rules:
+# SRE can portforward pods
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create

--- a/deploy/backplane/lpsre/02-lpsre-monitoring-rolebinding.yml
+++ b/deploy/backplane/lpsre/02-lpsre-monitoring-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-lpsre
+  namespace: openshift-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-lpsre
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-lpsre

--- a/generated_deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/generated_deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -66,6 +66,37 @@ spec:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
                         metadata:
+                            name: backplane-cee
+                            namespace: openshift-monitoring
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/portforward
+                              verbs:
+                                - create
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-cee
+                            namespace: openshift-monitoring
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-cee
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-cee
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
                             name: backplane-cee-mustgather
                             namespace: openshift-must-gather-operator
                         rules:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -823,6 +823,37 @@ objects:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
                   metadata:
+                    name: backplane-cee
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-cee
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-cee
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-cee
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
                     name: backplane-cee-mustgather
                     namespace: openshift-must-gather-operator
                   rules:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -823,6 +823,37 @@ objects:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
                   metadata:
+                    name: backplane-cee
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-cee
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-cee
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-cee
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
                     name: backplane-cee-mustgather
                     namespace: openshift-must-gather-operator
                   rules:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -823,6 +823,37 @@ objects:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
                   metadata:
+                    name: backplane-cee
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-cee
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-cee
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-cee
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
                     name: backplane-cee-mustgather
                     namespace: openshift-must-gather-operator
                   rules:


### PR DESCRIPTION
This reverts commit d0c456df82cfb915410bc85ca4ca203491b2eb88.

### What type of PR is this?
bug

### What this PR does / why we need it?
[OSD-17444](https://issues.redhat.com//browse/OSD-17444)

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-17444](https://issues.redhat.com//browse/OSD-17444)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
