### PR TITLE
Allow CEE/CSM/MOBB/SREP/TAM to create secrets in pcap-collector-creds namespace

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -145,8 +145,13 @@ spec:
                               resources:
                                 - secrets
                               verbs:
-                                - create
                                 - delete
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -114,8 +114,13 @@ spec:
                               resources:
                                 - secrets
                               verbs:
-                                - create
                                 - delete
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -114,8 +114,13 @@ spec:
                               resources:
                                 - secrets
                               verbs:
-                                - create
                                 - delete
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -404,8 +404,13 @@ spec:
                               resources:
                                 - secrets
                               verbs:
-                                - create
                                 - delete
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -114,8 +114,13 @@ spec:
                               resources:
                                 - secrets
                               verbs:
-                                - create
                                 - delete
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - create
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/cee/30-cee-pcap-collector.Role.yml
+++ b/deploy/backplane/cee/30-cee-pcap-collector.Role.yml
@@ -6,13 +6,18 @@ metadata:
 rules:
 # can create cred secret for mustgathers
 # Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
-- verbs:
-    - "create"
-    - "delete"
-  apiGroups:
-    - ""
-  resources:
-    - "secrets"
+- apiGroups:
+  - ""
   resourceNames:
-    - "pcap-collector-creds"
+  - pcap-collector-creds
+  resources:
+  - secrets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 ### END

--- a/deploy/backplane/csm/30-csm-pcap-collector.Role.yml
+++ b/deploy/backplane/csm/30-csm-pcap-collector.Role.yml
@@ -6,13 +6,18 @@ metadata:
 rules:
 # can create cred secret for mustgathers
 # Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
-- verbs:
-    - "create"
-    - "delete"
-  apiGroups:
-    - ""
-  resources:
-    - "secrets"
+- apiGroups:
+  - ""
   resourceNames:
-    - "pcap-collector-creds"
+  - pcap-collector-creds
+  resources:
+  - secrets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 ### END

--- a/deploy/backplane/mobb/30-mobb-pcap-collector.Role.yml
+++ b/deploy/backplane/mobb/30-mobb-pcap-collector.Role.yml
@@ -6,13 +6,18 @@ metadata:
 rules:
 # can create cred secret for mustgathers
 # Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
-- verbs:
-    - "create"
-    - "delete"
-  apiGroups:
-    - ""
-  resources:
-    - "secrets"
+- apiGroups:
+  - ""
   resourceNames:
-    - "pcap-collector-creds"
+  - pcap-collector-creds
+  resources:
+  - secrets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 ### END

--- a/deploy/backplane/srep/30-cee-pcap-collector.Role.yml
+++ b/deploy/backplane/srep/30-cee-pcap-collector.Role.yml
@@ -6,13 +6,18 @@ metadata:
 rules:
 # can create cred secret for mustgathers
 # Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
-- verbs:
-    - "create"
-    - "delete"
-  apiGroups:
-    - ""
-  resources:
-    - "secrets"
+- apiGroups:
+  - ""
   resourceNames:
-    - "pcap-collector-creds"
+  - pcap-collector-creds
+  resources:
+  - secrets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 ### END

--- a/deploy/backplane/tam/30-tam-pcap-collector.Role.yml
+++ b/deploy/backplane/tam/30-tam-pcap-collector.Role.yml
@@ -6,13 +6,18 @@ metadata:
 rules:
 # can create cred secret for mustgathers
 # Enables https://github.com/openshift/managed-scripts/blob/main/scripts/CEE/pcap-collector/metadata.yaml, which requires users to be able to create/get/delete the pcap-collector-creds secret in the managed scripts ns
-- verbs:
-    - "create"
-    - "delete"
-  apiGroups:
-    - ""
-  resources:
-    - "secrets"
+- apiGroups:
+  - ""
   resourceNames:
-    - "pcap-collector-creds"
+  - pcap-collector-creds
+  resources:
+  - secrets
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
 ### END

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -902,8 +902,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -1354,8 +1359,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2033,8 +2043,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2653,8 +2668,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2945,8 +2965,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -7495,15 +7520,20 @@ objects:
         name: backplane-cee-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7879,15 +7909,20 @@ objects:
         name: backplane-csm-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -20336,15 +20371,20 @@ objects:
         name: backplane-mobb-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -25008,15 +25048,20 @@ objects:
         name: backplane-srep-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
@@ -25512,15 +25557,20 @@ objects:
         name: backplane-tam-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -902,8 +902,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -1354,8 +1359,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2033,8 +2043,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2653,8 +2668,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2945,8 +2965,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -7495,15 +7520,20 @@ objects:
         name: backplane-cee-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7879,15 +7909,20 @@ objects:
         name: backplane-csm-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -20336,15 +20371,20 @@ objects:
         name: backplane-mobb-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -25008,15 +25048,20 @@ objects:
         name: backplane-srep-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
@@ -25512,15 +25557,20 @@ objects:
         name: backplane-tam-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -902,8 +902,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -1354,8 +1359,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2033,8 +2043,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2653,8 +2668,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -2945,8 +2965,13 @@ objects:
                     resources:
                     - secrets
                     verbs:
-                    - create
                     - delete
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - create
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -7495,15 +7520,20 @@ objects:
         name: backplane-cee-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -7879,15 +7909,20 @@ objects:
         name: backplane-csm-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -20336,15 +20371,20 @@ objects:
         name: backplane-mobb-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:
@@ -25008,15 +25048,20 @@ objects:
         name: backplane-srep-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
@@ -25512,15 +25557,20 @@ objects:
         name: backplane-tam-pcap-collector
         namespace: openshift-backplane-managed-scripts
       rules:
-      - verbs:
-        - create
+      - apiGroups:
+        - ''
+        resourceNames:
+        - pcap-collector-creds
+        resources:
+        - secrets
+        verbs:
         - delete
-        apiGroups:
+      - apiGroups:
         - ''
         resources:
         - secrets
-        resourceNames:
-        - pcap-collector-creds
+        verbs:
+        - create
     - apiVersion: managed.openshift.io/v1alpha1
       kind: SubjectPermission
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Allow CEE/CSM/MOBB/SREP/TAM to create secrets in pcap-collector-creds namespace, so that they can run the [pcap-collector](https://github.com/openshift/managed-scripts/tree/main/scripts/CEE/pcap-collector) managed script. 
Due to [a limitation in kubernetes](https://github.com/kubernetes/kubernetes/issues/80295), we are not able to restrict the 'create' action to specific resources in a namespace through RBAC. This pull request fixes that limitation, and allows CEE/CSM/MOBB/SREP/TAM to create any secret in the `openshift-backplane-managed-scripts` namespace, similar to how the [must gather operator](https://github.com/openshift/must-gather-operator) works.  
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-17122

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- Test here: https://gitlab.cee.redhat.com/-/snippets/6950
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
