### PR TITLE
Add version 4.13 clause to custom domains

### DIFF
--- a/deploy/osd-custom-domains/config.yaml
+++ b/deploy/osd-custom-domains/config.yaml
@@ -5,3 +5,6 @@ selectorSyncSet:
   - key: ext-managed.openshift.io/legacy-ingress-support
     operator: NotIn
     values: ["false"]
+  - key: hive.openshift.io/version-major-minor
+    operator: NotIn
+    values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"]

--- a/deploy/osd-rebalance-infra-nodes/legacy-ingress/config.yaml
+++ b/deploy/osd-rebalance-infra-nodes/legacy-ingress/config.yaml
@@ -5,3 +5,6 @@ selectorSyncSet:
   - key: ext-managed.openshift.io/legacy-ingress-support
     operator: NotIn
     values: ["false"]
+  - key: hive.openshift.io/version-major-minor
+    operator: NotIn
+    values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"]

--- a/deploy/osd-serviceaccounts/aws/config.yaml
+++ b/deploy/osd-serviceaccounts/aws/config.yaml
@@ -10,4 +10,7 @@ selectorSyncSet:
     - key: ext-managed.openshift.io/legacy-ingress-support
       operator: NotIn
       values: ["false"]
+    - key: hive.openshift.io/version-major-minor
+      operator: NotIn
+      values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"]
     resourceApplyMode: Upsert

--- a/deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
+++ b/deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
@@ -5,3 +5,6 @@ selectorSyncSet:
   - key: ext-managed.openshift.io/legacy-ingress-support
     operator: NotIn
     values: ["false"]
+  - key: hive.openshift.io/version-major-minor
+    operator: NotIn
+    values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30600,6 +30600,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -33439,6 +33450,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - kind: RoleBinding
@@ -34332,6 +34354,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -38606,6 +38639,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30600,6 +30600,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -33439,6 +33450,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - kind: RoleBinding
@@ -34332,6 +34354,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -38606,6 +38639,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30600,6 +30600,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -33439,6 +33450,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - kind: RoleBinding
@@ -34332,6 +34354,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -38606,6 +38639,17 @@ objects:
         operator: NotIn
         values:
         - 'false'
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
- If cluster is <4.13, or has legacy-ingress-support, deploy custom domains operator.

### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-17640

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
