### PR TITLE
[OSD-18400] SSH event_type produces false positives.

### DIFF
--- a/deploy/osd-suricata/hypershift-management-cluster/15-configmap.yaml
+++ b/deploy/osd-suricata/hypershift-management-cluster/15-configmap.yaml
@@ -294,7 +294,8 @@ data:
             - dhcp:
                 enabled: no
                 extended: no
-            - ssh
+            - ssh:
+                enabled: no
             - mqtt:
                 enabled: no
                 passwords: no
@@ -306,7 +307,8 @@ data:
             - flow:
                 enabled: no
             #- netflow
-            - metadata
+            - metadata:
+                enabled: no
 
       # a line based log of HTTP requests (no alerts)
       - http-log:


### PR DESCRIPTION
Disable everything except alerts for eve output.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
