### PR TITLE
fix(MTSRE-1560): add 'rhacs' namespace for lpsre backplane access

### DIFF
--- a/deploy/backplane/lpsre/acs/01-acs-lpsre-admins.SubjectPermission.yaml
+++ b/deploy/backplane/lpsre/acs/01-acs-lpsre-admins.SubjectPermission.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   permissions:
   - clusterRoleName: view
-    namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+    namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   - clusterRoleName: backplane-lpsre-acm-admins-project
-    namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+    namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-lpsre

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -16576,10 +16576,10 @@ objects:
       spec:
         permissions:
         - clusterRoleName: view
-          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         - clusterRoleName: backplane-lpsre-acm-admins-project
-          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-lpsre

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -16576,10 +16576,10 @@ objects:
       spec:
         permissions:
         - clusterRoleName: view
-          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         - clusterRoleName: backplane-lpsre-acm-admins-project
-          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-lpsre

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -16576,10 +16576,10 @@ objects:
       spec:
         permissions:
         - clusterRoleName: view
-          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         - clusterRoleName: backplane-lpsre-acm-admins-project
-          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs-.*)
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-lpsre


### PR DESCRIPTION
### What type of PR is this?
_fix_

### What this PR does / why we need it?

Provides restricted access to the `rhacs` namespace for LPSRE operators supporting the ACS addon.

### Which Jira/Github issue(s) this PR fixes?

Fixes [MTSRE-1560](https://issues.redhat.com//browse/MTSRE-1560)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
