### PR TITLE
Fix RBAC typo and add better logging for legacy ingress job

### DIFF
--- a/deploy/osd-legacy-ingress-feature-labeller/01-osd-legacy-ingress-feature-labeller.ClusterRole.yaml
+++ b/deploy/osd-legacy-ingress-feature-labeller/01-osd-legacy-ingress-feature-labeller.ClusterRole.yaml
@@ -10,4 +10,4 @@ rules:
   verbs:
   - "list"
   - "get"
-  - "update"
+  - "patch"

--- a/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
+++ b/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
@@ -42,6 +42,9 @@ spec:
 
               for item in cd_json_items:
                   labels = item["metadata"]["labels"]
+                  namespace = item["metadata"]["namespace"]
+                  name = item["metadata"]["name"]
+                  print(f'Cluster {name} in namespace {namespace}')
                   if not labels.get("hive.openshift.io/version-major-minor"):
                       print("No hive version label on cluster, exiting")
                       continue
@@ -55,8 +58,6 @@ spec:
                       continue
                   else:
                       print("ext-managed.openshift.io/legacy-ingress-support label does not exist and cluster is v4.13 or greater. Labelling as legacy-ingress: false.")
-                      namespace = item["metadata"]["namespace"]
-                      name = item["metadata"]["name"]
                       cmd = f'oc label clusterdeployment -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support="false"'
                       print(f"Running {cmd}")
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26496,7 +26496,7 @@ objects:
         verbs:
         - list
         - get
-        - update
+        - patch
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -26547,9 +26547,12 @@ objects:
                   - "import os\nimport json\n\nout = os.popen('oc get clusterdeployment\
                     \ -A -ojson').read()\ncd_json_items = json.loads(out)[\"items\"\
                     ]\n\nfor item in cd_json_items:\n    labels = item[\"metadata\"\
-                    ][\"labels\"]\n    if not labels.get(\"hive.openshift.io/version-major-minor\"\
-                    ):\n        print(\"No hive version label on cluster, exiting\"\
-                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    ][\"labels\"]\n    namespace = item[\"metadata\"][\"namespace\"\
+                    ]\n    name = item[\"metadata\"][\"name\"]\n    print(f'Cluster\
+                    \ {name} in namespace {namespace}')\n    if not labels.get(\"\
+                    hive.openshift.io/version-major-minor\"):\n        print(\"No\
+                    \ hive version label on cluster, exiting\")\n        continue\n\
+                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
                     .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\
@@ -26557,11 +26560,9 @@ objects:
                     \ label already exists, moving to next cluster\")\n        continue\n\
                     \    else:\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
                     \ label does not exist and cluster is v4.13 or greater. Labelling\
-                    \ as legacy-ingress: false.\")\n        namespace = item[\"metadata\"\
-                    ][\"namespace\"]\n        name = item[\"metadata\"][\"name\"]\n\
-                    \        cmd = f'oc label clusterdeployment -n {namespace} {name}\
-                    \ ext-managed.openshift.io/legacy-ingress-support=\"false\"'\n\
-                    \        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\
+                    \ as legacy-ingress: false.\")\n        cmd = f'oc label clusterdeployment\
+                    \ -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support=\"\
+                    false\"'\n        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\
                     \        print(out.read())\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26496,7 +26496,7 @@ objects:
         verbs:
         - list
         - get
-        - update
+        - patch
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -26547,9 +26547,12 @@ objects:
                   - "import os\nimport json\n\nout = os.popen('oc get clusterdeployment\
                     \ -A -ojson').read()\ncd_json_items = json.loads(out)[\"items\"\
                     ]\n\nfor item in cd_json_items:\n    labels = item[\"metadata\"\
-                    ][\"labels\"]\n    if not labels.get(\"hive.openshift.io/version-major-minor\"\
-                    ):\n        print(\"No hive version label on cluster, exiting\"\
-                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    ][\"labels\"]\n    namespace = item[\"metadata\"][\"namespace\"\
+                    ]\n    name = item[\"metadata\"][\"name\"]\n    print(f'Cluster\
+                    \ {name} in namespace {namespace}')\n    if not labels.get(\"\
+                    hive.openshift.io/version-major-minor\"):\n        print(\"No\
+                    \ hive version label on cluster, exiting\")\n        continue\n\
+                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
                     .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\
