### PR TITLE
Migrate InfraNodesNeedResizingSRE to roll-up alert for infra node resize warning alerts.

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -37,42 +37,6 @@ spec:
                 AND sre:node_workers:count > 250
               )
         record: sre:node_masters:need_resize
-      # infra has less than 16GB RAM or less than 5 CPU, worker count > 25, and worker count <= 100
-      # infra has less than 32GB RAM or less than 9 CPU, worker count > 100, and worker count <= 250
-      # infra has less than 128GB RAM or less than 17 CPU, worker count > 250
-      # infra has less than 128GB RAM or less than 33 CPU, worker count > 500
-      - expr: (
-                (
-                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 16*1024*1024*1024
-                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 4
-                )
-                AND sre:node_workers:count > 25
-                AND sre:node_workers:count <= 100
-              )
-              OR
-              (
-                (
-                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 32*1024*1024*1024
-                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 8
-                )
-                AND sre:node_workers:count > 100
-                AND sre:node_workers:count <= 250
-              )
-              OR
-              (
-                (
-                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 128*1024*1024*1024
-                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 16
-                )
-                AND sre:node_workers:count > 250
-              )
-              OR
-              (
-                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 128*1024*1024*1024
-                AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 32
-                AND sre:node_workers:count > 500
-              )
-        record: sre:node_infras:need_resize
   - name: sre-control-plane-resizing-alerts
     rules:
       - alert: MasterNodesNeedResizingSRE
@@ -91,11 +55,3 @@ spec:
           namespace: openshift-monitoring
         annotations:
           message: "The cluster's master instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."
-      - alert: InfraNodesNeedResizingSRE
-        expr: sre:node_infras:need_resize > 0
-        for: 2h
-        labels:
-          severity: critical
-          namespace: openshift-monitoring
-        annotations:
-          message: "The cluster's infra instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."

--- a/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
@@ -124,15 +124,8 @@ spec:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-      ## If the CPU or Memory related "InfraNodesExcessiveResourceConsumptionSRE" alerts are firing, raise a critical ticket to SRE to scale the infra nodes up
           message: "The cluster's infrastructure nodes have been consuming excessive memory for 24 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
-      - alert: InfraNodesNeedResizingSRE
-        expr: sre:node_infras:need_resize > 0
-        labels:
-          severity: warning
-          namespace: openshift-monitoring
-        annotations:
-          message: "The cluster's infrastructure nodes are undersized and must be vertically scaled to support the existing workers.  See linked SOP for details."
+      ## If the CPU or Memory related "InfraNodesExcessiveResourceConsumptionSRE" alerts are firing, raise a critical ticket to SRE to scale the infra nodes up
       - alert: InfraNodesNeedResizingSRE
         expr: sre:node_infras:need_resize > 0
         for: 2h

--- a/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
@@ -95,6 +95,15 @@ spec:
                 )
           )
         record: sre:node_infra:excessive_consumption_memory
+      ## If either of the CPU or Memory resource consumption alerts (see below) fire, then trigger an alert for SRE
+      - expr: (
+                count(
+                  ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE", alertstate="firing"}
+                  OR
+                  ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE", alertstate="firing"}
+                ) >= 1
+              )
+        record: sre:node_infras:need_resize
   - name: sre-infra-resizing-alerts
     rules:
     ## While individual spikes in CPU usage are acceptable, even if spikes are flappy, because CPU is a renewable resource,
@@ -106,7 +115,7 @@ spec:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's infrastructure nodes have been consuming excessive CPU for 16 hours and should be vertically scaled to support the existing workers. See linked SOP for details."
+          message: "The cluster's infrastructure nodes have been consuming excessive CPU for 16 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
       ## Given memory may be allocated but unused, 24h is good enough to catch gradual outgrowing of the cluster with critical node failures alerting via other alerts
       - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
         expr: sre:node_infra:excessive_consumption_memory > 0
