### PR TITLE
add management-cluster-v2 label selector

### DIFF
--- a/deploy/acm-policies/config.yaml
+++ b/deploy/acm-policies/config.yaml
@@ -3,7 +3,7 @@ selectorSyncSet:
   matchExpressions:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
-    values: ["service-cluster"]
+    values: ["service-cluster","management-cluster-v2"]
   - key: api.openshift.com/fedramp
     operator: NotIn
     values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -615,6 +615,7 @@ objects:
         operator: In
         values:
         - service-cluster
+        - management-cluster-v2
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -615,6 +615,7 @@ objects:
         operator: In
         values:
         - service-cluster
+        - management-cluster-v2
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -615,6 +615,7 @@ objects:
         operator: In
         values:
         - service-cluster
+        - management-cluster-v2
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
as part of SC removal architecture changes, FM introduce a new cluster-type label "management-cluster-v2".
right now, this cluster type is only in FM development/integration environment.

Adding this label, we will be able to push the acm-policies to this management cluster that has ACM running.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OCM-2967](https://issues.redhat.com//browse/OCM-2967)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
