### PR TITLE
[OSD-18400] Disable more eve types

### DIFF
--- a/deploy/osd-suricata/hypershift-management-cluster/15-configmap.yaml
+++ b/deploy/osd-suricata/hypershift-management-cluster/15-configmap.yaml
@@ -118,7 +118,7 @@ data:
           enabled: yes
           filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
           metadata: yes
-                # Enable for multi-threaded eve.json output; output files are amended with
+          # Enable for multi-threaded eve.json output; output files are amended with
           # with an identifier, e.g., eve.9.json
           #threaded: false
           #prefix: "@cee: " # prefix to prepend to each log entry
@@ -258,25 +258,37 @@ data:
                 enabled: no
                 force-magic: no # force logging magic on all logged files
                 #force-hash: [md5]
-            #- drop:
-            #    alerts: yes      # log alerts that caused drops
-            #    flows: all       # start or all: 'start' logs only a single drop
-            #                     # per flow direction. All logs each dropped pkt.
-            - smtp
+                #- drop:
+                #    alerts: yes      # log alerts that caused drops
+                #    flows: all       # start or all: 'start' logs only a single drop
+                #                     # per flow direction. All logs each dropped pkt.
+            - smtp:
+                enabled: no
                 #extended: yes # enable this for extended logging information
                 #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
                 #md5: [body, subject]
-            - dnp3
-            - ftp
-            - rdp
-            - nfs
-            - smb
-            - tftp
-            - ikev2
-            - dcerpc
-            - krb5
-            - snmp
-            - rfb
+            - dnp3:
+                enabled: no
+            - ftp:
+                enabled: no
+            - rdp:
+                enabled: no
+            - nfs:
+                enabled: no
+            - smb:
+                enabled: no
+            - tftp:
+                enabled: no
+            - ikev2:
+                enabled: no
+            - dcerpc:
+                enabled: no
+            - krb5:
+                enabled: no
+            - snmp:
+                enabled: no
+            - rfb:
+                enabled: no
             - sip:
                 enabled: no
             - dhcp:
@@ -284,7 +296,7 @@ data:
                 extended: no
             - ssh
             - mqtt:
-                enabled: yes
+                enabled: no
                 passwords: no
             - stats:
                 enabled: no

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30206,7 +30206,7 @@ objects:
           \ Event Format (nicknamed EVE) event log in JSON format\n  - eve-log:\n\
           \      filename: eve-%m-%d.json\n      rotate-interval: day\n      enabled:\
           \ yes\n      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis\n\
-          \      metadata: yes\n            # Enable for multi-threaded eve.json output;\
+          \      metadata: yes\n      # Enable for multi-threaded eve.json output;\
           \ output files are amended with\n      # with an identifier, e.g., eve.9.json\n\
           \      #threaded: false\n      #prefix: \"@cee: \" # prefix to prepend to\
           \ each log entry\n      # the following are valid when type: syslog above\n\
@@ -30302,53 +30302,57 @@ objects:
           \ sni, version, not_before, not_after, certificate, chain, ja3, ja3s]\n\
           \        - files:\n            enabled: no\n            force-magic: no\
           \ # force logging magic on all logged files\n            #force-hash: [md5]\n\
