### PR TITLE
Add Log Linking feature for specific orgs

### DIFF
--- a/deploy/crio-loglinking/01-machineconfig.yaml
+++ b/deploy/crio-loglinking/01-machineconfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-workers-linked-log
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.1.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
+        mode: 420
+        overwrite: true
+        path: /etc/crio/crio.conf.d/99-linked-log.conf
+  osImageURL: ""

--- a/deploy/crio-loglinking/config.yaml
+++ b/deploy/crio-loglinking/config.yaml
@@ -1,0 +1,13 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: hive.openshift.io/version-major-minor
+      operator: NotIn
+      values: ["4.0","4.1","4.2","4.3","4.4","4.5","4.6","4.7","4.8","4.9","4.10","4.11","4.12"]
+    - key: hive.openshift.io/version-major-minor-patch
+      operator: NotIn
+      values: ["4.13.0","4.13.1","4.13.2","4.13.3"]
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: "${{LOG_LINKING_ENTITY_IDS}}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -14,6 +14,8 @@ parameters:
   required: true
 - name: SREP_LEGAL_ENTITY_ID
   required: true
+- name: LOG_LINKING_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
@@ -20966,6 +20968,71 @@ objects:
             operator: Exists
         containerRuntimeConfig:
           pidsLimit: 4096
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: crio-loglinking
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: NotIn
+        values:
+        - 4.13.0
+        - 4.13.1
+        - 4.13.2
+        - 4.13.3
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{LOG_LINKING_ENTITY_IDS}}
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-workers-linked-log
+      spec:
+        config:
+          ignition:
+            config: {}
+            security:
+              tls: {}
+            timeouts: {}
+            version: 3.1.0
+          networkd: {}
+          passwd: {}
+          storage:
+            files:
+            - contents:
+                source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
+              mode: 420
+              overwrite: true
+              path: /etc/crio/crio.conf.d/99-linked-log.conf
+        osImageURL: ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -14,6 +14,8 @@ parameters:
   required: true
 - name: SREP_LEGAL_ENTITY_ID
   required: true
+- name: LOG_LINKING_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
@@ -20966,6 +20968,71 @@ objects:
             operator: Exists
         containerRuntimeConfig:
           pidsLimit: 4096
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: crio-loglinking
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: NotIn
+        values:
+        - 4.13.0
+        - 4.13.1
+        - 4.13.2
+        - 4.13.3
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{LOG_LINKING_ENTITY_IDS}}
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-workers-linked-log
+      spec:
+        config:
+          ignition:
+            config: {}
+            security:
+              tls: {}
+            timeouts: {}
+            version: 3.1.0
+          networkd: {}
+          passwd: {}
+          storage:
+            files:
+            - contents:
+                source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
+              mode: 420
+              overwrite: true
+              path: /etc/crio/crio.conf.d/99-linked-log.conf
+        osImageURL: ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -14,6 +14,8 @@ parameters:
   required: true
 - name: SREP_LEGAL_ENTITY_ID
   required: true
+- name: LOG_LINKING_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
@@ -20966,6 +20968,71 @@ objects:
             operator: Exists
         containerRuntimeConfig:
           pidsLimit: 4096
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: crio-loglinking
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.0'
+        - '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: NotIn
+        values:
+        - 4.13.0
+        - 4.13.1
+        - 4.13.2
+        - 4.13.3
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{LOG_LINKING_ENTITY_IDS}}
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-workers-linked-log
+      spec:
+        config:
+          ignition:
+            config: {}
+            security:
+              tls: {}
+            timeouts: {}
+            version: 3.1.0
+          networkd: {}
+          passwd: {}
+          storage:
+            files:
+            - contents:
+                source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
+              mode: 420
+              overwrite: true
+              path: /etc/crio/crio.conf.d/99-linked-log.conf
+        osImageURL: ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -14,6 +14,8 @@ parameters:
   required: true
 - name: SREP_LEGAL_ENTITY_ID
   required: true
+- name: LOG_LINKING_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Enables deployment of a specific MachineConfig to orgs that are enabled for the Log Linking feature

### Which Jira/Github issue(s) this PR fixes?
related to [OSD-18451](https://issues.redhat.com//browse/OSD-18451)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
