### PR TITLE
[OSD-17129] Addition of self-managed ACS namespace prefix regex for cee backplane access

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -86,6 +86,7 @@ spec:
                         - openshift-*
                         - default
                         - redhat-*
+                        - rhacs-*
                 object-templates:
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave

--- a/deploy/backplane/cee/40-cee.SubjectPermission.yml
+++ b/deploy/backplane/cee/40-cee.SubjectPermission.yml
@@ -9,7 +9,7 @@ spec:
   - backplane-readers-cluster
   permissions:
   - clusterRoleName: dedicated-readers
-    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhacs-.*)"
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-cee

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -712,6 +712,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhacs-*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -7515,7 +7516,7 @@ objects:
         - backplane-readers-cluster
         permissions:
         - clusterRoleName: dedicated-readers
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-cee

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -712,6 +712,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhacs-*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -7515,7 +7516,7 @@ objects:
         - backplane-readers-cluster
         permissions:
         - clusterRoleName: dedicated-readers
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-cee

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -712,6 +712,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhacs-*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -7515,7 +7516,7 @@ objects:
         - backplane-readers-cluster
         permissions:
         - clusterRoleName: dedicated-readers
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-cee


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
The goal of this PR is to add the Self-managed ACS tenant's namespace prefix to the list of Red Hat owned namespaces in order to grant permission for read-only access for MCS support.

### Which Jira/Github issue(s) this PR fixes?
[OSD-17129](https://issues.redhat.com/browse/OSD-17129)

_Fixes #_

This commit now includes generated files from `make`.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
