### PR TITLE
Skip non-AWS clusters for legacy ingress labeller 

### DIFF
--- a/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
+++ b/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
@@ -49,6 +49,10 @@ spec:
                       print("No hive version label on cluster, exiting")
                       continue
 
+                  if labels.get("hive.openshift.io/cluster-platform") != "aws":
+                      print("Cluster platform not aws, skipping")
+                      continue
+
                   if labels.get("hive.openshift.io/version-major-minor") and int(labels["hive.openshift.io/version-major-minor"].split(".")[1]) < 13:
                       print("Version less than v4.13, exiting")
                       continue

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26552,7 +26552,9 @@ objects:
                     \ {name} in namespace {namespace}')\n    if not labels.get(\"\
                     hive.openshift.io/version-major-minor\"):\n        print(\"No\
                     \ hive version label on cluster, exiting\")\n        continue\n\
-                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    \n    if labels.get(\"hive.openshift.io/cluster-platform\") !=\
+                    \ \"aws\":\n        print(\"Cluster platform not aws, skipping\"\
+                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
                     .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26552,7 +26552,9 @@ objects:
                     \ {name} in namespace {namespace}')\n    if not labels.get(\"\
                     hive.openshift.io/version-major-minor\"):\n        print(\"No\
                     \ hive version label on cluster, exiting\")\n        continue\n\
-                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    \n    if labels.get(\"hive.openshift.io/cluster-platform\") !=\
+                    \ \"aws\":\n        print(\"Cluster platform not aws, skipping\"\
+                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
                     .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26552,7 +26552,9 @@ objects:
                     \ {name} in namespace {namespace}')\n    if not labels.get(\"\
                     hive.openshift.io/version-major-minor\"):\n        print(\"No\
                     \ hive version label on cluster, exiting\")\n        continue\n\
-                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    \n    if labels.get(\"hive.openshift.io/cluster-platform\") !=\
+                    \ \"aws\":\n        print(\"Cluster platform not aws, skipping\"\
+                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
                     .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Upgrading GCP clusters from 4.12.28 to 4.13.8 results in cluster console being unreachable with an SSL error:

```
curl https://console-openshift-console.apps.cbussegapgcp.mjuy.s2.devshift.org
curl: (60) SSL certificate problem: self-signed certificate in certificate chain
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above. 
```
This is due to GCP clusters not being skipped (as the legacy ingress feature does not apply to them). 

This pull request skips adding the managed ingress feature (https://github.com/openshift/ops-sop/pull/2729) to clusters with type GCP.
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-17952
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
