### PR TITLE
Simple cronjob to fix backplane RBAC

### DIFF
--- a/deploy/backplane/osd-17545/00-OSD-17545.ServiceAccount.yaml
+++ b/deploy/backplane/osd-17545/00-OSD-17545.ServiceAccount.yaml
@@ -1,0 +1,8 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: osd-17545
+  namespace: openshift-sre-pruning
+  annotations:
+    kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545

--- a/deploy/backplane/osd-17545/10-OSD-17545-cluster.ClusterRole.yaml
+++ b/deploy/backplane/osd-17545/10-OSD-17545-cluster.ClusterRole.yaml
@@ -1,0 +1,18 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-17545-cluster
+  namespace: openshift-sre-pruning
+  annotations:
+    kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+rules:
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/backplane/osd-17545/20-OSD-17545.ClusterRoleBinding.yaml
+++ b/deploy/backplane/osd-17545/20-OSD-17545.ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-17545
+subjects:
+- kind: ServiceAccount
+  name: osd-17545
+  namespace: openshift-sre-pruning
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-17545-cluster

--- a/deploy/backplane/osd-17545/30-OSD-17545.CronJob.yaml
+++ b/deploy/backplane/osd-17545/30-OSD-17545.CronJob.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-17545
+  namespace: openshift-sre-pruning
+  annotations:
+    kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  schedule: "*/30 * * * *" # Every thirty minutes
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          name: osd-17545
+          namespace: openshift-sre-pruning
+          annotations:
+            kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          containers:
+          - name: osd-17545
+            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+            imagePullPolicy: Always
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              runAsNonRoot: true
+            command:
+            - /bin/bash
+            args:
+            - -c
+            - |
+              # cleanup rolebindings
+              oc get rolebindings -A | grep -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-lpsre -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-lpsre -e backplane-lpsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-lpsre -e backplane-mcg-osd-cr-admins-system:serviceaccounts:openshift-backplane-mcg -e backplane-mtsre-monitoring-system:serviceaccounts:openshift-backplane-mtsre -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-mtsre -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-mtsre -e backplane-openshift-connectors-cr-admins-system:serviceaccounts:openshift-backplane-mtsre -e backplane-mtsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-mtsre -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-odf -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-odf -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-odf-sre -e backplane-srep-system:serviceaccounts:openshift-backplane-srep | awk '{print "oc -n " $1 " delete rolebinding " $2}' | sh
+
+              # cleanup clusterrolebindings
+              oc delete clusterrolebinding backplane-lpsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-lpsre backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre || true
+
+          serviceAccountName: osd-17545
+          automountServiceAccountToken: true
+          restartPolicy: Never

--- a/deploy/backplane/osd-17545/README.md
+++ b/deploy/backplane/osd-17545/README.md
@@ -1,0 +1,4 @@
+Context: https://issues.redhat.com/browse/OSD-17545
+
+One time thing to run, so once it's in prod and had a chance to run across the fleet the cronjob can be deleted.
+NOTE this is fixing a UX thing, not a material permissions issue.