-          \        #- drop:\n        #    alerts: yes      # log alerts that caused\
-          \ drops\n        #    flows: all       # start or all: 'start' logs only\
-          \ a single drop\n        #                     # per flow direction. All\
-          \ logs each dropped pkt.\n        - smtp\n            #extended: yes # enable\
-          \ this for extended logging information\n            #custom: [received,\
-          \ x-mailer, x-originating-ip, relays, reply-to, bcc]\n            #md5:\
-          \ [body, subject]\n        - dnp3\n        - ftp\n        - rdp\n      \
-          \  - nfs\n        - smb\n        - tftp\n        - ikev2\n        - dcerpc\n\
-          \        - krb5\n        - snmp\n        - rfb\n        - sip:\n       \
-          \     enabled: no\n        - dhcp:\n            enabled: no\n          \
-          \  extended: no\n        - ssh\n        - mqtt:\n            enabled: yes\n\
-          \            passwords: no\n        - stats:\n            enabled: no\n\
-          \            totals: yes\n            threads: no\n            deltas: no\n\
-          \        - flow:\n            enabled: no\n        #- netflow\n        -\
-          \ metadata\n\n  # a line based log of HTTP requests (no alerts)\n  - http-log:\n\
-          \      enabled: no\n      filename: http.log\n      append: yes\n      #extended:\
-          \ yes     # enable this for extended logging information\n      #custom:\
-          \ yes       # enable the custom logging format (defined by customformat)\n\
-          \      #customformat: \"%{%D-%H:%M:%S}t.%z %{X-Forwarded-For}i %H %m %h\
-          \ %u %s %B %a:%p -> %A:%P\"\n      #filetype: regular # 'regular', 'unix_stream'\
-          \ or 'unix_dgram'\n\n  # a line based log of TLS handshake parameters (no\
-          \ alerts)\n  - tls-log:\n      enabled: no # Log TLS connections.\n    \
-          \  filename: tls.log # File to store TLS logs.\n      append: yes\n    \
-          \  #extended: yes     # Log extended information like fingerprint\n    \
-          \  #custom: yes       # enabled the custom logging format (defined by customformat)\n\
-          \      #customformat: \"%{%D-%H:%M:%S}t.%z %a:%p -> %A:%P %v %n %d %D\"\n\
-          \      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'\n \
-          \     # output TLS transaction where the session is resumed using a\n  \
-          \    # session id\n      #session-resumption: no\n\n  # output module to\
-          \ store certificates chain to disk\n  - tls-store:\n      enabled: no\n\
-          \      #certs-log-dir: certs # directory to store the certificates files\n\
-          \n  # Packet log... log packets in pcap format. 3 modes of operation: \"\
-          normal\"\n  # \"multi\" and \"sguil\".\n  #\n  # In normal mode a pcap file\
-          \ \"filename\" is created in the default-log-dir,\n  # or as specified by\
-          \ \"dir\".\n  # In multi mode, a file is created per thread. This will perform\
-          \ much\n  # better, but will create multiple files where 'normal' would\
-          \ create one.\n  # In multi mode the filename takes a few special variables:\n\
-          \  # - %n -- thread number\n  # - %i -- thread id\n  # - %t -- timestamp\
-          \ (secs or secs.usecs based on 'ts-format'\n  # E.g. filename: pcap.%n.%t\n\
-          \  #\n  # Note that it's possible to use directories, but the directories\
-          \ are not\n  # created by Suricata. E.g. filename: pcaps/%n/log.%s will\
-          \ log into the\n  # per thread directory.\n  #\n  # Also note that the limit\
-          \ and max-files settings are enforced per thread.\n  # So the size limit\
-          \ when using 8 threads with 1000mb files and 2000 files\n  # is: 8*1000*2000\
-          \ ~ 16TiB.\n  #\n  # In Sguil mode \"dir\" indicates the base directory.\
-          \ In this base dir the\n  # pcaps are created in the directory structure\
-          \ Sguil expects:\n  #\n  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>\n\
+          \            #- drop:\n            #    alerts: yes      # log alerts that\
+          \ caused drops\n            #    flows: all       # start or all: 'start'\
+          \ logs only a single drop\n            #                     # per flow\
+          \ direction. All logs each dropped pkt.\n        - smtp:\n            enabled:\
+          \ no\n            #extended: yes # enable this for extended logging information\n\
+          \            #custom: [received, x-mailer, x-originating-ip, relays, reply-to,\
+          \ bcc]\n            #md5: [body, subject]\n        - dnp3:\n           \
+          \ enabled: no\n        - ftp:\n            enabled: no\n        - rdp:\n\
+          \            enabled: no\n        - nfs:\n            enabled: no\n    \
+          \    - smb:\n            enabled: no\n        - tftp:\n            enabled:\
+          \ no\n        - ikev2:\n            enabled: no\n        - dcerpc:\n   \
+          \         enabled: no\n        - krb5:\n            enabled: no\n      \
+          \  - snmp:\n            enabled: no\n        - rfb:\n            enabled:\
+          \ no\n        - sip:\n            enabled: no\n        - dhcp:\n       \
+          \     enabled: no\n            extended: no\n        - ssh\n        - mqtt:\n\
+          \            enabled: no\n            passwords: no\n        - stats:\n\
+          \            enabled: no\n            totals: yes\n            threads:\
+          \ no\n            deltas: no\n        - flow:\n            enabled: no\n\
+          \        #- netflow\n        - metadata\n\n  # a line based log of HTTP\
+          \ requests (no alerts)\n  - http-log:\n      enabled: no\n      filename:\
+          \ http.log\n      append: yes\n      #extended: yes     # enable this for\
+          \ extended logging information\n      #custom: yes       # enable the custom\
+          \ logging format (defined by customformat)\n      #customformat: \"%{%D-%H:%M:%S}t.%z\
+          \ %{X-Forwarded-For}i %H %m %h %u %s %B %a:%p -> %A:%P\"\n      #filetype:\
+          \ regular # 'regular', 'unix_stream' or 'unix_dgram'\n\n  # a line based\
+          \ log of TLS handshake parameters (no alerts)\n  - tls-log:\n      enabled:\
+          \ no # Log TLS connections.\n      filename: tls.log # File to store TLS\
+          \ logs.\n      append: yes\n      #extended: yes     # Log extended information\
+          \ like fingerprint\n      #custom: yes       # enabled the custom logging\
+          \ format (defined by customformat)\n      #customformat: \"%{%D-%H:%M:%S}t.%z\
+          \ %a:%p -> %A:%P %v %n %d %D\"\n      #filetype: regular # 'regular', 'unix_stream'\
+          \ or 'unix_dgram'\n      # output TLS transaction where the session is resumed\
+          \ using a\n      # session id\n      #session-resumption: no\n\n  # output\
+          \ module to store certificates chain to disk\n  - tls-store:\n      enabled:\
+          \ no\n      #certs-log-dir: certs # directory to store the certificates\
+          \ files\n\n  # Packet log... log packets in pcap format. 3 modes of operation:\
+          \ \"normal\"\n  # \"multi\" and \"sguil\".\n  #\n  # In normal mode a pcap\
+          \ file \"filename\" is created in the default-log-dir,\n  # or as specified\
+          \ by \"dir\".\n  # In multi mode, a file is created per thread. This will\
+          \ perform much\n  # better, but will create multiple files where 'normal'\
+          \ would create one.\n  # In multi mode the filename takes a few special\
+          \ variables:\n  # - %n -- thread number\n  # - %i -- thread id\n  # - %t\
+          \ -- timestamp (secs or secs.usecs based on 'ts-format'\n  # E.g. filename:\
+          \ pcap.%n.%t\n  #\n  # Note that it's possible to use directories, but the\
+          \ directories are not\n  # created by Suricata. E.g. filename: pcaps/%n/log.%s\
+          \ will log into the\n  # per thread directory.\n  #\n  # Also note that\
+          \ the limit and max-files settings are enforced per thread.\n  # So the\
+          \ size limit when using 8 threads with 1000mb files and 2000 files\n  #\
+          \ is: 8*1000*2000 ~ 16TiB.\n  #\n  # In Sguil mode \"dir\" indicates the\
+          \ base directory. In this base dir the\n  # pcaps are created in the directory\
+          \ structure Sguil expects:\n  #\n  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>\n\
           \  #\n  # By default all packets are logged except:\n  # - TCP streams beyond\
           \ stream.reassembly.depth\n  # - encrypted streams after the key exchange\n\
           \  #\n  - pcap-log:\n      enabled: no\n\n  - alert-debug:\n      enabled:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30206,7 +30206,7 @@ objects:
           \ Event Format (nicknamed EVE) event log in JSON format\n  - eve-log:\n\
           \      filename: eve-%m-%d.json\n      rotate-interval: day\n      enabled:\
           \ yes\n      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis\n\
