### PR TITLE
reduce DNSErrors10MinSRE severity from critical to warning

### DIFF
--- a/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-dns-latency.PrometheusRule.yaml
@@ -15,7 +15,7 @@ spec:
       expr: increase(dns_failure_failure_total[10m]) >= 3
       for: 10m
       labels:
-        severity: critical
+        severity: warning
         namespace: openshift-monitoring
       annotations:
         message: At least 3 DNS checks have been failing for the past 10 minutes on pod- {{ $labels.pod }}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31555,7 +31555,7 @@ objects:
             expr: increase(dns_failure_failure_total[10m]) >= 3
             for: 10m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: At least 3 DNS checks have been failing for the past 10 minutes

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31555,7 +31555,7 @@ objects:
             expr: increase(dns_failure_failure_total[10m]) >= 3
             for: 10m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: At least 3 DNS checks have been failing for the past 10 minutes

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31555,7 +31555,7 @@ objects:
             expr: increase(dns_failure_failure_total[10m]) >= 3
             for: 10m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: At least 3 DNS checks have been failing for the past 10 minutes


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
reduce noise. this alert severity may be reduced because:
- it seems the sentiment is that it is noise
- it is usually accompanied by other alerts
- the metric comes from https://github.com/openshift/managed-prometheus-exporter-dns, which is being [deprecated](https://docs.google.com/document/d/1ypPZ_pd74vV8FUqU86F7CtC3c66ukuQ6p7CgF3P1wNk)

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/SDE-2864