### PR TITLE
cpms .spec.state must be a string

### DIFF
--- a/deploy/osd-17901-enable-cpms/cpms-cluster.state.patch.yaml
+++ b/deploy/osd-17901-enable-cpms/cpms-cluster.state.patch.yaml
@@ -2,5 +2,5 @@ apiVersion: machine.openshift.io/v1
 kind: ControlPlaneMachineSet
 name: cluster
 namespace: openshift-machine-api
-patch: '{"spec":{"state": Active}}'
+patch: '{"spec":{"state": "Active"}}'
 patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22810,7 +22810,7 @@ objects:
       kind: ControlPlaneMachineSet
       name: cluster
       namespace: openshift-machine-api
-      patch: '{"spec":{"state": Active}}'
+      patch: '{"spec":{"state": "Active"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22810,7 +22810,7 @@ objects:
       kind: ControlPlaneMachineSet
       name: cluster
       namespace: openshift-machine-api
-      patch: '{"spec":{"state": Active}}'
+      patch: '{"spec":{"state": "Active"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22810,7 +22810,7 @@ objects:
       kind: ControlPlaneMachineSet
       name: cluster
       namespace: openshift-machine-api
-      patch: '{"spec":{"state": Active}}'
+      patch: '{"spec":{"state": "Active"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
The current ClusterSync is failing with:
```
  - failureMessage: 'failed to apply patch 0: error decoding patch: invalid character
      ''A'' looking for beginning of value'
    lastTransitionTime: "2023-08-30T14:57:17Z"
    name: osd-17901-enable-cpms
    observedGeneration: 1
    result: Failure
```

### Which Jira/Github issue(s) this PR fixes?
[OSD-17901](https://issues.redhat.com//browse/OSD-17901)