### PR TITLE
updates limited support to not target FR

### DIFF
--- a/deploy/osd-limited-support/config.yaml
+++ b/deploy/osd-limited-support/config.yaml
@@ -4,3 +4,6 @@ selectorSyncSet:
   - key: api.openshift.com/limited-support
     operator: In
     values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]    

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27219,6 +27219,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27219,6 +27219,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27219,6 +27219,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

FedRAMP does not have osd metrics exporter since we do not have telemetry. When a cluster is put into limited support in FR, clustersyncs break because we do not have this namespaces and the SSS fails to apply

### Which Jira/Github issue(s) this PR fixes?

N/A -- adhoc issue noticed this morning

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
