### PR TITLE
mtsre-1450 initial commit of mcc to mitigate prom oom issue on odf

### DIFF
--- a/deploy/odf-prom-restart/00-mtsre-1450.ServiceAccount.yaml
+++ b/deploy/odf-prom-restart/00-mtsre-1450.ServiceAccount.yaml
@@ -4,4 +4,3 @@ apiVersion: v1
 metadata:
   name: prometheus-restarter
   namespace: openshift-storage
-

--- a/deploy/odf-prom-restart/00-mtsre-1450.ServiceAccount.yaml
+++ b/deploy/odf-prom-restart/00-mtsre-1450.ServiceAccount.yaml
@@ -1,0 +1,7 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prometheus-restarter
+  namespace: openshift-storage
+

--- a/deploy/odf-prom-restart/01-mtsre-1450.Role.yaml
+++ b/deploy/odf-prom-restart/01-mtsre-1450.Role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-restarter-role
+  namespace: openshift-storage 
+rules:
+- apiGroups: [""]
+  resources:
+     - "pods"
+  verbs: ["delete"]
+

--- a/deploy/odf-prom-restart/01-mtsre-1450.Role.yaml
+++ b/deploy/odf-prom-restart/01-mtsre-1450.Role.yaml
@@ -7,6 +7,5 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-     - "pods"
+    - "pods"
   verbs: ["delete"]
-

--- a/deploy/odf-prom-restart/01-mtsre-1450.Role.yaml
+++ b/deploy/odf-prom-restart/01-mtsre-1450.Role.yaml
@@ -8,4 +8,5 @@ rules:
 - apiGroups: [""]
   resources:
     - "pods"
+  resourceNames: ["prometheus-managed-ocs-prometheus-0"]
   verbs: ["delete"]

--- a/deploy/odf-prom-restart/02-mtsre-1450.RoleBinding.yaml
+++ b/deploy/odf-prom-restart/02-mtsre-1450.RoleBinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-restarter-rolebinding
+  namespace: openshift-storage 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-restarter-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-restarter
+    namespace: openshift-storage 
+

--- a/deploy/odf-prom-restart/02-mtsre-1450.RoleBinding.yaml
+++ b/deploy/odf-prom-restart/02-mtsre-1450.RoleBinding.yaml
@@ -12,4 +12,3 @@ subjects:
   - kind: ServiceAccount
     name: prometheus-restarter
     namespace: openshift-storage 
-

--- a/deploy/odf-prom-restart/10-mtsre-1450.cronjob.yaml
+++ b/deploy/odf-prom-restart/10-mtsre-1450.cronjob.yaml
@@ -16,11 +16,11 @@ spec:
           serviceAccountName: prometheus-restarter
           restartPolicy: Never
           containers:
-            - name: openshift-cli
-              image: quay.io/openshift-pipeline/openshift-cli
-              command:
-                - 'oc'
-                - 'delete'
-                - 'pod'
-                - 'prometheus-managed-ocs-prometheus-0'
-
+          - name: odf-delete-prom
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /bin/bash
+            - -c
+            - |
+              oc delete pod prometheus-managed-ocs-prometheus-0 -n openshift-storage --ignore-not-found

--- a/deploy/odf-prom-restart/10-mtsre-1450.cronjob.yaml
+++ b/deploy/odf-prom-restart/10-mtsre-1450.cronjob.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: prometheus-restart
+  namespace: openshift-storage 
+spec:
+  concurrencyPolicy: Forbid
+  schedule: "5 */8 * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: prometheus-restarter
+          restartPolicy: Never
+          containers:
+            - name: openshift-cli
+              image: quay.io/openshift-pipeline/openshift-cli
+              command:
+                - 'oc'
+                - 'delete'
+                - 'pod'
+                - 'prometheus-managed-ocs-prometheus-0'
+

--- a/deploy/odf-prom-restart/config.yaml
+++ b/deploy/odf-prom-restart/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchLabels:
+    api.openshift.com/addon-ocs-consumer: "true"
+    api.openshift.com/addon-ocs-provider: "true"
+  matchLabelsApplyMode: "OR"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22565,6 +22565,150 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: odf-prom-restart-addon-ocs-consumer
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-ocs-consumer: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-restarter-role
+        namespace: openshift-storage
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-restarter-rolebinding
+        namespace: openshift-storage
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-restarter-role
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: prometheus-restart
+        namespace: openshift-storage
+      spec:
+        concurrencyPolicy: Forbid
+        schedule: 5 */8 * * *
+        jobTemplate:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 600
+            template:
+              spec:
+                serviceAccountName: prometheus-restarter
+                restartPolicy: Never
+                containers:
+                - name: odf-delete-prom
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete pod prometheus-managed-ocs-prometheus-0 -n openshift-storage
+                    --ignore-not-found
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: odf-prom-restart-addon-ocs-provider
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-ocs-provider: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-restarter-role
+        namespace: openshift-storage
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-restarter-rolebinding
+        namespace: openshift-storage
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-restarter-role
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: prometheus-restart
+        namespace: openshift-storage
+      spec:
+        concurrencyPolicy: Forbid
+        schedule: 5 */8 * * *
+        jobTemplate:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 600
+            template:
+              spec:
+                serviceAccountName: prometheus-restarter
+                restartPolicy: Never
+                containers:
+                - name: odf-delete-prom
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete pod prometheus-managed-ocs-prometheus-0 -n openshift-storage
+                    --ignore-not-found
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-14634-disable-cpms
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22588,6 +22588,8 @@ objects:
         - ''
         resources:
         - pods
