### PR TITLE
Add ec2:DescribeAvailabilityZones to KCM policy for Hypershift 4.14

### DIFF
--- a/resources/sts/4.14/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
+++ b/resources/sts/4.14/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
@@ -5,6 +5,7 @@
       "Sid": "ReadPermissions",
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeRouteTables",
         "ec2:DescribeSecurityGroups",


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-18381

Adds `ec2:DescribeAvailabilityZones` to the HCP kube controller manager policy for 4.14. 

 https://github.com/kubernetes/cloud-provider-aws/blob/master/docs/prerequisites.md#iam-policies

Hypershift PR https://github.com/openshift/hypershift/pull/2271 pull in upstream `aws-cloud-controller-manager` updates described here: https://github.com/kubernetes/cloud-provider-aws/blob/master/docs/prerequisites.md#iam-policies

Out of the new permissions added, only `ec2:DescribeAvailabilityZones` is current used in HCP. 

Ref: https://issues.redhat.com//browse/HOSTEDCP-919