### PR TITLE
OSD-17664 adding a temporary CronJob to force MGO Subscription and CSV recreation.

### DIFF
--- a/deploy/osd-17664-reinstall-mgo/README.md
+++ b/deploy/osd-17664-reinstall-mgo/README.md
@@ -1,0 +1,7 @@
+
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OSD-17664
+
+Once clusters no longer report the issue it should be reverted.

--- a/deploy/osd-17664-reinstall-mgo/config.yaml
+++ b/deploy/osd-17664-reinstall-mgo/config.yaml
@@ -1,0 +1,12 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11","4.12","4.13","4.14"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]
+

--- a/deploy/osd-17664-reinstall-mgo/osd17664.CronJob.yaml
+++ b/deploy/osd-17664-reinstall-mgo/osd17664.CronJob.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-must-gather-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-must-gather-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-must-gather-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-must-gather-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-must-gather-operator
+              # unconditionally remove the Subscription, CSV and installplan, the Subscription will be recreated by the must-gather-operator SelectorSyncSet, CSV by the Subscription, and any installplans by the CSV
+              oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator -o name | xargs oc delete -n "$NAMESPACE"
+              oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+              oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+              #CronJob cleanup
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/deploy/osd-17664-reinstall-mgo/pre-4.11/README.md
+++ b/deploy/osd-17664-reinstall-mgo/pre-4.11/README.md
@@ -1,0 +1,7 @@
+
+# README
+
+This Cronjob should only be applied temporarily to fix
+https://issues.redhat.com/browse/OSD-17664
+
+Once clusters no longer report the issue it should be reverted.

--- a/deploy/osd-17664-reinstall-mgo/pre-4.11/config.yaml
+++ b/deploy/osd-17664-reinstall-mgo/pre-4.11/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.6","4.7","4.8","4.9","4.10"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/osd-17664-reinstall-mgo/pre-4.11/osd17664.CronJob.yaml
+++ b/deploy/osd-17664-reinstall-mgo/pre-4.11/osd17664.CronJob.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-must-gather-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-must-gather-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-must-gather-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-must-gather-operator
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-must-gather-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-must-gather-operator
+              # unconditionally remove the Subscription, CSV and installplan, the Subscription will be recreated by the must-gather-operator SelectorSyncSet, CSV by the Subscription, and any installplans by the CSV
+              oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator -o name | xargs oc delete -n "$NAMESPACE"
+              oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+              oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator="" -o name | xargs oc delete -n "$NAMESPACE"
+              #CronJob cleanup
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28197,6 +28197,303 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-17664-reinstall-mgo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-must-gather-operator
+
+                    # unconditionally remove the Subscription, CSV and installplan,
+                    the Subscription will be recreated by the must-gather-operator
+                    SelectorSyncSet, CSV by the Subscription, and any installplans
+                    by the CSV
+
+                    oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    #CronJob cleanup
+
+                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+
+                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role ||
+                    true
+
+                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb
+                    || true
+
+                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa
+                    || true
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-17664-reinstall-mgo-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-must-gather-operator
+
+                    # unconditionally remove the Subscription, CSV and installplan,
+                    the Subscription will be recreated by the must-gather-operator
+                    SelectorSyncSet, CSV by the Subscription, and any installplans
+                    by the CSV
+
+                    oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    #CronJob cleanup
+
+                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+
+                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role ||
+                    true
+
+                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb
+                    || true
+
+                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa
+                    || true
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28197,6 +28197,303 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-17664-reinstall-mgo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-must-gather-operator
+
+                    # unconditionally remove the Subscription, CSV and installplan,
+                    the Subscription will be recreated by the must-gather-operator
+                    SelectorSyncSet, CSV by the Subscription, and any installplans
+                    by the CSV
+
+                    oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    #CronJob cleanup
+
+                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+
+                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role ||
+                    true
+
+                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb
+                    || true
+
+                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa
+                    || true
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-17664-reinstall-mgo-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-must-gather-operator
+
+                    # unconditionally remove the Subscription, CSV and installplan,
+                    the Subscription will be recreated by the must-gather-operator
+                    SelectorSyncSet, CSV by the Subscription, and any installplans
+                    by the CSV
+
+                    oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    #CronJob cleanup
+
+                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+
+                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role ||
+                    true
+
+                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb
+                    || true
+
+                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa
+                    || true
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28197,6 +28197,303 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-17664-reinstall-mgo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-must-gather-operator
+
+                    # unconditionally remove the Subscription, CSV and installplan,
+                    the Subscription will be recreated by the must-gather-operator
+                    SelectorSyncSet, CSV by the Subscription, and any installplans
+                    by the CSV
+
+                    oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    #CronJob cleanup
+
+                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+
+                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role ||
+                    true
+
+                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb
+                    || true
+
+                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa
+                    || true
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-17664-reinstall-mgo-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-must-gather-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-must-gather-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-must-gather-operator
+    - apiVersion: batch/v1beta1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-must-gather-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-must-gather-operator
+
+                    # unconditionally remove the Subscription, CSV and installplan,
+                    the Subscription will be recreated by the must-gather-operator
+                    SelectorSyncSet, CSV by the Subscription, and any installplans
+                    by the CSV
+
+                    oc -n "$NAMESPACE" get subscriptions.operators.coreos.com must-gather-operator
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    oc -n "$NAMESPACE" get installplan.operators.coreos.com -l operators.coreos.com/must-gather-operator.openshift-must-gather-operator=""
+                    -o name | xargs oc delete -n "$NAMESPACE"
+
+                    #CronJob cleanup
+
+                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+
+                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role ||
+                    true
+
+                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb
+                    || true
+
+                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa
+                    || true
+
+                    exit 0
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_Cleanup_

### What this PR does / why we need it?
Removes an unpatchable Subscription related to the must-gather-operator, as well as CSV and installplans that could potentially block the newly synced Subscription.

### Which Jira/Github issue(s) this PR fixes?

[OSD-17664](https://issues.redhat.com/browse/OSD-17664) related to [OSD-17140](https://issues.redhat.com/browse/OSD-17140)

### Special notes for your reviewer:
Tested manual steps of the CronJob on 2 clusters. The Subscription was synced properly and CSV recreated. The installplan also succeeded.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
