### PR TITLE
updates images for clamd and suricata to patch CVEs

### DIFF
--- a/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
+++ b/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           value: /certs/tls.key
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/pod-logger@sha256:d6101e90a303992210ed575ed0a3162d3a150649e31f552ab47b4a4cb83d346a
+        image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
         name: logger
         ports:
         - containerPort: 8443
@@ -69,7 +69,7 @@ spec:
           value: "@rpc.pod.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+        image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
         name: pod-printer
         resources:
           limits:
@@ -85,7 +85,7 @@ spec:
           value: "@rpc.scan.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+        image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
         name: scan-printer
         resources:
           limits:

--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -24,7 +24,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+        image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
         name: clamsig-puller
         resources:
           limits:
@@ -43,7 +43,7 @@ spec:
           value: "false"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamd@sha256:c339c8c5fc8efd6e7de7b607c55f6583a5281fa53f5f01efb6d60771f32ee159 
+        image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
         name: clamd
         resources:
           limits:
@@ -67,7 +67,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/container-info@sha256:4e71325051cc6a7fe52bb6e52fa852f8747e1bac1e588faa0aff737b22fb03e2
+        image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
         name: info
         resources:
           limits:
@@ -111,7 +111,7 @@ spec:
           value: '@rpc.sock'
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+        image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
         name: watcher
         resources:
           limits:
@@ -165,7 +165,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+        image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
         name: scheduler
         resources:
           limits:
@@ -199,7 +199,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+        image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
         name: init-clamsig-puller
         resources:
           limits:

--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
+        image: quay.io/app-sre/suricata@sha256:2e7ff9481e89b521d5d17ec9d17752d65684dcb616bbaafb442dae3eb5b2ed66
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:
@@ -33,7 +33,7 @@ spec:
         - mountPath: /host/
           name: host-filesystem
       - name: log-cleaner
-        image: quay.io/app-sre/log-cleaner@sha256:23dafc5412f142e16a94dd783a75c774564eee8c8f24d81e8e6335453272c59b
+        image: quay.io/app-sre/log-cleaner@sha256:5796aba1ff3f592cadda48de61084d7d570b6ed4dc28185514a5856afa8c49c5
         volumeMounts:
         - mountPath: /host/
           name: host-filesystem        

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28465,7 +28465,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:d6101e90a303992210ed575ed0a3162d3a150649e31f552ab47b4a4cb83d346a
+              image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
               name: logger
               ports:
               - containerPort: 8443
@@ -28490,7 +28490,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
               name: pod-printer
               resources:
                 limits:
@@ -28506,7 +28506,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
               name: scan-printer
               resources:
                 limits:
@@ -28571,7 +28571,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
               name: clamsig-puller
               resources:
                 limits:
@@ -28590,7 +28590,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:c339c8c5fc8efd6e7de7b607c55f6583a5281fa53f5f01efb6d60771f32ee159
+              image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
               name: clamd
               resources:
                 limits:
@@ -28614,7 +28614,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:4e71325051cc6a7fe52bb6e52fa852f8747e1bac1e588faa0aff737b22fb03e2
+              image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
               name: info
               resources:
                 limits:
@@ -28658,7 +28658,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
               name: watcher
               resources:
                 limits:
@@ -28712,7 +28712,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
               name: scheduler
               resources:
                 limits:
@@ -28746,7 +28746,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
               name: init-clamsig-puller
               resources:
                 limits:
@@ -29261,7 +29261,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
+              image: quay.io/app-sre/suricata@sha256:2e7ff9481e89b521d5d17ec9d17752d65684dcb616bbaafb442dae3eb5b2ed66
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -29278,7 +29278,7 @@ objects:
               - mountPath: /host/
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:23dafc5412f142e16a94dd783a75c774564eee8c8f24d81e8e6335453272c59b
+              image: quay.io/app-sre/log-cleaner@sha256:5796aba1ff3f592cadda48de61084d7d570b6ed4dc28185514a5856afa8c49c5
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28465,7 +28465,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:d6101e90a303992210ed575ed0a3162d3a150649e31f552ab47b4a4cb83d346a
+              image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
               name: logger
               ports:
               - containerPort: 8443
