### PR TITLE
.spec.unhealthyConditions must have at least one condition

### DIFF
--- a/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -12,10 +12,12 @@ spec:
       - "infra"
       - "master"
     - key: hypershift.openshift.io/request-serving-component
+      operator: In
       values:
       - "true"
-  # An empty unhealthyConditions causes this MHC to execute only if a machine's underlying node is deleted
-  # https://github.com/openshift/machine-api-operator/blob/c11d6227cb4640ce979edd4e9469342274e88910/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go#L789-L793
-  unhealthyConditions: []
+  unhealthyConditions:
+  - type:    "Ready"
+    timeout: "480s"
+    status: "Unknown"
   maxUnhealthy: 100%
   nodeStartupTimeout: 25m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27910,9 +27910,13 @@ objects:
             - infra
             - master
           - key: hypershift.openshift.io/request-serving-component
+            operator: In
             values:
             - 'true'
-        unhealthyConditions: []
+        unhealthyConditions:
+        - type: Ready
+          timeout: 480s
+          status: Unknown
         maxUnhealthy: 100%
         nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27910,9 +27910,13 @@ objects:
             - infra
             - master
           - key: hypershift.openshift.io/request-serving-component
+            operator: In
             values:
             - 'true'
-        unhealthyConditions: []
+        unhealthyConditions:
+        - type: Ready
+          timeout: 480s
+          status: Unknown
         maxUnhealthy: 100%
         nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27910,9 +27910,13 @@ objects:
             - infra
             - master
           - key: hypershift.openshift.io/request-serving-component
+            operator: In
             values:
             - 'true'
-        unhealthyConditions: []
+        unhealthyConditions:
+        - type: Ready
+          timeout: 480s
+          status: Unknown
         maxUnhealthy: 100%
         nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This PR resolves syntax errors from #1879 it adds back this unhealthyCondition:

```
  - type:    "Ready"
    timeout: "300s"
    status: "Unknown"
```

as a stopgap - I believe this is not as impactful as we first anticipated https://docs.openshift.com/container-platform/4.13/machine_management/deploying-machine-health-checks.html#machine-health-checks-about_deploying-machine-health-checks

> To limit disruptive impact of the machine deletion, the controller drains and deletes only one node at a time. 

So I think this is still safe...

### Which Jira/Github issue(s) this PR fixes?

[OSD-18661](https://issues.redhat.com//browse/OSD-18661)