### PR TITLE
adds subject permission for fedramp for services we manage in FR only

### DIFF
--- a/deploy/backplane/srep/fedramp/30-srep-fedramp.SubjectPermission.yml
+++ b/deploy/backplane/srep/fedramp/30-srep-fedramp.SubjectPermission.yml
@@ -1,0 +1,15 @@
+apiVersion: managed.openshift.io/v1alpha1
+kind: SubjectPermission
+metadata:
+  name: backplane-srep-fedramp
+  namespace: openshift-rbac-permissions
+spec:
+  permissions:
+  - clusterRoleName: backplane-srep-admins-project
+    namespacesAllowedRegex: "(^keycloak$|^keycloak-.*|^goalert$)"
+    namespacesDeniedRegex: openshift-backplane-cluster-admin    
+  - clusterRoleName: dedicated-readers
+    namespacesAllowedRegex: "(^keycloak$|^keycloak-.*|^goalert$)"
+    namespacesDeniedRegex: openshift-backplane-cluster-admin    
+  subjectKind: Group
+  subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -19677,6 +19677,21 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-fedramp-muo
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-fedramp
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: backplane-srep-admins-project
+          namespacesAllowedRegex: (^keycloak$|^keycloak-.*|^goalert$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^keycloak$|^keycloak-.*|^goalert$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -19677,6 +19677,21 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-fedramp-muo
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-fedramp
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: backplane-srep-admins-project
+          namespacesAllowedRegex: (^keycloak$|^keycloak-.*|^goalert$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^keycloak$|^keycloak-.*|^goalert$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -19677,6 +19677,21 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-fedramp-muo
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-srep-fedramp
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: backplane-srep-admins-project
+          namespacesAllowedRegex: (^keycloak$|^keycloak-.*|^goalert$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^keycloak$|^keycloak-.*|^goalert$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-srep
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

feature

### What this PR does / why we need it?

This PR is to grant the basic permissions SREP should have on any namespaces we manage in OSD/ROSA clusters. Specifically this adds 2 namespaces in FedRAMP only (keycloak and goalert) so that we can manage those services and not trigger a bunch of compliance alerts. It leverages the existing backplane-srep-admins-project clusterole so there is no extra scope creep outside of standard namespaces

### Which Jira/Github issue(s) this PR fixes?

For [OSD-18759](https://issues.redhat.com//browse/OSD-18759) and [OSD-18758](https://issues.redhat.com//browse/OSD-18758)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
