### PR TITLE
fix: custom ingresscontroller OAO alerting

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -9,8 +9,6 @@ spec:
         Your cluster requires you to take action as there are multiple ingress controllers detected. Red Hat SRE strongly recommends using Openshift-managed Custom Domains instead, as multiple ingress controllers, if improperly configured, can lead to problems with internal and external networking.
       name: MultipleIngressControllersDetected
       resendWait: 24
-      resolvedBody: |-
-        Your cluster no longer has multiple Ingress Controllers installed. No additional action on this issue is required.
       severity: Info
       summary: "Multiple ingress controllers detected"
     - activeBody: |-

--- a/deploy/sre-prometheus/ocm-agent/legacy-ingress/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/legacy-ingress/100-ocm-agent.PrometheusRule.yaml
@@ -12,7 +12,6 @@ spec:
     rules:
     - alert: MultipleIngressControllersDetectedNotificationSRE
       expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]) or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m] offset 5m) or vector(0)) > 0
-      for: 30m
       labels:
         severity: Info
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21775,8 +21775,6 @@ objects:
             configured, can lead to problems with internal and external networking.
           name: MultipleIngressControllersDetected
           resendWait: 24
-          resolvedBody: Your cluster no longer has multiple Ingress Controllers installed.
-            No additional action on this issue is required.
           severity: Info
           summary: Multiple ingress controllers detected
         - activeBody: Your cluster requires you to take action as its ElasticSearch
@@ -33355,7 +33353,6 @@ objects:
             expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
               or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
               offset 5m) or vector(0)) > 0
-            for: 30m
             labels:
               severity: Info
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21775,8 +21775,6 @@ objects:
             configured, can lead to problems with internal and external networking.
           name: MultipleIngressControllersDetected
           resendWait: 24
-          resolvedBody: Your cluster no longer has multiple Ingress Controllers installed.
-            No additional action on this issue is required.
           severity: Info
           summary: Multiple ingress controllers detected
         - activeBody: Your cluster requires you to take action as its ElasticSearch
@@ -33355,7 +33353,6 @@ objects:
             expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
               or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
               offset 5m) or vector(0)) > 0
-            for: 30m
             labels:
               severity: Info
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21775,8 +21775,6 @@ objects:
             configured, can lead to problems with internal and external networking.
           name: MultipleIngressControllersDetected
           resendWait: 24
-          resolvedBody: Your cluster no longer has multiple Ingress Controllers installed.
-            No additional action on this issue is required.
           severity: Info
           summary: Multiple ingress controllers detected
         - activeBody: Your cluster requires you to take action as its ElasticSearch
@@ -33355,7 +33353,6 @@ objects:
             expr: sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m])
               or vector(0)) - sum(max_over_time(splunkforwarder_audit_filter_exposed_splunk_event_total{alert="UserCreatedIngressControllerDetected"}[5m]
               offset 5m) or vector(0)) > 0
-            for: 30m
             labels:
               severity: Info
               namespace: openshift-monitoring


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

This PR fixes two bugs:

- a bug preventing the alert for a custom IC to trigger.
**Explanation:** the alerting expression is already written to only alert for 5 minutes, with the `for: 30m`, this will never trigger. 

- a bug resulting in faulty resolve notifications.
**Explanation:**  as the alert only lasts for 5 minutes, we would (if the above is fixed) always send the resolution SL after 5 minutes. Even if the alert lasted forever, if the audit exporter pods restart, the cache is lost and the alert resets. Therefore, we cannot have a resolution SL here.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
