### PR TITLE
Only target staging hives for legacy ingress labeller

### DIFF
--- a/deploy/osd-legacy-ingress-feature-labeller/config.yaml
+++ b/deploy/osd-legacy-ingress-feature-labeller/config.yaml
@@ -2,3 +2,9 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchLabels:
     ext-managed.openshift.io/hive-shard: "true"
+  matchExpressions:
+    - key: api.openshift.com/id
+      operator: In
+      values:
+      - "1dn9fsn53b9vh3m63n8ajr679cslbkhd"
+      - "1farlonnersks14ohfp155uoonupr9id"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26471,6 +26471,12 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         ext-managed.openshift.io/hive-shard: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values:
+        - 1dn9fsn53b9vh3m63n8ajr679cslbkhd
+        - 1farlonnersks14ohfp155uoonupr9id
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26471,6 +26471,12 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         ext-managed.openshift.io/hive-shard: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values:
+        - 1dn9fsn53b9vh3m63n8ajr679cslbkhd
+        - 1farlonnersks14ohfp155uoonupr9id
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26471,6 +26471,12 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         ext-managed.openshift.io/hive-shard: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values:
+        - 1dn9fsn53b9vh3m63n8ajr679cslbkhd
+        - 1farlonnersks14ohfp155uoonupr9id
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Targets only staging hives (which run on production) for the legacy ingress labeller merged here https://github.com/openshift/managed-cluster-config/pull/1787/files. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com//browse/OSD-17024

### Special notes for your reviewer:
Will need to be reverted once tested and verified to work. 
### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
