### PR TITLE
rename MasterNodesNeedResizingSRE to ControlPlaneNodesNeedResizingSRE

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -17,9 +17,9 @@ spec:
         record: sre:node_roles:node_num_cpu
       - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
         record: sre:node_workers:count
-      # master has less than 32GB RAM, worker count > 25, and worker count <= 100
-      # master has less than 64GB RAM, worker count > 100, and worker count <= 250
-      # master has less than 128GB RAM, worker count > 250
+      # control plane has less than 32GB RAM, worker count > 25, and worker count <= 100
+      # control plane has less than 64GB RAM, worker count > 100, and worker count <= 250
+      # control plane has less than 128GB RAM, worker count > 250
       - expr: (
                 avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 32*1024*1024*1024
                 AND sre:node_workers:count > 25
@@ -36,22 +36,24 @@ spec:
                 avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 128*1024*1024*1024
                 AND sre:node_workers:count > 250
               )
-        record: sre:node_masters:need_resize
+        record: sre:node_control_plane:need_resize
   - name: sre-control-plane-resizing-alerts
     rules:
-      - alert: MasterNodesNeedResizingSRE
-        expr: sre:node_masters:need_resize > 0
+        # This used to be called MasterNodesNeedResizingSRE
+      - alert: ControlPlaneNodesNeedResizingSRE
+        expr: sre:node_control_plane:need_resize > 0
         for: 15m
         labels:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's master instance has been undersized for 15 minutes and should be vertically scaled to support the existing workers.  See linked SOP for details.  Critical alert will be raised at 2 hours."
-      - alert: MasterNodesNeedResizingSRE
-        expr: sre:node_masters:need_resize > 0
+          message: "The cluster's control plane nodes have been undersized for 15 minutes and should be vertically scaled to support the existing workers. See linked SOP for details. Critical alert will be raised at 2 hours."
+        # This used to be called MasterNodesNeedResizingSRE
+      - alert: ControlPlaneNodesNeedResizingSRE
+        expr: sre:node_control_plane:need_resize > 0
         for: 2h
         labels:
           severity: critical
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's master instance has been undersized for 2 hours and must be vertically scaled to support the existing workers.  See linked SOP for details."
+          message: "The cluster's control plane nodes have been undersized for 2 hours and must be vertically scaled to support the existing workers. See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31457,29 +31457,30 @@ objects:
               < 64*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
-            record: sre:node_masters:need_resize
+            record: sre:node_control_plane:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
-          - alert: MasterNodesNeedResizingSRE
-            expr: sre:node_masters:need_resize > 0
+          - alert: ControlPlaneNodesNeedResizingSRE
+            expr: sre:node_control_plane:need_resize > 0
             for: 15m
             labels:
               severity: warning
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's master instance has been undersized for 15 minutes
-                and should be vertically scaled to support the existing workers.  See
-                linked SOP for details.  Critical alert will be raised at 2 hours.
-          - alert: MasterNodesNeedResizingSRE
-            expr: sre:node_masters:need_resize > 0
+              message: The cluster's control plane nodes have been undersized for
+                15 minutes and should be vertically scaled to support the existing
+                workers. See linked SOP for details. Critical alert will be raised
+                at 2 hours.
+          - alert: ControlPlaneNodesNeedResizingSRE
+            expr: sre:node_control_plane:need_resize > 0
             for: 2h
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
+              message: The cluster's control plane nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.
+                See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31457,29 +31457,30 @@ objects:
               < 64*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
-            record: sre:node_masters:need_resize
+            record: sre:node_control_plane:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
-          - alert: MasterNodesNeedResizingSRE
-            expr: sre:node_masters:need_resize > 0
+          - alert: ControlPlaneNodesNeedResizingSRE
+            expr: sre:node_control_plane:need_resize > 0
             for: 15m
             labels:
               severity: warning
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's master instance has been undersized for 15 minutes
-                and should be vertically scaled to support the existing workers.  See
-                linked SOP for details.  Critical alert will be raised at 2 hours.
-          - alert: MasterNodesNeedResizingSRE
-            expr: sre:node_masters:need_resize > 0
+              message: The cluster's control plane nodes have been undersized for
+                15 minutes and should be vertically scaled to support the existing
+                workers. See linked SOP for details. Critical alert will be raised
+                at 2 hours.
+          - alert: ControlPlaneNodesNeedResizingSRE
+            expr: sre:node_control_plane:need_resize > 0
             for: 2h
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
+              message: The cluster's control plane nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.
+                See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31457,29 +31457,30 @@ objects:
               < 64*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
               <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
               < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
-            record: sre:node_masters:need_resize
+            record: sre:node_control_plane:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
-          - alert: MasterNodesNeedResizingSRE
-            expr: sre:node_masters:need_resize > 0
+          - alert: ControlPlaneNodesNeedResizingSRE
+            expr: sre:node_control_plane:need_resize > 0
             for: 15m
             labels:
               severity: warning
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's master instance has been undersized for 15 minutes
-                and should be vertically scaled to support the existing workers.  See
-                linked SOP for details.  Critical alert will be raised at 2 hours.
-          - alert: MasterNodesNeedResizingSRE
-            expr: sre:node_masters:need_resize > 0
+              message: The cluster's control plane nodes have been undersized for
+                15 minutes and should be vertically scaled to support the existing
+                workers. See linked SOP for details. Critical alert will be raised
+                at 2 hours.
+          - alert: ControlPlaneNodesNeedResizingSRE
+            expr: sre:node_control_plane:need_resize > 0
             for: 2h
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
-              message: The cluster's master instance has been undersized for 2 hours
-                and must be vertically scaled to support the existing workers.  See
-                linked SOP for details.
+              message: The cluster's control plane nodes have been undersized for
+                2 hours and must be vertically scaled to support the existing workers.
+                See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Renames the MasterNodesNeedResizingSRE alert to ControlPlaneNodesNeedResizingSRE - if this looks good I will also make a follow up PR to move the SOP https://github.com/openshift/ops-sop/blob/master/v4/alerts/MasterNodesNeedResizingSRE.md

### Which Jira/Github issue(s) this PR fixes?
[OSD-18358](https://issues.redhat.com//browse/OSD-18358)