### PR TITLE
Fix SecurityGroup describe actions in HCP support policy

### DIFF
--- a/resources/sts/4.13/hypershift/sts_hcp_support_permission_policy.json
+++ b/resources/sts/4.13/hypershift/sts_hcp_support_permission_policy.json
@@ -141,7 +141,7 @@
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeStaleSecurityGroups"
       ],
-      "Resource": "arn:aws:ec2:*:*:security-group*/*"
+      "Resource": "*"
     },
     {
       "Sid": "DescribeAddressesAttribute",


### PR DESCRIPTION
According to AWS docs [0], all ec2:Describe permissions require a Resoruce of * and are not allowed to use resource specification. Without *, this permission block provided no actual permissions, so changing to * will allow the permissions intended. The permissions should still only affect security groups since the Describe actions are specific to Security Groups and related resources.

[0] https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_policies.html?icmpid=docs_iam_console#mismatch_action-no-resource

### What type of PR is this?
bug fix

### What this PR does / why we need it?
To enable HCP Support managed policy to use SecurityGroup related read actions

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18534

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
