### PR TITLE
fix logic in defining the threshold for infra resize based on memory

### DIFF
--- a/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
@@ -74,26 +74,19 @@ spec:
             ) 
             > 
             (
-                sum (
-                    node_memory_MemTotal_bytes
-                    AND on (instance) label_replace(
-                        kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"
-                    )
+              scalar (
+                (
+                  count (
+                    cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
+                  )
+                  - 1
                 )
                 /
-                (
-                    count(
-                        cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
-                    )
+                count (
+                  cluster:nodes_roles{label_node_role_kubernetes_io ="infra"}
                 )
+              )
             )
-            /
-            sum (
-                node_memory_MemTotal_bytes
-                AND on (instance) label_replace(
-                    kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"
-                )
-          )
         record: sre:node_infra:excessive_consumption_memory
       ## If either of the CPU or Memory resource consumption alerts (see below) fire, then trigger an alert for SRE
       - expr: (

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31994,12 +31994,9 @@ objects:
               + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="infra"},
               "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
               AND on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) ) > ( sum ( node_memory_MemTotal_bytes AND
-              on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) / ( count( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) ) / sum ( node_memory_MemTotal_bytes AND on (instance)
-              label_replace( kube_node_role{role="infra"}, "instance", "$1", "node",
-              "(.+)" ) )
+              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
           - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
               alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31994,12 +31994,9 @@ objects:
               + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="infra"},
               "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
               AND on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) ) > ( sum ( node_memory_MemTotal_bytes AND
-              on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) / ( count( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) ) / sum ( node_memory_MemTotal_bytes AND on (instance)
-              label_replace( kube_node_role{role="infra"}, "instance", "$1", "node",
-              "(.+)" ) )
+              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
           - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
               alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31994,12 +31994,9 @@ objects:
               + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="infra"},
               "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
               AND on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) ) > ( sum ( node_memory_MemTotal_bytes AND
-              on (instance) label_replace( kube_node_role{role="infra"}, "instance",
-              "$1", "node", "(.+)" ) ) / ( count( cluster:nodes_roles{label_node_role_kubernetes_io
-              ="infra"} ) ) ) / sum ( node_memory_MemTotal_bytes AND on (instance)
-              label_replace( kube_node_role{role="infra"}, "instance", "$1", "node",
-              "(.+)" ) )
+              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
           - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
               alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Previously, the threshold was 1/3 when there were three infra nodes as opposed to 2/3, which was intended. We're now reusing logic that we have elsewhere: https://github.com/openshift/managed-cluster-config/blob/738d672547dbeba642465c97a38f6f5fec374842/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml#L37-L50

### Which Jira/Github issue(s) this PR fixes?

[OSD-17670](https://issues.redhat.com//browse/OSD-17670)