### PR TITLE
Add workaround for OCPBUGS-20184

### DIFF
--- a/deploy/ocpbugs-20184/00-ocpbugs-20184.ServiceAccount.yaml
+++ b/deploy/ocpbugs-20184/00-ocpbugs-20184.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocpbugs-20184
+  namespace: openshift-network-node-identity

--- a/deploy/ocpbugs-20184/01-ocpbugs-20184.Role.yaml
+++ b/deploy/ocpbugs-20184/01-ocpbugs-20184.Role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocpbugs-20184
+  namespace: openshift-network-node-identity
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete

--- a/deploy/ocpbugs-20184/02-ocpbugs-20184.RoleBinding.yaml
+++ b/deploy/ocpbugs-20184/02-ocpbugs-20184.RoleBinding.yaml
@@ -1,0 +1,14 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-20184
+  namespace: openshift-network-node-identity
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-20184
+  namespace: openshift-network-node-identity
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocpbugs-20184

--- a/deploy/ocpbugs-20184/10-ocpbugs-20184.CronJob.yaml
+++ b/deploy/ocpbugs-20184/10-ocpbugs-20184.CronJob.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ocpbugs-20184
+  namespace: openshift-network-node-identity
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "22 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: ocpbugs-20184
+          restartPolicy: Never
+          containers:
+          - name: ocpbugs-20184
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - oc
+            - delete
+            - pods
+            - --namespace=openshift-network-node-identity
+            - --selector=app=network-node-identity
+            - --wait=false
+            - --ignore-not-found
+            - --grace-period=1

--- a/deploy/ocpbugs-20184/config.yaml
+++ b/deploy/ocpbugs-20184/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version
+    operator: In
+    values: ["4.14.0-rc.3", "4.14.0-rc.4", "4.15.0-ec.0"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22551,6 +22551,101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-20184
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version
+        operator: In
+        values:
+        - 4.14.0-rc.3
+        - 4.14.0-rc.4
+        - 4.15.0-ec.0
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-20184
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 22 * * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 3600
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: ocpbugs-20184
+                restartPolicy: Never
+                containers:
+                - name: ocpbugs-20184
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - oc
+                  - delete
+                  - pods
+                  - --namespace=openshift-network-node-identity
+                  - --selector=app=network-node-identity
+                  - --wait=false
+                  - --ignore-not-found
+                  - --grace-period=1
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-773
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22551,6 +22551,101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-20184
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version
+        operator: In
+        values:
+        - 4.14.0-rc.3
+        - 4.14.0-rc.4
+        - 4.15.0-ec.0
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-20184
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 22 * * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 3600
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: ocpbugs-20184
+                restartPolicy: Never
+                containers:
+                - name: ocpbugs-20184
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - oc
+                  - delete
+                  - pods
+                  - --namespace=openshift-network-node-identity
+                  - --selector=app=network-node-identity
+                  - --wait=false
+                  - --ignore-not-found
+                  - --grace-period=1
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-773
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22551,6 +22551,101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-20184
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version
+        operator: In
+        values:
+        - 4.14.0-rc.3
+        - 4.14.0-rc.4
+        - 4.15.0-ec.0
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+        - delete
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-20184
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ocpbugs-20184
+        namespace: openshift-network-node-identity
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 22 * * * *
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 3600
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: ocpbugs-20184
+                restartPolicy: Never
+                containers:
+                - name: ocpbugs-20184
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - oc
+                  - delete
+                  - pods
+                  - --namespace=openshift-network-node-identity
+                  - --selector=app=network-node-identity
+                  - --wait=false
+                  - --ignore-not-found
+                  - --grace-period=1
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-773
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Adds a workaround script for OCPBUGS-20184 exposure in the managed fleet

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
