### PR TITLE
Add a new policy for the shared VPC flow

### DIFF
--- a/resources/sts/4.12/shared_vpc_openshift_ingress_operator_cloud_credentials_policy.json
+++ b/resources/sts/4.12/shared_vpc_openshift_ingress_operator_cloud_credentials_policy.json
@@ -1,0 +1,36 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Condition": {
+                "ForAllValues:StringLike": {
+                    "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+                        "*.devshift.org",
+                        "*.devshiftusgov.com",
+                        "*.openshiftapps.com",
+                        "*.openshiftusgov.com"
+                    ]
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "route53:ListHostedZones",
+                "tag:GetResources"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "%{shared_vpc_role_arn}"
+        }
+    ]
+}

--- a/resources/sts/4.13/shared_vpc_openshift_ingress_operator_cloud_credentials_policy.json
+++ b/resources/sts/4.13/shared_vpc_openshift_ingress_operator_cloud_credentials_policy.json
@@ -1,0 +1,36 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Condition": {
+                "ForAllValues:StringLike": {
+                    "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+                        "*.devshift.org",
+                        "*.devshiftusgov.com",
+                        "*.openshiftapps.com",
+                        "*.openshiftusgov.com"
+                    ]
+                }
+            },
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "route53:ListHostedZones",
+                "tag:GetResources"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "%{shared_vpc_role_arn}"
+        }
+    ]
+}


### PR DESCRIPTION
The new policy will be attached to the `openshift-ingress-operator-cloud-credentials` role.

1. Adding assume role permission.
2. Setting a resource with a specific role ARN.
3. Creating the new file with `shared_vpc` prefix for the ROSA CLI to differntiate the flows.

### What type of PR is this?
feature

### What this PR does / why we need it?
Enable the shared VPC flow, grant access to the operator role in account A.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OCM-2861

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP)

