### PR TITLE
[OCM-1016] Update HCP installer role permission policy

### DIFF
--- a/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.12/hypershift/sts_hcp_installer_permission_policy.json
@@ -20,6 +20,7 @@
                 "ec2:DescribeInstanceTypeOfferings",
                 "elasticloadbalancing:DescribeAccountLimits",
                 "elasticloadbalancing:DescribeLoadBalancers",
+                "iam:GetOpenIDConnectProvider",
                 "iam:GetRole",
                 "route53:ListHostedZones",
                 "route53:ListResourceRecordSets",

--- a/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.13/hypershift/sts_hcp_installer_permission_policy.json
@@ -20,6 +20,7 @@
                 "ec2:DescribeInstanceTypeOfferings",
                 "elasticloadbalancing:DescribeAccountLimits",
                 "elasticloadbalancing:DescribeLoadBalancers",
+                "iam:GetOpenIDConnectProvider",
                 "iam:GetRole",
                 "route53:ListHostedZones",
                 "route53:ListResourceRecordSets",


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
When a user tries to configure "audit log forwarding" on their HCP clusters, it requires the user to create the audit log forwarding role. Some of the prerequisites include the setup of trust policy, permissions policy (based on documentation: https://access.redhat.com/solutions/7002219) as well as having an OIDC provider.

This change allows OCM (Clusters Service) to assume role into the user's installer role and run validation on whether the user properly set up the needed OIDC provider.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OCM-1016

### Special notes for your reviewer:
We are only adding the "iam:GetOpenIDConnectProvider" permission to HCP cluster installer roles at the moment, since "Cloudwatch audit log forwarding" feature is currently available for HCP clusters ONLY.

NOTE: changes here need to be requested and made to AWS managed policy as well (ROSA HCP installer role)

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
