### PR TITLE
reduce UpgradeConfigValidationFailedSRE severity from critical to warning

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -15,7 +15,7 @@ spec:
       expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m]) == 1
       for: 10m
       labels:
-        severity: critical
+        severity: warning
         namespace: openshift-monitoring
       annotations:
         summary: "Upgrade config validation failed"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31844,7 +31844,7 @@ objects:
               == 1
             for: 10m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               summary: Upgrade config validation failed

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31844,7 +31844,7 @@ objects:
               == 1
             for: 10m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               summary: Upgrade config validation failed

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31844,7 +31844,7 @@ objects:
               == 1
             for: 10m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               summary: Upgrade config validation failed


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
reduce alert noise. from looking at the alert history, it seems that the alert is either:
- auto resolving
- not actionable
- not up-to-date

is this alert still really needed? i suggest we reduce the severity, at least for now.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18386
