### PR TITLE
Re-enable resource-based InfraNodesNeedResizingSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -37,42 +37,6 @@ spec:
                 AND sre:node_workers:count > 250
               )
         record: sre:node_masters:need_resize
-      # infra has less than 16GB RAM or less than 5 CPU, worker count > 25, and worker count <= 100
-      # infra has less than 32GB RAM or less than 9 CPU, worker count > 100, and worker count <= 250
-      # infra has less than 128GB RAM or less than 17 CPU, worker count > 250
-      # infra has less than 128GB RAM or less than 33 CPU, worker count > 500
-      - expr: (
-                (
-                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 16*1024*1024*1024
-                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 4
-                )
-                AND sre:node_workers:count > 25
-                AND sre:node_workers:count <= 100
-              )
-              OR
-              (
-                (
-                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 32*1024*1024*1024
-                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 8
-                )
-                AND sre:node_workers:count > 100
-                AND sre:node_workers:count <= 250
-              )
-              OR
-              (
-                (
-                  avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 128*1024*1024*1024
-                  OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 16
-                )
-                AND sre:node_workers:count > 250
-              )
-              OR
-              (
-                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"}) < 128*1024*1024*1024
-                AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"}) <= 32
-                AND sre:node_workers:count > 500
-              )
-        record: sre:node_infras:need_resize
   - name: sre-control-plane-resizing-alerts
     rules:
       - alert: MasterNodesNeedResizingSRE
@@ -91,11 +55,3 @@ spec:
           namespace: openshift-monitoring
         annotations:
           message: "The cluster's master instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."
-      - alert: InfraNodesNeedResizingSRE
-        expr: sre:node_infras:need_resize > 0
-        for: 2h
-        labels:
-          severity: critical
-          namespace: openshift-monitoring
-        annotations:
-          message: "The cluster's infra instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."

--- a/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
@@ -88,6 +88,15 @@ spec:
               )
             )
         record: sre:node_infra:excessive_consumption_memory
+      ## If either of the CPU or Memory resource consumption alerts (see below) fire, then trigger an alert for SRE
+      - expr: (
+                count(
+                  ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE", alertstate="firing"}
+                  OR
+                  ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE", alertstate="firing"}
+                ) >= 1
+              )
+        record: sre:node_infras:need_resize
   - name: sre-infra-resizing-alerts
     rules:
     ## While individual spikes in CPU usage are acceptable, even if spikes are flappy, because CPU is a renewable resource,
@@ -99,7 +108,7 @@ spec:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's infrastructure nodes have been consuming excessive CPU for 16 hours and should be vertically scaled to support the existing workers. See linked SOP for details."
+          message: "The cluster's infrastructure nodes have been consuming excessive CPU for 16 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
       ## Given memory may be allocated but unused, 24h is good enough to catch gradual outgrowing of the cluster with critical node failures alerting via other alerts
       - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
         expr: sre:node_infra:excessive_consumption_memory > 0
@@ -108,4 +117,13 @@ spec:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's infrastructure nodes have been consuming excessive memory for 24 hours and should be vertically scaled to support the existing workers. See linked SOP for details."
+          message: "The cluster's infrastructure nodes have been consuming excessive memory for 24 hours and may need to be vertically scaled to support the existing workers. See linked SOP for details."
+      ## If the CPU or Memory related "InfraNodesExcessiveResourceConsumptionSRE" alerts are firing, raise a critical ticket to SRE to scale the infra nodes up
+      - alert: InfraNodesNeedResizingSRE
+        expr: sre:node_infras:need_resize > 0
+        for: 2h
+        labels:
+          severity: critical
+          namespace: openshift-monitoring
+        annotations:
+          message: "The cluster's infrastructure nodes have been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31853,18 +31853,6 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
-          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
-              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
-              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 32 AND sre:node_workers:count > 500 )
-            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -31885,16 +31873,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 2h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
@@ -32020,6 +31998,10 @@ objects:
               ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} ) >= 1 )
