### PR TITLE
Update make GH action to include generated ACM policies

### DIFF
--- a/.github/workflows/makecommit.yml
+++ b/.github/workflows/makecommit.yml
@@ -19,4 +19,4 @@ jobs:
       uses: EndBug/add-and-commit@v9
       with:
         message: "on push: make"
-        add: "hack/00-osd-managed-cluster-config*.yaml.tmpl"
+        add: "hack/00-osd-managed-cluster-config*.yaml.tmpl deploy/acm-policies/50-GENERATED-*.yaml"


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Auto generated makes from the github action were not catching the generated ACM policies. This fixes that.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
