### PR TITLE
[OSD-17905] MachineOutOfCompliance alert

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
@@ -17,6 +17,7 @@ spec:
       for: 60m
       labels:
         severity: warning
+        namespace: "{{ $labels.namespace }}"
         node: "{{ $labels.node }}"
         source: "https://issues.redhat.com/browse/OSD-17905"
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md"

--- a/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-machine-out-of-compliance
+    role: alert-rules
+  name: sre-machine-out-of-compliance
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-machine-out-of-compliance
+    rules:
+    - alert: MachineOutOfComplianceSRE
+      # https://issues.redhat.com/browse/OSD-17905
+      # This alert is a fallback in case the workload in https://issues.redhat.com/browse/OSD-17902 doesn't do it's job.
+      expr: |
+        mapi_machine_created_timestamp_seconds > 2419200
+      for: 60m
+      labels:
+        severity: warning
+        node: "{{ $labels.node }}"
+        source: "https://issues.redhat.com/browse/OSD-17905"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md"
+      annotations:
+        message:  A machine on a management cluster is older than 28 days.

--- a/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
@@ -13,8 +13,7 @@ spec:
     - alert: MachineOutOfComplianceSRE
       # https://issues.redhat.com/browse/OSD-17905
       # This alert is a fallback in case the workload in https://issues.redhat.com/browse/OSD-17902 doesn't do it's job.
-      expr: |
-        mapi_machine_created_timestamp_seconds > 2419200
+      expr: mapi_machine_created_timestamp_seconds > 2419200
       for: 60m
       labels:
         severity: warning

--- a/deploy/sre-prometheus/management-cluster/config.yaml
+++ b/deploy/sre-prometheus/management-cluster/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33140,6 +33140,53 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-machine-out-of-compliance
+          role: alert-rules
+        name: sre-machine-out-of-compliance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-machine-out-of-compliance
+          rules:
+          - alert: MachineOutOfComplianceSRE
+            expr: 'mapi_machine_created_timestamp_seconds > 2419200
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              node: '{{ $labels.node }}'
+              source: https://issues.redhat.com/browse/OSD-17905
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md
+            annotations:
+              message: A machine on a management cluster is older than 28 days.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33173,6 +33173,7 @@ objects:
             for: 60m
             labels:
               severity: warning
+              namespace: '{{ $labels.namespace }}'
               node: '{{ $labels.node }}'
               source: https://issues.redhat.com/browse/OSD-17905
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33169,9 +33169,7 @@ objects:
         - name: sre-machine-out-of-compliance
           rules:
           - alert: MachineOutOfComplianceSRE
-            expr: 'mapi_machine_created_timestamp_seconds > 2419200
-
-              '
+            expr: mapi_machine_created_timestamp_seconds > 2419200
             for: 60m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33140,6 +33140,53 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-machine-out-of-compliance
+          role: alert-rules
+        name: sre-machine-out-of-compliance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-machine-out-of-compliance
+          rules:
+          - alert: MachineOutOfComplianceSRE
+            expr: 'mapi_machine_created_timestamp_seconds > 2419200
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              node: '{{ $labels.node }}'
+              source: https://issues.redhat.com/browse/OSD-17905
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md
+            annotations:
+              message: A machine on a management cluster is older than 28 days.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33173,6 +33173,7 @@ objects:
             for: 60m
             labels:
               severity: warning
+              namespace: '{{ $labels.namespace }}'
               node: '{{ $labels.node }}'
               source: https://issues.redhat.com/browse/OSD-17905
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33169,9 +33169,7 @@ objects:
         - name: sre-machine-out-of-compliance
           rules:
           - alert: MachineOutOfComplianceSRE
-            expr: 'mapi_machine_created_timestamp_seconds > 2419200
-
-              '
+            expr: mapi_machine_created_timestamp_seconds > 2419200
             for: 60m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33140,6 +33140,53 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-machine-out-of-compliance
+          role: alert-rules
+        name: sre-machine-out-of-compliance
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-machine-out-of-compliance
+          rules:
+          - alert: MachineOutOfComplianceSRE
+            expr: 'mapi_machine_created_timestamp_seconds > 2419200
+
+              '
+            for: 60m
+            labels:
+              severity: warning
+              node: '{{ $labels.node }}'
+              source: https://issues.redhat.com/browse/OSD-17905
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md
+            annotations:
+              message: A machine on a management cluster is older than 28 days.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33173,6 +33173,7 @@ objects:
             for: 60m
             labels:
               severity: warning
+              namespace: '{{ $labels.namespace }}'
               node: '{{ $labels.node }}'
               source: https://issues.redhat.com/browse/OSD-17905
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33169,9 +33169,7 @@ objects:
         - name: sre-machine-out-of-compliance
           rules:
           - alert: MachineOutOfComplianceSRE
-            expr: 'mapi_machine_created_timestamp_seconds > 2419200
-
-              '
+            expr: mapi_machine_created_timestamp_seconds > 2419200
             for: 60m
             labels:
               severity: warning


### PR DESCRIPTION
### What type of PR is this?
new alert

### What this PR does / why we need it?

This PR adds an alert to catch when the automated replacement of nodes that are >28 days old fails.


### Which Jira/Github issue(s) this PR fixes?

[_Fixes #_[OSD-17905](https://issues.redhat.com//browse/OSD-17905)](https://issues.redhat.com/browse/OSD-17905)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
