### PR TITLE
OSD-17493 2m policy evaluation

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-cee-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: backplane-cee-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -74,7 +74,7 @@ spec:
                 name: backplane-cee-sp3
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-cee
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-cse-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: backplane-cse-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-cse
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-csm-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: backplane-csm-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -74,7 +74,7 @@ spec:
                 name: backplane-csm-sp3
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-csm
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-cssre-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: backplane-cssre-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -74,7 +74,7 @@ spec:
                 name: backplane-cssre-sp3
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cssre.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-cssre
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-elevated-sre
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-mobb-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: backplane-mobb-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -74,7 +74,7 @@ spec:
                 name: backplane-mobb-sp3
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-mobb
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-srep-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: backplane-srep-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -74,7 +74,7 @@ spec:
                 name: backplane-srep-sp3
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:
@@ -112,7 +112,7 @@ spec:
                 name: backplane-srep-sp4
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-srep
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-tam-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: backplane-tam-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -74,7 +74,7 @@ spec:
                 name: backplane-tam-sp3
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane-tam
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: backplane
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: ccs-dedicated-admins-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     include:
@@ -49,7 +49,7 @@ spec:
                 name: ccs-dedicated-admins-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     include:

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: ccs-dedicated-admins
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: customer-registry-cas
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: hosted-uwm
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: hs-hosted-route-monitor-operator
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-mgmt-route-monitor-operator.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: hs-mgmt-route-monitor-operator
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     matchLabels:

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-backplane-managed-scripts
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-cluster-admin
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-customer-monitoring
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-delete-backplane-script-resources
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-delete-backplane-serviceaccounts-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: osd-delete-backplane-serviceaccounts-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     include:

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-delete-backplane-serviceaccounts
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-logging-unsupported
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-must-gather-operator
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-openshift-operators-redhat
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-pcap-collector
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-project-request-template
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-user-workload-monitoring-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: osd-user-workload-monitoring
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: rbac-permissions-operator-config-sp
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -46,7 +46,7 @@ spec:
                 name: rbac-permissions-operator-config-sp2
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:
@@ -84,7 +84,7 @@ spec:
                 name: rbac-permissions-operator-config-sp3
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:
@@ -122,7 +122,7 @@ spec:
                 name: rbac-permissions-operator-config-sp4
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave
@@ -150,7 +150,7 @@ spec:
                 name: rbac-permissions-operator-config-sp5
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:
@@ -188,7 +188,7 @@ spec:
                 name: rbac-permissions-operator-config-sp6
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     exclude:
@@ -226,7 +226,7 @@ spec:
                 name: rbac-permissions-operator-config-sp7
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     include:
@@ -258,7 +258,7 @@ spec:
                 name: rbac-permissions-operator-config-sp8
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     include:
@@ -290,7 +290,7 @@ spec:
                 name: rbac-permissions-operator-config-sp9
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     include:
@@ -322,7 +322,7 @@ spec:
                 name: rbac-permissions-operator-config-sp10
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 namespaceSelector:
                     include:

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: rbac-permissions-operator-config
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: rosa-console-branding-configmap
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: mustonlyhave

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
@@ -18,7 +18,7 @@ spec:
                 name: rosa-console-branding
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: musthave

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -53,7 +53,7 @@ spec:
                 name: rosa-ingress-certificate-policies
             spec:
                 evaluationInterval:
-                    compliant: 2h
+                    compliant: 2m
                     noncompliant: 45s
                 object-templates:
                     - complianceType: musthave

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -644,7 +644,7 @@ objects:
               name: backplane-cee-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -672,7 +672,7 @@ objects:
               name: backplane-cee-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -700,7 +700,7 @@ objects:
               name: backplane-cee-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -775,7 +775,7 @@ objects:
               name: backplane-cee
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -967,7 +967,7 @@ objects:
               name: backplane-cse-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -995,7 +995,7 @@ objects:
               name: backplane-cse-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1070,7 +1070,7 @@ objects:
               name: backplane-cse
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1127,7 +1127,7 @@ objects:
               name: backplane-csm-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1155,7 +1155,7 @@ objects:
               name: backplane-csm-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1183,7 +1183,7 @@ objects:
               name: backplane-csm-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1258,7 +1258,7 @@ objects:
               name: backplane-csm
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1419,7 +1419,7 @@ objects:
               name: backplane-cssre-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1447,7 +1447,7 @@ objects:
               name: backplane-cssre-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1475,7 +1475,7 @@ objects:
               name: backplane-cssre-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1550,7 +1550,7 @@ objects:
               name: backplane-cssre
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1694,7 +1694,7 @@ objects:
               name: backplane-elevated-sre
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1806,7 +1806,7 @@ objects:
               name: backplane-mobb-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1834,7 +1834,7 @@ objects:
               name: backplane-mobb-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1862,7 +1862,7 @@ objects:
               name: backplane-mobb-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1937,7 +1937,7 @@ objects:
               name: backplane-mobb
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2098,7 +2098,7 @@ objects:
               name: backplane-srep-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2126,7 +2126,7 @@ objects:
               name: backplane-srep-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2154,7 +2154,7 @@ objects:
               name: backplane-srep-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2192,7 +2192,7 @@ objects:
               name: backplane-srep-sp4
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2267,7 +2267,7 @@ objects:
               name: backplane-srep
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2701,7 +2701,7 @@ objects:
               name: backplane-tam-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2729,7 +2729,7 @@ objects:
               name: backplane-tam-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2757,7 +2757,7 @@ objects:
               name: backplane-tam-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2832,7 +2832,7 @@ objects:
               name: backplane-tam
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2993,7 +2993,7 @@ objects:
               name: backplane
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3064,7 +3064,7 @@ objects:
               name: ccs-dedicated-admins-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -3095,7 +3095,7 @@ objects:
               name: ccs-dedicated-admins-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -3163,7 +3163,7 @@ objects:
               name: ccs-dedicated-admins
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3229,7 +3229,7 @@ objects:
               name: customer-registry-cas
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3357,7 +3357,7 @@ objects:
               name: hosted-uwm
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3445,7 +3445,7 @@ objects:
               name: hs-hosted-route-monitor-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3511,7 +3511,7 @@ objects:
               name: hs-mgmt-route-monitor-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 matchLabels:
