### PR TITLE
promote MachineOutOfComplianceSRE to critical

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-machine-out-of-compliance.PrometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       expr: (time() - mapi_machine_created_timestamp_seconds) > 2419200
       for: 60m
       labels:
-        severity: warning
+        severity: critical
         namespace: "{{ $labels.namespace }}"
         node: "{{ $labels.node }}"
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33714,7 +33714,7 @@ objects:
             expr: (time() - mapi_machine_created_timestamp_seconds) > 2419200
             for: 60m
             labels:
-              severity: warning
+              severity: critical
               namespace: '{{ $labels.namespace }}'
               node: '{{ $labels.node }}'
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33714,7 +33714,7 @@ objects:
             expr: (time() - mapi_machine_created_timestamp_seconds) > 2419200
             for: 60m
             labels:
-              severity: warning
+              severity: critical
               namespace: '{{ $labels.namespace }}'
               node: '{{ $labels.node }}'
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33714,7 +33714,7 @@ objects:
             expr: (time() - mapi_machine_created_timestamp_seconds) > 2419200
             for: 60m
             labels:
-              severity: warning
+              severity: critical
               namespace: '{{ $labels.namespace }}'
               node: '{{ $labels.node }}'
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Now that compliance monkey is replacing machines before they reach this 28d threshold, the alert can become a critical alert as is the goal of the story

### Which Jira/Github issue(s) this PR fixes?
[OSD-18374](https://issues.redhat.com//browse/OSD-18374)
