### PR TITLE
Deploy api-ErrorBudgetBurn clusterurlmonitor to hcp workers

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hs-hosted-route-monitor-operator.Policy.yaml
@@ -25,6 +25,21 @@ spec:
                       metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: monitoring.openshift.io/v1alpha1
+                        kind: ClusterUrlMonitor
+                        metadata:
+                            name: api
+                            namespace: openshift-route-monitor-operator
+                        spec:
+                            port: "443"
+                            prefix: https://api.
+                            skipPrometheusRule: true
+                            slo:
+                                targetAvailabilityPercent: "99.0"
+                            suffix: /livez
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: monitoring.openshift.io/v1alpha1
                         kind: RouteMonitor
                         metadata:
                             annotations: null

--- a/deploy/hs-hosted-route-monitor-operator/api.ClusterURLMonitor.yaml
+++ b/deploy/hs-hosted-route-monitor-operator/api.ClusterURLMonitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: ClusterUrlMonitor
+metadata:
+  name: api
+  namespace: openshift-route-monitor-operator
+spec:
+  prefix: https://api.
+  port: "443"
+  suffix: /livez
+  slo:
+    targetAvailabilityPercent: "99.0"
+  skipPrometheusRule: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3494,6 +3494,21 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: ClusterUrlMonitor
+                  metadata:
+                    name: api
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    port: '443'
+                    prefix: https://api.
+                    skipPrometheusRule: true
+                    slo:
+                      targetAvailabilityPercent: '99.0'
+                    suffix: /livez
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
                   kind: RouteMonitor
                   metadata:
                     annotations: null

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3494,6 +3494,21 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: ClusterUrlMonitor
+                  metadata:
+                    name: api
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    port: '443'
+                    prefix: https://api.
+                    skipPrometheusRule: true
+                    slo:
+                      targetAvailabilityPercent: '99.0'
+                    suffix: /livez
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
                   kind: RouteMonitor
                   metadata:
                     annotations: null

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3494,6 +3494,21 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: monitoring.openshift.io/v1alpha1
+                  kind: ClusterUrlMonitor
+                  metadata:
+                    name: api
+                    namespace: openshift-route-monitor-operator
+                  spec:
+                    port: '443'
+                    prefix: https://api.
+                    skipPrometheusRule: true
+                    slo:
+                      targetAvailabilityPercent: '99.0'
+                    suffix: /livez
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: monitoring.openshift.io/v1alpha1
                   kind: RouteMonitor
                   metadata:
                     annotations: null


### PR DESCRIPTION
### What this PR does / why we need it?
We cannot measure api-ErrorBudgetBurn using RMO from the management clusters, so for now it must be deployed to the HCP workers

Depends on https://github.com/openshift/route-monitor-operator/pull/223 to be merged first

### Which Jira/Github issue(s) this PR fixes?

[OSD-16950](https://issues.redhat.com//browse/OSD-16950)