### PR TITLE
automate SL notification for ClusterOperatorDown for UWM

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-co-down.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-co-down.yaml
@@ -1,0 +1,13 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedNotification
+metadata:
+  name: sre-co-down-managed-notifications
+  namespace: openshift-ocm-agent-operator
+spec:
+  notifications:
+    - activeBody: |-
+        Your cluster requires you to take action. Your cluster's worker nodes do not have enough resources to run the cluster's User Workload Monitoring monitoring stack. As a result, its operation may be impaired. Please ensure that your workloads have CPU and Memory limits set to avoid overcommitting the worker nodes, and consider either reducing application load or increasing worker nodes. For more information on managing resource consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+      name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
+      resendWait: 24
+      severity: Warning
+      summary: "Action required: User Workload Monitoring impacted by cluster resource limits"

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-co-down.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-co-down.yaml
@@ -6,8 +6,8 @@ metadata:
 spec:
   notifications:
     - activeBody: |-
-        Your cluster requires you to take action. Your cluster's worker nodes do not have enough resources to run the cluster's User Workload Monitoring monitoring stack. As a result, its operation may be impaired. Please ensure that your workloads have CPU and Memory limits set to avoid overcommitting the worker nodes, and consider either reducing application load or increasing worker nodes. For more information on managing resource consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+        The {{ "{{ $labels.name }}" }} operator may be down or disabled because {{ "${{ $labels.reason }}" }}, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
       name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
       resendWait: 24
       severity: Warning
