### PR TITLE
Deploy legacy ingress labeller to all production hives

### DIFF
--- a/deploy/osd-legacy-ingress-feature-labeller/config.yaml
+++ b/deploy/osd-legacy-ingress-feature-labeller/config.yaml
@@ -2,9 +2,3 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchLabels:
     ext-managed.openshift.io/hive-shard: "true"
-  matchExpressions:
-    - key: api.openshift.com/id
-      operator: In
-      values:
-      - "1dn9fsn53b9vh3m63n8ajr679cslbkhd"
-      - "1farlonnersks14ohfp155uoonupr9id"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26471,12 +26471,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         ext-managed.openshift.io/hive-shard: 'true'
-      matchExpressions:
-      - key: api.openshift.com/id
-        operator: In
-        values:
-        - 1dn9fsn53b9vh3m63n8ajr679cslbkhd
-        - 1farlonnersks14ohfp155uoonupr9id
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26471,12 +26471,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         ext-managed.openshift.io/hive-shard: 'true'
-      matchExpressions:
-      - key: api.openshift.com/id
-        operator: In
-        values:
-        - 1dn9fsn53b9vh3m63n8ajr679cslbkhd
-        - 1farlonnersks14ohfp155uoonupr9id
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26471,12 +26471,6 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         ext-managed.openshift.io/hive-shard: 'true'
-      matchExpressions:
-      - key: api.openshift.com/id
-        operator: In
-        values:
-        - 1dn9fsn53b9vh3m63n8ajr679cslbkhd
-        - 1farlonnersks14ohfp155uoonupr9id
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
_(cleanup)_

### What this PR does / why we need it?
This pull request rolls out the legacy ingress labeller to all production hives. It has been tested and verified to work on both staging hives (see https://redhat-internal.slack.com/archives/CFJD1NZFT/p1692065087070769?thread_ts=1692062261.942239&cid=CFJD1NZFT). 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-17640
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
