### PR TITLE
Policy for ovn label in HCP namespaces

### DIFF
--- a/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: hypershift-ovn-logging
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: hypershift-ovn-logging
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates-raw: |
+                    {{- range (lookup "v1" "Namespace" "" "").items }}
+                    {{- if eq (index .metadata.labels "hypershift.openshift.io/hosted-control-plane") "true" }}
+                    - complianceType: musthave
+                      objectDefinition:
+                        kind: Namespace
+                        apiVersion: v1
+                        metadata:
+                          name: {{ .metadata.name }}
+                          annotations:
+                            k8s.ovn.org/acl-logging: '{ "deny": "info" }'
+                    {{- end }}
+                    {{- end }}
+                remediationAction: enforce
+                severity: low
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-hypershift-ovn-logging
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/management-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-hypershift-ovn-logging
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-hypershift-ovn-logging
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: hypershift-ovn-logging

--- a/deploy/hypershift-ovn-logging/config.yaml
+++ b/deploy/hypershift-ovn-logging/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: Policy
+clusterSelectors:
+  hypershift.open-cluster-management.io/management-cluster: true
+policy:
+  destination: "acm-policies"
+  complianceType: "musthave"

--- a/deploy/hypershift-ovn-logging/ovn-logging-label.Policy.yaml
+++ b/deploy/hypershift-ovn-logging/ovn-logging-label.Policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: hypershift-ovn-logging
+spec:
+  evaluationInterval:
+    compliant: 2h
+    noncompliant: 45s
+  object-templates-raw: |
+    {{- range (lookup "v1" "Namespace" "" "").items }}
+    {{- if eq (index .metadata.labels "hypershift.openshift.io/hosted-control-plane") "true" }}
+    - complianceType: musthave
+      objectDefinition:
+        kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: {{ .metadata.name }}
+          annotations:
+            k8s.ovn.org/acl-logging: '{ "deny": "info" }'
+    {{- end }}
+    {{- end }}
+  remediationAction: enforce
+  severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3843,6 +3843,60 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hypershift-ovn-logging
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "{{- range (lookup \"v1\" \"Namespace\" \"\" \"\
+                \").items }}\n{{- if eq (index .metadata.labels \"hypershift.openshift.io/hosted-control-plane\"\
+                ) \"true\" }}\n- complianceType: musthave\n  objectDefinition:\n \
+                \   kind: Namespace\n    apiVersion: v1\n    metadata:\n      name:\
+                \ {{ .metadata.name }}\n      annotations:\n        k8s.ovn.org/acl-logging:\
+                \ '{ \"deny\": \"info\" }'\n{{- end }}\n{{- end }}\n"
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hypershift-ovn-logging
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hypershift-ovn-logging
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3843,6 +3843,60 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hypershift-ovn-logging
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "{{- range (lookup \"v1\" \"Namespace\" \"\" \"\
+                \").items }}\n{{- if eq (index .metadata.labels \"hypershift.openshift.io/hosted-control-plane\"\
+                ) \"true\" }}\n- complianceType: musthave\n  objectDefinition:\n \
+                \   kind: Namespace\n    apiVersion: v1\n    metadata:\n      name:\
+                \ {{ .metadata.name }}\n      annotations:\n        k8s.ovn.org/acl-logging:\
+                \ '{ \"deny\": \"info\" }'\n{{- end }}\n{{- end }}\n"
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hypershift-ovn-logging
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hypershift-ovn-logging
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3843,6 +3843,60 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: hypershift-ovn-logging
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates-raw: "{{- range (lookup \"v1\" \"Namespace\" \"\" \"\
+                \").items }}\n{{- if eq (index .metadata.labels \"hypershift.openshift.io/hosted-control-plane\"\
+                ) \"true\" }}\n- complianceType: musthave\n  objectDefinition:\n \
+                \   kind: Namespace\n    apiVersion: v1\n    metadata:\n      name:\
+                \ {{ .metadata.name }}\n      annotations:\n        k8s.ovn.org/acl-logging:\
+                \ '{ \"deny\": \"info\" }'\n{{- end }}\n{{- end }}\n"
+              remediationAction: enforce
+              severity: low
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-hypershift-ovn-logging
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-hypershift-ovn-logging
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: hypershift-ovn-logging
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: osd-backplane-managed-scripts
         namespace: openshift-acm-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -24,6 +24,7 @@ directories = [
         'backplane/tam',
         'ccs-dedicated-admins',
         'customer-registry-cas',
+        'hypershift-ovn-logging',
         'osd-cluster-admin',
         'osd-customer-monitoring',
         'osd-delete-backplane-script-resources',


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
Creates a policy that applies to all management clusters. This policy will add an annotate to all HCP namespaces.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-17337 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