+        resourceNames:
+        - prometheus-managed-ocs-prometheus-0
         verbs:
         - delete
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -22660,6 +22662,8 @@ objects:
         - ''
         resources:
         - pods
+        resourceNames:
+        - prometheus-managed-ocs-prometheus-0
         verbs:
         - delete
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22565,6 +22565,150 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: odf-prom-restart-addon-ocs-consumer
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-ocs-consumer: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-restarter-role
+        namespace: openshift-storage
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-restarter-rolebinding
+        namespace: openshift-storage
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-restarter-role
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: prometheus-restart
+        namespace: openshift-storage
+      spec:
+        concurrencyPolicy: Forbid
+        schedule: 5 */8 * * *
+        jobTemplate:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 600
+            template:
+              spec:
+                serviceAccountName: prometheus-restarter
+                restartPolicy: Never
+                containers:
+                - name: odf-delete-prom
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete pod prometheus-managed-ocs-prometheus-0 -n openshift-storage
+                    --ignore-not-found
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: odf-prom-restart-addon-ocs-provider
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-ocs-provider: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-restarter-role
+        namespace: openshift-storage
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-restarter-rolebinding
+        namespace: openshift-storage
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-restarter-role
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: prometheus-restart
+        namespace: openshift-storage
+      spec:
+        concurrencyPolicy: Forbid
+        schedule: 5 */8 * * *
+        jobTemplate:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 600
+            template:
+              spec:
+                serviceAccountName: prometheus-restarter
+                restartPolicy: Never
+                containers:
+                - name: odf-delete-prom
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete pod prometheus-managed-ocs-prometheus-0 -n openshift-storage
+                    --ignore-not-found
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-14634-disable-cpms
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22588,6 +22588,8 @@ objects:
         - ''
         resources:
         - pods
+        resourceNames:
+        - prometheus-managed-ocs-prometheus-0
         verbs:
         - delete
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -22660,6 +22662,8 @@ objects:
         - ''
         resources:
         - pods
+        resourceNames:
+        - prometheus-managed-ocs-prometheus-0
         verbs:
         - delete
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22565,6 +22565,150 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: odf-prom-restart-addon-ocs-consumer
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-ocs-consumer: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-restarter-role
+        namespace: openshift-storage
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-restarter-rolebinding
+        namespace: openshift-storage
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-restarter-role
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: prometheus-restart
+        namespace: openshift-storage
+      spec:
+        concurrencyPolicy: Forbid
+        schedule: 5 */8 * * *
+        jobTemplate:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 600
+            template:
+              spec:
+                serviceAccountName: prometheus-restarter
+                restartPolicy: Never
+                containers:
+                - name: odf-delete-prom
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete pod prometheus-managed-ocs-prometheus-0 -n openshift-storage
+                    --ignore-not-found
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: odf-prom-restart-addon-ocs-provider
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-ocs-provider: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: prometheus-restarter-role
+        namespace: openshift-storage
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: prometheus-restarter-rolebinding
+        namespace: openshift-storage
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-restarter-role
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-restarter
+        namespace: openshift-storage
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: prometheus-restart
+        namespace: openshift-storage
+      spec:
+        concurrencyPolicy: Forbid
+        schedule: 5 */8 * * *
+        jobTemplate:
+          spec:
+            backoffLimit: 2
+            activeDeadlineSeconds: 600
+            template:
+              spec:
+                serviceAccountName: prometheus-restarter
+                restartPolicy: Never
+                containers:
+                - name: odf-delete-prom
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /bin/bash
+                  - -c
+                  - 'oc delete pod prometheus-managed-ocs-prometheus-0 -n openshift-storage
+                    --ignore-not-found
+
+                    '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-14634-disable-cpms
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22588,6 +22588,8 @@ objects:
         - ''
         resources:
         - pods
+        resourceNames:
+        - prometheus-managed-ocs-prometheus-0
         verbs:
         - delete
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -22660,6 +22662,8 @@ objects:
         - ''
         resources:
         - pods
+        resourceNames:
+        - prometheus-managed-ocs-prometheus-0
         verbs:
         - delete
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Deletes the prometheus pod in the openshift-storage namespace every 8 hours as a workaround to a memory leak issue in prometheus in ODF.  The pod eventually crashloops enough times to not come back up and fires a deadmanssnitch alert.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/MTSRE-1450

### Special notes for your reviewer:
I'm not sure of best practice in this situation, so happy to change as necessary.
