### PR TITLE
remove openshift-build-test/sre-build-test resources from managed resources

### DIFF
--- a/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
@@ -20,7 +20,6 @@ data:
       - name: openshift-backplane-mobb
       - name: openshift-backplane-srep
       - name: openshift-backplane-tam
-      - name: openshift-build-test
       - name: openshift-cloud-ingress-operator
       - name: openshift-codeready-workspaces
       - name: openshift-compliance
@@ -50,4 +49,3 @@ data:
       - name: openshift-monitoring
       - name: openshift
       - name: openshift-cluster-version
-

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27298,17 +27298,16 @@ objects:
           \ openshift-backplane-cse\n  - name: openshift-backplane-csm\n  - name:\
           \ openshift-backplane-managed-scripts\n  - name: openshift-backplane-mobb\n\
           \  - name: openshift-backplane-srep\n  - name: openshift-backplane-tam\n\
-          \  - name: openshift-build-test\n  - name: openshift-cloud-ingress-operator\n\
-          \  - name: openshift-codeready-workspaces\n  - name: openshift-compliance\n\
-          \  - name: openshift-container-security\n  - name: openshift-custom-domains-operator\n\
-          \  - name: openshift-customer-monitoring\n  - name: openshift-deployment-validation-operator\n\
-          \  - name: openshift-managed-node-metadata-operator      \n  - name: openshift-file-integrity\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
-          \  - name: openshift-must-gather-operator\n  - name: openshift-observability-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-scanning\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
+          \  - name: openshift-compliance\n  - name: openshift-container-security\n\
+          \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-deployment-validation-operator\n  - name: openshift-managed-node-metadata-operator\
+          \      \n  - name: openshift-file-integrity\n  - name: openshift-logging\n\
+          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
+          \  - name: openshift-observability-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-scanning\n  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-strimzi\n  - name:\
           \ openshift-suricata\n  - name: openshift-validation-webhook\n  - name:\
           \ openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27298,17 +27298,16 @@ objects:
           \ openshift-backplane-cse\n  - name: openshift-backplane-csm\n  - name:\
           \ openshift-backplane-managed-scripts\n  - name: openshift-backplane-mobb\n\
           \  - name: openshift-backplane-srep\n  - name: openshift-backplane-tam\n\
-          \  - name: openshift-build-test\n  - name: openshift-cloud-ingress-operator\n\
-          \  - name: openshift-codeready-workspaces\n  - name: openshift-compliance\n\
-          \  - name: openshift-container-security\n  - name: openshift-custom-domains-operator\n\
-          \  - name: openshift-customer-monitoring\n  - name: openshift-deployment-validation-operator\n\
-          \  - name: openshift-managed-node-metadata-operator      \n  - name: openshift-file-integrity\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
-          \  - name: openshift-must-gather-operator\n  - name: openshift-observability-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-scanning\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
+          \  - name: openshift-compliance\n  - name: openshift-container-security\n\
+          \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-deployment-validation-operator\n  - name: openshift-managed-node-metadata-operator\
+          \      \n  - name: openshift-file-integrity\n  - name: openshift-logging\n\
+          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
+          \  - name: openshift-observability-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-scanning\n  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-strimzi\n  - name:\
           \ openshift-suricata\n  - name: openshift-validation-webhook\n  - name:\
           \ openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27298,17 +27298,16 @@ objects:
           \ openshift-backplane-cse\n  - name: openshift-backplane-csm\n  - name:\
           \ openshift-backplane-managed-scripts\n  - name: openshift-backplane-mobb\n\
           \  - name: openshift-backplane-srep\n  - name: openshift-backplane-tam\n\
