### PR TITLE
Use SSS 'Sync' mode for disabling debugging handlers

### DIFF
--- a/deploy/kubelet-config/disable-debugging-handlers-masters/config.yaml
+++ b/deploy/kubelet-config/disable-debugging-handlers-masters/config.yaml
@@ -1,6 +1,7 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
-  resourceApplyMode: Upsert
+  # must be Sync so the KubeletConfig specific to this configuration is removed
+  resourceApplyMode: Sync
   matchLabelsApplyMode: "AND"
   matchExpressions:
     - key: hive.openshift.io/version-major-minor

--- a/deploy/kubelet-config/disable-debugging-handlers-workers/config.yaml
+++ b/deploy/kubelet-config/disable-debugging-handlers-workers/config.yaml
@@ -1,6 +1,7 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
-  resourceApplyMode: Upsert
+  # must be Sync so the KubeletConfig specific to this configuration is removed
+  resourceApplyMode: Sync
   matchLabelsApplyMode: "AND"
   matchExpressions:
     - key: hive.openshift.io/version-major-minor

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21361,7 +21361,7 @@ objects:
         operator: In
         values:
         - 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig
@@ -21402,7 +21402,7 @@ objects:
         operator: In
         values:
         - 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21361,7 +21361,7 @@ objects:
         operator: In
         values:
         - 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig
@@ -21402,7 +21402,7 @@ objects:
         operator: In
         values:
         - 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21361,7 +21361,7 @@ objects:
         operator: In
         values:
         - 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig
@@ -21402,7 +21402,7 @@ objects:
         operator: In
         values:
         - 'true'
-    resourceApplyMode: Upsert
+    resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
       kind: KubeletConfig


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
With the recent update, disabling debugging handlers creates a _new_ KubeletConfig.  Therefore to re-enable debugging handlers the KubeletConfig needs to be deleted.  To do this, set resourceApplyMode for the two new KubeletConfig's SSS to 'Sync'.

### Which Jira/Github issue(s) this PR fixes?
Related to https://issues.redhat.com/browse/OSD-16901

### Special notes for your reviewer:
Tested by manually editing one of the SSS resourceApplyMode on a staging hive shard.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
