### PR TITLE
OCM-3980 | feat: add 'ec2:DescribeSecurityGroups' to ocm role

### DIFF
--- a/resources/sts/4.12/sts_ocm_permission_policy.json
+++ b/resources/sts/4.12/sts_ocm_permission_policy.json
@@ -4,6 +4,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
         "ec2:DescribeRegions",

--- a/resources/sts/4.13/sts_ocm_permission_policy.json
+++ b/resources/sts/4.13/sts_ocm_permission_policy.json
@@ -4,6 +4,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
         "ec2:DescribeRegions",

--- a/resources/sts/4.14/sts_ocm_permission_policy.json
+++ b/resources/sts/4.14/sts_ocm_permission_policy.json
@@ -4,6 +4,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcs",
         "ec2:DescribeRegions",


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
OCM Roles are used when retrieving the VPCs from AWS accounts and we'll be supporting the security groups soon.

Added up to 4.12 as that is the version being loaded at the moment.

### Which Jira/Github issue(s) this PR fixes?
[OCM-3980](https://issues.redhat.com//browse/OCM-3980)

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP)