### PR TITLE
prevent UpgradeControlPlaneUpgradeTimeoutSRE from alerting if pull secret is invalid

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -22,7 +22,7 @@ spec:
         description: "Upgrade config validation failed"
     - alert: UpgradeControlPlaneUpgradeTimeoutSRE
       # Alert if the control plane timeout metric has been set for a ten-minute average window
-      expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+      expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1 and not ocm_agent_operator_pull_secret_invalid > 0
       for: 10m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32267,7 +32267,8 @@ objects:
               summary: Upgrade config validation failed
               description: Upgrade config validation failed
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1 and
+              not ocm_agent_operator_pull_secret_invalid > 0
             for: 10m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32267,7 +32267,8 @@ objects:
               summary: Upgrade config validation failed
               description: Upgrade config validation failed
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1 and
+              not ocm_agent_operator_pull_secret_invalid > 0
             for: 10m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32267,7 +32267,8 @@ objects:
               summary: Upgrade config validation failed
               description: Upgrade config validation failed
           - alert: UpgradeControlPlaneUpgradeTimeoutSRE
-            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1
+            expr: avg_over_time(upgradeoperator_controlplane_timeout[10m]) == 1 and
+              not ocm_agent_operator_pull_secret_invalid > 0
             for: 10m
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
if https://github.com/openshift/managed-cluster-config/pull/1847 is accepted, we can stop SRE from being paged on various alerts which may be related to an invalid pull secret.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18411
