### PR TITLE
Restrict node conditions to ROSA only

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/node-condition/100-ocm-agent-node-condition.PrometheusRule.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/node-condition/100-ocm-agent-node-condition.PrometheusRule.yaml
@@ -35,7 +35,7 @@ spec:
             ) > 0
       for: 5m
       labels:
-        severity: Info
+        severity: info
         namespace: openshift-node
         send_managed_notification: "true"
         managed_notification_template: "NodeConditionDiskPressureNotification"
@@ -48,7 +48,7 @@ spec:
             ) > 0
       for: 5m
       labels:
-        severity: Info
+        severity: info
         namespace: openshift-node
         send_managed_notification: "true"
         managed_notification_template: "NodeConditionMemoryPressureNotification"
@@ -61,7 +61,7 @@ spec:
             ) > 0
       for: 5m
       labels:
-        severity: Info
+        severity: info
         namespace: openshift-node
         send_managed_notification: "true"
         managed_notification_template: "NodeConditionPIDPressureNotification"
@@ -74,7 +74,7 @@ spec:
             ) > 0
       for: 5m
       labels:
-        severity: Info
+        severity: info
         namespace: openshift-node
         send_managed_notification: "true"
         managed_notification_template: "NodeConditionNetworkUnavailableNotification"

--- a/deploy/ocm-agent-operator-managednotifications/node-condition/config.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/node-condition/config.yaml
@@ -7,6 +7,10 @@ selectorSyncSet:
     values:
       - "integration"
       - "staging"
+  - key: api.openshift.com/product
+    operator: In
+    values:
+      - "rosa"
   - key: api.openshift.com/fedramp
     operator: NotIn
     values:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22026,6 +22026,10 @@ objects:
         values:
         - integration
         - staging
+      - key: api.openshift.com/product
+        operator: In
+        values:
+        - rosa
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:
@@ -22056,7 +22060,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionDiskPressureNotification
@@ -22066,7 +22070,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionMemoryPressureNotification
@@ -22076,7 +22080,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionPIDPressureNotification
@@ -22086,7 +22090,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionNetworkUnavailableNotification

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22026,6 +22026,10 @@ objects:
         values:
         - integration
         - staging
+      - key: api.openshift.com/product
+        operator: In
+        values:
+        - rosa
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:
@@ -22056,7 +22060,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionDiskPressureNotification
@@ -22066,7 +22070,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionMemoryPressureNotification
@@ -22076,7 +22080,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionPIDPressureNotification
@@ -22086,7 +22090,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionNetworkUnavailableNotification

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22026,6 +22026,10 @@ objects:
         values:
         - integration
         - staging
+      - key: api.openshift.com/product
+        operator: In
+        values:
+        - rosa
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:
@@ -22056,7 +22060,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionDiskPressureNotification
@@ -22066,7 +22070,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionMemoryPressureNotification
@@ -22076,7 +22080,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionPIDPressureNotification
@@ -22086,7 +22090,7 @@ objects:
               ) > 0
             for: 5m
             labels:
-              severity: Info
+              severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
               managed_notification_template: NodeConditionNetworkUnavailableNotification


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Limit node condition notifications to ROSA only.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18507

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
