### PR TITLE
Allow dedicated-admins to create/modify/delete ICSP objects

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -400,6 +400,31 @@ spec:
                               verbs:
                                 - patch
                                 - update
+                            - apiGroups:
+                                - operator.openshift.io
+                              resources:
+                                - imagecontentsourcepolicies
+                              verbs:
+                                - create
+                                - delete
+                                - patch
+                                - update
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - imagedigestmirrorsets
+                                - imagetagmirrorsets
+                              verbs:
+                                - create
+                                - delete
+                                - patch
+                                - update
+                                - get
+                                - list
+                                - watch
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml
@@ -335,3 +335,32 @@ rules:
   - patch
   - update
 ### END
+### Start - allow dedicated admin to modify ICSP/IDMS/ITMS objects
+# https://issues.redhat.com/browse/OSD-17561
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - imagecontentsourcepolicies
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - imagedigestmirrorsets
+  - imagetagmirrorsets
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
+  - get
+  - list
+  - watch
+### END
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6347,6 +6347,31 @@ objects:
                     verbs:
                     - patch
                     - update
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - imagecontentsourcepolicies
+                    verbs:
+                    - create
+                    - delete
+                    - patch
+                    - update
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - imagedigestmirrorsets
+                    - imagetagmirrorsets
+                    verbs:
+                    - create
+                    - delete
+                    - patch
+                    - update
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -35154,6 +35179,31 @@ objects:
         verbs:
         - patch
         - update
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - imagecontentsourcepolicies
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - imagedigestmirrorsets
+        - imagetagmirrorsets
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6347,6 +6347,31 @@ objects:
                     verbs:
                     - patch
                     - update
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - imagecontentsourcepolicies
+                    verbs:
+                    - create
+                    - delete
+                    - patch
+                    - update
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - imagedigestmirrorsets
+                    - imagetagmirrorsets
+                    verbs:
+                    - create
+                    - delete
+                    - patch
+                    - update
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -35154,6 +35179,31 @@ objects:
         verbs:
         - patch
         - update
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - imagecontentsourcepolicies
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - imagedigestmirrorsets
+        - imagetagmirrorsets
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6347,6 +6347,31 @@ objects:
                     verbs:
                     - patch
                     - update
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - imagecontentsourcepolicies
+                    verbs:
+                    - create
+                    - delete
+                    - patch
+                    - update
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - imagedigestmirrorsets
+                    - imagetagmirrorsets
+                    verbs:
+                    - create
+                    - delete
+                    - patch
+                    - update
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -35154,6 +35179,31 @@ objects:
         verbs:
         - patch
         - update
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - imagecontentsourcepolicies
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - imagedigestmirrorsets
+        - imagetagmirrorsets
+        verbs:
+        - create
+        - delete
+        - patch
+        - update
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Adds needed RBAC to allow dedicated-admins to manage ICSP/ITMS/IDMS objects

### Which Jira/Github issue(s) this PR fixes?
fixes [OSD-17561](https://issues.redhat.com//browse/OSD-17561)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
