### PR TITLE
Allow DNSErrors10MinSRE to reset in the 10 minutes interval

### DIFF
--- a/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
@@ -11,9 +11,9 @@ spec:
   - name: sre-dns-alerts
     rules:
     - alert: DNSErrors10MinSRE
-      # Alerts if we had any DNS failures in a 3 minutes interval three times in a row
-      expr: increase(dns_failure_failure_total[3m]) >= 1
-      for: 10m
+      # Alerts if we had DNS failures in multiple 4 minute windows for 15 minutes.
+      expr: increase(dns_failure_failure_total[4m]) >= 1
+      for: 15m
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
@@ -11,8 +11,8 @@ spec:
   - name: sre-dns-alerts
     rules:
     - alert: DNSErrors10MinSRE
-      # If the amount of DNS failures increases by 3 over the span of 10 minutes
-      expr: increase(dns_failure_failure_total[10m]) >= 3
+      # Alerts if we had any DNS failures in a 3 minutes interval three times in a row
+      expr: increase(dns_failure_failure_total[3m]) >= 1
       for: 10m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36159,8 +36159,8 @@ objects:
         - name: sre-dns-alerts
           rules:
           - alert: DNSErrors10MinSRE
-            expr: increase(dns_failure_failure_total[3m]) >= 1
-            for: 10m
+            expr: increase(dns_failure_failure_total[4m]) >= 1
+            for: 15m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36159,7 +36159,7 @@ objects:
         - name: sre-dns-alerts
           rules:
           - alert: DNSErrors10MinSRE
-            expr: increase(dns_failure_failure_total[10m]) >= 3
+            expr: increase(dns_failure_failure_total[3m]) >= 1
             for: 10m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36159,8 +36159,8 @@ objects:
         - name: sre-dns-alerts
           rules:
           - alert: DNSErrors10MinSRE
-            expr: increase(dns_failure_failure_total[3m]) >= 1
-            for: 10m
+            expr: increase(dns_failure_failure_total[4m]) >= 1
+            for: 15m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36159,7 +36159,7 @@ objects:
         - name: sre-dns-alerts
           rules:
           - alert: DNSErrors10MinSRE
-            expr: increase(dns_failure_failure_total[10m]) >= 3
+            expr: increase(dns_failure_failure_total[3m]) >= 1
             for: 10m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36159,8 +36159,8 @@ objects:
         - name: sre-dns-alerts
           rules:
           - alert: DNSErrors10MinSRE
-            expr: increase(dns_failure_failure_total[3m]) >= 1
-            for: 10m
+            expr: increase(dns_failure_failure_total[4m]) >= 1
+            for: 15m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36159,7 +36159,7 @@ objects:
         - name: sre-dns-alerts
           rules:
           - alert: DNSErrors10MinSRE
-            expr: increase(dns_failure_failure_total[10m]) >= 3
+            expr: increase(dns_failure_failure_total[3m]) >= 1
             for: 10m
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
This should get rid of most unactionable DNSErrors10MinSRE alerts, as it stops the alert from triggering for short window failures. 

Checking if there's over 3 failures over 10 minutes **for 10 minutes** is redundant. Instead, with this change, we check if we had at least one failure every 3 minutes over a 10 minute window. 

### What this PR does / why we need it?

Primary noise reduction

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