-          \      metadata: yes\n            # Enable for multi-threaded eve.json output;\
+          \      metadata: yes\n      # Enable for multi-threaded eve.json output;\
           \ output files are amended with\n      # with an identifier, e.g., eve.9.json\n\
           \      #threaded: false\n      #prefix: \"@cee: \" # prefix to prepend to\
           \ each log entry\n      # the following are valid when type: syslog above\n\
@@ -30302,53 +30302,57 @@ objects:
           \ sni, version, not_before, not_after, certificate, chain, ja3, ja3s]\n\
           \        - files:\n            enabled: no\n            force-magic: no\
           \ # force logging magic on all logged files\n            #force-hash: [md5]\n\
-          \        #- drop:\n        #    alerts: yes      # log alerts that caused\
-          \ drops\n        #    flows: all       # start or all: 'start' logs only\
-          \ a single drop\n        #                     # per flow direction. All\
-          \ logs each dropped pkt.\n        - smtp\n            #extended: yes # enable\
-          \ this for extended logging information\n            #custom: [received,\
-          \ x-mailer, x-originating-ip, relays, reply-to, bcc]\n            #md5:\
-          \ [body, subject]\n        - dnp3\n        - ftp\n        - rdp\n      \
-          \  - nfs\n        - smb\n        - tftp\n        - ikev2\n        - dcerpc\n\
-          \        - krb5\n        - snmp\n        - rfb\n        - sip:\n       \
-          \     enabled: no\n        - dhcp:\n            enabled: no\n          \
-          \  extended: no\n        - ssh\n        - mqtt:\n            enabled: yes\n\
-          \            passwords: no\n        - stats:\n            enabled: no\n\
-          \            totals: yes\n            threads: no\n            deltas: no\n\
-          \        - flow:\n            enabled: no\n        #- netflow\n        -\
-          \ metadata\n\n  # a line based log of HTTP requests (no alerts)\n  - http-log:\n\
-          \      enabled: no\n      filename: http.log\n      append: yes\n      #extended:\
-          \ yes     # enable this for extended logging information\n      #custom:\
-          \ yes       # enable the custom logging format (defined by customformat)\n\
-          \      #customformat: \"%{%D-%H:%M:%S}t.%z %{X-Forwarded-For}i %H %m %h\
-          \ %u %s %B %a:%p -> %A:%P\"\n      #filetype: regular # 'regular', 'unix_stream'\
-          \ or 'unix_dgram'\n\n  # a line based log of TLS handshake parameters (no\
-          \ alerts)\n  - tls-log:\n      enabled: no # Log TLS connections.\n    \
-          \  filename: tls.log # File to store TLS logs.\n      append: yes\n    \
-          \  #extended: yes     # Log extended information like fingerprint\n    \
-          \  #custom: yes       # enabled the custom logging format (defined by customformat)\n\
-          \      #customformat: \"%{%D-%H:%M:%S}t.%z %a:%p -> %A:%P %v %n %d %D\"\n\
-          \      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'\n \
-          \     # output TLS transaction where the session is resumed using a\n  \
-          \    # session id\n      #session-resumption: no\n\n  # output module to\
-          \ store certificates chain to disk\n  - tls-store:\n      enabled: no\n\
-          \      #certs-log-dir: certs # directory to store the certificates files\n\
-          \n  # Packet log... log packets in pcap format. 3 modes of operation: \"\
-          normal\"\n  # \"multi\" and \"sguil\".\n  #\n  # In normal mode a pcap file\
-          \ \"filename\" is created in the default-log-dir,\n  # or as specified by\
-          \ \"dir\".\n  # In multi mode, a file is created per thread. This will perform\
-          \ much\n  # better, but will create multiple files where 'normal' would\
-          \ create one.\n  # In multi mode the filename takes a few special variables:\n\
-          \  # - %n -- thread number\n  # - %i -- thread id\n  # - %t -- timestamp\
-          \ (secs or secs.usecs based on 'ts-format'\n  # E.g. filename: pcap.%n.%t\n\
-          \  #\n  # Note that it's possible to use directories, but the directories\
-          \ are not\n  # created by Suricata. E.g. filename: pcaps/%n/log.%s will\
-          \ log into the\n  # per thread directory.\n  #\n  # Also note that the limit\
-          \ and max-files settings are enforced per thread.\n  # So the size limit\
-          \ when using 8 threads with 1000mb files and 2000 files\n  # is: 8*1000*2000\
-          \ ~ 16TiB.\n  #\n  # In Sguil mode \"dir\" indicates the base directory.\
-          \ In this base dir the\n  # pcaps are created in the directory structure\
-          \ Sguil expects:\n  #\n  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>\n\
+          \            #- drop:\n            #    alerts: yes      # log alerts that\
+          \ caused drops\n            #    flows: all       # start or all: 'start'\
+          \ logs only a single drop\n            #                     # per flow\
+          \ direction. All logs each dropped pkt.\n        - smtp:\n            enabled:\
+          \ no\n            #extended: yes # enable this for extended logging information\n\
+          \            #custom: [received, x-mailer, x-originating-ip, relays, reply-to,\
+          \ bcc]\n            #md5: [body, subject]\n        - dnp3:\n           \
+          \ enabled: no\n        - ftp:\n            enabled: no\n        - rdp:\n\
+          \            enabled: no\n        - nfs:\n            enabled: no\n    \
+          \    - smb:\n            enabled: no\n        - tftp:\n            enabled:\
+          \ no\n        - ikev2:\n            enabled: no\n        - dcerpc:\n   \
+          \         enabled: no\n        - krb5:\n            enabled: no\n      \
+          \  - snmp:\n            enabled: no\n        - rfb:\n            enabled:\
+          \ no\n        - sip:\n            enabled: no\n        - dhcp:\n       \
+          \     enabled: no\n            extended: no\n        - ssh\n        - mqtt:\n\
+          \            enabled: no\n            passwords: no\n        - stats:\n\
+          \            enabled: no\n            totals: yes\n            threads:\
+          \ no\n            deltas: no\n        - flow:\n            enabled: no\n\
+          \        #- netflow\n        - metadata\n\n  # a line based log of HTTP\
+          \ requests (no alerts)\n  - http-log:\n      enabled: no\n      filename:\
+          \ http.log\n      append: yes\n      #extended: yes     # enable this for\
+          \ extended logging information\n      #custom: yes       # enable the custom\
+          \ logging format (defined by customformat)\n      #customformat: \"%{%D-%H:%M:%S}t.%z\
+          \ %{X-Forwarded-For}i %H %m %h %u %s %B %a:%p -> %A:%P\"\n      #filetype:\
+          \ regular # 'regular', 'unix_stream' or 'unix_dgram'\n\n  # a line based\
+          \ log of TLS handshake parameters (no alerts)\n  - tls-log:\n      enabled:\
+          \ no # Log TLS connections.\n      filename: tls.log # File to store TLS\
+          \ logs.\n      append: yes\n      #extended: yes     # Log extended information\
+          \ like fingerprint\n      #custom: yes       # enabled the custom logging\
+          \ format (defined by customformat)\n      #customformat: \"%{%D-%H:%M:%S}t.%z\
+          \ %a:%p -> %A:%P %v %n %d %D\"\n      #filetype: regular # 'regular', 'unix_stream'\
+          \ or 'unix_dgram'\n      # output TLS transaction where the session is resumed\
+          \ using a\n      # session id\n      #session-resumption: no\n\n  # output\
+          \ module to store certificates chain to disk\n  - tls-store:\n      enabled:\
+          \ no\n      #certs-log-dir: certs # directory to store the certificates\
+          \ files\n\n  # Packet log... log packets in pcap format. 3 modes of operation:\
+          \ \"normal\"\n  # \"multi\" and \"sguil\".\n  #\n  # In normal mode a pcap\
+          \ file \"filename\" is created in the default-log-dir,\n  # or as specified\
+          \ by \"dir\".\n  # In multi mode, a file is created per thread. This will\
+          \ perform much\n  # better, but will create multiple files where 'normal'\
+          \ would create one.\n  # In multi mode the filename takes a few special\
+          \ variables:\n  # - %n -- thread number\n  # - %i -- thread id\n  # - %t\
+          \ -- timestamp (secs or secs.usecs based on 'ts-format'\n  # E.g. filename:\
+          \ pcap.%n.%t\n  #\n  # Note that it's possible to use directories, but the\
+          \ directories are not\n  # created by Suricata. E.g. filename: pcaps/%n/log.%s\
+          \ will log into the\n  # per thread directory.\n  #\n  # Also note that\
+          \ the limit and max-files settings are enforced per thread.\n  # So the\
+          \ size limit when using 8 threads with 1000mb files and 2000 files\n  #\
+          \ is: 8*1000*2000 ~ 16TiB.\n  #\n  # In Sguil mode \"dir\" indicates the\
+          \ base directory. In this base dir the\n  # pcaps are created in the directory\
+          \ structure Sguil expects:\n  #\n  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>\n\
           \  #\n  # By default all packets are logged except:\n  # - TCP streams beyond\
           \ stream.reassembly.depth\n  # - encrypted streams after the key exchange\n\
           \  #\n  - pcap-log:\n      enabled: no\n\n  - alert-debug:\n      enabled:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30206,7 +30206,7 @@ objects:
           \ Event Format (nicknamed EVE) event log in JSON format\n  - eve-log:\n\
           \      filename: eve-%m-%d.json\n      rotate-interval: day\n      enabled:\
           \ yes\n      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis\n\
