### PR TITLE
Ignoring resize alerts for upgrade

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -51,6 +51,7 @@ data:
       - ThanosNoRuleEvaluations
       # OSD-13649
       - etcdGRPCRequestsSlow
+      # OHSS-24871
       - MasterNodesNeedResizingSRE
       - InfraNodesNeedResizingSRE
       ignoredNamespaces:

--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -51,6 +51,8 @@ data:
       - ThanosNoRuleEvaluations
       # OSD-13649
       - etcdGRPCRequestsSlow
+      - MasterNodesNeedResizingSRE
+      - InfraNodesNeedResizingSRE
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27044,7 +27044,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MasterNodesNeedResizingSRE\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
           \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27044,7 +27044,8 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MasterNodesNeedResizingSRE\n\
+          \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27044,7 +27044,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MasterNodesNeedResizingSRE\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
           \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27044,7 +27044,8 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MasterNodesNeedResizingSRE\n\
+          \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27044,7 +27044,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MasterNodesNeedResizingSRE\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
           \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27044,7 +27044,8 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MasterNodesNeedResizingSRE\n\
+          \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
           \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
           \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?
The *NeedResizing alerts are based on node count only, and as such, are requiring check and are most of the time silenced (as the cluster CPU/Mem consumption on masters do not require a scale up). As a consequence, managed-upgrade-operator should ignore those alerts are we are expecting those to remain 'Firing' in valid cases. 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OHSS-24871

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