@@ -28490,7 +28490,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
               name: pod-printer
               resources:
                 limits:
@@ -28506,7 +28506,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
               name: scan-printer
               resources:
                 limits:
@@ -28571,7 +28571,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
               name: clamsig-puller
               resources:
                 limits:
@@ -28590,7 +28590,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:c339c8c5fc8efd6e7de7b607c55f6583a5281fa53f5f01efb6d60771f32ee159
+              image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
               name: clamd
               resources:
                 limits:
@@ -28614,7 +28614,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:4e71325051cc6a7fe52bb6e52fa852f8747e1bac1e588faa0aff737b22fb03e2
+              image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
               name: info
               resources:
                 limits:
@@ -28658,7 +28658,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
               name: watcher
               resources:
                 limits:
@@ -28712,7 +28712,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
               name: scheduler
               resources:
                 limits:
@@ -28746,7 +28746,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
               name: init-clamsig-puller
               resources:
                 limits:
@@ -29261,7 +29261,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
+              image: quay.io/app-sre/suricata@sha256:2e7ff9481e89b521d5d17ec9d17752d65684dcb616bbaafb442dae3eb5b2ed66
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -29278,7 +29278,7 @@ objects:
               - mountPath: /host/
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:23dafc5412f142e16a94dd783a75c774564eee8c8f24d81e8e6335453272c59b
+              image: quay.io/app-sre/log-cleaner@sha256:5796aba1ff3f592cadda48de61084d7d570b6ed4dc28185514a5856afa8c49c5
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28465,7 +28465,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:d6101e90a303992210ed575ed0a3162d3a150649e31f552ab47b4a4cb83d346a
+              image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
               name: logger
               ports:
               - containerPort: 8443
@@ -28490,7 +28490,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
               name: pod-printer
               resources:
                 limits:
@@ -28506,7 +28506,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:8a8870ce5f6e1c14f115c970a5e9db35e8946cc6746604e27cc20dbaff270ff6
+              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
               name: scan-printer
               resources:
                 limits:
@@ -28571,7 +28571,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
               name: clamsig-puller
               resources:
                 limits:
@@ -28590,7 +28590,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:c339c8c5fc8efd6e7de7b607c55f6583a5281fa53f5f01efb6d60771f32ee159
+              image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
               name: clamd
               resources:
                 limits:
@@ -28614,7 +28614,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:4e71325051cc6a7fe52bb6e52fa852f8747e1bac1e588faa0aff737b22fb03e2
+              image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
               name: info
               resources:
                 limits:
@@ -28658,7 +28658,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
               name: watcher
               resources:
                 limits:
@@ -28712,7 +28712,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:ad45fcb27c0d0d681bf6fc9fee0a035b192cf2e377a9d78f42a8fdb4bc1667d5
+              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
               name: scheduler
               resources:
                 limits:
@@ -28746,7 +28746,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:d62ffc60e426a6820bf9ad1fd5775be70c6137e8ae1eb89a6d30053b6e4e4b6d
+              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
               name: init-clamsig-puller
               resources:
                 limits:
@@ -29261,7 +29261,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:52a1815dddc4dd856ae3a86dee2a53b55d26a6d06d536252665756af92e60f7b
+              image: quay.io/app-sre/suricata@sha256:2e7ff9481e89b521d5d17ec9d17752d65684dcb616bbaafb442dae3eb5b2ed66
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -29278,7 +29278,7 @@ objects:
               - mountPath: /host/
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:23dafc5412f142e16a94dd783a75c774564eee8c8f24d81e8e6335453272c59b
+              image: quay.io/app-sre/log-cleaner@sha256:5796aba1ff3f592cadda48de61084d7d570b6ed4dc28185514a5856afa8c49c5
               volumeMounts:
               - mountPath: /host/
                 name: host-filesystem


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

Patches CVE's found in the base image of our ClamAV and Suricata pods

### Which Jira/Github issue(s) this PR fixes?

For [OSD-17208](https://issues.redhat.com//browse/OSD-17208)

### Special notes for your reviewer:

New images have been tested in FedRAMP and functioning

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
