### PR TITLE
Update Managed Ingress feature labeller to reflect new business requirements

### DIFF
--- a/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
+++ b/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
@@ -49,19 +49,15 @@ spec:
                       print("No hive version label on cluster, exiting")
                       continue
 
-                  if labels.get("hive.openshift.io/cluster-platform") != "aws":
-                      print("Cluster platform not aws, skipping")
-                      continue
-
-                  if labels.get("hive.openshift.io/version-major-minor") and int(labels["hive.openshift.io/version-major-minor"].split(".")[1]) < 13:
-                      print("Version less than v4.13, exiting")
+                  if labels.get("hive.openshift.io/version-major-minor") and int(labels["hive.openshift.io/version-major-minor"].split(".")[1]) < 14:
+                      print("Version less than v4.14, exiting")
                       continue
 
                   if labels.get("ext-managed.openshift.io/legacy-ingress-support"):
                       print("ext-managed.openshift.io/legacy-ingress-support label already exists, moving to next cluster")
                       continue
                   else:
-                      print("ext-managed.openshift.io/legacy-ingress-support label does not exist and cluster is v4.13 or greater. Labelling as legacy-ingress: false.")
+                      print("ext-managed.openshift.io/legacy-ingress-support label does not exist and cluster is v4.14 or greater. Labelling as legacy-ingress: false.")
                       cmd = f'oc label clusterdeployment -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support="false"'
                       print(f"Running {cmd}")
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26605,16 +26605,14 @@ objects:
                     \ {name} in namespace {namespace}')\n    if not labels.get(\"\
                     hive.openshift.io/version-major-minor\"):\n        print(\"No\
                     \ hive version label on cluster, exiting\")\n        continue\n\
-                    \n    if labels.get(\"hive.openshift.io/cluster-platform\") !=\
-                    \ \"aws\":\n        print(\"Cluster platform not aws, skipping\"\
-                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
-                    .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
+                    .\")[1]) < 14:\n        print(\"Version less than v4.14, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\
                     ):\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
                     \ label already exists, moving to next cluster\")\n        continue\n\
                     \    else:\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
-                    \ label does not exist and cluster is v4.13 or greater. Labelling\
+                    \ label does not exist and cluster is v4.14 or greater. Labelling\
                     \ as legacy-ingress: false.\")\n        cmd = f'oc label clusterdeployment\
                     \ -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support=\"\
                     false\"'\n        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26605,16 +26605,14 @@ objects:
                     \ {name} in namespace {namespace}')\n    if not labels.get(\"\
                     hive.openshift.io/version-major-minor\"):\n        print(\"No\
                     \ hive version label on cluster, exiting\")\n        continue\n\
-                    \n    if labels.get(\"hive.openshift.io/cluster-platform\") !=\
-                    \ \"aws\":\n        print(\"Cluster platform not aws, skipping\"\
-                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
-                    .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
+                    .\")[1]) < 14:\n        print(\"Version less than v4.14, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\
                     ):\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
                     \ label already exists, moving to next cluster\")\n        continue\n\
                     \    else:\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
-                    \ label does not exist and cluster is v4.13 or greater. Labelling\
+                    \ label does not exist and cluster is v4.14 or greater. Labelling\
                     \ as legacy-ingress: false.\")\n        cmd = f'oc label clusterdeployment\
                     \ -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support=\"\
                     false\"'\n        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26605,16 +26605,14 @@ objects:
                     \ {name} in namespace {namespace}')\n    if not labels.get(\"\
                     hive.openshift.io/version-major-minor\"):\n        print(\"No\
                     \ hive version label on cluster, exiting\")\n        continue\n\
-                    \n    if labels.get(\"hive.openshift.io/cluster-platform\") !=\
-                    \ \"aws\":\n        print(\"Cluster platform not aws, skipping\"\
-                    )\n        continue\n\n    if labels.get(\"hive.openshift.io/version-major-minor\"\
+                    \n    if labels.get(\"hive.openshift.io/version-major-minor\"\
                     ) and int(labels[\"hive.openshift.io/version-major-minor\"].split(\"\
-                    .\")[1]) < 13:\n        print(\"Version less than v4.13, exiting\"\
+                    .\")[1]) < 14:\n        print(\"Version less than v4.14, exiting\"\
                     )\n        continue\n\n    if labels.get(\"ext-managed.openshift.io/legacy-ingress-support\"\
                     ):\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
                     \ label already exists, moving to next cluster\")\n        continue\n\
                     \    else:\n        print(\"ext-managed.openshift.io/legacy-ingress-support\
-                    \ label does not exist and cluster is v4.13 or greater. Labelling\
+                    \ label does not exist and cluster is v4.14 or greater. Labelling\
                     \ as legacy-ingress: false.\")\n        cmd = f'oc label clusterdeployment\
                     \ -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support=\"\
                     false\"'\n        print(f\"Running {cmd}\")\n\n        out = os.popen(cmd)\n\


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
- Updates target 'managed ingress' version from 4.13 to 4.14. Also updates the CronJob to target all cloud providers (and not just AWS). Was decided by BU [here](https://redhat-internal.slack.com/archives/CB53T9ZHQ/p1692895237660949).
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
