### PR TITLE
deprecate direct deployment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ add the policy as a new SelectorySyncSet.
 
 All resources in `generated_deploy/` are bundled into a template that is used by config management to apply to target "hive" clusters.  The configuration is deployed to the "hive" cluster inside a SelectorSyncSet.
 
-SelectorSyncSet deployment supports resoures that are synced down to OSD clusters.  Each are explained in detail here.  The general configuration is managed in a `config.yaml` file in each deploy directory.  Key things of note:
+SelectorSyncSet deployment supports resources that are synced down to OSD clusters.  Each are explained in detail here.  The general configuration is managed in a `config.yaml` file in each deploy directory.  Key things of note:
 
 * This file is now mandatory in the scope of OSD-15267 and have been added to all folders. In case it is not define, `make` will fail
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ You must specify a `deploymentMode` property in `config.yaml`.
 
 * `deploymentMode` (optional, default = `"SelectorSyncSet"`) - either "Policy" or "SelectorSyncSet".
 
+## Direct Deployment
+
+Direct deployments to Hive clusters should be done via [app-interface](https://gitlab.cee.redhat.com/service/app-interface#manage-openshift-resources-via-app-interface-openshiftnamespace-1yml).
+
 ## SelectorSyncSet Deployment
 
 In the `config.yaml` file you define a top level property `selectorSyncSet`.  Within this configuration is supported for `matchLabels`, `matchExpressions`, `matchLabelsApplyMode`, `resourceApplyMode` and `applyBehavior`.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,9 @@ add the policy as a new SelectorySyncSet.
 
 # Configuration
 
-All resources in `generated_deploy/` are bundled into a template that is used by config management to apply to target "hive" clusters.  The configuration for this supports two options for deployment.  They can be deployed in the template so they are:
+All resources in `generated_deploy/` are bundled into a template that is used by config management to apply to target "hive" clusters.  The configuration is deployed to the "hive" cluster inside a SelectorSyncSet.
 
-1. deployed directly to the "hive" cluster
-2. deployed to the "hive" cluster inside a SelectorSyncSet
-
-Direct deployment (#1) supports resources that are not synced down to OSD clusters.  SelectorSyncSet deployment (#2) supports resoures that _are_ synced down to OSD clusters.  Each are explained in detail here.  The general configuration is managed in a `config.yaml` file in each deploy directory.  Key things of note:
+SelectorSyncSet deployment supports resoures that are synced down to OSD clusters.  Each are explained in detail here.  The general configuration is managed in a `config.yaml` file in each deploy directory.  Key things of note:
 
 * This file is now mandatory in the scope of OSD-15267 and have been added to all folders. In case it is not define, `make` will fail
 ```
@@ -41,27 +38,7 @@ make: *** [generate-hive-templates] Error 1
 
 You must specify a `deploymentMode` property in `config.yaml`.
 
-* `deploymentMode` (optional, default = `"SelectorSyncSet"`) - either "Direct" or "SelectorSyncSet".
-
-## Direct Deployment
-
-You must specify the `environments` where the resource is deployed.  There is no default set of environments.  It is a child of the top level `direct` property.
-
-* `environments` (required, no default) - manages what environments the resources are deployed into.  Valid values are any of `"integration"`, `"stage"`, and `"production"`.
-
-Example to deploy only to all environments:
-```yaml
-deploymentMode: "Direct"
-direct:
-    environments: ["integration", "stage", "production"]
-```
-
-Example to deploy only to integration and stage:
-```yaml
-deploymentMode: "Direct"
-direct:
-    environments: ["integration", "stage"]
-```
+* `deploymentMode` (optional, default = `"SelectorSyncSet"`) - either "Policy" or "SelectorSyncSet".
 
 ## SelectorSyncSet Deployment
 

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -93,18 +93,6 @@ def add_sss_for(name, directory, config):
     # collect the new sss for later processing
     data_sss.append(o)
 
-def add_resources_for(directory, config):
-    # there isn't a template, only thing we really care about is the environments and simply add each resource to each of those environments.
-    # at this point the properties we care about are _required_
-    yamls = get_all_yaml_obj(get_all_yaml_files(directory))
-    if len(yamls) == 0:
-        return
-
-    for y in yamls:
-        for environment in config["environments"]:
-            data_resources[environment].append(y)
-
-
 if __name__ == '__main__':
     #Argument parser
     parser = argparse.ArgumentParser(description="template generation tool", usage='%(prog)s [options]')
@@ -141,9 +129,6 @@ if __name__ == '__main__':
         # skip any directory only containing governance policies, as they are only for hypershift
         if deploymentMode == "Policy":
             continue
-
-        if deploymentMode == "Direct":
-            add_resources_for(dirpath, config["direct"])
 
         elif deploymentMode == "SelectorSyncSet":
             # initialize defaults for config


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
remove no longer used deployment method - `Direct`

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18588

### Special notes for your reviewer:
related to:
- https://github.com/openshift/managed-cluster-config/pull/1861
- https://github.com/openshift/managed-cluster-config/pull/1862