### PR TITLE
reverting to an earlier clamd version

### DIFF
--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -43,7 +43,7 @@ spec:
           value: "false"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamd@sha256:779c1a15b321963754840d695ac726112e9ee524705d097d296737612d36407c
+        image: quay.io/app-sre/clamd@sha256:196ebe61263f2cfe0c33b6b01f7a1097c687d92f6ac5904a40682ce530670028 
         name: clamd
         resources:
           limits:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33395,7 +33395,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:779c1a15b321963754840d695ac726112e9ee524705d097d296737612d36407c
+              image: quay.io/app-sre/clamd@sha256:196ebe61263f2cfe0c33b6b01f7a1097c687d92f6ac5904a40682ce530670028
               name: clamd
               resources:
                 limits:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33395,7 +33395,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:779c1a15b321963754840d695ac726112e9ee524705d097d296737612d36407c
+              image: quay.io/app-sre/clamd@sha256:196ebe61263f2cfe0c33b6b01f7a1097c687d92f6ac5904a40682ce530670028
               name: clamd
               resources:
                 limits:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33395,7 +33395,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:779c1a15b321963754840d695ac726112e9ee524705d097d296737612d36407c
+              image: quay.io/app-sre/clamd@sha256:196ebe61263f2cfe0c33b6b01f7a1097c687d92f6ac5904a40682ce530670028
               name: clamd
               resources:
                 limits:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
reverts to the previous clamd image used in the scanning daemonset to avoid an incompatibility issue with later versions of the base image.

### Which Jira/Github issue(s) this PR fixes?
OSD-17333, [OHSS-2407](https://issues.redhat.com//browse/OHSS-2407)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
