### PR TITLE
add region leads as owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,10 @@
 reviewers:
+- srep-region-leads
 - srep-functional-leads
 - srep-team-leads
 - sre-group-leads
 approvers:
+- srep-region-leads
 - srep-functional-leads
 - srep-team-leads
 - sre-group-leads

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,14 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
 
 aliases:
+  srep-region-leads:
+    - geowa4
+    - lnguyen1401
+    - Makdaam
+    - rendhalver
+    - Tessg22
+    - MitaliBhalla
+    - weherdh
   srep-functional-leads:
     - mrbarge
     - rafael-azevedo


### PR DESCRIPTION
An addition of SREP region leads as reviewers and approvers, which seems to be well within immediate consensus.

split from #1854