### PR TITLE
Small fix to linked log machineconfig

### DIFF
--- a/deploy/crio-loglinking/01-machineconfig.yaml
+++ b/deploy/crio-loglinking/01-machineconfig.yaml
@@ -3,22 +3,16 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: 99-workers-linked-log
+  name: 90-worker-linked-log
 spec:
   config:
     ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 3.1.0
-    networkd: {}
-    passwd: {}
+      version: 3.2.0
     storage:
       files:
       - contents:
           source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
         mode: 420
         overwrite: true
-        path: /etc/crio/crio.conf.d/99-linked-log.conf
+        path: /etc/crio/crio.conf.d/90-linked-log.conf
   osImageURL: ""

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21014,24 +21014,18 @@ objects:
       metadata:
         labels:
           machineconfiguration.openshift.io/role: worker
-        name: 99-workers-linked-log
+        name: 90-worker-linked-log
       spec:
         config:
           ignition:
-            config: {}
-            security:
-              tls: {}
-            timeouts: {}
-            version: 3.1.0
-          networkd: {}
-          passwd: {}
+            version: 3.2.0
           storage:
             files:
             - contents:
                 source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
               mode: 420
               overwrite: true
-              path: /etc/crio/crio.conf.d/99-linked-log.conf
+              path: /etc/crio/crio.conf.d/90-linked-log.conf
         osImageURL: ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21014,24 +21014,18 @@ objects:
       metadata:
         labels:
           machineconfiguration.openshift.io/role: worker
-        name: 99-workers-linked-log
+        name: 90-worker-linked-log
       spec:
         config:
           ignition:
-            config: {}
-            security:
-              tls: {}
-            timeouts: {}
-            version: 3.1.0
-          networkd: {}
-          passwd: {}
+            version: 3.2.0
           storage:
             files:
             - contents:
                 source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
               mode: 420
               overwrite: true
-              path: /etc/crio/crio.conf.d/99-linked-log.conf
+              path: /etc/crio/crio.conf.d/90-linked-log.conf
         osImageURL: ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21014,24 +21014,18 @@ objects:
       metadata:
         labels:
           machineconfiguration.openshift.io/role: worker
-        name: 99-workers-linked-log
+        name: 90-worker-linked-log
       spec:
         config:
           ignition:
-            config: {}
-            security:
-              tls: {}
-            timeouts: {}
-            version: 3.1.0
-          networkd: {}
-          passwd: {}
+            version: 3.2.0
           storage:
             files:
             - contents:
                 source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubGlua2VkXQphY3RpdmF0aW9uX2Fubm90YXRpb24gPSAiaW8ua3ViZXJuZXRlcy5jcmktby5MaW5rTG9ncyIgCmFsbG93ZWRfYW5ub3RhdGlvbnMgPSBbICJpby5rdWJlcm5ldGVzLmNyaS1vLkxpbmtMb2dzIiBdCg==
               mode: 420
               overwrite: true
-              path: /etc/crio/crio.conf.d/99-linked-log.conf
+              path: /etc/crio/crio.conf.d/90-linked-log.conf
         osImageURL: ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
fixes up naming and ignition version for config

### Which Jira/Github issue(s) this PR fixes?

related to [OSD-18451](https://issues.redhat.com//browse/OSD-18451)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
