### PR TITLE
itn-2023-00101 - Remove CDO's pre-v205 olm objects

### DIFF
--- a/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
+++ b/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
@@ -35,8 +35,7 @@ spec:
 
               # Check for the presence of CDO v0.1.201, then we know we're stuck
               # stuck
-              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893 -o name --ignore-not-found) || true
-              if [[ ! -z "$CSV_FOUND" ]]; then
+              if ! oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.205-5b1688f; then
                 # It is present, so wipe out CDO
                 oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=""
                 oc -n "$NAMESPACE" delete installplans.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=""

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22769,11 +22769,10 @@ objects:
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
                     \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893\
-                    \ -o name --ignore-not-found) || true\nif [[ ! -z \"$CSV_FOUND\"\
-                    \ ]]; then\n  # It is present, so wipe out CDO\n  oc -n \"$NAMESPACE\"\
-                    \ delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
+                    \ know we're stuck\n# stuck\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ custom-domains-operator.v0.1.205-5b1688f; then\n  # It is present,\
+                    \ so wipe out CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22769,11 +22769,10 @@ objects:
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
                     \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893\
-                    \ -o name --ignore-not-found) || true\nif [[ ! -z \"$CSV_FOUND\"\
-                    \ ]]; then\n  # It is present, so wipe out CDO\n  oc -n \"$NAMESPACE\"\
-                    \ delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
+                    \ know we're stuck\n# stuck\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ custom-domains-operator.v0.1.205-5b1688f; then\n  # It is present,\
+                    \ so wipe out CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22769,11 +22769,10 @@ objects:
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
                     \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.201-b9b8893\
-                    \ -o name --ignore-not-found) || true\nif [[ ! -z \"$CSV_FOUND\"\
-                    \ ]]; then\n  # It is present, so wipe out CDO\n  oc -n \"$NAMESPACE\"\
-                    \ delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
+                    \ know we're stuck\n# stuck\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ custom-domains-operator.v0.1.205-5b1688f; then\n  # It is present,\
+                    \ so wipe out CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
hotfix

### What this PR does / why we need it?
Applies minor tweak to #1807's if statement to apply more generally

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