-          \  - name: openshift-build-test\n  - name: openshift-cloud-ingress-operator\n\
-          \  - name: openshift-codeready-workspaces\n  - name: openshift-compliance\n\
-          \  - name: openshift-container-security\n  - name: openshift-custom-domains-operator\n\
-          \  - name: openshift-customer-monitoring\n  - name: openshift-deployment-validation-operator\n\
-          \  - name: openshift-managed-node-metadata-operator      \n  - name: openshift-file-integrity\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
-          \  - name: openshift-must-gather-operator\n  - name: openshift-observability-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-scanning\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-cloud-ingress-operator\n  - name: openshift-codeready-workspaces\n\
+          \  - name: openshift-compliance\n  - name: openshift-container-security\n\
+          \  - name: openshift-custom-domains-operator\n  - name: openshift-customer-monitoring\n\
+          \  - name: openshift-deployment-validation-operator\n  - name: openshift-managed-node-metadata-operator\
+          \      \n  - name: openshift-file-integrity\n  - name: openshift-logging\n\
+          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
+          \  - name: openshift-observability-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-scanning\n  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-strimzi\n  - name:\
           \ openshift-suricata\n  - name: openshift-validation-webhook\n  - name:\
           \ openshift-velero\n  - name: openshift-monitoring\n  - name: openshift\n\

--- a/resources/managed/all-osd-resources.yaml
+++ b/resources/managed/all-osd-resources.yaml
@@ -69,7 +69,6 @@ Resources:
   - name: openshift-backplane-mobb
   - name: openshift-backplane-srep
   - name: openshift-backplane-tam
-  - name: openshift-build-test
   - name: openshift-cloud-ingress-operator
   - name: openshift-codeready-workspaces
   - name: openshift-compliance
@@ -158,8 +157,6 @@ Resources:
     name: osd-delete-ownerrefs-serviceaccounts
   - namespace: openshift-backplane
     name: osd-delete-backplane-serviceaccounts
-  - namespace: openshift-build-test
-    name: sre-build-test
   - namespace: openshift-cloud-ingress-operator
     name: cloud-ingress-operator
   - namespace: openshift-custom-domains-operator
@@ -277,7 +274,6 @@ Resources:
   - name: pcap-dedicated-admins
   - name: splunk-forwarder-operator
   - name: splunk-forwarder-operator-clusterrolebinding
-  - name: sre-build-test
   - name: sre-pod-network-connectivity-check-pruner
   - name: sre-pruner-buildsdeploys-pruning
   - name: velero
@@ -314,7 +310,6 @@ Resources:
   - name: pcap-dedicated-admins
   - name: splunk-forwarder-operator
   - name: sre-allow-read-machine-info
-  - name: sre-build-test
   - name: sre-pruner-buildsdeploys-cr
   - name: webhook-validation-cr
   RoleBinding:
@@ -330,8 +325,6 @@ Resources:
     name: backplane-srep-mustgather
   - namespace: openshift-backplane-managed-scripts
     name: osd-delete-backplane-script-resources
-  - namespace: openshift-build-test
-    name: sre-build-test
   - namespace: openshift-cloud-ingress-operator
     name: osd-rebalance-infra-nodes-openshift-pod-rebalance
   - namespace: openshift-codeready-workspaces
@@ -473,8 +466,6 @@ Resources:
     name: backplane-srep-pcap-collector
   - namespace: openshift-backplane-managed-scripts
     name: osd-delete-backplane-script-resources
-  - namespace: openshift-build-test
-    name: sre-build-test
   - namespace: openshift-codeready-workspaces
     name: dedicated-admins-openshift-codeready-workspaces
   - namespace: openshift-config
@@ -558,8 +549,6 @@ Resources:
     name: osd-delete-ownerrefs-serviceaccounts
   - namespace: openshift-backplane
     name: osd-delete-backplane-serviceaccounts
-  - namespace: openshift-build-test
-    name: sre-build-test
   - namespace: openshift-machine-api
     name: osd-disable-cpms
   - namespace: openshift-marketplace
@@ -679,8 +668,6 @@ Resources:
     name: dedicated-admins-customer-monitoring
   - namespace: openshift-rbac-permissions
     name: osd-delete-backplane-serviceaccounts
-  - namespace: openshift-rbac-permissions
-    name: sre-build-test
   VeleroInstall:
   - namespace: openshift-velero
     name: cluster
@@ -976,7 +963,6 @@ Resources:
   - name: openshift-backplane-mobb
   - name: openshift-backplane-srep
   - name: openshift-backplane-tam
-  - name: openshift-build-test
   - name: openshift-cloud-ingress-operator
   - name: openshift-codeready-workspaces
   - name: openshift-compliance


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
In this story and through #1818, this namespace and the corresponding resources have been removed.

### Which Jira/Github issue(s) this PR fixes?

[OSD-17694](https://issues.redhat.com//browse/OSD-17694)