### PR TITLE
Splitting osd-serviceaccounts nonsts into private-link and not private-link

### DIFF
--- a/deploy/osd-serviceaccounts/nonsts-private-link/00-serviceaccounts.yaml
+++ b/deploy/osd-serviceaccounts/nonsts-private-link/00-serviceaccounts.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: managed-upgrade-operator
+  namespace: openshift-managed-upgrade-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: configure-alertmanager-operator
+  namespace: openshift-monitoring
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbac-permissions-operator
+  namespace: openshift-rbac-permissions
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: splunk-forwarder-operator
+  namespace: openshift-splunk-forwarder-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: managed-velero-operator
+  namespace: openshift-velero
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocm-agent-operator 
+  namespace: openshift-ocm-agent-operator

--- a/deploy/osd-serviceaccounts/nonsts-private-link/README.md
+++ b/deploy/osd-serviceaccounts/nonsts-private-link/README.md
@@ -1,0 +1,1 @@
+For non-STS private-link clusters the cloud-ingress-operator is not deployed so we don't need to ensure the service account for this operators exists.

--- a/deploy/osd-serviceaccounts/nonsts-private-link/config.yaml
+++ b/deploy/osd-serviceaccounts/nonsts-private-link/config.yaml
@@ -6,7 +6,7 @@ selectorSyncSet:
     operator: NotIn
     values: ["true"]
   - key: api.openshift.com/private-link
-    operator: NotIn
+    operator: In
     values: ["true"]
   - key: api.openshift.com/fedramp
     operator: NotIn

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34630,6 +34630,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:
@@ -34786,6 +34790,63 @@ objects:
                     Removing owner ref from SA '$SA' in NS '$NS'\"\n    oc -n $NS\
                     \ patch serviceaccount $SA --type=json -p '[{\"op\":\"remove\"\
                     ,\"path\":\"/metadata/ownerReferences\"}]'\n  done\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-nonsts-private-link
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: configure-alertmanager-operator
+        namespace: openshift-monitoring
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: rbac-permissions-operator
+        namespace: openshift-rbac-permissions
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: splunk-forwarder-operator
+        namespace: openshift-splunk-forwarder-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocm-agent-operator
+        namespace: openshift-ocm-agent-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34630,6 +34630,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:
@@ -34786,6 +34790,63 @@ objects:
                     Removing owner ref from SA '$SA' in NS '$NS'\"\n    oc -n $NS\
                     \ patch serviceaccount $SA --type=json -p '[{\"op\":\"remove\"\
                     ,\"path\":\"/metadata/ownerReferences\"}]'\n  done\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-nonsts-private-link
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: configure-alertmanager-operator
+        namespace: openshift-monitoring
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: rbac-permissions-operator
+        namespace: openshift-rbac-permissions
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: splunk-forwarder-operator
+        namespace: openshift-splunk-forwarder-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocm-agent-operator
+        namespace: openshift-ocm-agent-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34630,6 +34630,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/private-link
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:
@@ -34786,6 +34790,63 @@ objects:
                     Removing owner ref from SA '$SA' in NS '$NS'\"\n    oc -n $NS\
                     \ patch serviceaccount $SA --type=json -p '[{\"op\":\"remove\"\
                     ,\"path\":\"/metadata/ownerReferences\"}]'\n  done\ndone\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-serviceaccounts-nonsts-private-link
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/sts
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/private-link
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: managed-upgrade-operator
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: configure-alertmanager-operator
+        namespace: openshift-monitoring
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: rbac-permissions-operator
+        namespace: openshift-rbac-permissions
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: splunk-forwarder-operator
+        namespace: openshift-splunk-forwarder-operator
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: managed-velero-operator
+        namespace: openshift-velero
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocm-agent-operator
+        namespace: openshift-ocm-agent-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?
It stops syncing the cluster-ingress-operator SA to private-link clusters, which don't have the operator installed by default.
We need it to get ClusterSyncs healthy on Hive clusters, the sync fails due to missing operator namespace.

This gets MCC in sync with https://github.com/openshift/cloud-ingress-operator/blob/master/hack/olm-registry/olm-artifacts-template.yaml#L42-L53

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-17775_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
