### PR TITLE
automate ServiceLog notification for PodDisruptionBudgetLimit alert

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-pdb.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: ocmagent.managed.openshift.io/v1alpha1
 kind: ManagedNotification
 metadata:
-  name: sre-managed-notifications
+  name: sre-pdb-managed-notifications
   namespace: openshift-ocm-agent-operator
 spec:
   notifications:

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-pdb.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-pdb.yaml
@@ -1,0 +1,13 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedNotification
+metadata:
+  name: sre-managed-notifications
+  namespace: openshift-ocm-agent-operator
+spec:
+  notifications:
+    - activeBody: |-
+        The pod disruption budget is below the minimum disruptions allowed level and is not satisfied. The number of current healthy pods is less than the desired healthy pods. For more information, please refer to https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetLimit.md
+      name: PodDisruptionBudgetLimit
+      resendWait: 24
+      severity: Warning
+      summary: "The pod disruption budget registers insufficient amount of pods."

--- a/deploy/sre-prometheus/ocm-agent/100-pdb.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-pdb.PrometheusRule.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-pdb-managed-notification-alerts
+    role: alert-rules 
+  name: sre-pdb-managed-notification-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-pdb-managed-notification-alerts
+    rules:
+    # https://github.com/openshift/cluster-kube-controller-manager-operator/blob/3041547f5fe3227501532028e5a6993f139f6f63/manifests/0000_90_kube-controller-manager-operator_05_alerts.yaml#L35-L44
+    - alert: PodDisruptionBudgetLimit
+      expr: |
+        max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy < kube_poddisruptionbudget_status_desired_healthy)
+      for: 15m
+      labels:
+        severity: Warning
+        managed_notification_template: "PodDisruptionBudgetLimit"
+        send_managed_notification: "true"
+        source: "https://issues.redhat.com/browse/OSD-14158"

--- a/deploy/sre-prometheus/ocm-agent/100-pdb.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-pdb.PrometheusRule.yaml
@@ -17,6 +17,7 @@ spec:
       for: 15m
       labels:
         severity: Warning
+        namespace: openshift-monitoring
         managed_notification_template: "PodDisruptionBudgetLimit"
         send_managed_notification: "true"
         source: "https://issues.redhat.com/browse/OSD-14158"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21877,7 +21877,7 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
-        name: sre-managed-notifications
+        name: sre-pdb-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21877,6 +21877,20 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
+        name: sre-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - activeBody: The pod disruption budget is below the minimum disruptions allowed
+            level and is not satisfied. The number of current healthy pods is less
+            than the desired healthy pods. For more information, please refer to https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetLimit.md
+          name: PodDisruptionBudgetLimit
+          resendWait: 24
+          severity: Warning
+          summary: The pod disruption budget registers insufficient amount of pods.
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
         name: sre-proxy-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
@@ -33381,6 +33395,29 @@ objects:
             annotations:
               message: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-pdb-managed-notification-alerts
+          role: alert-rules
+        name: sre-pdb-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-pdb-managed-notification-alerts
+          rules:
+          - alert: PodDisruptionBudgetLimit
+            expr: 'max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy
+              < kube_poddisruptionbudget_status_desired_healthy)
+
+              '
+            for: 15m
+            labels:
+              severity: Warning
+              managed_notification_template: PodDisruptionBudgetLimit
+              send_managed_notification: 'true'
+              source: https://issues.redhat.com/browse/OSD-14158
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33415,6 +33415,7 @@ objects:
             for: 15m
             labels:
               severity: Warning
+              namespace: openshift-monitoring
               managed_notification_template: PodDisruptionBudgetLimit
               send_managed_notification: 'true'
               source: https://issues.redhat.com/browse/OSD-14158

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21877,7 +21877,7 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
-        name: sre-managed-notifications
+        name: sre-pdb-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21877,6 +21877,20 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
+        name: sre-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - activeBody: The pod disruption budget is below the minimum disruptions allowed
+            level and is not satisfied. The number of current healthy pods is less
+            than the desired healthy pods. For more information, please refer to https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetLimit.md
+          name: PodDisruptionBudgetLimit
+          resendWait: 24
+          severity: Warning
+          summary: The pod disruption budget registers insufficient amount of pods.
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
         name: sre-proxy-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
@@ -33381,6 +33395,29 @@ objects:
             annotations:
               message: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-pdb-managed-notification-alerts
+          role: alert-rules
+        name: sre-pdb-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-pdb-managed-notification-alerts
+          rules:
+          - alert: PodDisruptionBudgetLimit
+            expr: 'max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy
+              < kube_poddisruptionbudget_status_desired_healthy)
+
+              '
+            for: 15m
+            labels:
+              severity: Warning
+              managed_notification_template: PodDisruptionBudgetLimit
+              send_managed_notification: 'true'
+              source: https://issues.redhat.com/browse/OSD-14158
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33415,6 +33415,7 @@ objects:
             for: 15m
             labels:
               severity: Warning
+              namespace: openshift-monitoring
               managed_notification_template: PodDisruptionBudgetLimit
               send_managed_notification: 'true'
               source: https://issues.redhat.com/browse/OSD-14158

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21877,7 +21877,7 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
-        name: sre-managed-notifications
+        name: sre-pdb-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21877,6 +21877,20 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
+        name: sre-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - activeBody: The pod disruption budget is below the minimum disruptions allowed
+            level and is not satisfied. The number of current healthy pods is less
+            than the desired healthy pods. For more information, please refer to https://github.com/openshift/runbooks/blob/master/alerts/cluster-kube-controller-manager-operator/PodDisruptionBudgetLimit.md
+          name: PodDisruptionBudgetLimit
+          resendWait: 24
+          severity: Warning
+          summary: The pod disruption budget registers insufficient amount of pods.
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
         name: sre-proxy-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
@@ -33381,6 +33395,29 @@ objects:
             annotations:
               message: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-pdb-managed-notification-alerts
+          role: alert-rules
+        name: sre-pdb-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-pdb-managed-notification-alerts
+          rules:
+          - alert: PodDisruptionBudgetLimit
+            expr: 'max by (namespace, poddisruptionbudget) (kube_poddisruptionbudget_status_current_healthy
+              < kube_poddisruptionbudget_status_desired_healthy)
+
+              '
+            for: 15m
+            labels:
+              severity: Warning
+              managed_notification_template: PodDisruptionBudgetLimit
+              send_managed_notification: 'true'
+              source: https://issues.redhat.com/browse/OSD-14158
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33415,6 +33415,7 @@ objects:
             for: 15m
             labels:
               severity: Warning
+              namespace: openshift-monitoring
               managed_notification_template: PodDisruptionBudgetLimit
               send_managed_notification: 'true'
               source: https://issues.redhat.com/browse/OSD-14158


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
toil reduction.

this is an OCP alert and is being silenced in https://github.com/openshift/configure-alertmanager-operator/pull/295
adding it here so we can automate the SL notification (is there a better way?)

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-14158