### PR TITLE
Create a specific MHC for management clusters

### DIFF
--- a/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -1,0 +1,21 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: srep-management-cluster-node-recovery
+  namespace: openshift-machine-api
+spec:
+  selector:
+    matchExpressions:
+    - key: machine.openshift.io/cluster-api-machine-role
+      operator: NotIn
+      values:
+      - "infra"
+      - "master"
+    - key: hypershift.openshift.io/request-serving-component
+      values:
+      - "true"
+  # An empty unhealthyConditions causes this MHC to execute only if a machine's underlying node is deleted
+  # https://github.com/openshift/machine-api-operator/blob/c11d6227cb4640ce979edd4e9469342274e88910/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go#L789-L793
+  unhealthyConditions: []
+  maxUnhealthy: 100%
+  nodeStartupTimeout: 25m

--- a/deploy/osd-machine-api/management-clusters/config.yaml
+++ b/deploy/osd-machine-api/management-clusters/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27884,6 +27884,44 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-machine-api-management-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machine.openshift.io/v1beta1
+      kind: MachineHealthCheck
+      metadata:
+        name: srep-management-cluster-node-recovery
+        namespace: openshift-machine-api
+      spec:
+        selector:
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: NotIn
+            values:
+            - infra
+            - master
+          - key: hypershift.openshift.io/request-serving-component
+            values:
+            - 'true'
+        unhealthyConditions: []
+        maxUnhealthy: 100%
+        nodeStartupTimeout: 25m
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-managed-resources
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27884,6 +27884,44 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-machine-api-management-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machine.openshift.io/v1beta1
+      kind: MachineHealthCheck
+      metadata:
+        name: srep-management-cluster-node-recovery
+        namespace: openshift-machine-api
+      spec:
+        selector:
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: NotIn
+            values:
+            - infra
+            - master
+          - key: hypershift.openshift.io/request-serving-component
+            values:
+            - 'true'
+        unhealthyConditions: []
+        maxUnhealthy: 100%
+        nodeStartupTimeout: 25m
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-managed-resources
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27884,6 +27884,44 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-machine-api-management-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machine.openshift.io/v1beta1
+      kind: MachineHealthCheck
+      metadata:
+        name: srep-management-cluster-node-recovery
+        namespace: openshift-machine-api
+      spec:
+        selector:
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: NotIn
+            values:
+            - infra
+            - master
+          - key: hypershift.openshift.io/request-serving-component
+            values:
+            - 'true'
+        unhealthyConditions: []
+        maxUnhealthy: 100%
+        nodeStartupTimeout: 25m
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-managed-resources
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This MHC will be specifically used to recover request-serving nodes on the Hosted Control Plane Management Clusters. It's needed because the HyperShift Operator currently deletes underlying nodes when a hostedcluster is uninstalled and specifying no `.spec.unhealthyConditions` allows a MHC to detect this without overlapping with other unhealthy node conditions that can be caused by widespread issues such as AZ outages.

### Which Jira/Github issue(s) this PR fixes?
[OSD-18661](https://issues.redhat.com//browse/OSD-18661)