### PR TITLE
Change deployment of EBS related alerts to only non-CCS clusters

### DIFF
--- a/deploy/sre-prometheus/aws/config.yaml
+++ b/deploy/sre-prometheus/aws/config.yaml
@@ -2,3 +2,7 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchLabels:
       hive.openshift.io/cluster-platform: aws
+  matchExpressions:
+    - key: api.openshift.com/ccs
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37785,6 +37785,11 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         hive.openshift.io/cluster-platform: aws
+      matchExpressions:
+      - key: api.openshift.com/ccs
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37785,6 +37785,11 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         hive.openshift.io/cluster-platform: aws
+      matchExpressions:
+      - key: api.openshift.com/ccs
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37785,6 +37785,11 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         hive.openshift.io/cluster-platform: aws
+      matchExpressions:
+      - key: api.openshift.com/ccs
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
### What type of PR is this?
Change

### What this PR does / why we need it?
Changes EBS volume related alerts to only fire on non-CCS clusters. 
The EbsVolumeStuckAttaching10MinSRE alert usually resolves itself shortly after firing. The SOP itself can be simplified to "Check to see what namespace the volume is. If it's not a managed namespace, ignore the alert"

Additionally, the only EBS volumes that the core platform uses in AWS Managed OpenShift products are the prometheus and alertmanager volumes. If either of these two volumes get stuck attaching, this would present as a ClusterOperatorDown, alerting us to the issue, thus making this alert redundant. 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-16627

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
