### PR TITLE
OLM Dance CDO if v205 is not running

### DIFF
--- a/deploy/osd-17042-cdo-olm-dance/04-cronjob.yaml
+++ b/deploy/osd-17042-cdo-olm-dance/04-cronjob.yaml
@@ -33,13 +33,11 @@ spec:
                 oc patch -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator --type json --patch='[ { "op": "remove", "path": "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration" } ]'
               fi
 
-              # Check for the presence of CDO v0.1.201, then we know we're stuck
-              # stuck
-              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893 -o name --ignore-not-found) || true
-              if [[ ! -z "$CSV_FOUND" ]]; then
-                # It is present, so wipe out CDO
-                oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=""
-                oc -n "$NAMESPACE" delete installplans.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=""
+              # Check for the presence of CDO v0.1.205, if it's not v0.1.205, then assume we're stuck
+              if ! $(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.205-5b1688f); then
+                # OLM Dance CDO
+                oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com $(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName=="custom-domains-operator")].metadata.name}') || true
+                oc -n "$NAMESPACE" delete installplans.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator="" --ignore-not-found
                 oc -n "$NAMESPACE" delete subscriptions.operators.coreos.com custom-domains-operator --ignore-not-found
               fi
               exit 0

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22848,15 +22848,15 @@ objects:
                     \ custom-domains-operator; then\n  oc patch -n \"$NAMESPACE\"\
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
-                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893\
-                    \ -o name --ignore-not-found) || true\nif [[ ! -z \"$CSV_FOUND\"\
-                    \ ]]; then\n  # It is present, so wipe out CDO\n  oc -n \"$NAMESPACE\"\
-                    \ delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
+                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.205, if it's\
+                    \ not v0.1.205, then assume we're stuck\nif ! $(oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.205-5b1688f);\
+                    \ then\n  # OLM Dance CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"custom-domains-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                    \" --ignore-not-found\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
                     \ custom-domains-operator --ignore-not-found\nfi\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22848,15 +22848,15 @@ objects:
                     \ custom-domains-operator; then\n  oc patch -n \"$NAMESPACE\"\
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
-                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893\
-                    \ -o name --ignore-not-found) || true\nif [[ ! -z \"$CSV_FOUND\"\
-                    \ ]]; then\n  # It is present, so wipe out CDO\n  oc -n \"$NAMESPACE\"\
-                    \ delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
+                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.205, if it's\
+                    \ not v0.1.205, then assume we're stuck\nif ! $(oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.205-5b1688f);\
+                    \ then\n  # OLM Dance CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"custom-domains-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                    \" --ignore-not-found\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
                     \ custom-domains-operator --ignore-not-found\nfi\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22848,15 +22848,15 @@ objects:
                     \ custom-domains-operator; then\n  oc patch -n \"$NAMESPACE\"\
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
-                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893\
-                    \ -o name --ignore-not-found) || true\nif [[ ! -z \"$CSV_FOUND\"\
-                    \ ]]; then\n  # It is present, so wipe out CDO\n  oc -n \"$NAMESPACE\"\
-                    \ delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
+                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.205, if it's\
+                    \ not v0.1.205, then assume we're stuck\nif ! $(oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.205-5b1688f);\
+                    \ then\n  # OLM Dance CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"custom-domains-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                    \" --ignore-not-found\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
                     \ custom-domains-operator --ignore-not-found\nfi\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Due to previous bugs, we have and orphaned v201 as well as some other clusters that are stuck on old versions of CDO. This is intended to be a one-off to sync up the state of CDO across the fleet onto v205.

This PR essentially should block any CDO prod promotions until this CronJob is removed in a follow up PR.

### Which Jira/Github issue(s) this PR fixes?
OSD-17042

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
