### PR TITLE
Don't include remoteWrite for non-uwm CMO config

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
@@ -7,22 +7,6 @@ data:
   config.yaml: |
     enableUserWorkload: false
     prometheusK8s:
-      remoteWrite:
-      - url: http://token-refresher.openshift-monitoring.svc.cluster.local
-        remoteTimeout: 30s
-        writeRelabelConfigs:
-        - sourceLabels:
-          - __name__
-          action: keep
-          regex: (addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)
-        queueConfig:
-          capacity: 2500
-          maxShards: 1000
-          minShards: 1
-          maxSamplesPerSend: 500
-          batchSendDeadline: 60s
-          minBackoff: 30ms
-          maxBackoff: 5s
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26250,26 +26250,21 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
-          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)\n\
-          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
-          \ 1\n      maxSamplesPerSend: 500\n      batchSendDeadline: 60s\n      minBackoff:\
-          \ 30ms\n      maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
+          \ 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n    metadata:\n  \
+          \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
+          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
+          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -26305,26 +26300,21 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
-          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)\n\
-          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
-          \ 1\n      maxSamplesPerSend: 500\n      batchSendDeadline: 60s\n      minBackoff:\
-          \ 30ms\n      maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
+          \ 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n    metadata:\n  \
+          \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
+          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
+          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26250,26 +26250,21 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
-          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)\n\
-          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
-          \ 1\n      maxSamplesPerSend: 500\n      batchSendDeadline: 60s\n      minBackoff:\
-          \ 30ms\n      maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
+          \ 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n    metadata:\n  \
+          \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
+          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
+          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -26305,26 +26300,21 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
-          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)\n\
-          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
-          \ 1\n      maxSamplesPerSend: 500\n      batchSendDeadline: 60s\n      minBackoff:\
-          \ 30ms\n      maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
+          \ 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n    metadata:\n  \
+          \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
+          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
+          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26250,26 +26250,21 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
-          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)\n\
-          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
-          \ 1\n      maxSamplesPerSend: 500\n      batchSendDeadline: 60s\n      minBackoff:\
-          \ 30ms\n      maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
+          \ 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n    metadata:\n  \
+          \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
+          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
+          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -26305,26 +26300,21 @@ objects:
         name: cluster-monitoring-config
         namespace: openshift-monitoring
       data:
-        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
-          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
-          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo)\n\
-          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
-          \ 1\n      maxSamplesPerSend: 500\n      batchSendDeadline: 60s\n      minBackoff:\
-          \ 30ms\n      maxBackoff: 5s\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
-          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
-          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
-          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
-          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
-          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  retention:\
+          \ 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n    metadata:\n  \
+          \    name: prometheus-data\n    spec:\n      resources:\n        requests:\n\
+          \          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\n  volumeClaimTemplate:\n    metadata:\n      name:\
+          \ alertmanager-data\n    spec:\n      resources:\n        requests:\n  \
+          \        storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
+          \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
+          \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
+          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/scripts/generate-cmo-config.py
+++ b/scripts/generate-cmo-config.py
@@ -19,6 +19,10 @@ def dump_configmap(configmap_path, enableUserWorkload):
     with open(input_file_path,'r') as input_file:
         config = yaml.safe_load(input_file)
         config["enableUserWorkload"] = enableUserWorkload
+        if not enableUserWorkload and "prometheusK8s" in config and "remoteWrite" in config["prometheusK8s"]:
+           # not remoteWrite when UWM is disabled
+           del config["prometheusK8s"]["remoteWrite"]
+           
         cmo_config = {
             "apiVersion": "v1",
             "kind": "ConfigMap",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Fixes generation of CMO config for "non-uwm".  It is now consistent with the config that previously existed, does not include remoteWrite.

### Which Jira/Github issue(s) this PR fixes?
N/A

### Special notes for your reviewer:
Untested as of yet...

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