@@ -115,4 +124,20 @@ spec:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's infrastructure nodes have been consuming excessive memory for 24 hours and should be vertically scaled to support the existing workers. See linked SOP for details."
+      ## If the CPU or Memory related "InfraNodesExcessiveResourceConsumptionSRE" alerts are firing, raise a critical ticket to SRE to scale the infra nodes up
+          message: "The cluster's infrastructure nodes have been consuming excessive memory for 24 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
+      - alert: InfraNodesNeedResizingSRE
+        expr: sre:node_infras:need_resize > 0
+        labels:
+          severity: warning
+          namespace: openshift-monitoring
+        annotations:
+          message: "The cluster's infrastructure nodes are undersized and must be vertically scaled to support the existing workers.  See linked SOP for details."
+      - alert: InfraNodesNeedResizingSRE
+        expr: sre:node_infras:need_resize > 0
+        for: 2h
+        labels:
+          severity: critical
+          namespace: openshift-monitoring
+        annotations:
+          message: "The cluster's infrastructure nodes have been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31597,18 +31597,6 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
-          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
-              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
-              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 32 AND sre:node_workers:count > 500 )
-            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -31629,16 +31617,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 2h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
@@ -31767,6 +31745,10 @@ objects:
               label_replace( kube_node_role{role="infra"}, "instance", "$1", "node",
               "(.+)" ) )
             record: sre:node_infra:excessive_consumption_memory
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} ) >= 1 )
+            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
           - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
@@ -31777,8 +31759,8 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and should be vertically scaled to support the existing
-                workers. See linked SOP for details.
+                CPU for 16 hours and may need to be vertically scaled to support the
+                existing workers. See linked SOP for details.
           - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
             expr: sre:node_infra:excessive_consumption_memory > 0
             for: 24h
@@ -31787,8 +31769,27 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and should be vertically scaled to support the
-                existing workers. See linked SOP for details.
+                memory for 24 hours and may need to be vertically scaled to support
+                the existing workers. See linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes are undersized and must
+                be vertically scaled to support the existing workers.  See linked
+                SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31773,15 +31773,6 @@ objects:
                 the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
             expr: sre:node_infras:need_resize > 0
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes are undersized and must
-                be vertically scaled to support the existing workers.  See linked
-                SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
             for: 2h
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31597,18 +31597,6 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
-          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
-              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
-              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 32 AND sre:node_workers:count > 500 )
-            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -31629,16 +31617,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 2h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
@@ -31767,6 +31745,10 @@ objects:
               label_replace( kube_node_role{role="infra"}, "instance", "$1", "node",
               "(.+)" ) )
             record: sre:node_infra:excessive_consumption_memory
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} ) >= 1 )
+            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
           - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
@@ -31777,8 +31759,8 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and should be vertically scaled to support the existing
-                workers. See linked SOP for details.
+                CPU for 16 hours and may need to be vertically scaled to support the
+                existing workers. See linked SOP for details.
           - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
             expr: sre:node_infra:excessive_consumption_memory > 0
             for: 24h
@@ -31787,8 +31769,27 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and should be vertically scaled to support the
-                existing workers. See linked SOP for details.
+                memory for 24 hours and may need to be vertically scaled to support
+                the existing workers. See linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes are undersized and must
+                be vertically scaled to support the existing workers.  See linked
+                SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31773,15 +31773,6 @@ objects:
                 the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
             expr: sre:node_infras:need_resize > 0
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes are undersized and must
-                be vertically scaled to support the existing workers.  See linked
-                SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
             for: 2h
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31597,18 +31597,6 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
-          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
-              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
-              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 32 AND sre:node_workers:count > 500 )
-            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -31629,16 +31617,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 2h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
@@ -31767,6 +31745,10 @@ objects:
               label_replace( kube_node_role{role="infra"}, "instance", "$1", "node",
               "(.+)" ) )
             record: sre:node_infra:excessive_consumption_memory
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} ) >= 1 )
+            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
           - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
@@ -31777,8 +31759,8 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and should be vertically scaled to support the existing
-                workers. See linked SOP for details.
+                CPU for 16 hours and may need to be vertically scaled to support the
+                existing workers. See linked SOP for details.
           - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
             expr: sre:node_infra:excessive_consumption_memory > 0
             for: 24h
@@ -31787,8 +31769,27 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and should be vertically scaled to support the
-                existing workers. See linked SOP for details.
+                memory for 24 hours and may need to be vertically scaled to support
+                the existing workers. See linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes are undersized and must
+                be vertically scaled to support the existing workers.  See linked
+                SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31773,15 +31773,6 @@ objects:
                 the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
             expr: sre:node_infras:need_resize > 0
-            labels:
-              severity: warning
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infrastructure nodes are undersized and must
-                be vertically scaled to support the existing workers.  See linked
-                SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
             for: 2h
             labels:
               severity: critical


### PR DESCRIPTION
This changes the InfraNodesNeedResizingSRE alert from a simple node-count metric trigger to an alert triggered by the existence of firing cpu-InfraNodesExcessiveResourceConsumptionSRE or memory-InfraNodesExcessiveResourceConsumptionSRE, which should provide a more accurate representation of over- and under- utilized infrastructure nodes.

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
