### PR TITLE
Add LPSRE to backplane group that can impersonate backplane-cluster-admin

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -59,6 +59,8 @@ spec:
                               name: system:serviceaccounts:openshift-backplane-srep
                             - kind: Group
                               name: system:serviceaccounts:openshift-backplane-cssre
+                            - kind: Group
+                              name: system:serviceaccounts:openshift-backplane-lpsre
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/elevated-sre/10-impersonate-cluster-admin.ClusterRoleBinding.yml
+++ b/deploy/backplane/elevated-sre/10-impersonate-cluster-admin.ClusterRoleBinding.yml
@@ -11,3 +11,5 @@ subjects:
   name: system:serviceaccounts:openshift-backplane-srep
 - kind: Group
   name: system:serviceaccounts:openshift-backplane-cssre
+- kind: Group
+  name: system:serviceaccounts:openshift-backplane-lpsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1704,6 +1704,8 @@ objects:
                     name: system:serviceaccounts:openshift-backplane-srep
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
+                  - kind: Group
+                    name: system:serviceaccounts:openshift-backplane-lpsre
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10146,6 +10148,8 @@ objects:
         name: system:serviceaccounts:openshift-backplane-srep
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-cssre
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
     - apiVersion: user.openshift.io/v1
       kind: User
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1704,6 +1704,8 @@ objects:
                     name: system:serviceaccounts:openshift-backplane-srep
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
+                  - kind: Group
+                    name: system:serviceaccounts:openshift-backplane-lpsre
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10146,6 +10148,8 @@ objects:
         name: system:serviceaccounts:openshift-backplane-srep
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-cssre
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
     - apiVersion: user.openshift.io/v1
       kind: User
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1704,6 +1704,8 @@ objects:
                     name: system:serviceaccounts:openshift-backplane-srep
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-cssre
+                  - kind: Group
+                    name: system:serviceaccounts:openshift-backplane-lpsre
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10146,6 +10148,8 @@ objects:
         name: system:serviceaccounts:openshift-backplane-srep
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-cssre
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
     - apiVersion: user.openshift.io/v1
       kind: User
       metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Add impersonate to LPSRE per recently merged backplane guideline.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-17466

### Special notes for your reviewer:


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
