### PR TITLE
Remove 'jq' dependency from job run

### DIFF
--- a/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
+++ b/deploy/osd-17042-cdo-olm-dance/pre-4.11/04-cronjob.yaml
@@ -30,10 +30,9 @@ spec:
 
               # Fix failing CDO clustersyncs by wiping out last-applied-configuration
               # Ensure we only attempt to patch if the annotation exists
-              ANNOTATIONS_EXIST=X$(oc get subscriptions.operators.coreos.com custom-domains-operator -n openshift-custom-domains-operator -o json | jq 'any(.metadata; .Key == "annotations")')
-              if [ "$ANNOTATIONS_EXIST" != "Xfalse" ]; then
-                if oc get -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator; then
-                  oc patch -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator --type json --patch='[ { "op": "remove", "path": "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration" } ]'
+              if oc get -n openshift-custom-domains-operator subscriptions.operators.coreos.com custom-domains-operator; then
+                if [[ $(oc get -n openshift-custom-domains-operator subscriptions.operators.coreos.com custom-domains-operator -o custom-columns=ANNOTATIONS:.metadata.annotations --no-headers) != "<none>" ]]; then
+                     oc patch -n "$NAMESPACE" subscriptions.operators.coreos.com custom-domains-operator --type json --patch='[ { "op": "remove", "path": "/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration" } ]'
                 fi
               fi
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22764,14 +22764,14 @@ objects:
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
                     \n# Fix failing CDO clustersyncs by wiping out last-applied-configuration\n\
-                    # Ensure we only attempt to patch if the annotation exists\nANNOTATIONS_EXIST=X$(oc\
-                    \ get subscriptions.operators.coreos.com custom-domains-operator\
-                    \ -n openshift-custom-domains-operator -o json | jq 'any(.metadata;\
-                    \ .Key == \"annotations\")')\nif [ \"$ANNOTATIONS_EXIST\" != \"\
-                    Xfalse\" ]; then\n  if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
-                    \ custom-domains-operator; then\n    oc patch -n \"$NAMESPACE\"\
-                    \ subscriptions.operators.coreos.com custom-domains-operator --type\
-                    \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
+                    # Ensure we only attempt to patch if the annotation exists\nif\
+                    \ oc get -n openshift-custom-domains-operator subscriptions.operators.coreos.com\
+                    \ custom-domains-operator; then\n  if [[ $(oc get -n openshift-custom-domains-operator\
+                    \ subscriptions.operators.coreos.com custom-domains-operator -o\
+                    \ custom-columns=ANNOTATIONS:.metadata.annotations --no-headers)\
+                    \ != \"<none>\" ]]; then\n       oc patch -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
+                    \ custom-domains-operator --type json --patch='[ { \"op\": \"\
+                    remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
                     \ } ]'\n  fi\nfi\n\n# Check for the presence of CDO v0.1.205 and\
                     \ do nothing, if any other version is found clean up OLM resources\n\
                     # Hive will sync these back\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22764,14 +22764,14 @@ objects:
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
                     \n# Fix failing CDO clustersyncs by wiping out last-applied-configuration\n\
-                    # Ensure we only attempt to patch if the annotation exists\nANNOTATIONS_EXIST=X$(oc\
-                    \ get subscriptions.operators.coreos.com custom-domains-operator\
-                    \ -n openshift-custom-domains-operator -o json | jq 'any(.metadata;\
-                    \ .Key == \"annotations\")')\nif [ \"$ANNOTATIONS_EXIST\" != \"\
-                    Xfalse\" ]; then\n  if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
-                    \ custom-domains-operator; then\n    oc patch -n \"$NAMESPACE\"\
-                    \ subscriptions.operators.coreos.com custom-domains-operator --type\
-                    \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
+                    # Ensure we only attempt to patch if the annotation exists\nif\
+                    \ oc get -n openshift-custom-domains-operator subscriptions.operators.coreos.com\
+                    \ custom-domains-operator; then\n  if [[ $(oc get -n openshift-custom-domains-operator\
+                    \ subscriptions.operators.coreos.com custom-domains-operator -o\
+                    \ custom-columns=ANNOTATIONS:.metadata.annotations --no-headers)\
+                    \ != \"<none>\" ]]; then\n       oc patch -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
+                    \ custom-domains-operator --type json --patch='[ { \"op\": \"\
+                    remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
                     \ } ]'\n  fi\nfi\n\n# Check for the presence of CDO v0.1.205 and\
                     \ do nothing, if any other version is found clean up OLM resources\n\
                     # Hive will sync these back\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22764,14 +22764,14 @@ objects:
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
                     \n# Fix failing CDO clustersyncs by wiping out last-applied-configuration\n\
-                    # Ensure we only attempt to patch if the annotation exists\nANNOTATIONS_EXIST=X$(oc\
-                    \ get subscriptions.operators.coreos.com custom-domains-operator\
-                    \ -n openshift-custom-domains-operator -o json | jq 'any(.metadata;\
-                    \ .Key == \"annotations\")')\nif [ \"$ANNOTATIONS_EXIST\" != \"\
-                    Xfalse\" ]; then\n  if oc get -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
-                    \ custom-domains-operator; then\n    oc patch -n \"$NAMESPACE\"\
-                    \ subscriptions.operators.coreos.com custom-domains-operator --type\
-                    \ json --patch='[ { \"op\": \"remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
+                    # Ensure we only attempt to patch if the annotation exists\nif\
+                    \ oc get -n openshift-custom-domains-operator subscriptions.operators.coreos.com\
+                    \ custom-domains-operator; then\n  if [[ $(oc get -n openshift-custom-domains-operator\
+                    \ subscriptions.operators.coreos.com custom-domains-operator -o\
+                    \ custom-columns=ANNOTATIONS:.metadata.annotations --no-headers)\
+                    \ != \"<none>\" ]]; then\n       oc patch -n \"$NAMESPACE\" subscriptions.operators.coreos.com\
+                    \ custom-domains-operator --type json --patch='[ { \"op\": \"\
+                    remove\", \"path\": \"/metadata/annotations/kubectl.kubernetes.io~1last-applied-configuration\"\
                     \ } ]'\n  fi\nfi\n\n# Check for the presence of CDO v0.1.205 and\
                     \ do nothing, if any other version is found clean up OLM resources\n\
                     # Hive will sync these back\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
hotfix

### What this PR does / why we need it?
Removes a dependency on `jq` preventing the olm dance cronjob from succeeding

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
