### PR TITLE
update ControlPlaneNodesNeedResizingSRE's warning level alert

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -13,8 +13,80 @@ spec:
     rules:
       - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)") * on(instance) group_left node_memory_MemTotal_bytes
         record: sre:node_roles:memory_total_bytes
-      - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)") * on(instance) group_left instance:node_num_cpu:sum
-        record: sre:node_roles:node_num_cpu
+      ## Expression Explanation:
+      ## Average of value of
+      ## the Average (per node) rate of change of CPU time spent in non-idle modes, totalled by CPU, looking back across the past 8h,
+      ## "*" applies a label replace to limit output to control plane nodes
+      ## Greater than (>) the threshold which is (n-1)/n where n is the number of control plane nodes, evaluating to 2/3 in most circumstances.
+      - expr: ( 
+                avg (
+                  avg by (instance) (
+                    sum by (cpu, instance) (
+                      rate(
+                        node_cpu_seconds_total{mode!="idle"}[8h]
+                      )
+                    )
+                  )
+                  *
+                  on (instance) (
+                    label_replace (
+                      kube_node_role{role ="master"}, "instance", "$1", "node", "(.*)"
+                    )
+                  )
+                )
+                >
+                (
+                  scalar (
+                    (
+                      count (
+                        cluster:nodes_roles{label_node_role_kubernetes_io ="master"}
+                      )
+                      - 1
+                    )
+                    /
+                    count (
+                      cluster:nodes_roles{label_node_role_kubernetes_io ="master"}
+                    )
+                  )
+                )
+              )
+        record: sre:node_control_plane:excessive_consumption_cpu
+      ## Expression Explanation: 
+      ## 1, minus the total amount of free memory divided by the total amount of memory for the infra node type, gives us the percent used memory as a decimal value: 0.%%
+      ## Greater than (>) the threshold which is (n-1)/n where n is the number of control plane nodes, evaluating to 2/3 in most circumstances.
+      - expr: ( 1 -
+                sum (
+                    node_memory_MemFree_bytes +
+                    node_memory_Buffers_bytes +
+                    node_memory_Cached_bytes
+                    AND on (instance) label_replace(
+                        kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"
+                    )
+                ) 
+                / 
+                sum (
+                    node_memory_MemTotal_bytes
+                    AND on (instance) label_replace(
+                        kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"
+                    )
+                )
+            ) 
+            > 
+            (
+              scalar (
+                (
+                  count (
+                    cluster:nodes_roles{label_node_role_kubernetes_io ="master"}
+                  )
+                  - 1
+                )
+                /
+                count (
+                  cluster:nodes_roles{label_node_role_kubernetes_io ="master"}
+                )
+              )
+            )
+        record: sre:node_control_plane:excessive_consumption_memory
       - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
         record: sre:node_workers:count
       # control plane has less than 32GB RAM, worker count > 25, and worker count <= 100
@@ -41,7 +113,7 @@ spec:
     rules:
         # This used to be called MasterNodesNeedResizingSRE
       - alert: ControlPlaneNodesNeedResizingSRE
-        expr: sre:node_control_plane:need_resize > 0
+        expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu > 0)
         for: 15m
         labels:
           severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31495,9 +31495,20 @@ objects:
           - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
               * on(instance) group_left node_memory_MemTotal_bytes
             record: sre:node_roles:memory_total_bytes
