### PR TITLE
Rename alert silence for MasterNodesNeedResizingSRE

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -53,7 +53,6 @@ data:
       - etcdGRPCRequestsSlow
       # OHSS-24871
       - MasterNodesNeedResizingSRE
-      - InfraNodesNeedResizingSRE
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -52,7 +52,7 @@ data:
       # OSD-13649
       - etcdGRPCRequestsSlow
       # OHSS-24871
-      - MasterNodesNeedResizingSRE
+      - ControlPlaneNodesNeedResizingSRE
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21518,7 +21518,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - ControlPlaneNodesNeedResizingSRE\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
           \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21519,9 +21519,9 @@ objects:
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
           \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
-          \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21518,7 +21518,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - ControlPlaneNodesNeedResizingSRE\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
           \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21519,9 +21519,9 @@ objects:
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
           \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
-          \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21518,7 +21518,7 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - ControlPlaneNodesNeedResizingSRE\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
           \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21519,9 +21519,9 @@ objects:
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
           \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - MasterNodesNeedResizingSRE\n\
-          \  - InfraNodesNeedResizingSRE\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
With #1820, MasterNodesNeedResizingSRE was renamed to ControlPlaneNodesNeedResizingSRE, but the alert silence was not renamed - should merge #1829 first

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-18358](https://issues.redhat.com//browse/OSD-18358)