### PR TITLE
OSD-18456 Disable critical elasticsearch alerts

### DIFF
--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -35,7 +35,7 @@ spec:
           for: 7m
           labels:
             namespace: openshift-logging
-            severity: critical
+            severity: warning
         - alert: ElasticsearchClusterNotHealthySRE
           annotations:
             message: Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated.
@@ -89,7 +89,7 @@ spec:
           for: 5m
           labels:
             namespace: openshift-logging
-            severity: critical
+            severity: warning
         - alert: ElasticsearchNodeDiskWatermarkReachedSRE
           annotations:
             message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
@@ -106,7 +106,7 @@ spec:
           for: 5m
           labels:
             namespace: openshift-logging
-            severity: critical
+            severity: warning
         - alert: ElasticsearchJVMHeapUseHighSRE
           annotations:
             message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
@@ -146,7 +146,7 @@ spec:
           for: 1h
           labels:
             namespace: openshift-logging
-            severity: critical
+            severity: warning
         - alert: ElasticsearchHighFileDescriptorUsageSRE
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32773,7 +32773,7 @@ objects:
             for: 7m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchClusterNotHealthySRE
             annotations:
               message: Cluster {{ $labels.cluster }} health status has been YELLOW
@@ -32826,7 +32826,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -32841,7 +32841,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -32891,7 +32891,7 @@ objects:
             for: 1h
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchHighFileDescriptorUsageSRE
             annotations:
               message: Cluster {{ $labels.cluster }} is predicted to be out of file

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32773,7 +32773,7 @@ objects:
             for: 7m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchClusterNotHealthySRE
             annotations:
               message: Cluster {{ $labels.cluster }} health status has been YELLOW
@@ -32826,7 +32826,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -32841,7 +32841,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -32891,7 +32891,7 @@ objects:
             for: 1h
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchHighFileDescriptorUsageSRE
             annotations:
               message: Cluster {{ $labels.cluster }} is predicted to be out of file

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32773,7 +32773,7 @@ objects:
             for: 7m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchClusterNotHealthySRE
             annotations:
               message: Cluster {{ $labels.cluster }} health status has been YELLOW
@@ -32826,7 +32826,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -32841,7 +32841,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -32891,7 +32891,7 @@ objects:
             for: 1h
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchHighFileDescriptorUsageSRE
             annotations:
               message: Cluster {{ $labels.cluster }} is predicted to be out of file


### PR DESCRIPTION
### What this PR does / why we need it?
https://issues.redhat.com/browse/OSD-18456

This PR sets the following critical elasticsearch alerts to warning:
- ElasticsearchClusterNotHealthySRE
- ElasticsearchNodeDiskWatermarkReachedSRE
- ElasticsearchDiskSpaceRunningLowSRE


**Reasoning:** from my understanding we have 3 different alerts for "disk is filling up":
-KubePersistentVolumeFillingUp
-ElasticsearchDiskSpaceRunningLowSRE
-ElasticsearchNodeDiskWatermarkReachedSRE

[OAO already automatically sends SLs for logging PV filling up](https://github.com/openshift/managed-cluster-config/blob/12229907c5f6a22b4d2e27e0748a73d78becca87/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml#L13):
```
count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-logging"}) >= 1
```
The above 3 should be covered by that.

ElasticsearchClusterNotHealthySRE from what I've seen is caused by the disks being filled up.


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
