### PR TITLE
Fix bug where runAsNonRoot specified without runAsUser/Group

### DIFF
--- a/deploy/backplane/osd-17545/30-OSD-17545.CronJob.yaml
+++ b/deploy/backplane/osd-17545/30-OSD-17545.CronJob.yaml
@@ -43,7 +43,6 @@ spec:
               capabilities:
                 drop:
                 - ALL
-              runAsNonRoot: true
             command:
             - /bin/bash
             args:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24544,7 +24544,6 @@ objects:
                     capabilities:
                       drop:
                       - ALL
-                    runAsNonRoot: true
                   command:
                   - /bin/bash
                   args:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24544,7 +24544,6 @@ objects:
                     capabilities:
                       drop:
                       - ALL
-                    runAsNonRoot: true
                   command:
                   - /bin/bash
                   args:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24544,7 +24544,6 @@ objects:
                     capabilities:
                       drop:
                       - ALL
-                    runAsNonRoot: true
                   command:
                   - /bin/bash
                   args:


### PR DESCRIPTION
### What this PR does / why we need it?
The CronJob is currently running into:

```
container has runAsNonRoot and image will run as root (pod: "osd-17545-28170390-682f7_openshift-sre-pruning(19980675-bb02-48a8-a142-427b0671d8b3)", container: osd-17545)
```

### Which Jira/Github issue(s) this PR fixes?
[OSD-17545](https://issues.redhat.com//browse/OSD-17545)