@@ -26557,11 +26560,9 @@ objects:
                     \ label already exists, moving to next cluster\")\n        continue\n\
                     \    else:\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
                     \ label does not exist and cluster is v4.13 or greater. Labelling\
-                    \ as legacy-ingress: false.\")\n        namespace = item[\"metadata\"\
-                    ][\"namespace\"]\n        name = item[\"metadata\"][\"name\"]\n\
-                    \        cmd = f'oc label clusterdeployment -n {namespace} {name}\
-                    \ ext-managed.openshift.io/legacy-ingress-support=\"false\"'\n\
-                    \        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\
+                    \ as legacy-ingress: false.\")\n        cmd = f'oc label clusterdeployment\
+                    \ -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support=\"\
+                    false\"'\n        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\
                     \        print(out.read())\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26496,7 +26496,7 @@ objects:
         verbs:
         - list
         - get
-        - update
+        - patch
     - kind: ClusterRoleBinding
       apiVersion: rbac.authorization.k8s.io/v1
       metadata:
@@ -26547,9 +26547,12 @@ objects:
                   - "import os\nimport json\n\nout = os.popen('oc get clusterdeployment\
                     \ -A -ojson').read()\ncd_json_items = json.loads(out)[\"items\"\
                     ]\n\nfor item in cd_json_items:\n    labels = item[\"metadata\"\
-                    ][\"labels\"]\n    if not labels.get(\"hive.openshift.io/version-major-minor\"\
-                    ):\n        print(\"No hive version label on cluster, exiting\"\
-                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    ][\"labels\"]\n    namespace = item[\"metadata\"][\"namespace\"\
+                    ]\n    name = item[\"metadata\"][\"name\"]\n    print(f'Cluster\
+                    \ {name} in namespace {namespace}')\n    if not labels.get(\"\
+                    hive.openshift.io/version-major-minor\"):\n        print(\"No\
+                    \ hive version label on cluster, exiting\")\n        continue\n\
+                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
                     .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\
@@ -26557,11 +26560,9 @@ objects:
                     \ label already exists, moving to next cluster\")\n        continue\n\
                     \    else:\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
                     \ label does not exist and cluster is v4.13 or greater. Labelling\
-                    \ as legacy-ingress: false.\")\n        namespace = item[\"metadata\"\
-                    ][\"namespace\"]\n        name = item[\"metadata\"][\"name\"]\n\
-                    \        cmd = f'oc label clusterdeployment -n {namespace} {name}\
-                    \ ext-managed.openshift.io/legacy-ingress-support=\"false\"'\n\
-                    \        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\
+                    \ as legacy-ingress: false.\")\n        cmd = f'oc label clusterdeployment\
+                    \ -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support=\"\
+                    false\"'\n        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\
                     \        print(out.read())\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
### What type of PR is this?
_(cleanup)_

### What this PR does / why we need it?
Fixes RBAC bug that appeared [here](https://redhat-internal.slack.com/archives/CFJD1NZFT/p1691985996593009) when testing the legacy ingress labeller job. 
Original bug: 
```
Error from server (Forbidden): clusterdeployments.hive.openshift.io "rhods-gcpug" is forbidden: User "system:serviceaccount:openshift-config:osd-legacy-ingress-feature-labeller" cannot patch resource "clusterdeployments" in API group "hive.openshift.io" in the namespace "uhc-staging-25h2p73b67d3gj1s5nvvrm2860ca42ev"
```
The fix is to add `patch` instead of `update`. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com//browse/OSD-17024

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
  - https://redhat-internal.slack.com/archives/CFJD1NZFT/p1691997604530579?thread_ts=1691985996.593009&cid=CFJD1NZFT
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
