### PR TITLE
Support enableDebuggingHandlers per default MCP

### DIFF
--- a/deploy/kubelet-config/disable-debugging-handlers-masters/01-disable-debugging-handlers-masters.KubeletConfig.yaml
+++ b/deploy/kubelet-config/disable-debugging-handlers-masters/01-disable-debugging-handlers-masters.KubeletConfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: disable-debugging-handlers-masters
+spec:
+  kubeletConfig:
+    enableDebuggingHandlers: false
+  machineConfigPoolSelector:
+    matchExpressions:
+    - key: pools.operator.machineconfiguration.openshift.io/master
+      operator: Exists

--- a/deploy/kubelet-config/disable-debugging-handlers-masters/config.yaml
+++ b/deploy/kubelet-config/disable-debugging-handlers-masters/config.yaml
@@ -6,3 +6,6 @@ selectorSyncSet:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
       values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"]
+    - key: ext-managed.openshift.io/disable-debugging-handlers-masters
+      operator: In
+      values: ["true"]

--- a/deploy/kubelet-config/disable-debugging-handlers-workers/01-disable-debugging-handlers-workers.KubeletConfig.yaml
+++ b/deploy/kubelet-config/disable-debugging-handlers-workers/01-disable-debugging-handlers-workers.KubeletConfig.yaml
@@ -1,12 +1,11 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: custom-kubelet
+  name: disable-debugging-handlers-workers
 spec:
   kubeletConfig:
     enableDebuggingHandlers: false
   machineConfigPoolSelector:
     matchExpressions:
-    - key: machineconfiguration.openshift.io/mco-built-in
+    - key: pools.operator.machineconfiguration.openshift.io/worker
       operator: Exists
-  autoSizingReserved: true

--- a/deploy/kubelet-config/disable-debugging-handlers-workers/config.yaml
+++ b/deploy/kubelet-config/disable-debugging-handlers-workers/config.yaml
@@ -6,6 +6,6 @@ selectorSyncSet:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
       values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"]
-    - key: ext-managed.openshift.io/disable-debugging-handlers
+    - key: ext-managed.openshift.io/disable-debugging-handlers-workers
       operator: In
       values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21321,10 +21321,6 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: ext-managed.openshift.io/disable-debugging-handlers
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -21344,7 +21340,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-post-4.9-disable-debugging-handlers
+    name: kubelet-config-disable-debugging-handlers-masters
   spec:
     clusterDeploymentSelector:
       matchLabels:
@@ -21361,7 +21357,7 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: ext-managed.openshift.io/disable-debugging-handlers
+      - key: ext-managed.openshift.io/disable-debugging-handlers-masters
         operator: In
         values:
         - 'true'
@@ -21370,15 +21366,55 @@ objects:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig
       metadata:
-        name: custom-kubelet
+        name: disable-debugging-handlers-masters
       spec:
         kubeletConfig:
           enableDebuggingHandlers: false
         machineConfigPoolSelector:
           matchExpressions:
-          - key: machineconfiguration.openshift.io/mco-built-in
+          - key: pools.operator.machineconfiguration.openshift.io/master
             operator: Exists
-        autoSizingReserved: true
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: kubelet-config-disable-debugging-handlers-workers
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers-workers
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      metadata:
+        name: disable-debugging-handlers-workers
+      spec:
+        kubeletConfig:
+          enableDebuggingHandlers: false
+        machineConfigPoolSelector:
+          matchExpressions:
+          - key: pools.operator.machineconfiguration.openshift.io/worker
+            operator: Exists
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21321,10 +21321,6 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: ext-managed.openshift.io/disable-debugging-handlers
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -21344,7 +21340,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-post-4.9-disable-debugging-handlers
+    name: kubelet-config-disable-debugging-handlers-masters
   spec:
     clusterDeploymentSelector:
       matchLabels:
@@ -21361,7 +21357,7 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: ext-managed.openshift.io/disable-debugging-handlers
+      - key: ext-managed.openshift.io/disable-debugging-handlers-masters
         operator: In
         values:
         - 'true'
@@ -21370,15 +21366,55 @@ objects:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig
       metadata:
-        name: custom-kubelet
+        name: disable-debugging-handlers-masters
       spec:
         kubeletConfig:
           enableDebuggingHandlers: false
         machineConfigPoolSelector:
           matchExpressions:
-          - key: machineconfiguration.openshift.io/mco-built-in
+          - key: pools.operator.machineconfiguration.openshift.io/master
             operator: Exists
-        autoSizingReserved: true
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: kubelet-config-disable-debugging-handlers-workers
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers-workers
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      metadata:
+        name: disable-debugging-handlers-workers
+      spec:
+        kubeletConfig:
+          enableDebuggingHandlers: false
+        machineConfigPoolSelector:
+          matchExpressions:
+          - key: pools.operator.machineconfiguration.openshift.io/worker
+            operator: Exists
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21321,10 +21321,6 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: ext-managed.openshift.io/disable-debugging-handlers
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -21344,7 +21340,7 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: kubelet-config-post-4.9-disable-debugging-handlers
+    name: kubelet-config-disable-debugging-handlers-masters
   spec:
     clusterDeploymentSelector:
       matchLabels:
@@ -21361,7 +21357,7 @@ objects:
         - '4.6'
         - '4.7'
         - '4.8'
-      - key: ext-managed.openshift.io/disable-debugging-handlers
+      - key: ext-managed.openshift.io/disable-debugging-handlers-masters
         operator: In
         values:
         - 'true'
@@ -21370,15 +21366,55 @@ objects:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig
       metadata:
-        name: custom-kubelet
+        name: disable-debugging-handlers-masters
       spec:
         kubeletConfig:
           enableDebuggingHandlers: false
         machineConfigPoolSelector:
           matchExpressions:
-          - key: machineconfiguration.openshift.io/mco-built-in
+          - key: pools.operator.machineconfiguration.openshift.io/master
             operator: Exists
-        autoSizingReserved: true
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: kubelet-config-disable-debugging-handlers-workers
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+      - key: ext-managed.openshift.io/disable-debugging-handlers-workers
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      metadata:
+        name: disable-debugging-handlers-workers
+      spec:
+        kubeletConfig:
+          enableDebuggingHandlers: false
+        machineConfigPoolSelector:
+          matchExpressions:
+          - key: pools.operator.machineconfiguration.openshift.io/worker
+            operator: Exists
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Original implementation was for all machines.  The updates to support managing for 'masters' separate from 'workers' and creates new KubeletConfig for each.

### Which Jira/Github issue(s) this PR fixes?
Related to https://issues.redhat.com/browse/OSD-16901

### Special notes for your reviewer:
Did not open a new JIRA for this work, just piggybacking on existing closed JIRA.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
