### PR TITLE
Remove ControlPlaneNodesNeedResizingSRE from MUO ignoredCriticals

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -51,8 +51,6 @@ data:
       - ThanosNoRuleEvaluations
       # OSD-13649
       - etcdGRPCRequestsSlow
-      # OHSS-24871
-      - ControlPlaneNodesNeedResizingSRE
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21621,10 +21621,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - ControlPlaneNodesNeedResizingSRE\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21621,10 +21621,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - ControlPlaneNodesNeedResizingSRE\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21621,10 +21621,9 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  # OHSS-24871\n  - ControlPlaneNodesNeedResizingSRE\n\
-          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
-          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
-          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This PR removes ControlPlaneNodesNeedResizingSRE from MUO ignoredCriticals. The alert is no longer subjective due to work in [OSD-18359](https://issues.redhat.com/browse/OSD-18359) and every time it fires, it should be actioned.

### Which Jira/Github issue(s) this PR fixes?

[OSD-18410](https://issues.redhat.com//browse/OSD-18410)