-      summary: "Action required: User Workload Monitoring impacted by cluster resource limits"
+      summary: "Cluster operator has not been available for 10 minutes."

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent-cluster-operator-down.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent-cluster-operator-down.PrometheusRule.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-proxy-managed-notification-alerts
+    role: alert-rules 
+  name: sre-co-down-managed-notification-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-co-down-managed-notification-alerts
+    rules:
+    - alert: ClusterOperatorDownNotificationSRE
+      expr: max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator",name="monitoring",reason="UpdatingPrometheusUserWorkloadFailed"} == 0)
+      for: 10m
+      labels:
+        severity: Warning
+        namespace: openshift-monitoring
+        managed_notification_template: "ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed"
+        send_managed_notification: "true"
+      annotations:
+        message: "Action required: User Workload Monitoring impacted by cluster resource limits"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21864,18 +21864,17 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
-        - activeBody: Your cluster requires you to take action. Your cluster's worker
-            nodes do not have enough resources to run the cluster's User Workload
-            Monitoring monitoring stack. As a result, its operation may be impaired.
-            Please ensure that your workloads have CPU and Memory limits set to avoid
-            overcommitting the worker nodes, and consider either reducing application
-            load or increasing worker nodes. For more information on managing resource
-            consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+        - activeBody: The {{ "{{ $labels.name }}" }} operator may be down or disabled
+            because {{ "${{ $labels.reason }}" }}, and the components it manages may
+            be unavailable or degraded.  Cluster upgrades may not complete. For more
+            information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
+            }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne
+            (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
+            (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
           name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
           resendWait: 24
           severity: Warning
-          summary: 'Action required: User Workload Monitoring impacted by cluster
-            resource limits'
+          summary: Cluster operator has not been available for 10 minutes.
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21860,6 +21860,25 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
+        name: sre-co-down-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - activeBody: Your cluster requires you to take action. Your cluster's worker
+            nodes do not have enough resources to run the cluster's User Workload
+            Monitoring monitoring stack. As a result, its operation may be impaired.
+            Please ensure that your workloads have CPU and Memory limits set to avoid
+            overcommitting the worker nodes, and consider either reducing application
+            load or increasing worker nodes. For more information on managing resource
+            consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+          name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: User Workload Monitoring impacted by cluster
+            resource limits'
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
         name: sre-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
@@ -33644,6 +33663,30 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
             annotations:
               message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-proxy-managed-notification-alerts
+          role: alert-rules
+        name: sre-co-down-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-co-down-managed-notification-alerts
+          rules:
+          - alert: ClusterOperatorDownNotificationSRE
+            expr: max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator",name="monitoring",reason="UpdatingPrometheusUserWorkloadFailed"}
+              == 0)
+            for: 10m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
+              send_managed_notification: 'true'
+            annotations:
+              message: 'Action required: User Workload Monitoring impacted by cluster
+                resource limits'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21864,18 +21864,17 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
-        - activeBody: Your cluster requires you to take action. Your cluster's worker
-            nodes do not have enough resources to run the cluster's User Workload
-            Monitoring monitoring stack. As a result, its operation may be impaired.
-            Please ensure that your workloads have CPU and Memory limits set to avoid
-            overcommitting the worker nodes, and consider either reducing application
-            load or increasing worker nodes. For more information on managing resource
-            consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+        - activeBody: The {{ "{{ $labels.name }}" }} operator may be down or disabled
+            because {{ "${{ $labels.reason }}" }}, and the components it manages may
+            be unavailable or degraded.  Cluster upgrades may not complete. For more
+            information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
+            }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne
+            (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
+            (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
           name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
           resendWait: 24
           severity: Warning
-          summary: 'Action required: User Workload Monitoring impacted by cluster
-            resource limits'
+          summary: Cluster operator has not been available for 10 minutes.
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21860,6 +21860,25 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
+        name: sre-co-down-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - activeBody: Your cluster requires you to take action. Your cluster's worker
+            nodes do not have enough resources to run the cluster's User Workload
+            Monitoring monitoring stack. As a result, its operation may be impaired.
+            Please ensure that your workloads have CPU and Memory limits set to avoid
+            overcommitting the worker nodes, and consider either reducing application
+            load or increasing worker nodes. For more information on managing resource
+            consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+          name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: User Workload Monitoring impacted by cluster
+            resource limits'
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
         name: sre-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
@@ -33644,6 +33663,30 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
             annotations:
               message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-proxy-managed-notification-alerts
+          role: alert-rules
+        name: sre-co-down-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-co-down-managed-notification-alerts
+          rules:
+          - alert: ClusterOperatorDownNotificationSRE
+            expr: max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator",name="monitoring",reason="UpdatingPrometheusUserWorkloadFailed"}
+              == 0)
+            for: 10m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
+              send_managed_notification: 'true'
+            annotations:
+              message: 'Action required: User Workload Monitoring impacted by cluster
+                resource limits'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21864,18 +21864,17 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
-        - activeBody: Your cluster requires you to take action. Your cluster's worker
-            nodes do not have enough resources to run the cluster's User Workload
-            Monitoring monitoring stack. As a result, its operation may be impaired.
-            Please ensure that your workloads have CPU and Memory limits set to avoid
-            overcommitting the worker nodes, and consider either reducing application
-            load or increasing worker nodes. For more information on managing resource
-            consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+        - activeBody: The {{ "{{ $labels.name }}" }} operator may be down or disabled
+            because {{ "${{ $labels.reason }}" }}, and the components it manages may
+            be unavailable or degraded.  Cluster upgrades may not complete. For more
+            information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
+            }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne
+            (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
+            (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
           name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
           resendWait: 24
           severity: Warning
-          summary: 'Action required: User Workload Monitoring impacted by cluster
-            resource limits'
+          summary: Cluster operator has not been available for 10 minutes.
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21860,6 +21860,25 @@ objects:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
+        name: sre-co-down-managed-notifications
+        namespace: openshift-ocm-agent-operator
+      spec:
+        notifications:
+        - activeBody: Your cluster requires you to take action. Your cluster's worker
+            nodes do not have enough resources to run the cluster's User Workload
+            Monitoring monitoring stack. As a result, its operation may be impaired.
+            Please ensure that your workloads have CPU and Memory limits set to avoid
+            overcommitting the worker nodes, and consider either reducing application
+            load or increasing worker nodes. For more information on managing resource
+            consumption, please see https://docs.openshift.com/container-platform/latest/nodes/clusters/nodes-cluster-limit-ranges.html.
+          name: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
+          resendWait: 24
+          severity: Warning
+          summary: 'Action required: User Workload Monitoring impacted by cluster
+            resource limits'
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedNotification
+      metadata:
         name: sre-managed-notifications
         namespace: openshift-ocm-agent-operator
       spec:
@@ -33644,6 +33663,30 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/MultipleVersionsOfEFSCSIDriverInstalled.md
             annotations:
               message: Multiple versions of EFS CSI Driver installed
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-proxy-managed-notification-alerts
+          role: alert-rules
+        name: sre-co-down-managed-notification-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-co-down-managed-notification-alerts
+          rules:
+          - alert: ClusterOperatorDownNotificationSRE
+            expr: max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator",name="monitoring",reason="UpdatingPrometheusUserWorkloadFailed"}
+              == 0)
+            for: 10m
+            labels:
+              severity: Warning
+              namespace: openshift-monitoring
+              managed_notification_template: ClusterOperatorDownMonitoringUpdatingPrometheusUserWorkloadFailed
+              send_managed_notification: 'true'
+            annotations:
+              message: 'Action required: User Workload Monitoring impacted by cluster
+                resource limits'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
toil reduction.

this is an OCP alert and is being silenced in https://github.com/openshift/configure-alertmanager-operator/pull/296
adding it here so we can automate the SL notification: https://github.com/openshift/managed-notifications/blob/master/osd/no_resources_to_run_userworkloadmonitoring.json

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-15940