### PR TITLE
Add admin-ack gate for Managed Ingress feature from 4.12->4.13

### DIFF
--- a/deploy/osd-cluster-acks/ocp/4.13/admin-gates.yaml
+++ b/deploy/osd-cluster-acks/ocp/4.13/admin-gates.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   ack-4.12-kube-1.26-api-removals-in-4.13: "true"
+  ack-4.12-ingress-changes-in-4.13: "true"
 kind: ConfigMap
 metadata:
   name: admin-acks

--- a/deploy/osd-cluster-admin-gates/admin-gate-ingress.patch.yaml
+++ b/deploy/osd-cluster-admin-gates/admin-gate-ingress.patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+applyMode: AlwaysApply
+kind: ConfigMap
+name: admin-gates
+namespace: openshift-config-managed
+# patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
+patch: '{"data":{"ack-4.12-ingress-changes-in-4.13": "In version 4.13 of OSD/ROSA, we are changing how we manage Ingress Controllers. If you are using additonal ingresses, or Custom Domains, your cluster may be affected. See https://access.redhat.com/node/7028653 for further details."}}'
+patchType: merge

--- a/deploy/osd-cluster-admin-gates/config.yaml
+++ b/deploy/osd-cluster-admin-gates/config.yaml
@@ -5,9 +5,3 @@ selectorSyncSet:
   - key: hive.openshift.io/version-major-minor
     operator: In
     values: ["4.12"]
-  - key: api.openshift.com/gate-ocp
-    operator: In
-    values: ["4.13"]
-  - key: api.openshift.com/gate-ingress
-    operator: In
-    values: ["4.13"]

--- a/deploy/osd-ingress/controller/router-infraNodes.patch.yaml
+++ b/deploy/osd-ingress/controller/router-infraNodes.patch.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: operator.openshift.io/v1
 applyMode: AlwaysApply
 kind: IngressController

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24677,11 +24677,16 @@ objects:
         operator: In
         values:
         - '4.13'
+      - key: api.openshift.com/gate-ingress
+        operator: In
+        values:
+        - '4.13'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       data:
         ack-4.12-kube-1.26-api-removals-in-4.13: 'true'
+        ack-4.12-ingress-changes-in-4.13: 'true'
       kind: ConfigMap
       metadata:
         name: admin-acks
@@ -24908,6 +24913,35 @@ objects:
       - apiGroup: rbac.authorization.k8s.io
         kind: Group
         name: cluster-admins
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-cluster-admin-gates
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Upsert
+    patches:
+    - apiVersion: v1
+      applyMode: AlwaysApply
+      kind: ConfigMap
+      name: admin-gates
+      namespace: openshift-config-managed
+      patch: '{"data":{"ack-4.12-ingress-changes-in-4.13": "In version 4.13 of OSD/ROSA,
+        we are changing how we manage Ingress Controllers. If you are using additonal
+        ingresses, or Custom Domains, your cluster may be affected. See https://access.redhat.com/node/7028653
+        for further details."}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24677,11 +24677,16 @@ objects:
         operator: In
         values:
         - '4.13'
+      - key: api.openshift.com/gate-ingress
+        operator: In
+        values:
+        - '4.13'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       data:
         ack-4.12-kube-1.26-api-removals-in-4.13: 'true'
+        ack-4.12-ingress-changes-in-4.13: 'true'
       kind: ConfigMap
       metadata:
         name: admin-acks
@@ -24908,6 +24913,35 @@ objects:
       - apiGroup: rbac.authorization.k8s.io
         kind: Group
         name: cluster-admins
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-cluster-admin-gates
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Upsert
+    patches:
+    - apiVersion: v1
+      applyMode: AlwaysApply
+      kind: ConfigMap
+      name: admin-gates
+      namespace: openshift-config-managed
+      patch: '{"data":{"ack-4.12-ingress-changes-in-4.13": "In version 4.13 of OSD/ROSA,
+        we are changing how we manage Ingress Controllers. If you are using additonal
+        ingresses, or Custom Domains, your cluster may be affected. See https://access.redhat.com/node/7028653
+        for further details."}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24677,11 +24677,16 @@ objects:
         operator: In
         values:
         - '4.13'
+      - key: api.openshift.com/gate-ingress
+        operator: In
+        values:
+        - '4.13'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       data:
         ack-4.12-kube-1.26-api-removals-in-4.13: 'true'
+        ack-4.12-ingress-changes-in-4.13: 'true'
       kind: ConfigMap
       metadata:
         name: admin-acks
@@ -24908,6 +24913,35 @@ objects:
       - apiGroup: rbac.authorization.k8s.io
         kind: Group
         name: cluster-admins
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-cluster-admin-gates
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+    resourceApplyMode: Upsert
+    patches:
+    - apiVersion: v1
+      applyMode: AlwaysApply
+      kind: ConfigMap
+      name: admin-gates
+      namespace: openshift-config-managed
+      patch: '{"data":{"ack-4.12-ingress-changes-in-4.13": "In version 4.13 of OSD/ROSA,
+        we are changing how we manage Ingress Controllers. If you are using additonal
+        ingresses, or Custom Domains, your cluster may be affected. See https://access.redhat.com/node/7028653
+        for further details."}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
This pull request adds an explicit 'ack' gate for admins upgrading to v4.13. It is needed as there are significant changes introduced in the 'Managed Ingress' epic to how we handle `IngressController` resources. 

KCS describing changes from 4.12->4.13: https://access.redhat.com/node/7028653
From the KCS:

> In version 4.13 of Red Hat OpenShift Service on AWS (ROSA), we are changing Ingress to give customers more control over their workloads and configuration. Customers will be able to create a fully customizable additional [Ingress Controller](https://docs.openshift.com/container-platform/4.12/networking/ingress-operator.html) alongside the default Ingress provided by the installer.

Tested and working here:
https://gitlab.cee.redhat.com/-/snippets/7105
Epic link:
https://issues.redhat.com/browse/SDE-1768
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-17988

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