-          \      metadata: yes\n            # Enable for multi-threaded eve.json output;\
+          \      metadata: yes\n      # Enable for multi-threaded eve.json output;\
           \ output files are amended with\n      # with an identifier, e.g., eve.9.json\n\
           \      #threaded: false\n      #prefix: \"@cee: \" # prefix to prepend to\
           \ each log entry\n      # the following are valid when type: syslog above\n\
@@ -30302,53 +30302,57 @@ objects:
           \ sni, version, not_before, not_after, certificate, chain, ja3, ja3s]\n\
           \        - files:\n            enabled: no\n            force-magic: no\
           \ # force logging magic on all logged files\n            #force-hash: [md5]\n\
-          \        #- drop:\n        #    alerts: yes      # log alerts that caused\
-          \ drops\n        #    flows: all       # start or all: 'start' logs only\
-          \ a single drop\n        #                     # per flow direction. All\
-          \ logs each dropped pkt.\n        - smtp\n            #extended: yes # enable\
-          \ this for extended logging information\n            #custom: [received,\
-          \ x-mailer, x-originating-ip, relays, reply-to, bcc]\n            #md5:\
-          \ [body, subject]\n        - dnp3\n        - ftp\n        - rdp\n      \
-          \  - nfs\n        - smb\n        - tftp\n        - ikev2\n        - dcerpc\n\
-          \        - krb5\n        - snmp\n        - rfb\n        - sip:\n       \
-          \     enabled: no\n        - dhcp:\n            enabled: no\n          \
-          \  extended: no\n        - ssh\n        - mqtt:\n            enabled: yes\n\
-          \            passwords: no\n        - stats:\n            enabled: no\n\
-          \            totals: yes\n            threads: no\n            deltas: no\n\
-          \        - flow:\n            enabled: no\n        #- netflow\n        -\
-          \ metadata\n\n  # a line based log of HTTP requests (no alerts)\n  - http-log:\n\
-          \      enabled: no\n      filename: http.log\n      append: yes\n      #extended:\
-          \ yes     # enable this for extended logging information\n      #custom:\
-          \ yes       # enable the custom logging format (defined by customformat)\n\
-          \      #customformat: \"%{%D-%H:%M:%S}t.%z %{X-Forwarded-For}i %H %m %h\
-          \ %u %s %B %a:%p -> %A:%P\"\n      #filetype: regular # 'regular', 'unix_stream'\
-          \ or 'unix_dgram'\n\n  # a line based log of TLS handshake parameters (no\
-          \ alerts)\n  - tls-log:\n      enabled: no # Log TLS connections.\n    \
-          \  filename: tls.log # File to store TLS logs.\n      append: yes\n    \
-          \  #extended: yes     # Log extended information like fingerprint\n    \
-          \  #custom: yes       # enabled the custom logging format (defined by customformat)\n\
-          \      #customformat: \"%{%D-%H:%M:%S}t.%z %a:%p -> %A:%P %v %n %d %D\"\n\
-          \      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'\n \
-          \     # output TLS transaction where the session is resumed using a\n  \
-          \    # session id\n      #session-resumption: no\n\n  # output module to\
-          \ store certificates chain to disk\n  - tls-store:\n      enabled: no\n\
-          \      #certs-log-dir: certs # directory to store the certificates files\n\
-          \n  # Packet log... log packets in pcap format. 3 modes of operation: \"\
-          normal\"\n  # \"multi\" and \"sguil\".\n  #\n  # In normal mode a pcap file\
-          \ \"filename\" is created in the default-log-dir,\n  # or as specified by\
-          \ \"dir\".\n  # In multi mode, a file is created per thread. This will perform\
-          \ much\n  # better, but will create multiple files where 'normal' would\
-          \ create one.\n  # In multi mode the filename takes a few special variables:\n\
-          \  # - %n -- thread number\n  # - %i -- thread id\n  # - %t -- timestamp\
-          \ (secs or secs.usecs based on 'ts-format'\n  # E.g. filename: pcap.%n.%t\n\
-          \  #\n  # Note that it's possible to use directories, but the directories\
-          \ are not\n  # created by Suricata. E.g. filename: pcaps/%n/log.%s will\
-          \ log into the\n  # per thread directory.\n  #\n  # Also note that the limit\
-          \ and max-files settings are enforced per thread.\n  # So the size limit\
-          \ when using 8 threads with 1000mb files and 2000 files\n  # is: 8*1000*2000\
-          \ ~ 16TiB.\n  #\n  # In Sguil mode \"dir\" indicates the base directory.\
-          \ In this base dir the\n  # pcaps are created in the directory structure\
-          \ Sguil expects:\n  #\n  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>\n\
+          \            #- drop:\n            #    alerts: yes      # log alerts that\
+          \ caused drops\n            #    flows: all       # start or all: 'start'\
+          \ logs only a single drop\n            #                     # per flow\
+          \ direction. All logs each dropped pkt.\n        - smtp:\n            enabled:\
+          \ no\n            #extended: yes # enable this for extended logging information\n\
+          \            #custom: [received, x-mailer, x-originating-ip, relays, reply-to,\
+          \ bcc]\n            #md5: [body, subject]\n        - dnp3:\n           \
+          \ enabled: no\n        - ftp:\n            enabled: no\n        - rdp:\n\
+          \            enabled: no\n        - nfs:\n            enabled: no\n    \
+          \    - smb:\n            enabled: no\n        - tftp:\n            enabled:\
+          \ no\n        - ikev2:\n            enabled: no\n        - dcerpc:\n   \
+          \         enabled: no\n        - krb5:\n            enabled: no\n      \
+          \  - snmp:\n            enabled: no\n        - rfb:\n            enabled:\
+          \ no\n        - sip:\n            enabled: no\n        - dhcp:\n       \
+          \     enabled: no\n            extended: no\n        - ssh\n        - mqtt:\n\
+          \            enabled: no\n            passwords: no\n        - stats:\n\
+          \            enabled: no\n            totals: yes\n            threads:\
+          \ no\n            deltas: no\n        - flow:\n            enabled: no\n\
+          \        #- netflow\n        - metadata\n\n  # a line based log of HTTP\
+          \ requests (no alerts)\n  - http-log:\n      enabled: no\n      filename:\
+          \ http.log\n      append: yes\n      #extended: yes     # enable this for\
+          \ extended logging information\n      #custom: yes       # enable the custom\
+          \ logging format (defined by customformat)\n      #customformat: \"%{%D-%H:%M:%S}t.%z\
+          \ %{X-Forwarded-For}i %H %m %h %u %s %B %a:%p -> %A:%P\"\n      #filetype:\
+          \ regular # 'regular', 'unix_stream' or 'unix_dgram'\n\n  # a line based\
+          \ log of TLS handshake parameters (no alerts)\n  - tls-log:\n      enabled:\
+          \ no # Log TLS connections.\n      filename: tls.log # File to store TLS\
+          \ logs.\n      append: yes\n      #extended: yes     # Log extended information\
+          \ like fingerprint\n      #custom: yes       # enabled the custom logging\
+          \ format (defined by customformat)\n      #customformat: \"%{%D-%H:%M:%S}t.%z\
+          \ %a:%p -> %A:%P %v %n %d %D\"\n      #filetype: regular # 'regular', 'unix_stream'\
+          \ or 'unix_dgram'\n      # output TLS transaction where the session is resumed\
+          \ using a\n      # session id\n      #session-resumption: no\n\n  # output\
+          \ module to store certificates chain to disk\n  - tls-store:\n      enabled:\
+          \ no\n      #certs-log-dir: certs # directory to store the certificates\
+          \ files\n\n  # Packet log... log packets in pcap format. 3 modes of operation:\
+          \ \"normal\"\n  # \"multi\" and \"sguil\".\n  #\n  # In normal mode a pcap\
+          \ file \"filename\" is created in the default-log-dir,\n  # or as specified\
+          \ by \"dir\".\n  # In multi mode, a file is created per thread. This will\
+          \ perform much\n  # better, but will create multiple files where 'normal'\
+          \ would create one.\n  # In multi mode the filename takes a few special\
+          \ variables:\n  # - %n -- thread number\n  # - %i -- thread id\n  # - %t\
+          \ -- timestamp (secs or secs.usecs based on 'ts-format'\n  # E.g. filename:\
+          \ pcap.%n.%t\n  #\n  # Note that it's possible to use directories, but the\
+          \ directories are not\n  # created by Suricata. E.g. filename: pcaps/%n/log.%s\
+          \ will log into the\n  # per thread directory.\n  #\n  # Also note that\
+          \ the limit and max-files settings are enforced per thread.\n  # So the\
+          \ size limit when using 8 threads with 1000mb files and 2000 files\n  #\
+          \ is: 8*1000*2000 ~ 16TiB.\n  #\n  # In Sguil mode \"dir\" indicates the\
+          \ base directory. In this base dir the\n  # pcaps are created in the directory\
+          \ structure Sguil expects:\n  #\n  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>\n\
           \  #\n  # By default all packets are logged except:\n  # - TCP streams beyond\
           \ stream.reassembly.depth\n  # - encrypted streams after the key exchange\n\
           \  #\n  - pcap-log:\n      enabled: no\n\n  - alert-debug:\n      enabled:\


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?

Disable more types for the eve output of suricata.
It seems that by default it will put far too much information in the eve.json output, we don't care about in hypershift, we only want alerts.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
