### PR TITLE
add an alert for invalid pull secret

### DIFF
--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -21,3 +21,14 @@ spec:
 
       annotations:
         message: OCM Agent has failed to receive a response from the service_logs service for 60 minutes.
+    - alert: OCMAgentOperatorPullSecretInvalidSRE
+      # Alert if the OCM agent response failure metric has been set for an hour average window
+      expr: ocm_agent_operator_pull_secret_invalid > 0
+      for: 15m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets"
+
+      annotations:
+        message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com` pull secret.

--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -22,7 +22,6 @@ spec:
       annotations:
         message: OCM Agent has failed to receive a response from the service_logs service for 60 minutes.
     - alert: OCMAgentOperatorPullSecretInvalidSRE
-      # Alert if the OCM agent response failure metric has been set for an hour average window
       expr: ocm_agent_operator_pull_secret_invalid > 0
       for: 15m
       labels:

--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -25,7 +25,7 @@ spec:
       expr: ocm_agent_operator_pull_secret_invalid > 0
       for: 15m
       labels:
-        severity: critical
+        severity: low
         namespace: openshift-monitoring
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets"
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32490,6 +32490,16 @@ objects:
             annotations:
               message: OCM Agent has failed to receive a response from the service_logs
                 service for 60 minutes.
+          - alert: OCMAgentOperatorPullSecretInvalidSRE
+            expr: ocm_agent_operator_pull_secret_invalid > 0
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
+            annotations:
+              message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com`
+                pull secret.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32494,7 +32494,7 @@ objects:
             expr: ocm_agent_operator_pull_secret_invalid > 0
             for: 15m
             labels:
-              severity: critical
+              severity: low
               namespace: openshift-monitoring
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
             annotations:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32490,6 +32490,16 @@ objects:
             annotations:
               message: OCM Agent has failed to receive a response from the service_logs
                 service for 60 minutes.
+          - alert: OCMAgentOperatorPullSecretInvalidSRE
+            expr: ocm_agent_operator_pull_secret_invalid > 0
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
+            annotations:
+              message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com`
+                pull secret.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32494,7 +32494,7 @@ objects:
             expr: ocm_agent_operator_pull_secret_invalid > 0
             for: 15m
             labels:
-              severity: critical
+              severity: low
               namespace: openshift-monitoring
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
             annotations:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32490,6 +32490,16 @@ objects:
             annotations:
               message: OCM Agent has failed to receive a response from the service_logs
                 service for 60 minutes.
+          - alert: OCMAgentOperatorPullSecretInvalidSRE
+            expr: ocm_agent_operator_pull_secret_invalid > 0
+            for: 15m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
+            annotations:
+              message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com`
+                pull secret.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32494,7 +32494,7 @@ objects:
             expr: ocm_agent_operator_pull_secret_invalid > 0
             for: 15m
             labels:
-              severity: critical
+              severity: low
               namespace: openshift-monitoring
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
             annotations:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
with this alert, SRE will be paged when a cluster's pull secret is invalid. this symptom causes many other alerts that may take longer to investigate. with this very particular alert, we will reduce investigation time and prevent other alerts from popping up.

it is possible to use the same metric later to prevent other alerts. for example: #1848

this metric comes from https://github.com/mrbarge/ocm-agent-operator/blob/master/docs/metrics.md#ocm_agent_operator_pull_secret_invalid

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18411
