### PR TITLE
Update MC MHC to select serving-* machines

### DIFF
--- a/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/management-clusters/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -91,10 +91,6 @@ spec:
       - "serving-78"
       - "serving-79"
       - "serving-80"
-    - key: hypershift.openshift.io/request-serving-component
-      operator: In
-      values:
-      - "true"
   unhealthyConditions:
   # Neither NonexistentStatus nor NonexistentCondition really exist as status conditions on a node.
   # This lets the MachineHealthCheck only trigger when a node is deleted and not on any other node

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27760,10 +27760,6 @@ objects:
             - serving-78
             - serving-79
             - serving-80
-          - key: hypershift.openshift.io/request-serving-component
-            operator: In
-            values:
-            - 'true'
         unhealthyConditions:
         - status: NonexistentStatus
           type: NonexistentCondition

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27760,10 +27760,6 @@ objects:
             - serving-78
             - serving-79
             - serving-80
-          - key: hypershift.openshift.io/request-serving-component
-            operator: In
-            values:
-            - 'true'
         unhealthyConditions:
         - status: NonexistentStatus
           type: NonexistentCondition

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27760,10 +27760,6 @@ objects:
             - serving-78
             - serving-79
             - serving-80
-          - key: hypershift.openshift.io/request-serving-component
-            operator: In
-            values:
-            - 'true'
         unhealthyConditions:
         - status: NonexistentStatus
           type: NonexistentCondition


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
The label `hypershift.openshift.io/request-serving-component: true` does not exist on management cluster machines, so this MHC is currently selecting 0 serving machines.

### Which Jira/Github issue(s) this PR fixes?

[OSD-18661](https://issues.redhat.com//browse/OSD-18661)