### PR TITLE
[OSD-17347] Make token refresher FIPS compliant

### DIFF
--- a/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/osd-token-refresher/01-token-refresher.Deployment.yaml
@@ -65,7 +65,7 @@ spec:
               key: receiver-url
         - name: ISSUER_URL
           value: "https://sso.redhat.com/auth/realms/redhat-external"
-        image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
+        image: quay.io/observatorium/token-refresher@sha256:af05fa79b7b9a629e4914aeec0697f884183f41f950a3a887a742349a74e2872
         name: token-refresher
         ports:
         - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34123,7 +34123,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
+              image: quay.io/observatorium/token-refresher@sha256:af05fa79b7b9a629e4914aeec0697f884183f41f950a3a887a742349a74e2872
               name: token-refresher
               ports:
               - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34123,7 +34123,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
+              image: quay.io/observatorium/token-refresher@sha256:af05fa79b7b9a629e4914aeec0697f884183f41f950a3a887a742349a74e2872
               name: token-refresher
               ports:
               - containerPort: 8080

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34123,7 +34123,7 @@ objects:
                     key: receiver-url
               - name: ISSUER_URL
                 value: https://sso.redhat.com/auth/realms/redhat-external
-              image: quay.io/observatorium/token-refresher@sha256:9225afc5c75cd584f939afc175e86d70ed93c9e308dfd7ffc20932725bf573cd
+              image: quay.io/observatorium/token-refresher@sha256:af05fa79b7b9a629e4914aeec0697f884183f41f950a3a887a742349a74e2872
               name: token-refresher
               ports:
               - containerPort: 8080


### PR DESCRIPTION
### What type of PR is this?
Security fix

### What this PR does / why we need it?
Updating the token refresher image to use FIPS compliant version

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-17347


### Special notes for your reviewer:
Tested on a stage cluster and it worked ok. metrics were still passing through to observatorium

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
