### PR TITLE
remove misleading runbook_url for ES alerts

### DIFF
--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -30,7 +30,6 @@ spec:
           annotations:
             message: Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet.
             summary: Cluster health status is RED
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
           expr: |
             sum by (cluster) (es_cluster_status == 2)
           for: 7m
@@ -41,7 +40,6 @@ spec:
           annotations:
             message: Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated.
             summary: Cluster health status is YELLOW
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
           expr: |
             sum by (cluster) (es_cluster_status == 1)
           for: 20m
@@ -52,7 +50,6 @@ spec:
           annotations:
             message: High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed.
             summary: High Write Rejection Ratio - {{ $value }}%
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
           expr: |
             round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
           for: 10m
@@ -63,7 +60,6 @@ spec:
           annotations:
             message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node.
             summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
           expr: |
             sum by (instance, pod) (
               round(
@@ -81,7 +77,6 @@ spec:
           annotations:
             message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.
             summary: Disk High Watermark Reached - disk saturation is {{ $value }}%
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
           expr: |
             sum by (instance, pod) (
               round(
@@ -99,7 +94,6 @@ spec:
           annotations:
             message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
             summary: Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
           expr: |
             sum by (instance, pod) (
               round(
@@ -117,7 +111,6 @@ spec:
           annotations:
             message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
             summary: JVM Heap usage on the node is high
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
           expr: |
             sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
           for: 10m
@@ -128,7 +121,6 @@ spec:
           annotations:
             message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
             summary: System CPU usage is high
-            runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
           expr: |
             sum by (cluster, instance, node) (es_os_cpu_percent) > 90
           for: 1m
@@ -139,7 +131,6 @@ spec:
           annotations:
             message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
             summary: ES process CPU usage is high
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
           expr: |
             sum by (cluster, instance, node) (es_process_cpu_percent) > 90
           for: 1m
@@ -150,7 +141,6 @@ spec:
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h.
             summary: Cluster low on disk space
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
           expr: |
             sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
           for: 1h
@@ -161,7 +151,6 @@ spec:
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour.
             summary: Cluster low on file descriptors
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
           expr: |
             predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
           for: 10m
@@ -182,7 +171,6 @@ spec:
           annotations:
             message: Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node.
             summary: Disk Low Watermark is predicted to be reached within next 6h.
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
           expr: |
             sum by (instance, pod) (
               round(
@@ -200,7 +188,6 @@ spec:
           annotations:
             message: Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.
             summary: Disk High Watermark is predicted to be reached within next 6h.
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
           expr: |
             sum by (instance, pod) (
               round(
@@ -218,7 +205,6 @@ spec:
           annotations:
             message: Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
             summary: Disk Flood Stage Watermark is predicted to be reached within next 6h.
-            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
           expr: |
             sum by (instance, pod) (
               round(

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33100,7 +33100,6 @@ objects:
                 at least 7m. Cluster does not accept writes, shards may be missing
                 or master node hasn't been elected yet.
               summary: Cluster health status is RED
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
             expr: 'sum by (cluster) (es_cluster_status == 2)
 
               '
@@ -33113,7 +33112,6 @@ objects:
               message: Cluster {{ $labels.cluster }} health status has been YELLOW
                 for at least 20m. Some shard replicas are not allocated.
               summary: Cluster health status is YELLOW
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
             expr: 'sum by (cluster) (es_cluster_status == 1)
 
               '
@@ -33127,7 +33125,6 @@ objects:
                 $labels.cluster }} cluster. This node may not be keeping up with the
                 indexing speed.
               summary: High Write Rejection Ratio - {{ $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
             expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
 
               '
@@ -33141,7 +33138,6 @@ objects:
                 can not be allocated to this node anymore. You should consider adding
                 more disk to the node.
               summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
@@ -33157,7 +33153,6 @@ objects:
                 to this node.
               summary: Disk High Watermark Reached - disk saturation is {{ $value
                 }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
@@ -33173,7 +33168,6 @@ objects:
                 falls below the high watermark.
               summary: Disk Flood Stage Watermark Reached - disk saturation is {{
                 $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
@@ -33186,7 +33180,6 @@ objects:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: JVM Heap usage on the node is high
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
             expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent)
               > 75
 
@@ -33200,7 +33193,6 @@ objects:
               message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: System CPU usage is high
-              runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
             expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
 
               '
@@ -33213,7 +33205,6 @@ objects:
               message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: ES process CPU usage is high
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
             expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
 
               '
@@ -33226,7 +33217,6 @@ objects:
               message: Cluster {{ $labels.cluster }} is predicted to be out of disk
                 space within the next 6h.
               summary: Cluster low on disk space
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
             expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <
               0
 
@@ -33240,7 +33230,6 @@ objects:
               message: Cluster {{ $labels.cluster }} is predicted to be out of file
                 descriptors within the next hour.
               summary: Cluster low on file descriptors
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
             expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
               - predict_linear(es_process_file_descriptors_open_number[1h], 3600)
               < 0
@@ -33267,7 +33256,6 @@ objects:
                 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node
                 anymore. You should consider adding more disk to the node.
               summary: Disk Low Watermark is predicted to be reached within next 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
@@ -33283,7 +33271,6 @@ objects:
                 or drop old indices allocated to this node.
               summary: Disk High Watermark is predicted to be reached within next
                 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
@@ -33299,7 +33286,6 @@ objects:
                 released manually when the disk utilization falls below the high watermark.
               summary: Disk Flood Stage Watermark is predicted to be reached within
                 next 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33100,7 +33100,6 @@ objects:
                 at least 7m. Cluster does not accept writes, shards may be missing
                 or master node hasn't been elected yet.
               summary: Cluster health status is RED
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
             expr: 'sum by (cluster) (es_cluster_status == 2)
 
               '
@@ -33113,7 +33112,6 @@ objects:
               message: Cluster {{ $labels.cluster }} health status has been YELLOW
                 for at least 20m. Some shard replicas are not allocated.
               summary: Cluster health status is YELLOW
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
             expr: 'sum by (cluster) (es_cluster_status == 1)
 
               '
@@ -33127,7 +33125,6 @@ objects:
                 $labels.cluster }} cluster. This node may not be keeping up with the
                 indexing speed.
               summary: High Write Rejection Ratio - {{ $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
             expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
 
               '
@@ -33141,7 +33138,6 @@ objects:
                 can not be allocated to this node anymore. You should consider adding
                 more disk to the node.
               summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
@@ -33157,7 +33153,6 @@ objects:
                 to this node.
               summary: Disk High Watermark Reached - disk saturation is {{ $value
                 }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
@@ -33173,7 +33168,6 @@ objects:
                 falls below the high watermark.
               summary: Disk Flood Stage Watermark Reached - disk saturation is {{
                 $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
@@ -33186,7 +33180,6 @@ objects:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: JVM Heap usage on the node is high
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
             expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent)
               > 75
 
@@ -33200,7 +33193,6 @@ objects:
               message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: System CPU usage is high
-              runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
             expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
 
               '
@@ -33213,7 +33205,6 @@ objects:
               message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: ES process CPU usage is high
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
             expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
 
               '
@@ -33226,7 +33217,6 @@ objects:
               message: Cluster {{ $labels.cluster }} is predicted to be out of disk
                 space within the next 6h.
               summary: Cluster low on disk space
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
             expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <
               0
 
@@ -33240,7 +33230,6 @@ objects:
               message: Cluster {{ $labels.cluster }} is predicted to be out of file
                 descriptors within the next hour.
               summary: Cluster low on file descriptors
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
             expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
               - predict_linear(es_process_file_descriptors_open_number[1h], 3600)
               < 0
@@ -33267,7 +33256,6 @@ objects:
                 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node
                 anymore. You should consider adding more disk to the node.
               summary: Disk Low Watermark is predicted to be reached within next 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
@@ -33283,7 +33271,6 @@ objects:
                 or drop old indices allocated to this node.
               summary: Disk High Watermark is predicted to be reached within next
                 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
@@ -33299,7 +33286,6 @@ objects:
                 released manually when the disk utilization falls below the high watermark.
               summary: Disk Flood Stage Watermark is predicted to be reached within
                 next 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33100,7 +33100,6 @@ objects:
                 at least 7m. Cluster does not accept writes, shards may be missing
                 or master node hasn't been elected yet.
               summary: Cluster health status is RED
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
             expr: 'sum by (cluster) (es_cluster_status == 2)
 
               '
@@ -33113,7 +33112,6 @@ objects:
               message: Cluster {{ $labels.cluster }} health status has been YELLOW
                 for at least 20m. Some shard replicas are not allocated.
               summary: Cluster health status is YELLOW
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
             expr: 'sum by (cluster) (es_cluster_status == 1)
 
               '
@@ -33127,7 +33125,6 @@ objects:
                 $labels.cluster }} cluster. This node may not be keeping up with the
                 indexing speed.
               summary: High Write Rejection Ratio - {{ $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
             expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
 
               '
@@ -33141,7 +33138,6 @@ objects:
                 can not be allocated to this node anymore. You should consider adding
                 more disk to the node.
               summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
@@ -33157,7 +33153,6 @@ objects:
                 to this node.
               summary: Disk High Watermark Reached - disk saturation is {{ $value
                 }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
@@ -33173,7 +33168,6 @@ objects:
                 falls below the high watermark.
               summary: Disk Flood Stage Watermark Reached - disk saturation is {{
                 $value }}%
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
               \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
               \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
@@ -33186,7 +33180,6 @@ objects:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: JVM Heap usage on the node is high
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
             expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent)
               > 75
 
@@ -33200,7 +33193,6 @@ objects:
               message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: System CPU usage is high
-              runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
             expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
 
               '
@@ -33213,7 +33205,6 @@ objects:
               message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
                 }} cluster is {{ $value }}%.
               summary: ES process CPU usage is high
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
             expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
 
               '
@@ -33226,7 +33217,6 @@ objects:
               message: Cluster {{ $labels.cluster }} is predicted to be out of disk
                 space within the next 6h.
               summary: Cluster low on disk space
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
             expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <
               0
 
@@ -33240,7 +33230,6 @@ objects:
               message: Cluster {{ $labels.cluster }} is predicted to be out of file
                 descriptors within the next hour.
               summary: Cluster low on file descriptors
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
             expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
               - predict_linear(es_process_file_descriptors_open_number[1h], 3600)
               < 0
@@ -33267,7 +33256,6 @@ objects:
                 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node
                 anymore. You should consider adding more disk to the node.
               summary: Disk Low Watermark is predicted to be reached within next 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
@@ -33283,7 +33271,6 @@ objects:
                 or drop old indices allocated to this node.
               summary: Disk High Watermark is predicted to be reached within next
                 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
@@ -33299,7 +33286,6 @@ objects:
                 released manually when the disk utilization falls below the high watermark.
               summary: Disk Flood Stage Watermark is predicted to be reached within
                 next 6h.
-              runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
             expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
               \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 *\
               \ 3600)\n    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
We have SOPs for alerts like `ElasticsearchNodeDiskWatermarkReachedSRE`, but the current `runbook_url` configuration stops it from working. We can rely on the auto-generated URL when this in unset, which is [configured in CAMO](https://github.com/openshift/configure-alertmanager-operator/blob/345e6bf2e03538a4f805bd0bd73b94f910a5fd7f/controllers/secret_controller.go#L530) --> e.g. for [ElasticSearchNodeDiskWatermarkReachedSRE](https://github.com/openshift/ops-sop/blob/master/v4/alerts/ElasticsearchNodeDiskWatermarkReachedSRE.md)

### Which Jira/Github issue(s) this PR fixes?
[OSD-17979](https://issues.redhat.com//browse/OSD-17979)
