### PR TITLE
feat(OSD-19000): directly use KubePersistentVolumeFillingUp expression

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -10,10 +10,45 @@ spec:
   groups:
   - name: sre-managed-notification-alerts
     rules:
-    - alert: LoggingVolumeFillingUpNotificationSRE
+    - alert: LoggingVolumeFillingUpNotificationSRE1m
     # KubePersistentVolumeFillingUp alert firing in openshift-logging Namespace.
-      expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-logging"}) >= 1
-      for: 30m
+    # See https://github.com/openshift/cluster-monitoring-operator/blob/master/assets/control-plane/prometheus-rule.yaml#L299
+      expr: |
+        (
+          kubelet_volume_stats_available_bytes{namespace="openshift-logging",job="kubelet", metrics_path="/metrics"}
+            /
+          kubelet_volume_stats_capacity_bytes{namespace="openshift-logging",job="kubelet", metrics_path="/metrics"}
+        ) < 0.03
+        and
+        kubelet_volume_stats_used_bytes{namespace="openshift-logging",job="kubelet", metrics_path="/metrics"} > 0
+        unless on(namespace, persistentvolumeclaim)
+        kube_persistentvolumeclaim_access_mode{namespace="openshift-logging", access_mode="ReadOnlyMany"} == 1
+        unless on(namespace, persistentvolumeclaim)
+        kube_persistentvolumeclaim_labels{namespace="openshift-logging",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+      for: 1m
+      labels:
+        severity: Info
+        namespace: openshift-logging
+        send_managed_notification: "true"
+        managed_notification_template: "LoggingVolumeFillingUp"
+    - alert: LoggingVolumeFillingUpNotificationSRE1h
+    # KubePersistentVolumeFillingUp alert firing in openshift-logging Namespace.
+    # See https://github.com/openshift/cluster-monitoring-operator/blob/b836b1929584f47862cf0693b3b2d6299542cdee/assets/control-plane/prometheus-rule.yaml#L317
+      expr: |
+       (
+          kubelet_volume_stats_available_bytes{namespace="openshift-logging",job="kubelet", metrics_path="/metrics"}
+            /
+          kubelet_volume_stats_capacity_bytes{namespace="openshift-logging",job="kubelet", metrics_path="/metrics"}
+        ) < 0.15
+        and
+        kubelet_volume_stats_used_bytes{namespace="openshift-logging",job="kubelet", metrics_path="/metrics"} > 0
+        and
+        predict_linear(kubelet_volume_stats_available_bytes{namespace="openshift-logging",job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+        unless on(namespace, persistentvolumeclaim)
+        kube_persistentvolumeclaim_access_mode{namespace="openshift-logging", access_mode="ReadOnlyMany"} == 1
+        unless on(namespace, persistentvolumeclaim)
+        kube_persistentvolumeclaim_labels{namespace="openshift-logging",label_alerts_k8s_io_kube_persistent_volume_filling_up="disabled"} == 1
+      for: 1h
       labels:
         severity: Info
         namespace: openshift-logging

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34940,10 +34940,37 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
-          - alert: LoggingVolumeFillingUpNotificationSRE
-            expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
-              namespace="openshift-logging"}) >= 1
-            for: 30m
+          - alert: LoggingVolumeFillingUpNotificationSRE1m
+            expr: "(\n  kubelet_volume_stats_available_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"}\n    /\n  kubelet_volume_stats_capacity_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}\n) <\
+              \ 0.03\nand\nkubelet_volume_stats_used_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"} > 0\nunless on(namespace,\
+              \ persistentvolumeclaim)\nkube_persistentvolumeclaim_access_mode{namespace=\"\
+              openshift-logging\", access_mode=\"ReadOnlyMany\"} == 1\nunless on(namespace,\
+              \ persistentvolumeclaim)\nkube_persistentvolumeclaim_labels{namespace=\"\
+              openshift-logging\",label_alerts_k8s_io_kube_persistent_volume_filling_up=\"\
+              disabled\"} == 1\n"
+            for: 1m
+            labels:
+              severity: Info
+              namespace: openshift-logging
+              send_managed_notification: 'true'
+              managed_notification_template: LoggingVolumeFillingUp
+          - alert: LoggingVolumeFillingUpNotificationSRE1h
+            expr: "(\n   kubelet_volume_stats_available_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"}\n     /\n   kubelet_volume_stats_capacity_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}\n )\
+              \ < 0.15\n and\n kubelet_volume_stats_used_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"} > 0\n and\n predict_linear(kubelet_volume_stats_available_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}[6h],\
+              \ 4 * 24 * 3600) < 0\n unless on(namespace, persistentvolumeclaim)\n\
+              \ kube_persistentvolumeclaim_access_mode{namespace=\"openshift-logging\"\
+              , access_mode=\"ReadOnlyMany\"} == 1\n unless on(namespace, persistentvolumeclaim)\n\
+              \ kube_persistentvolumeclaim_labels{namespace=\"openshift-logging\"\
+              ,label_alerts_k8s_io_kube_persistent_volume_filling_up=\"disabled\"\
+              } == 1\n"
+            for: 1h
             labels:
               severity: Info
               namespace: openshift-logging

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34940,10 +34940,37 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
-          - alert: LoggingVolumeFillingUpNotificationSRE
-            expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
-              namespace="openshift-logging"}) >= 1
-            for: 30m
+          - alert: LoggingVolumeFillingUpNotificationSRE1m
+            expr: "(\n  kubelet_volume_stats_available_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"}\n    /\n  kubelet_volume_stats_capacity_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}\n) <\
+              \ 0.03\nand\nkubelet_volume_stats_used_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"} > 0\nunless on(namespace,\
+              \ persistentvolumeclaim)\nkube_persistentvolumeclaim_access_mode{namespace=\"\
+              openshift-logging\", access_mode=\"ReadOnlyMany\"} == 1\nunless on(namespace,\
+              \ persistentvolumeclaim)\nkube_persistentvolumeclaim_labels{namespace=\"\
+              openshift-logging\",label_alerts_k8s_io_kube_persistent_volume_filling_up=\"\
+              disabled\"} == 1\n"
+            for: 1m
+            labels:
+              severity: Info
+              namespace: openshift-logging
+              send_managed_notification: 'true'
+              managed_notification_template: LoggingVolumeFillingUp
+          - alert: LoggingVolumeFillingUpNotificationSRE1h
+            expr: "(\n   kubelet_volume_stats_available_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"}\n     /\n   kubelet_volume_stats_capacity_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}\n )\
+              \ < 0.15\n and\n kubelet_volume_stats_used_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"} > 0\n and\n predict_linear(kubelet_volume_stats_available_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}[6h],\
+              \ 4 * 24 * 3600) < 0\n unless on(namespace, persistentvolumeclaim)\n\
+              \ kube_persistentvolumeclaim_access_mode{namespace=\"openshift-logging\"\
+              , access_mode=\"ReadOnlyMany\"} == 1\n unless on(namespace, persistentvolumeclaim)\n\
+              \ kube_persistentvolumeclaim_labels{namespace=\"openshift-logging\"\
+              ,label_alerts_k8s_io_kube_persistent_volume_filling_up=\"disabled\"\
+              } == 1\n"
+            for: 1h
             labels:
               severity: Info
               namespace: openshift-logging

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34940,10 +34940,37 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
-          - alert: LoggingVolumeFillingUpNotificationSRE
-            expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
-              namespace="openshift-logging"}) >= 1
-            for: 30m
+          - alert: LoggingVolumeFillingUpNotificationSRE1m
+            expr: "(\n  kubelet_volume_stats_available_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"}\n    /\n  kubelet_volume_stats_capacity_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}\n) <\
+              \ 0.03\nand\nkubelet_volume_stats_used_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"} > 0\nunless on(namespace,\
+              \ persistentvolumeclaim)\nkube_persistentvolumeclaim_access_mode{namespace=\"\
+              openshift-logging\", access_mode=\"ReadOnlyMany\"} == 1\nunless on(namespace,\
+              \ persistentvolumeclaim)\nkube_persistentvolumeclaim_labels{namespace=\"\
+              openshift-logging\",label_alerts_k8s_io_kube_persistent_volume_filling_up=\"\
+              disabled\"} == 1\n"
+            for: 1m
+            labels:
+              severity: Info
+              namespace: openshift-logging
+              send_managed_notification: 'true'
+              managed_notification_template: LoggingVolumeFillingUp
+          - alert: LoggingVolumeFillingUpNotificationSRE1h
+            expr: "(\n   kubelet_volume_stats_available_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"}\n     /\n   kubelet_volume_stats_capacity_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}\n )\
+              \ < 0.15\n and\n kubelet_volume_stats_used_bytes{namespace=\"openshift-logging\"\
+              ,job=\"kubelet\", metrics_path=\"/metrics\"} > 0\n and\n predict_linear(kubelet_volume_stats_available_bytes{namespace=\"\
+              openshift-logging\",job=\"kubelet\", metrics_path=\"/metrics\"}[6h],\
+              \ 4 * 24 * 3600) < 0\n unless on(namespace, persistentvolumeclaim)\n\
+              \ kube_persistentvolumeclaim_access_mode{namespace=\"openshift-logging\"\
+              , access_mode=\"ReadOnlyMany\"} == 1\n unless on(namespace, persistentvolumeclaim)\n\
+              \ kube_persistentvolumeclaim_labels{namespace=\"openshift-logging\"\
+              ,label_alerts_k8s_io_kube_persistent_volume_filling_up=\"disabled\"\
+              } == 1\n"
+            for: 1h
             labels:
               severity: Info
               namespace: openshift-logging


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

We currently are already automating service logs with OAO for this, but still route it to primary. This PR uses the direct expression(s) from https://github.com/openshift/cluster-monitoring-operator/blob/master/assets/control-plane/prometheus-rule.yaml#L317 and routes them to OAO.

Ref: https://github.com/openshift/configure-alertmanager-operator/pull/298

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-19000

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
