### PR TITLE
Renames infra resizing rules and extends CPU alerting threshold

### DIFF
--- a/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
@@ -8,26 +8,29 @@ metadata:
   namespace: openshift-monitoring
 spec:
   groups:
-  - name: sre-infra-resizing-recording.rules
+  - name: sre-infra-resource-consumption-recording.rules
     rules:
     ## Expression Explanation:
-    ## Average rate of change of CPU time spent in non-idle modes, totalled by CPU, looking back across the past 8h,
+    ## Average of value of
+    ## the Average (per node) rate of change of CPU time spent in non-idle modes, totalled by CPU, looking back across the past 8h,
     ## "*" applies a label replace to limit output to infra nodes
     ## Greater than (>) is the threshold
     ## Count of the infra nodes - 1, divided by the total infra nodes gives the max percent CPU utilization free required to handle a full node failure, as a decimal value: 0.%%
     ## Scalar converts the percent value from a vector to allow comparison with the rate vector
       - expr: ( 
-                avg by (instance) (
-                  sum by (cpu, instance) (
-                    rate(
-                      node_cpu_seconds_total{mode!="idle"}[8h]
+                avg (
+                  avg by (instance) (
+                    sum by (cpu, instance) (
+                      rate(
+                        node_cpu_seconds_total{mode!="idle"}[8h]
+                      )
                     )
                   )
-                )
-                *
-                on (instance) (
-                  label_replace (
-                    kube_node_role{role ="infra"}, "instance", "$1", "node", "(.*)"
+                  *
+                  on (instance) (
+                    label_replace (
+                      kube_node_role{role ="infra"}, "instance", "$1", "node", "(.*)"
+                    )
                   )
                 )
                 >
@@ -37,16 +40,16 @@ spec:
                       count (
                         cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
                       )
-                    - 1
-                  )
-                  / 
-                  count (
-                    cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
+                      - 1
+                    )
+                    /
+                    count (
+                      cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
+                    )
                   )
                 )
               )
-            )
-        record: sre:node_infra:need_resize_cpu
+        record: sre:node_infra:excessive_consumption_cpu
       ## Expression Explanation: 
       ## 1, minus the total amount of free memory divided by the total amount of memory for the infra node type, gives us the percent used memory as a decimal value: 0.%%
       ## Greater than (>) is the threshold
@@ -91,25 +94,25 @@ spec:
                     kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"
                 )
           )
-        record: sre:node_infra:need_resize_memory
+        record: sre:node_infra:excessive_consumption_memory
   - name: sre-infra-resizing-alerts
     rules:
     ## While individual spikes in CPU usage are acceptable, even if spikes are flappy, because CPU is a renewable resource,
     ## long term (8h) CPU consumption above the threshold indicates CPU consumption has outgrown the cluster
-      - alert: cpu-InfraNodesNeedResizingSRE
-        expr: sre:node_infra:need_resize_cpu > 0
-        for: 8h
+      - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
+        expr: sre:node_infra:excessive_consumption_cpu > 0
+        for: 16h
         labels:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's infrastructure nodes have been undersized for their CPU utilization for 8 hours and should be vertically scaled to support the existing workers. See linked SOP for details."
+          message: "The cluster's infrastructure nodes have been consuming excessive CPU for 16 hours and should be vertically scaled to support the existing workers. See linked SOP for details."
       ## Given memory may be allocated but unused, 24h is good enough to catch gradual outgrowing of the cluster with critical node failures alerting via other alerts
-      - alert: memory-InfraNodesNeedResizingSRE
-        expr: sre:node_infra:need_resize_memory > 0
+      - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
+        expr: sre:node_infra:excessive_consumption_memory > 0
         for: 24h
         labels:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's infrastructure nodes have been undersized for their memory utilization for 24 hours and should be vertically scaled to support the existing workers. See linked SOP for details."
+          message: "The cluster's infrastructure nodes have been consuming excessive memory for 24 hours and should be vertically scaled to support the existing workers. See linked SOP for details."


### PR DESCRIPTION
This PR renames the infra resizing expression names to be more in line with what they're actually reporting, and renames the alerts triggered for the same reason.  These alerts will not make it to Primary on-call, because they're warnings, but will be (via a follow-up PR) used to trigger a single InfraNodeNeedsResizingSRE alert that will roll up to Primary.
    
This also extends the CPU `for` threshold from 8 hours to 16 hours, to account for increased "daytime" usage that may be causing some flapping alerts.  The longer threshold will ensure excessive CPU utilization continues for more than just the workday before triggering a "resize required" alert.
    
Finally, this adds an average of the values of the CPU excessive resource consumption, so we receive just one alert, rather than one for every node in the cluster that is currently firing.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
