### PR TITLE
Remove ticket number from MachineOutOfCompliance alert

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
@@ -19,7 +19,6 @@ spec:
         severity: warning
         namespace: "{{ $labels.namespace }}"
         node: "{{ $labels.node }}"
-        source: "https://issues.redhat.com/browse/OSD-17905"
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md"
       annotations:
         message:  A machine on a management cluster is older than 28 days.


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Sanitizes the `MachineOutOfCompliance` alert by removing the OSD ticket number from its labels
