### PR TITLE
Lower ElasticsearchNodeDiskWatermarkReachedSRE to warning

### DIFF
--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -89,7 +89,7 @@ spec:
           for: 5m
           labels:
             namespace: openshift-logging
-            severity: critical
+            severity: warning
         - alert: ElasticsearchNodeDiskWatermarkReachedSRE
           annotations:
             message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
@@ -106,7 +106,7 @@ spec:
           for: 5m
           labels:
             namespace: openshift-logging
-            severity: critical
+            severity: warning
         - alert: ElasticsearchJVMHeapUseHighSRE
           annotations:
             message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33249,7 +33249,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -33264,7 +33264,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33249,7 +33249,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -33264,7 +33264,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33249,7 +33249,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -33264,7 +33264,7 @@ objects:
             for: 5m
             labels:
               namespace: openshift-logging
-              severity: critical
+              severity: warning
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
These alerts fire fairly often but they are not actionable as automation already sends a service log to the cluster owner.

### Which Jira/Github issue(s) this PR fixes?
[OSD-18456](https://issues.redhat.com//browse/OSD-18456)

### Special notes for your reviewer:
Added first in https://github.com/openshift/managed-cluster-config/pull/1839 and then reverted in https://github.com/openshift/managed-cluster-config/pull/1846. This PR targets only ElasticsearchNodeDiskWatermarkReachedSRE.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment 

