### PR TITLE
Add severity property to WorkerNodeFilesystemSpaceFillingUp

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -58,4 +58,5 @@ spec:
         Your cluster requires you to take action. The file system usage for a worker node is currently at or above 90% and is predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of space used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
       name: WorkerNodeFilesystemSpaceFillingUp
       resendWait: 24
+      severity: Info
       summary: Worker node is predicted to run out of inodes in 4 hours

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25874,6 +25874,7 @@ objects:
             to other nodes.
           name: WorkerNodeFilesystemSpaceFillingUp
           resendWait: 24
+          severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25874,6 +25874,7 @@ objects:
             to other nodes.
           name: WorkerNodeFilesystemSpaceFillingUp
           resendWait: 24
+          severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25874,6 +25874,7 @@ objects:
             to other nodes.
           name: WorkerNodeFilesystemSpaceFillingUp
           resendWait: 24
+          severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
- Fixes broken clustersyncs in stage, due to a missing property in `WorkerNodeFilesystemSpaceFillingUp` managed notifications. 
```
        - failureMessage: 'failed to apply resource 0: error when creating "object": ManagedNotification.ocmagent.managed.openshift.io
            "sre-managed-notifications" is invalid: spec.notifications[6].severity: Required
            value'
          lastTransitionTime: "2023-07-12T01:50:57Z"
          name: ocm-agent-operator-managednotifications
          observedGeneration: 11
          result: Failure
```
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
