### PR TITLE
add cluster type management-cluster-v2

### DIFF
--- a/deploy/acm-policies/config.yaml
+++ b/deploy/acm-policies/config.yaml
@@ -3,7 +3,7 @@ selectorSyncSet:
   matchExpressions:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
-    values: ["service-cluster"]
+    values: ["service-cluster", "management-cluster-v2"]
   - key: api.openshift.com/fedramp
     operator: NotIn
     values: ["true"]


### PR DESCRIPTION
### What type of PR is this?

feature: [OCM-2967](https://issues.redhat.com//browse/OCM-2967)

### What this PR does / why we need it?

support SC removal
management-cluster-v2 is where ACM hub will be deployed

### Which Jira/Github issue(s) this PR fixes?

Fixes [OCM-2967](https://issues.redhat.com//browse/OCM-2967)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
