### PR TITLE
add region leads as OWNERS for alerts

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,14 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
 
 aliases:
+  srep-region-leads:
+    - geowa4
+    - lnguyen1401
+    - Makdaam
+    - rendhalver
+    - Tessg22
+    - MitaliBhalla
+    - weherdh
   srep-functional-leads:
     - mrbarge
     - rafael-azevedo

--- a/deploy/sre-prometheus/OWNERS
+++ b/deploy/sre-prometheus/OWNERS
@@ -1,3 +1,7 @@
 reviewers:
 - cblecker
 - sre-alert-sme
+- srep-region-leads
+approvers:
+- sre-alert-sme
+- srep-region-leads

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- srep-region-leads
+- srep-functional-leads
+- srep-team-leads
+approvers:
+- srep-region-leads
+- srep-team-leads
+- srep-architects


### PR DESCRIPTION
An addition of SREP region leads as reviewers and approvers for alerts, which seems to be within immediate consensus.

split from #1858