### PR TITLE
SRE-P permissions to manage Dynatrace / Otel resources

### DIFF
--- a/deploy/backplane/srep/dynatrace/10-srep-dynatrace.Role.yml
+++ b/deploy/backplane/srep/dynatrace/10-srep-dynatrace.Role.yml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-srep-dynatrace
+  namespace: dynatrace
+rules:
+# can view dynakubes
+- apiGroups:
+  - dynatrace.com
+  resources:
+  - dynakubes
+  verbs:
+  - list
+  - get
+### END

--- a/deploy/backplane/srep/dynatrace/10-srep-dynatrace.Role.yml
+++ b/deploy/backplane/srep/dynatrace/10-srep-dynatrace.Role.yml
@@ -12,4 +12,5 @@ rules:
   verbs:
   - list
   - get
+  - watch
 ### END

--- a/deploy/backplane/srep/dynatrace/10-srep-opentelemetry.Role.yml
+++ b/deploy/backplane/srep/dynatrace/10-srep-opentelemetry.Role.yml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-srep-opentelemetry
+  namespace: openshift-opentelemetry-operator
+rules:
+# can view opentelemetry collectors
+- apiGroups:
+  - opentelemetry.io
+  resources:
+  - opentelemetrycollectors
+  verbs:
+  - list
+  - get
+  - watch
+### END

--- a/deploy/backplane/srep/dynatrace/10-srep-opentelemetry.Role.yml
+++ b/deploy/backplane/srep/dynatrace/10-srep-opentelemetry.Role.yml
@@ -9,6 +9,7 @@ rules:
   - opentelemetry.io
   resources:
   - opentelemetrycollectors
+  - instrumentations
   verbs:
   - list
   - get

--- a/deploy/backplane/srep/dynatrace/20-srep-dynatrace.RoleBinding.yml
+++ b/deploy/backplane/srep/dynatrace/20-srep-dynatrace.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-srep-dynatrace
+  namespace: dynatrace
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-srep-dynatrace

--- a/deploy/backplane/srep/dynatrace/20-srep-opentelemetry.RoleBinding.yml
+++ b/deploy/backplane/srep/dynatrace/20-srep-opentelemetry.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-srep-opentelemetry
+  namespace: openshift-opentelemetry-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-srep-opentelemetry

--- a/deploy/backplane/srep/dynatrace/config.yaml
+++ b/deploy/backplane/srep/dynatrace/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster","service-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25078,6 +25078,7 @@ objects:
         - opentelemetry.io
         resources:
         - opentelemetrycollectors
+        - instrumentations
         verbs:
         - list
         - get

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25037,6 +25037,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-dynatrace
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-dynatrace
+        namespace: dynatrace
+      rules:
+      - apiGroups:
+        - dynatrace.com
+        resources:
+        - dynakubes
+        verbs:
+        - list
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-opentelemetry
+        namespace: openshift-opentelemetry-operator
+      rules:
+      - apiGroups:
+        - opentelemetry.io
+        resources:
+        - opentelemetrycollectors
+        verbs:
+        - list
+        - get
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-dynatrace
+        namespace: dynatrace
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-dynatrace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-opentelemetry
+        namespace: openshift-opentelemetry-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-opentelemetry
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-srep-hive
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25067,6 +25067,7 @@ objects:
         verbs:
         - list
         - get
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25078,6 +25078,7 @@ objects:
         - opentelemetry.io
         resources:
         - opentelemetrycollectors
+        - instrumentations
         verbs:
         - list
         - get

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25037,6 +25037,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-dynatrace
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-dynatrace
+        namespace: dynatrace
+      rules:
+      - apiGroups:
+        - dynatrace.com
+        resources:
+        - dynakubes
+        verbs:
+        - list
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-opentelemetry
+        namespace: openshift-opentelemetry-operator
+      rules:
+      - apiGroups:
+        - opentelemetry.io
+        resources:
+        - opentelemetrycollectors
+        verbs:
+        - list
+        - get
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-dynatrace
+        namespace: dynatrace
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-dynatrace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-opentelemetry
+        namespace: openshift-opentelemetry-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-opentelemetry
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-srep-hive
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25067,6 +25067,7 @@ objects:
         verbs:
         - list
         - get
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25078,6 +25078,7 @@ objects:
         - opentelemetry.io
         resources:
         - opentelemetrycollectors
+        - instrumentations
         verbs:
         - list
         - get

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25037,6 +25037,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-srep-dynatrace
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-dynatrace
+        namespace: dynatrace
+      rules:
+      - apiGroups:
+        - dynatrace.com
+        resources:
+        - dynakubes
+        verbs:
+        - list
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-opentelemetry
+        namespace: openshift-opentelemetry-operator
+      rules:
+      - apiGroups:
+        - opentelemetry.io
+        resources:
+        - opentelemetrycollectors
+        verbs:
+        - list
+        - get
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-dynatrace
+        namespace: dynatrace
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-dynatrace
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-opentelemetry
+        namespace: openshift-opentelemetry-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-opentelemetry
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-srep-hive
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25067,6 +25067,7 @@ objects:
         verbs:
         - list
         - get
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Allows members of the SRE-P group to monitor Dynatrace and OpenTelemetry related resources on HyperShift Management/Service clusters without elevation.

- get/list/watch on `dynakubes`
- get/list/watch on `opentelemetrycollectors`

These permissions are tightly bound to specific namespaces so are not needed to be ClusterRoles and/or managed by rbac-permissions-operator.

### Which Jira/Github issue(s) this PR fixes?

[OSD-17552](https://issues.redhat.com//browse/OSD-17552)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