+            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
           - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
@@ -32030,8 +32012,8 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and should be vertically scaled to support the existing
-                workers. See linked SOP for details.
+                CPU for 16 hours and may need to be vertically scaled to support the
+                existing workers. See linked SOP for details.
           - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
             expr: sre:node_infra:excessive_consumption_memory > 0
             for: 24h
@@ -32040,8 +32022,18 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and should be vertically scaled to support the
-                existing workers. See linked SOP for details.
+                memory for 24 hours and may need to be vertically scaled to support
+                the existing workers. See linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31853,18 +31853,6 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
-          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
-              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
-              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 32 AND sre:node_workers:count > 500 )
-            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -31885,16 +31873,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 2h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
@@ -32020,6 +31998,10 @@ objects:
               ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} ) >= 1 )
+            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
           - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
@@ -32030,8 +32012,8 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and should be vertically scaled to support the existing
-                workers. See linked SOP for details.
+                CPU for 16 hours and may need to be vertically scaled to support the
+                existing workers. See linked SOP for details.
           - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
             expr: sre:node_infra:excessive_consumption_memory > 0
             for: 24h
@@ -32040,8 +32022,18 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and should be vertically scaled to support the
-                existing workers. See linked SOP for details.
+                memory for 24 hours and may need to be vertically scaled to support
+                the existing workers. See linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31853,18 +31853,6 @@ objects:
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
             record: sre:node_masters:need_resize
-          - expr: ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 16*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 4 ) AND sre:node_workers:count > 25 AND sre:node_workers:count <=
-              100 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 32*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 8 ) AND sre:node_workers:count > 100 AND sre:node_workers:count <=
-              250 ) OR ( ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 OR avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 16 ) AND sre:node_workers:count > 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="infra"})
-              < 128*1024*1024*1024 AND avg(sre:node_roles:node_num_cpu{label_node_role_kubernetes_io="infra"})
-              <= 32 AND sre:node_workers:count > 500 )
-            record: sre:node_infras:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: MasterNodesNeedResizingSRE
@@ -31885,16 +31873,6 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
-          - alert: InfraNodesNeedResizingSRE
-            expr: sre:node_infras:need_resize > 0
-            for: 2h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              message: The cluster's infra instance has been undersized for 2 hours
                 and must be vertically scaled to support the existing workers.  See
                 linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
@@ -32020,6 +31998,10 @@ objects:
               ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
+              alertstate="firing"} ) >= 1 )
+            record: sre:node_infras:need_resize
         - name: sre-infra-resizing-alerts
           rules:
           - alert: cpu-InfraNodesExcessiveResourceConsumptionSRE
@@ -32030,8 +32012,8 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                CPU for 16 hours and should be vertically scaled to support the existing
-                workers. See linked SOP for details.
+                CPU for 16 hours and may need to be vertically scaled to support the
+                existing workers. See linked SOP for details.
           - alert: memory-InfraNodesExcessiveResourceConsumptionSRE
             expr: sre:node_infra:excessive_consumption_memory > 0
             for: 24h
@@ -32040,8 +32022,18 @@ objects:
               namespace: openshift-monitoring
             annotations:
               message: The cluster's infrastructure nodes have been consuming excessive
-                memory for 24 hours and should be vertically scaled to support the
-                existing workers. See linked SOP for details.
+                memory for 24 hours and may need to be vertically scaled to support
+                the existing workers. See linked SOP for details.
+          - alert: InfraNodesNeedResizingSRE
+            expr: sre:node_infras:need_resize > 0
+            for: 2h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The cluster's infrastructure nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.  See
+                linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION

Re-add new InfraNodeNeedResizingSRE alert criteria
    
This re-enables the previously reverted InfraNodesNeedResizingSRE alert to fire based on resource utilization and not node count.  See #1792, #1798 and #1799 for details.
