### PR TITLE
Ensure annotations exist before patching

### DIFF
--- a/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
+++ b/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
@@ -27,11 +27,11 @@ spec:
               #!/bin/bash
               set -euxo pipefail
               NAMESPACE=openshift-custom-domains-operator
-              
+
               # Fix failing CDO clustersyncs by wiping out last-applied-configuration
               # Ensure we only attempt to patch if the annotation exists
               ANNOTATIONS_EXIST=X$(oc get subscriptions.operators.coreos.com custom-domains-operator -n openshift-custom-domains-operator -o json | jq 'any(.metadata; .Key == "annotations")')
-              if [ "ANNOTATIONS_EXIST" != "Xfalse" ];
+              if [ "$ANNOTATIONS_EXIST" != "Xfalse" ]; then
                 if oc get -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator; then
                   oc patch -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator --type json --patch='[ { "op": "remove", "path": "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration" } ]'
                 fi

--- a/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
+++ b/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
@@ -29,15 +29,19 @@ spec:
               NAMESPACE=openshift-custom-domains-operator
               
               # Fix failing CDO clustersyncs by wiping out last-applied-configuration
-              if oc get -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator; then
-                oc patch -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator --type json --patch='[ { "op": "remove", "path": "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration" } ]'
+              # Ensure we only attempt to patch if the annotation exists
+              ANNOTATIONS_EXIST=X$(oc get subscriptions.operators.coreos.com custom-domains-operator -n openshift-custom-domains-operator -o json | jq 'any(.metadata; .Key == "annotations")')
+              if [ "ANNOTATIONS_EXIST" != "Xfalse" ];
+                if oc get -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator; then
+                  oc patch -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator --type json --patch='[ { "op": "remove", "path": "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration" } ]'
+                fi
               fi
 
-              # Check for the presence of CDO v0.1.201, then we know we're stuck
-              # stuck
+              # Check for the presence of CDO v0.1.205 and do nothing, if any other version is found clean up OLM resources
+              # Hive will sync these back
               if ! oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.205-5b1688f; then
                 # It is present, so wipe out CDO
-                oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=""
+                oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com $(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName=="custom-domains-operator")].metadata.name}') || true
                 oc -n "$NAMESPACE" delete installplans.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=""
                 oc -n "$NAMESPACE" delete subscriptions.operators.coreos.com custom-domains-operator --ignore-not-found
               fi

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22764,16 +22764,22 @@ objects:
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
                     \n# Fix failing CDO clustersyncs by wiping out last-applied-configuration\n\
-                    if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
-                    \ custom-domains-operator; then\n  oc patch -n \"$NAMESPACE\"\
+                    # Ensure we only attempt to patch if the annotation exists\nANNOTATIONS_EXIST=X$(oc\
+                    \ get subscriptions.operators.coreos.com custom-domains-operator\
+                    \ -n openshift-custom-domains-operator -o json | jq 'any(.metadata;\
+                    \ .Key == \"annotations\")')\nif [ \"$ANNOTATIONS_EXIST\" != \"\
+                    Xfalse\" ]; then\n  if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
+                    \ custom-domains-operator; then\n    oc patch -n \"$NAMESPACE\"\
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
-                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ } ]'\n  fi\nfi\n\n# Check for the presence of CDO v0.1.205 and\
+                    \ do nothing, if any other version is found clean up OLM resources\n\
+                    # Hive will sync these back\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
                     \ custom-domains-operator.v0.1.205-5b1688f; then\n  # It is present,\
                     \ so wipe out CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
-                    \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"custom-domains-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
                     \ custom-domains-operator --ignore-not-found\nfi\nexit 0\n"

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22764,16 +22764,22 @@ objects:
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
                     \n# Fix failing CDO clustersyncs by wiping out last-applied-configuration\n\
-                    if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
-                    \ custom-domains-operator; then\n  oc patch -n \"$NAMESPACE\"\
+                    # Ensure we only attempt to patch if the annotation exists\nANNOTATIONS_EXIST=X$(oc\
+                    \ get subscriptions.operators.coreos.com custom-domains-operator\
+                    \ -n openshift-custom-domains-operator -o json | jq 'any(.metadata;\
+                    \ .Key == \"annotations\")')\nif [ \"$ANNOTATIONS_EXIST\" != \"\
+                    Xfalse\" ]; then\n  if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
+                    \ custom-domains-operator; then\n    oc patch -n \"$NAMESPACE\"\
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
-                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ } ]'\n  fi\nfi\n\n# Check for the presence of CDO v0.1.205 and\
+                    \ do nothing, if any other version is found clean up OLM resources\n\
+                    # Hive will sync these back\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
                     \ custom-domains-operator.v0.1.205-5b1688f; then\n  # It is present,\
                     \ so wipe out CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
-                    \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"custom-domains-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
                     \ custom-domains-operator --ignore-not-found\nfi\nexit 0\n"

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22764,16 +22764,22 @@ objects:
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
                     \n# Fix failing CDO clustersyncs by wiping out last-applied-configuration\n\
-                    if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
-                    \ custom-domains-operator; then\n  oc patch -n \"$NAMESPACE\"\
+                    # Ensure we only attempt to patch if the annotation exists\nANNOTATIONS_EXIST=X$(oc\
+                    \ get subscriptions.operators.coreos.com custom-domains-operator\
+                    \ -n openshift-custom-domains-operator -o json | jq 'any(.metadata;\
+                    \ .Key == \"annotations\")')\nif [ \"$ANNOTATIONS_EXIST\" != \"\
+                    Xfalse\" ]; then\n  if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
+                    \ custom-domains-operator; then\n    oc patch -n \"$NAMESPACE\"\
                     \ subscriptions.operators.coreos.com custom-domains-operator --type\
                     \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
-                    \ } ]'\nfi\n\n# Check for the presence of CDO v0.1.201, then we\
-                    \ know we're stuck\n# stuck\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ } ]'\n  fi\nfi\n\n# Check for the presence of CDO v0.1.205 and\
+                    \ do nothing, if any other version is found clean up OLM resources\n\
+                    # Hive will sync these back\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
                     \ custom-domains-operator.v0.1.205-5b1688f; then\n  # It is present,\
                     \ so wipe out CDO\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
-                    \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
-                    \"\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"custom-domains-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplans.operators.coreos.com\
                     \ -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
                     \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
                     \ custom-domains-operator --ignore-not-found\nfi\nexit 0\n"


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Fixes cron applied for [OHSS-25830](https://issues.redhat.com//browse/OHSS-25830) for CDO OLM deployments

Also adds a jsonpath selector from https://github.com/openshift/managed-cluster-config/commit/5e8ffffeab6b6e277ecdfd44de428ffe7fa290f9#diff-49ee0cdf459249b1d4e823c802b7d708bf759df34b42443f441f64bd4cfb0497L39 for the CSV

### Which Jira/Github issue(s) this PR fixes?
[OHSS-25830](https://issues.redhat.com//browse/OHSS-25830)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
