### PR TITLE
switch suricata base image from fedora to UBI

### DIFF
--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:f20d62e34c37b4761d5625594a5adf1c62bc44452e74d31d989a1cbd13c01962
+        image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34501,7 +34501,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:f20d62e34c37b4761d5625594a5adf1c62bc44452e74d31d989a1cbd13c01962
+              image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34501,7 +34501,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:f20d62e34c37b4761d5625594a5adf1c62bc44452e74d31d989a1cbd13c01962
+              image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34501,7 +34501,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:f20d62e34c37b4761d5625594a5adf1c62bc44452e74d31d989a1cbd13c01962
+              image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:


### PR DESCRIPTION
### What type of PR is this?
refactor

### What this PR does / why we need it?
Changes the base image of suricata from Fedora to RHEL UBI

### Which Jira/Github issue(s) this PR fixes?
_Fixes #_OSD-17546

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
