### PR TITLE
[WIP] OSD-18411 automate SL notification for KubeNodeUnschedulable alert if customer workloads prevent drain

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -58,3 +58,15 @@ spec:
       resendWait: 24
       severity: Info
       summary: Worker node is predicted to run out of inodes in 4 hours
+    - activeBody: |-
+        Your cluster is attempting to drain worker nodes but there are workloads preventing the drain. The affected nodes can be found by reviewing the customer_pod_preventing_drain metric. Please re-schedule the impacted pod(s) so that the node can drain.
+      name: KubeNodeUnschedulableCustomerPodPreventingDrain
+      resendWait: 24
+      severity: Warning
+      summary: "Action required: Pod(s) preventing Node Drain"
+    - activeBody: |-
+        Your cluster is attempting to drain nodes but there is a pod disruption budget set that is preventing the drain. The affected nodes can be found by reviewing the customer_pdb_preventing_drain metric. Please re-schedule this pod so that the nodes can drain. For more information on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring.
+      name: KubeNodeUnschedulableCustomerPDBPreventingDrain
+      resendWait: 24
+      severity: Warning
+      summary: "Action required: Pod Disruption Budget preventing Node Drain"

--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -10,8 +10,28 @@ spec:
   groups:
   - name: sre-node-unschedulable
     rules:
+    - alert: KubeNodeUnschedulableNotificationSRE
+      expr: customer_pod_preventing_drain > 0
+      for: 60m
+      labels:
+        severity: Warning
+        namespace: openshift-monitoring
+        managed_notification_template: "KubeNodeUnschedulableCustomerPodPreventingDrain"
+        send_managed_notification: "true"
+      annotations:
+        message: "The node {{ $labels.node }} has been unschedulable for more than an hour."
+    - alert: KubeNodeUnschedulableNotificationSRE
+      expr: customer_pdb_preventing_drain > 0
+      for: 60m
+      labels:
+        severity: Warning
+        namespace: openshift-monitoring
+        managed_notification_template: "KubeNodeUnschedulableCustomerPDBPreventingDrain"
+        send_managed_notification: "true"
+      annotations:
+        message: "The node {{ $labels.node }} has been unschedulable for more than an hour."
     - alert: KubeNodeUnschedulableSRE
-      expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+      expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)) and not (customer_pod_preventing_drain > 0 or customer_pdb_preventing_drain > 0)
       for: 60m
       labels:
         severity: critical

--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -10,26 +10,6 @@ spec:
   groups:
   - name: sre-node-unschedulable
     rules:
-    - alert: KubeNodeUnschedulableNotificationSRE
-      expr: customer_pod_preventing_drain > 0
-      for: 60m
-      labels:
-        severity: Warning
-        namespace: openshift-monitoring
-        managed_notification_template: "KubeNodeUnschedulableCustomerPodPreventingDrain"
-        send_managed_notification: "true"
-      annotations:
-        message: "The node {{ $labels.node }} has been unschedulable for more than an hour."
-    - alert: KubeNodeUnschedulableNotificationSRE
-      expr: customer_pdb_preventing_drain > 0
-      for: 60m
-      labels:
-        severity: Warning
-        namespace: openshift-monitoring
-        managed_notification_template: "KubeNodeUnschedulableCustomerPDBPreventingDrain"
-        send_managed_notification: "true"
-      annotations:
-        message: "The node {{ $labels.node }} has been unschedulable for more than an hour."
     - alert: KubeNodeUnschedulableSRE
       expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)) and not (customer_pod_preventing_drain > 0 or customer_pdb_preventing_drain > 0)
       for: 60m

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent-node-unschedulable.PrometheusRule.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-node-unschedulable
+    role: alert-rules
+  name: sre-node-unschedulable
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-node-unschedulable
+    rules:
+    - alert: KubeNodeUnschedulableNotificationSRE
+      expr: customer_pod_preventing_drain > 0
+      for: 60m
+      labels:
+        severity: Warning
+        namespace: openshift-monitoring
+        managed_notification_template: "KubeNodeUnschedulableCustomerPodPreventingDrain"
+        send_managed_notification: "true"
+      annotations:
+        message: "The node {{ $labels.node }} has been unschedulable for more than an hour."
+    - alert: KubeNodeUnschedulableNotificationSRE
+      expr: customer_pdb_preventing_drain > 0
+      for: 60m
+      labels:
+        severity: Warning
+        namespace: openshift-monitoring
+        managed_notification_template: "KubeNodeUnschedulableCustomerPDBPreventingDrain"
+        send_managed_notification: "true"
+      annotations:
+        message: "The node {{ $labels.node }} has been unschedulable for more than an hour."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21874,6 +21874,23 @@ objects:
           resendWait: 24
           severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