--- a/deploy/backplane/osd-17545/config.yaml
+++ b/deploy/backplane/osd-17545/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet: 
+  resourceApplyMode: "Sync"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24385,6 +24385,136 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-osd-17545
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: osd-17545
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+    - kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-17545-cluster
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        - rolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-17545
+      subjects:
+      - kind: ServiceAccount
+        name: osd-17545
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-17545-cluster
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-17545
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        schedule: '*/30 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 3600
+            template:
+              metadata:
+                name: osd-17545
+                namespace: openshift-sre-pruning
+                annotations:
+                  kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: osd-17545
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - '# cleanup rolebindings
+
+                    oc get rolebindings -A | grep -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-mcg-osd-cr-admins-system:serviceaccounts:openshift-backplane-mcg
+                    -e backplane-mtsre-monitoring-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-openshift-connectors-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-mtsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-odf
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-odf
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-odf-sre
+                    -e backplane-srep-system:serviceaccounts:openshift-backplane-srep
+                    | awk ''{print "oc -n " $1 " delete rolebinding " $2}'' | sh
+
+
+                    # cleanup clusterrolebindings
+
+                    oc delete clusterrolebinding backplane-lpsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-lpsre
+                    backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre
+                    || true
+
+                    '
+                serviceAccountName: osd-17545
+                automountServiceAccountToken: true
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-sdcicd
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24385,6 +24385,136 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-osd-17545
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: osd-17545
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+    - kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-17545-cluster
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        - rolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-17545
+      subjects:
+      - kind: ServiceAccount
+        name: osd-17545
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-17545-cluster
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-17545
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        schedule: '*/30 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 3600
+            template:
+              metadata:
+                name: osd-17545
+                namespace: openshift-sre-pruning
+                annotations:
+                  kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: osd-17545
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - '# cleanup rolebindings
+
+                    oc get rolebindings -A | grep -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-mcg-osd-cr-admins-system:serviceaccounts:openshift-backplane-mcg
+                    -e backplane-mtsre-monitoring-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-openshift-connectors-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-mtsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-odf
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-odf
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-odf-sre
+                    -e backplane-srep-system:serviceaccounts:openshift-backplane-srep
+                    | awk ''{print "oc -n " $1 " delete rolebinding " $2}'' | sh
+
+
+                    # cleanup clusterrolebindings
+
+                    oc delete clusterrolebinding backplane-lpsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-lpsre
+                    backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre
+                    || true
+
+                    '
+                serviceAccountName: osd-17545
+                automountServiceAccountToken: true
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-sdcicd
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24385,6 +24385,136 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-osd-17545
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: osd-17545
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+    - kind: ClusterRole
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-17545-cluster
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterrolebindings
+        - rolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-17545
+      subjects:
+      - kind: ServiceAccount
+        name: osd-17545
+        namespace: openshift-sre-pruning
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-17545-cluster
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-17545
+        namespace: openshift-sre-pruning
+        annotations:
+          kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        schedule: '*/30 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            backoffLimit: 0
+            ttlSecondsAfterFinished: 3600
+            template:
+              metadata:
+                name: osd-17545
+                namespace: openshift-sre-pruning
+                annotations:
+                  kubernetes.io/description: Mitigate https://issues.redhat.com/browse/OSD-17545
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: osd-17545
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - '# cleanup rolebindings
+
+                    oc get rolebindings -A | grep -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-lpsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-lpsre
+                    -e backplane-mcg-osd-cr-admins-system:serviceaccounts:openshift-backplane-mcg
+                    -e backplane-mtsre-monitoring-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-openshift-connectors-cr-admins-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-mtsre-addon-operator-olm-admin-system:serviceaccounts:openshift-backplane-mtsre
+                    -e backplane-ocs-consumer-cr-admins-system:serviceaccounts:openshift-backplane-odf
+                    -e backplane-ocs-provider-cr-admins-system:serviceaccounts:openshift-backplane-odf
+                    -e backplane-lpsre-monitoring-system:serviceaccounts:openshift-backplane-odf-sre
+                    -e backplane-srep-system:serviceaccounts:openshift-backplane-srep
+                    | awk ''{print "oc -n " $1 " delete rolebinding " $2}'' | sh
+
+
+                    # cleanup clusterrolebindings
+
+                    oc delete clusterrolebinding backplane-lpsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-lpsre
+                    backplane-mtsre-addon-operator-admin-system:serviceaccounts:openshift-backplane-mtsre
+                    || true
+
+                    '
+                serviceAccountName: osd-17545
+                automountServiceAccountToken: true
+                restartPolicy: Never
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-sdcicd
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Several things were renamed recently
(https://issues.redhat.com/browse/OSD-17458) and the rbac permissions operator doesn't cleanup (https://issues.redhat.com/browse/OSD-17531).  This cronjob is a one-off cleanup for those, tracked in https://issues.redhat.com/browse/OSD-17545


### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-17545


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
