### PR TITLE
[OSD-16014] split the haproxyDown alert for default and non-default ingresscontroller

### DIFF
--- a/deploy/sre-prometheus/100-sre-haproxydown.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-haproxydown.PrometheusRule.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-ingresscontroller-alerts
+    role: alert-rules
+  name: sre-haproxydown-default
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-haproxydown-alerts
+    rules:
+    - alert: HAProxyDownSRE
+      expr: haproxy_up{job="router-internal-default"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        namespace: "{{ $labels.namespace }}"
+      annotations:
+        summary: HAProxy is down
+        description: "This alert fires when metrics report that HAProxy is down."
+        message: "HAProxy metrics are reporting that HAProxy is down on pod {{ $labels.namespace }} / {{ $labels.pod }}"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md"

--- a/deploy/sre-prometheus/legacy-ingress/100-sre-haproxydown.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/legacy-ingress/100-sre-haproxydown.PrometheusRule.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-ingresscontroller-alerts
+    role: alert-rules
+  name: sre-haproxydown-non-default
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-haproxydown-alerts
+    rules:
+    - alert: HAProxyDownSRENonDefault
+      expr: haproxy_up{job!="router-internal-default"} == 0
+      for: 5m
+      labels:
+        severity: critical
+        namespace: "{{ $labels.namespace }}"
+      annotations:
+        summary: HAProxy is down
+        description: "This alert fires when metrics report that HAProxy is down."
+        message: "HAProxy metrics are reporting that HAProxy is down on pod {{ $labels.namespace }} / {{ $labels.pod }}"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md"

--- a/deploy/sre-prometheus/legacy-ingress/config.yaml
+++ b/deploy/sre-prometheus/legacy-ingress/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+    - key: ext-managed.openshift.io/legacy-ingress-support
+      operator: NotIn
+      values: ["false"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37697,6 +37697,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-ingresscontroller-alerts
+          role: alert-rules
+        name: sre-haproxydown-default
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxydown-alerts
+          rules:
+          - alert: HAProxyDownSRE
+            expr: haproxy_up{job="router-internal-default"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              summary: HAProxy is down
+              description: This alert fires when metrics report that HAProxy is down.
+              message: HAProxy metrics are reporting that HAProxy is down on pod {{
+                $labels.namespace }} / {{ $labels.pod }}
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubejobfailing
           role: alert-rules
         name: sre-kubejobfailing
@@ -38517,6 +38541,49 @@ objects:
               message: Critical - node file system almost full on {{ $labels.label_node_role_kubernetes_io
                 }} node, instance {{ $labels.instance }}.  {{ $labels.instance }}
                 is only {{ $value }}% free.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-legacy-ingress
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/legacy-ingress-support
+        operator: NotIn
+        values:
+        - 'false'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-ingresscontroller-alerts
+          role: alert-rules
+        name: sre-haproxydown-non-default
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxydown-alerts
+          rules:
+          - alert: HAProxyDownSRENonDefault
+            expr: haproxy_up{job!="router-internal-default"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              summary: HAProxy is down
+              description: This alert fires when metrics report that HAProxy is down.
+              message: HAProxy metrics are reporting that HAProxy is down on pod {{
+                $labels.namespace }} / {{ $labels.pod }}
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37697,6 +37697,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-ingresscontroller-alerts
+          role: alert-rules
+        name: sre-haproxydown-default
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxydown-alerts
+          rules:
+          - alert: HAProxyDownSRE
+            expr: haproxy_up{job="router-internal-default"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              summary: HAProxy is down
+              description: This alert fires when metrics report that HAProxy is down.
+              message: HAProxy metrics are reporting that HAProxy is down on pod {{
+                $labels.namespace }} / {{ $labels.pod }}
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubejobfailing
           role: alert-rules
         name: sre-kubejobfailing
@@ -38517,6 +38541,49 @@ objects:
               message: Critical - node file system almost full on {{ $labels.label_node_role_kubernetes_io
                 }} node, instance {{ $labels.instance }}.  {{ $labels.instance }}
                 is only {{ $value }}% free.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-legacy-ingress
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/legacy-ingress-support
+        operator: NotIn
+        values:
+        - 'false'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-ingresscontroller-alerts
+          role: alert-rules
+        name: sre-haproxydown-non-default
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxydown-alerts
+          rules:
+          - alert: HAProxyDownSRENonDefault
+            expr: haproxy_up{job!="router-internal-default"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              summary: HAProxy is down
+              description: This alert fires when metrics report that HAProxy is down.
+              message: HAProxy metrics are reporting that HAProxy is down on pod {{
+                $labels.namespace }} / {{ $labels.pod }}
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37697,6 +37697,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-ingresscontroller-alerts
+          role: alert-rules
+        name: sre-haproxydown-default
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxydown-alerts
+          rules:
+          - alert: HAProxyDownSRE
+            expr: haproxy_up{job="router-internal-default"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              summary: HAProxy is down
+              description: This alert fires when metrics report that HAProxy is down.
+              message: HAProxy metrics are reporting that HAProxy is down on pod {{
+                $labels.namespace }} / {{ $labels.pod }}
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-kubejobfailing
           role: alert-rules
         name: sre-kubejobfailing
@@ -38517,6 +38541,49 @@ objects:
               message: Critical - node file system almost full on {{ $labels.label_node_role_kubernetes_io
                 }} node, instance {{ $labels.instance }}.  {{ $labels.instance }}
                 is only {{ $value }}% free.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: sre-prometheus-legacy-ingress
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-managed.openshift.io/legacy-ingress-support
+        operator: NotIn
+        values:
+        - 'false'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-ingresscontroller-alerts
+          role: alert-rules
+        name: sre-haproxydown-non-default
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-haproxydown-alerts
+          rules:
+          - alert: HAProxyDownSRENonDefault
+            expr: haproxy_up{job!="router-internal-default"} == 0
+            for: 5m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              summary: HAProxy is down
+              description: This alert fires when metrics report that HAProxy is down.
+              message: HAProxy metrics are reporting that HAProxy is down on pod {{
+                $labels.namespace }} / {{ $labels.pod }}
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/HAProxyDown.md
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
As the ingresscontroller will be managed by the customer in the upcoming released feature, we should not receive the alert for the customer owned ingresscontrollers.
Split the existing HAProxyDown alert into default IC and non-default IC and deploy them on cluster with different annotations

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-16014](https://issues.redhat.com//browse/OSD-16014)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
