### PR TITLE
Rename SubjectPermissions to cleanup orphaned RBAC

### DIFF
--- a/deploy/backplane/lpsre/20-lpsre-addon-operator.SubjectPermission.yml
+++ b/deploy/backplane/lpsre/20-lpsre-addon-operator.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-lpsre-addon-operator-admins
+  name: backplane-lpsre-addon-operator
   namespace: openshift-rbac-permissions
 spec:
   clusterPermissions:

--- a/deploy/backplane/lpsre/managed-odh/10-lpsre-odh-admins.SubjectPermission.yml
+++ b/deploy/backplane/lpsre/managed-odh/10-lpsre-odh-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-lpsre-managed-odh-admins
+  name: backplane-lpsre-managed-odh
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/lpsre/ocs-consumer/10-lpsre-ocs-consumer-admins.SubjectPermission.yml
+++ b/deploy/backplane/lpsre/ocs-consumer/10-lpsre-ocs-consumer-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-lpsre-ocs-consumer-admins
+  name: backplane-lpsre-ocs-consumer
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/lpsre/ocs-converged/10-lpsre-ocs-converged-admins.SubjectPermission.yml
+++ b/deploy/backplane/lpsre/ocs-converged/10-lpsre-ocs-converged-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-lpsre-ocs-converged-admins
+  name: backplane-lpsre-ocs-converged
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/lpsre/ocs-provider/10-lpsre-ocs-provider-admins.SubjectPermission.yml
+++ b/deploy/backplane/lpsre/ocs-provider/10-lpsre-ocs-provider-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-lpsre-ocs-provider-admins
+  name: backplane-lpsre-ocs-provider
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/lpsre/reference-addon/10-lpsre-reference-addon-admins.SubjectPermission.yml
+++ b/deploy/backplane/lpsre/reference-addon/10-lpsre-reference-addon-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-lpsre-reference-addon-admins
+  name: backplane-lpsre-reference-addon
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/mcg/mcg-osd/10-mcg-mcg-osd-admins.SubjectPermission.yml
+++ b/deploy/backplane/mcg/mcg-osd/10-mcg-mcg-osd-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mcg-mcg-osd-admins
+  name: backplane-mcg-mcg-osd
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/mtsre/20-mtsre-addon-operator.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/20-mtsre-addon-operator.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-addon-operator-admins
+  name: backplane-mtsre-addon-operator
   namespace: openshift-rbac-permissions
 spec:
   clusterPermissions:

--- a/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/managed-odh/10-mtsre-odh-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-managed-odh-admins
+  name: backplane-mtsre-managed-odh
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/mtsre/ocs-consumer/10-mtsre-ocs-consumer-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/ocs-consumer/10-mtsre-ocs-consumer-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-ocs-consumer-admins
+  name: backplane-mtsre-ocs-consumer
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/mtsre/ocs-converged/10-mtsre-ocs-converged-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/ocs-converged/10-mtsre-ocs-converged-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-ocs-converged-admins
+  name: backplane-mtsre-ocs-converged
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/mtsre/ocs-provider/10-mtsre-ocs-provider-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/ocs-provider/10-mtsre-ocs-provider-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-ocs-provider-admins
+  name: backplane-mtsre-ocs-provider
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/mtsre/openshift-connectors/10-mtsre-openshift-connectors-admins.SubjectPermissions.yml
+++ b/deploy/backplane/mtsre/openshift-connectors/10-mtsre-openshift-connectors-admins.SubjectPermissions.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-openshift-connectors-admins
+  name: backplane-mtsre-openshift-connectors
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/mtsre/reference-addon/10-mtsre-reference-addon-admins.SubjectPermission.yml
+++ b/deploy/backplane/mtsre/reference-addon/10-mtsre-reference-addon-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-mtsre-reference-addon-admins
+  name: backplane-mtsre-reference-addon
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/odf-sre/ocs-consumer/10-odf-sre.SubjectPermission.yml
+++ b/deploy/backplane/odf-sre/ocs-consumer/10-odf-sre.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-odf-sre-ocs-consumer
+  name: backplane-odf-sre-ocs
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/odf-sre/ocs-provider/10-odf-sre.SubjectPermission.yml
+++ b/deploy/backplane/odf-sre/ocs-provider/10-odf-sre.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-odf-sre-ocs-provider
+  name: backplane-odf-sre-ocs-provider-admins
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/odf/ocs-consumer/10-odf-ocs-consumer-admins.SubjectPermission.yml
+++ b/deploy/backplane/odf/ocs-consumer/10-odf-ocs-consumer-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-odf-ocs-consumer-admins
+  name: backplane-odf-ocs-consumer
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/odf/ocs-provider/10-odf-ocs-provider-admins.SubjectPermission.yml
+++ b/deploy/backplane/odf/ocs-provider/10-odf-ocs-provider-admins.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-odf-ocs-provider-admins
+  name: backplane-odf-ocs-provider
   namespace: openshift-rbac-permissions
 spec:
   permissions:

--- a/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/management-cluster/20-srep.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-srep-management-cluster
+  name: backplane-srep-management-cluster-admins
   namespace: openshift-rbac-permissions
 spec:
   clusterPermissions:

--- a/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
@@ -1,7 +1,7 @@
 apiVersion: managed.openshift.io/v1alpha1
 kind: SubjectPermission
 metadata:
-  name: backplane-srep-service-cluster
+  name: backplane-srep-service-cluster-admins
   namespace: openshift-rbac-permissions
 spec:
   clusterPermissions:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10406,7 +10406,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -10658,7 +10658,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -10910,7 +10910,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11162,7 +11162,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11414,7 +11414,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11666,7 +11666,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11918,7 +11918,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12170,7 +12170,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12422,7 +12422,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12674,7 +12674,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12926,7 +12926,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13178,7 +13178,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13430,7 +13430,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13682,7 +13682,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13934,7 +13934,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14186,7 +14186,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14438,7 +14438,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14690,7 +14690,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14942,7 +14942,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15194,7 +15194,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15446,7 +15446,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15698,7 +15698,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15950,7 +15950,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16202,7 +16202,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16454,7 +16454,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16706,7 +16706,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16958,7 +16958,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17210,7 +17210,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17462,7 +17462,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17714,7 +17714,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17966,7 +17966,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -18218,7 +18218,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -18506,7 +18506,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-managed-odh-admins
