### PR TITLE
Update MC MHC to trigger on an undefined status condition

### DIFF
--- a/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -16,8 +16,12 @@ spec:
       values:
       - "true"
   unhealthyConditions:
-  - type:    "Ready"
-    timeout: "480s"
-    status: "Unknown"
+  # Neither NonexistentStatus nor NonexistentCondition really exist as status conditions on a node.
+  # This lets the MachineHealthCheck only trigger when a node is deleted and not on any other node
+  # status conditions.
+  # # https://github.com/openshift/machine-api-operator/blob/c11d6227cb4640ce979edd4e9469342274e88910/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go#L789-L793
+  - status: "NonexistentStatus"
+    type: "NonexistentCondition"
+    timeout: "0s"
   maxUnhealthy: 100%
   nodeStartupTimeout: 25m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27914,9 +27914,9 @@ objects:
             values:
             - 'true'
         unhealthyConditions:
-        - type: Ready
-          timeout: 480s
-          status: Unknown
+        - status: NonexistentStatus
+          type: NonexistentCondition
+          timeout: 0s
         maxUnhealthy: 100%
         nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27914,9 +27914,9 @@ objects:
             values:
             - 'true'
         unhealthyConditions:
-        - type: Ready
-          timeout: 480s
-          status: Unknown
+        - status: NonexistentStatus
+          type: NonexistentCondition
+          timeout: 0s
         maxUnhealthy: 100%
         nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27914,9 +27914,9 @@ objects:
             values:
             - 'true'
         unhealthyConditions:
-        - type: Ready
-          timeout: 480s
-          status: Unknown
+        - status: NonexistentStatus
+          type: NonexistentCondition
+          timeout: 0s
         maxUnhealthy: 100%
         nodeStartupTimeout: 25m
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This means that it will effectively never trigger "normally" as the status condition will never occur. However, it will replace nodes that have been deleted directly. Previously, with its `Ready: Unknown` trigger, this MHC would replace nodes when they became unhealthy, which is not desired. We want to use this MHC: https://github.com/openshift/managed-cluster-config/blob/master/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml for remediating unhealthy nodes as it has a `maxUnhealthy: 3` configured to prevent floods of machine replacements in scenarios such as AZ outages.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-18661](https://issues.redhat.com//browse/OSD-18661)