### PR TITLE
updates MUO config for FedRAMP int for QE testing

### DIFF
--- a/deploy/osd-fedramp-managed-upgrade-operator-config/int/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/int/10-managed-upgrade-operator-configmap.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: managed-upgrade-operator-config
+  namespace: openshift-managed-upgrade-operator
+data:
+  config.yaml: |
+    upgradeType: OSD
+    configManager:
+      source: OCM
+      ocmBaseUrl: ${OCM_BASE_URL}
+      watchInterval: 60
+    maintenance:
+      controlPlaneTime: 130
+      ignoredAlerts:
+        controlPlaneCriticals:
+        - ClusterOperatorDown
+    scale:
+      timeOut: 30
+    upgradeWindow:
+      delayTrigger: 30
+      timeOut: 120
+    nodeDrain:
+      timeOut: 45
+      expectedNodeDrainTime: 8
+    healthCheck:
+      ignoredCriticals:
+      - DNSErrors05MinSRE
+      - MetricsClientSendFailingSRE
+      - UpgradeNodeScalingFailedSRE
+      - UpgradeClusterCheckFailedSRE
+      - PruningCronjobErrorSRE
+      - PrometheusRuleFailures
+      - CannotRetrieveUpdates
+      - FluentdNodeDown
+      - ClusterProxyCAExpiringSRE
+      - PrometheusRemoteWriteBehind
+      - KubePersistentVolumeErrors
+      - PrometheusBadConfig
+      - PrometheusRemoteStorageFailures
+      - AlertmanagerMembersInconsistent
+      - AlertmanagerClusterFailedToSendAlerts
+      - AlertmanagerConfigInconsistent
+      - AlertmanagerClusterDown
+      - KubeStateMetricsListErrors
+      - KubeStateMetricsWatchErrors
+      - ThanosRuleSenderIsFailingAlerts
+      - ThanosRuleHighRuleEvaluationFailures
+      - ThanosNoRuleEvaluations
+      ignoredNamespaces:
+      - openshift-logging
+      - openshift-redhat-marketplace
+      - openshift-operators
+      - openshift-customer-monitoring
+      - openshift-cnv
+      - openshift-route-monitoring-operator
+      - openshift-user-workload-monitoring
+      - openshift-pipelines
+    extDependencyAvailabilityChecks:
+      http:
+        timeout: 10
+        urls:
+          - ${OCM_BASE_URL}/api/clusters_mgmt/v1      
+    environment:
+      fedramp: true

--- a/deploy/osd-fedramp-managed-upgrade-operator-config/int/config.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/int/config.yaml
@@ -9,7 +9,7 @@ selectorSyncSet:
       values:
         - "true"
     - key: api.openshift.com/environment
-      operator: NotIn
+      operator: In
       values:
-        - "integration"         
+        - "integration"        
   resourceApplyMode: Upsert

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26810,6 +26810,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - integration
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -26837,6 +26841,60 @@ objects:
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
           \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nenvironment:\n  fedramp: true\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-int
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  - ClusterProxyCAExpiringSRE\n\
+          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
+          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
+          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
+          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
+          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
+          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
+          \      \nenvironment:\n  fedramp: true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26810,6 +26810,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - integration
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -26837,6 +26841,60 @@ objects:
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
           \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nenvironment:\n  fedramp: true\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-int
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  - ClusterProxyCAExpiringSRE\n\
+          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
+          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
+          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
+          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
+          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
+          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
+          \      \nenvironment:\n  fedramp: true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26810,6 +26810,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - integration
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -26837,6 +26841,60 @@ objects:
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
           \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nenvironment:\n  fedramp: true\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-int
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: NotIn
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  - ClusterProxyCAExpiringSRE\n\
+          \  - PrometheusRemoteWriteBehind\n  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n\
+          \  - PrometheusRemoteStorageFailures\n  - AlertmanagerMembersInconsistent\n\
+          \  - AlertmanagerClusterFailedToSendAlerts\n  - AlertmanagerConfigInconsistent\n\
+          \  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n  - KubeStateMetricsWatchErrors\n\
+          \  - ThanosRuleSenderIsFailingAlerts\n  - ThanosRuleHighRuleEvaluationFailures\n\
+          \  - ThanosNoRuleEvaluations\n  ignoredNamespaces:\n  - openshift-logging\n\
+          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
+          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
+          \      \nenvironment:\n  fedramp: true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

feature

### What this PR does / why we need it?

Updates MUO in FedRAMP integration to use OCM instead of local configs. This will enable QE to validate updates to Hive/OCM for [OCM-1606](https://issues.redhat.com/browse/OCM-1606) and enable upgrades in FedRAMP using rosa cli

### Which Jira/Github issue(s) this PR fixes?

For [OCM-1606](https://issues.redhat.com//browse/OCM-1606)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