+        - activeBody: Your cluster is attempting to drain worker nodes but there are
+            workloads preventing the drain. The affected nodes can be found by reviewing
+            the customer_pod_preventing_drain metric. Please re-schedule the impacted
+            pod(s) so that the node can drain.
+          name: KubeNodeUnschedulableCustomerPodPreventingDrain
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: Pod(s) preventing Node Drain'
+        - activeBody: Your cluster is attempting to drain nodes but there is a pod
+            disruption budget set that is preventing the drain. The affected nodes
+            can be found by reviewing the customer_pdb_preventing_drain metric. Please
+            re-schedule this pod so that the nodes can drain. For more information
+            on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring.
+          name: KubeNodeUnschedulableCustomerPDBPreventingDrain
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: Pod Disruption Budget preventing Node Drain'
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -32001,10 +32018,34 @@ objects:
         groups:
         - name: sre-node-unschedulable
           rules:
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pod_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pdb_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
           - alert: KubeNodeUnschedulableSRE
-            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+            expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
-              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)) and
+              not (customer_pod_preventing_drain > 0 or customer_pdb_preventing_drain
+              > 0)
             for: 60m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32018,28 +32018,6 @@ objects:
         groups:
         - name: sre-node-unschedulable
           rules:
-          - alert: KubeNodeUnschedulableNotificationSRE
-            expr: customer_pod_preventing_drain > 0
-            for: 60m
-            labels:
-              severity: Warning
-              namespace: openshift-monitoring
-              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
-              send_managed_notification: 'true'
-            annotations:
-              message: The node {{ $labels.node }} has been unschedulable for more
-                than an hour.
-          - alert: KubeNodeUnschedulableNotificationSRE
-            expr: customer_pdb_preventing_drain > 0
-            for: 60m
-            labels:
-              severity: Warning
-              namespace: openshift-monitoring
-              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
-              send_managed_notification: 'true'
-            annotations:
-              message: The node {{ $labels.node }} has been unschedulable for more
-                than an hour.
           - alert: KubeNodeUnschedulableSRE
             expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
@@ -33235,6 +33213,40 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
             annotations:
               message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-node-unschedulable
+          role: alert-rules
+        name: sre-node-unschedulable
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-node-unschedulable
+          rules:
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pod_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pdb_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21874,6 +21874,23 @@ objects:
           resendWait: 24
           severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
+        - activeBody: Your cluster is attempting to drain worker nodes but there are
+            workloads preventing the drain. The affected nodes can be found by reviewing
+            the customer_pod_preventing_drain metric. Please re-schedule the impacted
+            pod(s) so that the node can drain.
+          name: KubeNodeUnschedulableCustomerPodPreventingDrain
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: Pod(s) preventing Node Drain'
+        - activeBody: Your cluster is attempting to drain nodes but there is a pod
+            disruption budget set that is preventing the drain. The affected nodes
+            can be found by reviewing the customer_pdb_preventing_drain metric. Please
+            re-schedule this pod so that the nodes can drain. For more information
+            on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring.
+          name: KubeNodeUnschedulableCustomerPDBPreventingDrain
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: Pod Disruption Budget preventing Node Drain'
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -32001,10 +32018,34 @@ objects:
         groups:
         - name: sre-node-unschedulable
           rules:
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pod_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pdb_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
           - alert: KubeNodeUnschedulableSRE
-            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+            expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
-              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)) and
+              not (customer_pod_preventing_drain > 0 or customer_pdb_preventing_drain
+              > 0)
             for: 60m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32018,28 +32018,6 @@ objects:
         groups:
         - name: sre-node-unschedulable
           rules:
-          - alert: KubeNodeUnschedulableNotificationSRE
-            expr: customer_pod_preventing_drain > 0
-            for: 60m
-            labels:
-              severity: Warning
-              namespace: openshift-monitoring
-              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
-              send_managed_notification: 'true'
-            annotations:
-              message: The node {{ $labels.node }} has been unschedulable for more
-                than an hour.
-          - alert: KubeNodeUnschedulableNotificationSRE
-            expr: customer_pdb_preventing_drain > 0
-            for: 60m
-            labels:
-              severity: Warning
-              namespace: openshift-monitoring
-              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
-              send_managed_notification: 'true'
-            annotations:
-              message: The node {{ $labels.node }} has been unschedulable for more
-                than an hour.
           - alert: KubeNodeUnschedulableSRE
             expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
@@ -33235,6 +33213,40 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
             annotations:
               message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-node-unschedulable
+          role: alert-rules
+        name: sre-node-unschedulable
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-node-unschedulable
+          rules:
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pod_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pdb_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21874,6 +21874,23 @@ objects:
           resendWait: 24
           severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
+        - activeBody: Your cluster is attempting to drain worker nodes but there are
+            workloads preventing the drain. The affected nodes can be found by reviewing
+            the customer_pod_preventing_drain metric. Please re-schedule the impacted
+            pod(s) so that the node can drain.
+          name: KubeNodeUnschedulableCustomerPodPreventingDrain
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: Pod(s) preventing Node Drain'
+        - activeBody: Your cluster is attempting to drain nodes but there is a pod
+            disruption budget set that is preventing the drain. The affected nodes
+            can be found by reviewing the customer_pdb_preventing_drain metric. Please
+            re-schedule this pod so that the nodes can drain. For more information
+            on pod disruption budgets please see https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring.
+          name: KubeNodeUnschedulableCustomerPDBPreventingDrain
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: Pod Disruption Budget preventing Node Drain'
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -32001,10 +32018,34 @@ objects:
         groups:
         - name: sre-node-unschedulable
           rules:
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pod_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pdb_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
           - alert: KubeNodeUnschedulableSRE
-            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+            expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
-              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)) and
+              not (customer_pod_preventing_drain > 0 or customer_pdb_preventing_drain
+              > 0)
             for: 60m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32018,28 +32018,6 @@ objects:
         groups:
         - name: sre-node-unschedulable
           rules:
-          - alert: KubeNodeUnschedulableNotificationSRE
-            expr: customer_pod_preventing_drain > 0
-            for: 60m
-            labels:
-              severity: Warning
-              namespace: openshift-monitoring
-              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
-              send_managed_notification: 'true'
-            annotations:
-              message: The node {{ $labels.node }} has been unschedulable for more
-                than an hour.
-          - alert: KubeNodeUnschedulableNotificationSRE
-            expr: customer_pdb_preventing_drain > 0
-            for: 60m
-            labels:
-              severity: Warning
-              namespace: openshift-monitoring
-              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
-              send_managed_notification: 'true'
-            annotations:
-              message: The node {{ $labels.node }} has been unschedulable for more
-                than an hour.
           - alert: KubeNodeUnschedulableSRE
             expr: ((kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
@@ -33235,6 +33213,40 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
             annotations:
               message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-node-unschedulable
+          role: alert-rules
+        name: sre-node-unschedulable
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-node-unschedulable
+          rules:
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pod_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPodPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
+          - alert: KubeNodeUnschedulableNotificationSRE
+            expr: customer_pdb_preventing_drain > 0
+            for: 60m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: KubeNodeUnschedulableCustomerPDBPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: The node {{ $labels.node }} has been unschedulable for more
+                than an hour.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
this is an attempt to automate SL notification for the KubeNodeUnschedulable alert, in case the alert is firing while customer workloads are preventing the node from draining.

the implementation comes from this SOP: https://github.com/openshift/ops-sop/blob/master/v4/alerts/KubeNodeUnschedulableSRE.md

this discrimination is done by using new metrics:
- `customer_pod_preventing_drain`
- `customer_pdb_preventing_drain`

these metrics do not exist yet, and the plan is to introduce them in https://github.com/openshift/osd-metrics-exporter
(something along the lines of https://github.com/openshift/osd-metrics-exporter/pull/112)

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18411

### Special notes for your reviewer:
how do you like this idea?