### PR TITLE
Ignore 'MachineOutOfComplianceSRE' alerts during upgrade healthchecks

### DIFF
--- a/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
@@ -52,6 +52,7 @@ data:
       - ThanosNoRuleEvaluations
       # OSD-13649
       - etcdGRPCRequestsSlow
+      - MachineOutOfComplianceSRE
       ignoredNamespaces:
       - openshift-logging
       - openshift-redhat-marketplace

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21867,9 +21867,10 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MachineOutOfComplianceSRE\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21867,9 +21867,10 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MachineOutOfComplianceSRE\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21867,9 +21867,10 @@ objects:
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
           \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
           \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
-          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  ignoredNamespaces:\n  - openshift-logging\n\
-          \  - openshift-redhat-marketplace\n  - openshift-operators\n  - openshift-customer-monitoring\n\
-          \  - openshift-cnv\n  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  # OSD-13649\n  - etcdGRPCRequestsSlow\n  - MachineOutOfComplianceSRE\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}\n"
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION

### What type of PR is this?
_bug_

### What this PR does / why we need it?

Adds `MachineOutOfComplianceSRE` to the list of alerts we can safely ignore during upgrade. This alert only indicates that machines older than 28 days are present on the cluster, which doesn't necessarily indicate anything functionally wrong with the platform.