-          - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
-              * on(instance) group_left instance:node_num_cpu:sum
-            record: sre:node_roles:node_num_cpu
+          - expr: ( avg ( avg by (instance) ( sum by (cpu, instance) ( rate( node_cpu_seconds_total{mode!="idle"}[8h]
+              ) ) ) * on (instance) ( label_replace ( kube_node_role{role ="master"},
+              "instance", "$1", "node", "(.*)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) ) ) )
+            record: sre:node_control_plane:excessive_consumption_cpu
+          - expr: ( 1 - sum ( node_memory_MemFree_bytes + node_memory_Buffers_bytes
+              + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"},
+              "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
+              AND on (instance) label_replace( kube_node_role{role="master"}, "instance",
+              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) ) )
+            record: sre:node_control_plane:excessive_consumption_memory
           - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
             record: sre:node_workers:count
           - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
@@ -31510,7 +31521,8 @@ objects:
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
-            expr: sre:node_control_plane:need_resize > 0
+            expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu
+              > 0)
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31495,9 +31495,20 @@ objects:
           - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
               * on(instance) group_left node_memory_MemTotal_bytes
             record: sre:node_roles:memory_total_bytes
-          - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
-              * on(instance) group_left instance:node_num_cpu:sum
-            record: sre:node_roles:node_num_cpu
+          - expr: ( avg ( avg by (instance) ( sum by (cpu, instance) ( rate( node_cpu_seconds_total{mode!="idle"}[8h]
+              ) ) ) * on (instance) ( label_replace ( kube_node_role{role ="master"},
+              "instance", "$1", "node", "(.*)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) ) ) )
+            record: sre:node_control_plane:excessive_consumption_cpu
+          - expr: ( 1 - sum ( node_memory_MemFree_bytes + node_memory_Buffers_bytes
+              + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"},
+              "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
+              AND on (instance) label_replace( kube_node_role{role="master"}, "instance",
+              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) ) )
+            record: sre:node_control_plane:excessive_consumption_memory
           - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
             record: sre:node_workers:count
           - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
@@ -31510,7 +31521,8 @@ objects:
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
-            expr: sre:node_control_plane:need_resize > 0
+            expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu
+              > 0)
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31495,9 +31495,20 @@ objects:
           - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
               * on(instance) group_left node_memory_MemTotal_bytes
             record: sre:node_roles:memory_total_bytes
-          - expr: label_replace(cluster:nodes_roles, "instance", "$1", "node", "(.*)")
-              * on(instance) group_left instance:node_num_cpu:sum
-            record: sre:node_roles:node_num_cpu
+          - expr: ( avg ( avg by (instance) ( sum by (cpu, instance) ( rate( node_cpu_seconds_total{mode!="idle"}[8h]
+              ) ) ) * on (instance) ( label_replace ( kube_node_role{role ="master"},
+              "instance", "$1", "node", "(.*)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) ) ) )
+            record: sre:node_control_plane:excessive_consumption_cpu
+          - expr: ( 1 - sum ( node_memory_MemFree_bytes + node_memory_Buffers_bytes
+              + node_memory_Cached_bytes AND on (instance) label_replace( kube_node_role{role="master"},
+              "instance", "$1", "node", "(.+)" ) ) / sum ( node_memory_MemTotal_bytes
+              AND on (instance) label_replace( kube_node_role{role="master"}, "instance",
+              "$1", "node", "(.+)" ) ) ) > ( scalar ( ( count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
+              ="master"} ) ) )
+            record: sre:node_control_plane:excessive_consumption_memory
           - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
             record: sre:node_workers:count
           - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
@@ -31510,7 +31521,8 @@ objects:
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
-            expr: sre:node_control_plane:need_resize > 0
+            expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu
+              > 0)
             for: 15m
             labels:
               severity: warning


### PR DESCRIPTION
This commit adds the recording rules:
* sre:node_control_plane:excessive_consumption_memory
* sre:node_control_plane:excessive_consumption_cpu

which will evaluate to true if the overall memory or CPU utilization of the control plane nodes is greater than (n-1)/n where n is the number of control plane nodes. Since we only support 3 control plane nodes this should always be 2/3. The warning level version of the alert has been updated to take these two expressions into account, just like what was done with InfraNodesNeedResizingSRE in #1784.

It also removes the recording rule:
* sre:node_roles:node_num_cpu

as it is no longer used anywhere.

### What type of PR is this?
feature

### Which Jira/Github issue(s) this PR fixes?
[OSD-18359](https://issues.redhat.com//browse/OSD-18359)