@@ -3587,7 +3587,7 @@ objects:
               name: osd-backplane-managed-scripts
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3672,7 +3672,7 @@ objects:
               name: osd-cluster-admin
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3737,7 +3737,7 @@ objects:
               name: osd-customer-monitoring
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4389,7 +4389,7 @@ objects:
               name: osd-delete-backplane-script-resources
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4617,7 +4617,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4645,7 +4645,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -4713,7 +4713,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4859,7 +4859,7 @@ objects:
               name: osd-logging-unsupported
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5068,7 +5068,7 @@ objects:
               name: osd-must-gather-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5130,7 +5130,7 @@ objects:
               name: osd-openshift-operators-redhat
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5251,7 +5251,7 @@ objects:
               name: osd-pcap-collector
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5352,7 +5352,7 @@ objects:
               name: osd-project-request-template
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5435,7 +5435,7 @@ objects:
               name: osd-user-workload-monitoring-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5511,7 +5511,7 @@ objects:
               name: osd-user-workload-monitoring
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5651,7 +5651,7 @@ objects:
               name: rbac-permissions-operator-config-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5679,7 +5679,7 @@ objects:
               name: rbac-permissions-operator-config-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5717,7 +5717,7 @@ objects:
               name: rbac-permissions-operator-config-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5755,7 +5755,7 @@ objects:
               name: rbac-permissions-operator-config-sp4
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5783,7 +5783,7 @@ objects:
               name: rbac-permissions-operator-config-sp5
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5821,7 +5821,7 @@ objects:
               name: rbac-permissions-operator-config-sp6
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5859,7 +5859,7 @@ objects:
               name: rbac-permissions-operator-config-sp7
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5891,7 +5891,7 @@ objects:
               name: rbac-permissions-operator-config-sp8
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5923,7 +5923,7 @@ objects:
               name: rbac-permissions-operator-config-sp9
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5955,7 +5955,7 @@ objects:
               name: rbac-permissions-operator-config-sp10
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -6024,7 +6024,7 @@ objects:
               name: rbac-permissions-operator-config
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -7065,7 +7065,7 @@ objects:
               name: rosa-console-branding-configmap
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -7225,7 +7225,7 @@ objects:
               name: rosa-console-branding
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: musthave
@@ -7321,7 +7321,7 @@ objects:
               name: rosa-ingress-certificate-policies
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: musthave

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -644,7 +644,7 @@ objects:
               name: backplane-cee-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -672,7 +672,7 @@ objects:
               name: backplane-cee-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -700,7 +700,7 @@ objects:
               name: backplane-cee-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -775,7 +775,7 @@ objects:
               name: backplane-cee
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -967,7 +967,7 @@ objects:
               name: backplane-cse-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -995,7 +995,7 @@ objects:
               name: backplane-cse-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1070,7 +1070,7 @@ objects:
               name: backplane-cse
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1127,7 +1127,7 @@ objects:
               name: backplane-csm-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1155,7 +1155,7 @@ objects:
               name: backplane-csm-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1183,7 +1183,7 @@ objects:
               name: backplane-csm-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1258,7 +1258,7 @@ objects:
               name: backplane-csm
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1419,7 +1419,7 @@ objects:
               name: backplane-cssre-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1447,7 +1447,7 @@ objects:
               name: backplane-cssre-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1475,7 +1475,7 @@ objects:
               name: backplane-cssre-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1550,7 +1550,7 @@ objects:
               name: backplane-cssre
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1694,7 +1694,7 @@ objects:
               name: backplane-elevated-sre
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1806,7 +1806,7 @@ objects:
               name: backplane-mobb-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1834,7 +1834,7 @@ objects:
               name: backplane-mobb-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1862,7 +1862,7 @@ objects:
               name: backplane-mobb-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1937,7 +1937,7 @@ objects:
               name: backplane-mobb
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2098,7 +2098,7 @@ objects:
               name: backplane-srep-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2126,7 +2126,7 @@ objects:
               name: backplane-srep-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2154,7 +2154,7 @@ objects:
               name: backplane-srep-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2192,7 +2192,7 @@ objects:
               name: backplane-srep-sp4
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2267,7 +2267,7 @@ objects:
               name: backplane-srep
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2701,7 +2701,7 @@ objects:
               name: backplane-tam-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2729,7 +2729,7 @@ objects:
               name: backplane-tam-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2757,7 +2757,7 @@ objects:
               name: backplane-tam-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2832,7 +2832,7 @@ objects:
               name: backplane-tam
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2993,7 +2993,7 @@ objects:
               name: backplane
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3064,7 +3064,7 @@ objects:
               name: ccs-dedicated-admins-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -3095,7 +3095,7 @@ objects:
               name: ccs-dedicated-admins-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -3163,7 +3163,7 @@ objects:
               name: ccs-dedicated-admins
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3229,7 +3229,7 @@ objects:
               name: customer-registry-cas
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3357,7 +3357,7 @@ objects:
               name: hosted-uwm
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3445,7 +3445,7 @@ objects:
               name: hs-hosted-route-monitor-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3511,7 +3511,7 @@ objects:
               name: hs-mgmt-route-monitor-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 matchLabels:
@@ -3587,7 +3587,7 @@ objects:
               name: osd-backplane-managed-scripts
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3672,7 +3672,7 @@ objects:
               name: osd-cluster-admin
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3737,7 +3737,7 @@ objects:
               name: osd-customer-monitoring
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4389,7 +4389,7 @@ objects:
               name: osd-delete-backplane-script-resources
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4617,7 +4617,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4645,7 +4645,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -4713,7 +4713,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4859,7 +4859,7 @@ objects:
               name: osd-logging-unsupported
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5068,7 +5068,7 @@ objects:
               name: osd-must-gather-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5130,7 +5130,7 @@ objects:
               name: osd-openshift-operators-redhat
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5251,7 +5251,7 @@ objects:
               name: osd-pcap-collector
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5352,7 +5352,7 @@ objects:
               name: osd-project-request-template
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5435,7 +5435,7 @@ objects:
               name: osd-user-workload-monitoring-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5511,7 +5511,7 @@ objects:
               name: osd-user-workload-monitoring
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5651,7 +5651,7 @@ objects:
               name: rbac-permissions-operator-config-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5679,7 +5679,7 @@ objects:
               name: rbac-permissions-operator-config-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5717,7 +5717,7 @@ objects:
               name: rbac-permissions-operator-config-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5755,7 +5755,7 @@ objects:
               name: rbac-permissions-operator-config-sp4
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5783,7 +5783,7 @@ objects:
               name: rbac-permissions-operator-config-sp5
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5821,7 +5821,7 @@ objects:
               name: rbac-permissions-operator-config-sp6
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5859,7 +5859,7 @@ objects:
               name: rbac-permissions-operator-config-sp7
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5891,7 +5891,7 @@ objects:
               name: rbac-permissions-operator-config-sp8
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5923,7 +5923,7 @@ objects:
               name: rbac-permissions-operator-config-sp9
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5955,7 +5955,7 @@ objects:
               name: rbac-permissions-operator-config-sp10
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -6024,7 +6024,7 @@ objects:
               name: rbac-permissions-operator-config
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -7065,7 +7065,7 @@ objects:
               name: rosa-console-branding-configmap
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -7225,7 +7225,7 @@ objects:
               name: rosa-console-branding
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: musthave
@@ -7321,7 +7321,7 @@ objects:
               name: rosa-ingress-certificate-policies
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: musthave

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -644,7 +644,7 @@ objects:
               name: backplane-cee-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -672,7 +672,7 @@ objects:
               name: backplane-cee-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -700,7 +700,7 @@ objects:
               name: backplane-cee-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -775,7 +775,7 @@ objects:
               name: backplane-cee
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -967,7 +967,7 @@ objects:
               name: backplane-cse-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -995,7 +995,7 @@ objects:
               name: backplane-cse-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1070,7 +1070,7 @@ objects:
               name: backplane-cse
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1127,7 +1127,7 @@ objects:
               name: backplane-csm-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1155,7 +1155,7 @@ objects:
               name: backplane-csm-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1183,7 +1183,7 @@ objects:
               name: backplane-csm-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1258,7 +1258,7 @@ objects:
               name: backplane-csm
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1419,7 +1419,7 @@ objects:
               name: backplane-cssre-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1447,7 +1447,7 @@ objects:
               name: backplane-cssre-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1475,7 +1475,7 @@ objects:
               name: backplane-cssre-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1550,7 +1550,7 @@ objects:
               name: backplane-cssre
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1694,7 +1694,7 @@ objects:
               name: backplane-elevated-sre
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1806,7 +1806,7 @@ objects:
               name: backplane-mobb-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1834,7 +1834,7 @@ objects:
               name: backplane-mobb-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -1862,7 +1862,7 @@ objects:
               name: backplane-mobb-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -1937,7 +1937,7 @@ objects:
               name: backplane-mobb
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2098,7 +2098,7 @@ objects:
               name: backplane-srep-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2126,7 +2126,7 @@ objects:
               name: backplane-srep-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2154,7 +2154,7 @@ objects:
               name: backplane-srep-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2192,7 +2192,7 @@ objects:
               name: backplane-srep-sp4
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2267,7 +2267,7 @@ objects:
               name: backplane-srep
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2701,7 +2701,7 @@ objects:
               name: backplane-tam-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2729,7 +2729,7 @@ objects:
               name: backplane-tam-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2757,7 +2757,7 @@ objects:
               name: backplane-tam-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -2832,7 +2832,7 @@ objects:
               name: backplane-tam
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -2993,7 +2993,7 @@ objects:
               name: backplane
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3064,7 +3064,7 @@ objects:
               name: ccs-dedicated-admins-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -3095,7 +3095,7 @@ objects:
               name: ccs-dedicated-admins-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -3163,7 +3163,7 @@ objects:
               name: ccs-dedicated-admins
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3229,7 +3229,7 @@ objects:
               name: customer-registry-cas
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3357,7 +3357,7 @@ objects:
               name: hosted-uwm
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3445,7 +3445,7 @@ objects:
               name: hs-hosted-route-monitor-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3511,7 +3511,7 @@ objects:
               name: hs-mgmt-route-monitor-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 matchLabels:
