### PR TITLE
OSDOCS-6662 Adding KCS Article about PID Pressure to notification

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/node-condition/200-sre-node-condition-managed-notification.ManagedNotification.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/node-condition/200-sre-node-condition-managed-notification.ManagedNotification.yaml
@@ -27,7 +27,7 @@ spec:
       severity: Warning
       summary: "Worker node is experiencing PIDPressure"
       activeBody: |-
-        PIDPressure condition is true for at least one worker. This means that more than the maximum allowed number of process identifiers are consumed on one or more worker nodes. This is likely to create instability in the node, as required system services may not be able to create new processes. Reduce the number of pods scheduled to the impacted nodes, or reduce the number of process identifiers consumed by applications on the impacted nodes.
+        PIDPressure condition is true for at least one worker. This means that more than the maximum allowed number of process identifiers are consumed on one or more worker nodes. This is likely to create instability in the node, as required system services may not be able to create new processes. For more information see https://access.redhat.com/articles/7033551. Reduce the number of pods scheduled to the impacted nodes, or reduce the number of process identifiers consumed by applications on the impacted nodes.
       resolvedBody: |-
         PIDPressure condition is resolved.
       resendWait: 6

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22163,9 +22163,10 @@ objects:
             means that more than the maximum allowed number of process identifiers
             are consumed on one or more worker nodes. This is likely to create instability
             in the node, as required system services may not be able to create new
-            processes. Reduce the number of pods scheduled to the impacted nodes,
-            or reduce the number of process identifiers consumed by applications on
-            the impacted nodes.
+            processes. For more information see https://access.redhat.com/articles/7033551.
+            Reduce the number of pods scheduled to the impacted nodes, or reduce the
+            number of process identifiers consumed by applications on the impacted
+            nodes.
           resolvedBody: PIDPressure condition is resolved.
           resendWait: 6
         - name: NodeConditionNetworkUnavailableNotification

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22163,9 +22163,10 @@ objects:
             means that more than the maximum allowed number of process identifiers
             are consumed on one or more worker nodes. This is likely to create instability
             in the node, as required system services may not be able to create new
-            processes. Reduce the number of pods scheduled to the impacted nodes,
-            or reduce the number of process identifiers consumed by applications on
-            the impacted nodes.
+            processes. For more information see https://access.redhat.com/articles/7033551.
+            Reduce the number of pods scheduled to the impacted nodes, or reduce the
+            number of process identifiers consumed by applications on the impacted
+            nodes.
           resolvedBody: PIDPressure condition is resolved.
           resendWait: 6
         - name: NodeConditionNetworkUnavailableNotification

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22163,9 +22163,10 @@ objects:
             means that more than the maximum allowed number of process identifiers
             are consumed on one or more worker nodes. This is likely to create instability
             in the node, as required system services may not be able to create new
-            processes. Reduce the number of pods scheduled to the impacted nodes,
-            or reduce the number of process identifiers consumed by applications on
-            the impacted nodes.
+            processes. For more information see https://access.redhat.com/articles/7033551.
+            Reduce the number of pods scheduled to the impacted nodes, or reduce the
+            number of process identifiers consumed by applications on the impacted
+            nodes.
           resolvedBody: PIDPressure condition is resolved.
           resendWait: 6
         - name: NodeConditionNetworkUnavailableNotification


### PR DESCRIPTION
### What type of PR is this?
documentation

### What this PR does / why we need it?
Adds KCS article as reference information to PIDPressure notification.

### Which Jira/Github issue(s) this PR fixes?
[OSDOCS-6662](https://issues.redhat.com/browse/OSDOCS-6662)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