+        name: backplane-lpsre-managed-odh
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18640,7 +18640,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-consumer-admins
+        name: backplane-lpsre-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18673,7 +18673,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-converged-admins
+        name: backplane-lpsre-ocs-converged
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18804,7 +18804,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-provider-admins
+        name: backplane-lpsre-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -19161,7 +19161,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-reference-addon-admins
+        name: backplane-lpsre-reference-addon
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -20239,7 +20239,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mcg-mcg-osd-admins
+        name: backplane-mcg-mcg-osd
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -20465,7 +20465,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20575,7 +20575,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20685,7 +20685,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20795,7 +20795,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20905,7 +20905,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21015,7 +21015,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21125,7 +21125,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21235,7 +21235,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21345,7 +21345,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21455,7 +21455,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21565,7 +21565,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21675,7 +21675,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21785,7 +21785,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21895,7 +21895,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22005,7 +22005,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22115,7 +22115,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22225,7 +22225,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22335,7 +22335,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22445,7 +22445,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22555,7 +22555,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22665,7 +22665,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22775,7 +22775,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22885,7 +22885,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22995,7 +22995,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23105,7 +23105,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23215,7 +23215,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23325,7 +23325,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23435,7 +23435,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23471,7 +23471,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-managed-odh-admins
+        name: backplane-mtsre-managed-odh
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23605,7 +23605,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-consumer-admins
+        name: backplane-mtsre-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23638,7 +23638,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-converged-admins
+        name: backplane-mtsre-ocs-converged
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23803,7 +23803,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-provider-admins
+        name: backplane-mtsre-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23855,7 +23855,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-openshift-connectors-admins
+        name: backplane-mtsre-openshift-connectors
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23888,7 +23888,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-reference-addon-admins
+        name: backplane-mtsre-reference-addon
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24169,7 +24169,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-sre-ocs-consumer
+        name: backplane-odf-sre-ocs
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24303,7 +24303,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-sre-ocs-provider
+        name: backplane-odf-sre-ocs-provider-admins
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24336,7 +24336,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-ocs-consumer-admins
+        name: backplane-odf-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24366,7 +24366,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-ocs-provider-admins
+        name: backplane-odf-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -25112,7 +25112,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-srep-management-cluster
+        name: backplane-srep-management-cluster-admins
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -25279,7 +25279,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-srep-service-cluster
+        name: backplane-srep-service-cluster-admins
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10406,7 +10406,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -10658,7 +10658,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -10910,7 +10910,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11162,7 +11162,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11414,7 +11414,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11666,7 +11666,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11918,7 +11918,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12170,7 +12170,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12422,7 +12422,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12674,7 +12674,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12926,7 +12926,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13178,7 +13178,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13430,7 +13430,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13682,7 +13682,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13934,7 +13934,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14186,7 +14186,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14438,7 +14438,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14690,7 +14690,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14942,7 +14942,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15194,7 +15194,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15446,7 +15446,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15698,7 +15698,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15950,7 +15950,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16202,7 +16202,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16454,7 +16454,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16706,7 +16706,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16958,7 +16958,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17210,7 +17210,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17462,7 +17462,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17714,7 +17714,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17966,7 +17966,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -18218,7 +18218,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -18506,7 +18506,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-managed-odh-admins
+        name: backplane-lpsre-managed-odh
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18640,7 +18640,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-consumer-admins
+        name: backplane-lpsre-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18673,7 +18673,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-converged-admins
+        name: backplane-lpsre-ocs-converged
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18804,7 +18804,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-provider-admins
+        name: backplane-lpsre-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -19161,7 +19161,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-reference-addon-admins
+        name: backplane-lpsre-reference-addon
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -20239,7 +20239,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mcg-mcg-osd-admins
+        name: backplane-mcg-mcg-osd
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -20465,7 +20465,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20575,7 +20575,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20685,7 +20685,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20795,7 +20795,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20905,7 +20905,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21015,7 +21015,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21125,7 +21125,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21235,7 +21235,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21345,7 +21345,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21455,7 +21455,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21565,7 +21565,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21675,7 +21675,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21785,7 +21785,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21895,7 +21895,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22005,7 +22005,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22115,7 +22115,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22225,7 +22225,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22335,7 +22335,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22445,7 +22445,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22555,7 +22555,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22665,7 +22665,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22775,7 +22775,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22885,7 +22885,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22995,7 +22995,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23105,7 +23105,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23215,7 +23215,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23325,7 +23325,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23435,7 +23435,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23471,7 +23471,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-managed-odh-admins
+        name: backplane-mtsre-managed-odh
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23605,7 +23605,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-consumer-admins
+        name: backplane-mtsre-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23638,7 +23638,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-converged-admins
+        name: backplane-mtsre-ocs-converged
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23803,7 +23803,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-provider-admins
+        name: backplane-mtsre-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23855,7 +23855,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-openshift-connectors-admins
+        name: backplane-mtsre-openshift-connectors
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23888,7 +23888,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-reference-addon-admins
+        name: backplane-mtsre-reference-addon
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24169,7 +24169,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-sre-ocs-consumer
+        name: backplane-odf-sre-ocs
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24303,7 +24303,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-sre-ocs-provider
+        name: backplane-odf-sre-ocs-provider-admins
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24336,7 +24336,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-ocs-consumer-admins
+        name: backplane-odf-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24366,7 +24366,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-ocs-provider-admins
+        name: backplane-odf-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -25112,7 +25112,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-srep-management-cluster
+        name: backplane-srep-management-cluster-admins
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -25279,7 +25279,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-srep-service-cluster
+        name: backplane-srep-service-cluster-admins
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10406,7 +10406,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -10658,7 +10658,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -10910,7 +10910,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11162,7 +11162,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11414,7 +11414,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11666,7 +11666,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -11918,7 +11918,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12170,7 +12170,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12422,7 +12422,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12674,7 +12674,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -12926,7 +12926,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13178,7 +13178,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13430,7 +13430,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13682,7 +13682,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -13934,7 +13934,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14186,7 +14186,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14438,7 +14438,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14690,7 +14690,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -14942,7 +14942,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15194,7 +15194,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15446,7 +15446,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15698,7 +15698,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -15950,7 +15950,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16202,7 +16202,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16454,7 +16454,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16706,7 +16706,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -16958,7 +16958,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17210,7 +17210,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17462,7 +17462,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17714,7 +17714,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -17966,7 +17966,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -18218,7 +18218,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-addon-operator-admins
+        name: backplane-lpsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -18506,7 +18506,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-managed-odh-admins
+        name: backplane-lpsre-managed-odh
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18640,7 +18640,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-consumer-admins
+        name: backplane-lpsre-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18673,7 +18673,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-converged-admins
+        name: backplane-lpsre-ocs-converged
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -18804,7 +18804,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-ocs-provider-admins
+        name: backplane-lpsre-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -19161,7 +19161,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-lpsre-reference-addon-admins
+        name: backplane-lpsre-reference-addon
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -20239,7 +20239,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mcg-mcg-osd-admins
+        name: backplane-mcg-mcg-osd
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -20465,7 +20465,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20575,7 +20575,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20685,7 +20685,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20795,7 +20795,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -20905,7 +20905,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21015,7 +21015,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21125,7 +21125,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21235,7 +21235,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21345,7 +21345,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21455,7 +21455,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21565,7 +21565,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21675,7 +21675,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21785,7 +21785,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -21895,7 +21895,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22005,7 +22005,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22115,7 +22115,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22225,7 +22225,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22335,7 +22335,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22445,7 +22445,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22555,7 +22555,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22665,7 +22665,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22775,7 +22775,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22885,7 +22885,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -22995,7 +22995,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23105,7 +23105,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23215,7 +23215,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23325,7 +23325,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23435,7 +23435,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-addon-operator-admins
+        name: backplane-mtsre-addon-operator
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -23471,7 +23471,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-managed-odh-admins
+        name: backplane-mtsre-managed-odh
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23605,7 +23605,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-consumer-admins
+        name: backplane-mtsre-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23638,7 +23638,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-converged-admins
+        name: backplane-mtsre-ocs-converged
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23803,7 +23803,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-ocs-provider-admins
+        name: backplane-mtsre-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23855,7 +23855,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-openshift-connectors-admins
+        name: backplane-mtsre-openshift-connectors
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -23888,7 +23888,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-mtsre-reference-addon-admins
+        name: backplane-mtsre-reference-addon
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24169,7 +24169,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-sre-ocs-consumer
+        name: backplane-odf-sre-ocs
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24303,7 +24303,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-sre-ocs-provider
+        name: backplane-odf-sre-ocs-provider-admins
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24336,7 +24336,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-ocs-consumer-admins
+        name: backplane-odf-ocs-consumer
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -24366,7 +24366,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-odf-ocs-provider-admins
+        name: backplane-odf-ocs-provider
         namespace: openshift-rbac-permissions
       spec:
         permissions:
@@ -25112,7 +25112,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-srep-management-cluster
+        name: backplane-srep-management-cluster-admins
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:
@@ -25279,7 +25279,7 @@ objects:
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
-        name: backplane-srep-service-cluster
+        name: backplane-srep-service-cluster-admins
         namespace: openshift-rbac-permissions
       spec:
         clusterPermissions:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Cleans up permissions from rbac-permissions-operator bug

### Which Jira/Github issue(s) this PR fixes?
Caused by https://issues.redhat.com/browse/OSD-17531
Does not fix the bug.

### Special notes for your reviewer:
One off cleanup, still need operator bug fix for this to not happen again.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
