### PR TITLE
[OSD-18359] Updated  control-plane-resizing alert to alert on CPU and Memory consumption

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -87,28 +87,6 @@ spec:
               )
             )
         record: sre:node_control_plane:excessive_consumption_memory
-      - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
-        record: sre:node_workers:count
-      # control plane has less than 32GB RAM, worker count > 25, and worker count <= 100
-      # control plane has less than 64GB RAM, worker count > 100, and worker count <= 250
-      # control plane has less than 128GB RAM, worker count > 250
-      - expr: (
-                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 32*1024*1024*1024
-                AND sre:node_workers:count > 25
-                AND sre:node_workers:count <= 100
-              )
-              OR
-              (
-                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 64*1024*1024*1024
-                AND sre:node_workers:count > 100
-                AND sre:node_workers:count <= 250
-              )
-              OR
-              (
-                avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"}) < 128*1024*1024*1024
-                AND sre:node_workers:count > 250
-              )
-        record: sre:node_control_plane:need_resize
   - name: sre-control-plane-resizing-alerts
     rules:
         # This used to be called MasterNodesNeedResizingSRE
@@ -119,13 +97,13 @@ spec:
           severity: warning
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's control plane nodes have been undersized for 15 minutes and should be vertically scaled to support the existing workers. See linked SOP for details. Critical alert will be raised at 2 hours."
+          message: "The cluster's control plane nodes have been undersized for 15 minutes and should be vertically scaled to support the existing workload. See linked SOP for details. Critical alert will be raised at 24 hours."
         # This used to be called MasterNodesNeedResizingSRE
       - alert: ControlPlaneNodesNeedResizingSRE
-        expr: sre:node_control_plane:need_resize > 0
-        for: 2h
+        expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu > 0)
+        for: 24h
         labels:
           severity: critical
           namespace: openshift-monitoring
         annotations:
-          message: "The cluster's control plane nodes have been undersized for 2 hours and must be vertically scaled to support the existing workers. See linked SOP for details."
+          message: "The cluster's control plane nodes have been undersized for 24 hours and must be vertically scaled to support the existing workload. See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31927,15 +31927,6 @@ objects:
               ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="master"} ) ) )
             record: sre:node_control_plane:excessive_consumption_memory
-          - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
-            record: sre:node_workers:count
-          - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 32*1024*1024*1024 AND sre:node_workers:count > 25 AND sre:node_workers:count
-              <= 100 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 64*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
-              <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
-            record: sre:node_control_plane:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
@@ -31948,17 +31939,18 @@ objects:
             annotations:
               message: The cluster's control plane nodes have been undersized for
                 15 minutes and should be vertically scaled to support the existing
-                workers. See linked SOP for details. Critical alert will be raised
-                at 2 hours.
+                workload. See linked SOP for details. Critical alert will be raised
+                at 24 hours.
           - alert: ControlPlaneNodesNeedResizingSRE
-            expr: sre:node_control_plane:need_resize > 0
-            for: 2h
+            expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu
+              > 0)
+            for: 24h
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The cluster's control plane nodes have been undersized for
-                2 hours and must be vertically scaled to support the existing workers.
+                24 hours and must be vertically scaled to support the existing workload.
                 See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31927,15 +31927,6 @@ objects:
               ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="master"} ) ) )
             record: sre:node_control_plane:excessive_consumption_memory
-          - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
-            record: sre:node_workers:count
-          - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 32*1024*1024*1024 AND sre:node_workers:count > 25 AND sre:node_workers:count
-              <= 100 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 64*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
-              <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
-            record: sre:node_control_plane:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
@@ -31948,17 +31939,18 @@ objects:
             annotations:
               message: The cluster's control plane nodes have been undersized for
                 15 minutes and should be vertically scaled to support the existing
-                workers. See linked SOP for details. Critical alert will be raised
-                at 2 hours.
+                workload. See linked SOP for details. Critical alert will be raised
+                at 24 hours.
           - alert: ControlPlaneNodesNeedResizingSRE
-            expr: sre:node_control_plane:need_resize > 0
-            for: 2h
+            expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu
+              > 0)
+            for: 24h
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The cluster's control plane nodes have been undersized for
-                2 hours and must be vertically scaled to support the existing workers.
+                24 hours and must be vertically scaled to support the existing workload.
                 See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31927,15 +31927,6 @@ objects:
               ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="master"} ) ) )
             record: sre:node_control_plane:excessive_consumption_memory
-          - expr: count(cluster:nodes_roles{label_node_role_kubernetes_io!~"(master|infra)"})
-            record: sre:node_workers:count
-          - expr: ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 32*1024*1024*1024 AND sre:node_workers:count > 25 AND sre:node_workers:count
-              <= 100 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 64*1024*1024*1024 AND sre:node_workers:count > 100 AND sre:node_workers:count
-              <= 250 ) OR ( avg(sre:node_roles:memory_total_bytes{label_node_role_kubernetes_io="master"})
-              < 128*1024*1024*1024 AND sre:node_workers:count > 250 )
-            record: sre:node_control_plane:need_resize
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
@@ -31948,17 +31939,18 @@ objects:
             annotations:
               message: The cluster's control plane nodes have been undersized for
                 15 minutes and should be vertically scaled to support the existing
-                workers. See linked SOP for details. Critical alert will be raised
-                at 2 hours.
+                workload. See linked SOP for details. Critical alert will be raised
+                at 24 hours.
           - alert: ControlPlaneNodesNeedResizingSRE
-            expr: sre:node_control_plane:need_resize > 0
-            for: 2h
+            expr: (sre:node_control_plane:excessive_consumption_memory > 0) or (sre:node_control_plane:excessive_consumption_cpu
+              > 0)
+            for: 24h
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The cluster's control plane nodes have been undersized for
-                2 hours and must be vertically scaled to support the existing workers.
+                24 hours and must be vertically scaled to support the existing workload.
                 See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / why we need it?

This PR updates the Contreolplane Needs Resize alert to be based on memory and CPU consumption instead of  number of worker nodes in the cluster 

### Which Jira/Github issue(s) this PR fixes?

[_Fixes #[OSD-18359](https://issues.redhat.com//browse/OSD-18359)_](https://issues.redhat.com/browse/OSD-18359)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR 
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