@@ -3587,7 +3587,7 @@ objects:
               name: osd-backplane-managed-scripts
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3672,7 +3672,7 @@ objects:
               name: osd-cluster-admin
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -3737,7 +3737,7 @@ objects:
               name: osd-customer-monitoring
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4389,7 +4389,7 @@ objects:
               name: osd-delete-backplane-script-resources
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4617,7 +4617,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4645,7 +4645,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -4713,7 +4713,7 @@ objects:
               name: osd-delete-backplane-serviceaccounts
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -4859,7 +4859,7 @@ objects:
               name: osd-logging-unsupported
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5068,7 +5068,7 @@ objects:
               name: osd-must-gather-operator
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5130,7 +5130,7 @@ objects:
               name: osd-openshift-operators-redhat
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5251,7 +5251,7 @@ objects:
               name: osd-pcap-collector
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5352,7 +5352,7 @@ objects:
               name: osd-project-request-template
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5435,7 +5435,7 @@ objects:
               name: osd-user-workload-monitoring-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5511,7 +5511,7 @@ objects:
               name: osd-user-workload-monitoring
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5651,7 +5651,7 @@ objects:
               name: rbac-permissions-operator-config-sp
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5679,7 +5679,7 @@ objects:
               name: rbac-permissions-operator-config-sp2
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5717,7 +5717,7 @@ objects:
               name: rbac-permissions-operator-config-sp3
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5755,7 +5755,7 @@ objects:
               name: rbac-permissions-operator-config-sp4
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -5783,7 +5783,7 @@ objects:
               name: rbac-permissions-operator-config-sp5
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5821,7 +5821,7 @@ objects:
               name: rbac-permissions-operator-config-sp6
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 exclude:
@@ -5859,7 +5859,7 @@ objects:
               name: rbac-permissions-operator-config-sp7
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5891,7 +5891,7 @@ objects:
               name: rbac-permissions-operator-config-sp8
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5923,7 +5923,7 @@ objects:
               name: rbac-permissions-operator-config-sp9
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -5955,7 +5955,7 @@ objects:
               name: rbac-permissions-operator-config-sp10
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               namespaceSelector:
                 include:
@@ -6024,7 +6024,7 @@ objects:
               name: rbac-permissions-operator-config
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -7065,7 +7065,7 @@ objects:
               name: rosa-console-branding-configmap
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: mustonlyhave
@@ -7225,7 +7225,7 @@ objects:
               name: rosa-console-branding
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: musthave
@@ -7321,7 +7321,7 @@ objects:
               name: rosa-ingress-certificate-policies
             spec:
               evaluationInterval:
-                compliant: 2h
+                compliant: 2m
                 noncompliant: 45s
               object-templates:
               - complianceType: musthave

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -9,7 +9,7 @@ policyDefaults:
           hypershift.open-cluster-management.io/hosted-cluster: "true" # Can be overridden by script
     remediationAction: enforce
     evaluationInterval:
-        compliant: 2h
+        compliant: 2m
         noncompliant: 45s
     pruneObjectBehavior: "DeleteIfCreated"
     complianceType: "mustonlyhave"


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
A 2 hour evaluation interval allows too great a window before alerting
us, which causes SLAs to be vulnerable for too long.

This PR reduces the evaluation interval to 2 minutes

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-17493](https://issues.redhat.com//browse/OSD-17493)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
