### PR TITLE
Allow ocpbugs-20184 cronjob to schedule anywhere

### DIFF
--- a/deploy/ocpbugs-20184/10-ocpbugs-20184.CronJob.yaml
+++ b/deploy/ocpbugs-20184/10-ocpbugs-20184.CronJob.yaml
@@ -5,14 +5,17 @@ metadata:
   name: ocpbugs-20184
   namespace: openshift-network-node-identity
 spec:
-  failedJobsHistoryLimit: 3
-  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 2
   concurrencyPolicy: Replace
-  schedule: "22 * * * *"
+  schedule: "*/10 * * * *"
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 3600
       template:
+        metadata:
+          labels:
+            app: ocpbugs-20184
         spec:
           affinity:
             nodeAffinity:
@@ -22,9 +25,19 @@ spec:
                   - key: node-role.kubernetes.io/infra
                     operator: Exists
                 weight: 1
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                      - ocpbugs-20184
+                  topologyKey: kubernetes.io/hostname
+                weight: 1
           tolerations:
             - effect: NoSchedule
-              key: node-role.kubernetes.io/infra
               operator: Exists
           serviceAccountName: ocpbugs-20184
           restartPolicy: Never
@@ -32,6 +45,13 @@ spec:
           - name: ocpbugs-20184
             image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
             imagePullPolicy: Always
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+              limits:
+                cpu: 100m
+                memory: 100Mi
             command:
             - oc
             - delete

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22605,14 +22605,17 @@ objects:
         name: ocpbugs-20184
         namespace: openshift-network-node-identity
       spec:
-        failedJobsHistoryLimit: 3
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 2
+        successfulJobsHistoryLimit: 2
         concurrencyPolicy: Replace
-        schedule: 22 * * * *
+        schedule: '*/10 * * * *'
         jobTemplate:
           spec:
             ttlSecondsAfterFinished: 3600
             template:
+              metadata:
+                labels:
+                  app: ocpbugs-20184
               spec:
                 affinity:
                   nodeAffinity:
@@ -22622,9 +22625,19 @@ objects:
                         - key: node-role.kubernetes.io/infra
                           operator: Exists
                       weight: 1
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchExpressions:
+                          - key: app
+                            operator: In
+                            values:
+                            - ocpbugs-20184
+                        topologyKey: kubernetes.io/hostname
+                      weight: 1
                 tolerations:
                 - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
                   operator: Exists
                 serviceAccountName: ocpbugs-20184
                 restartPolicy: Never
@@ -22632,6 +22645,13 @@ objects:
                 - name: ocpbugs-20184
                   image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
+                    limits:
+                      cpu: 100m
+                      memory: 100Mi
                   command:
                   - oc
                   - delete

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22605,14 +22605,17 @@ objects:
         name: ocpbugs-20184
         namespace: openshift-network-node-identity
       spec:
-        failedJobsHistoryLimit: 3
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 2
+        successfulJobsHistoryLimit: 2
         concurrencyPolicy: Replace
-        schedule: 22 * * * *
+        schedule: '*/10 * * * *'
         jobTemplate:
           spec:
             ttlSecondsAfterFinished: 3600
             template:
+              metadata:
+                labels:
+                  app: ocpbugs-20184
               spec:
                 affinity:
                   nodeAffinity:
@@ -22622,9 +22625,19 @@ objects:
                         - key: node-role.kubernetes.io/infra
                           operator: Exists
                       weight: 1
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchExpressions:
+                          - key: app
+                            operator: In
+                            values:
+                            - ocpbugs-20184
+                        topologyKey: kubernetes.io/hostname
+                      weight: 1
                 tolerations:
                 - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
                   operator: Exists
                 serviceAccountName: ocpbugs-20184
                 restartPolicy: Never
@@ -22632,6 +22645,13 @@ objects:
                 - name: ocpbugs-20184
                   image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
+                    limits:
+                      cpu: 100m
+                      memory: 100Mi
                   command:
                   - oc
                   - delete

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22605,14 +22605,17 @@ objects:
         name: ocpbugs-20184
         namespace: openshift-network-node-identity
       spec:
-        failedJobsHistoryLimit: 3
-        successfulJobsHistoryLimit: 3
+        failedJobsHistoryLimit: 2
+        successfulJobsHistoryLimit: 2
         concurrencyPolicy: Replace
-        schedule: 22 * * * *
+        schedule: '*/10 * * * *'
         jobTemplate:
           spec:
             ttlSecondsAfterFinished: 3600
             template:
+              metadata:
+                labels:
+                  app: ocpbugs-20184
               spec:
                 affinity:
                   nodeAffinity:
@@ -22622,9 +22625,19 @@ objects:
                         - key: node-role.kubernetes.io/infra
                           operator: Exists
                       weight: 1
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchExpressions:
+                          - key: app
+                            operator: In
+                            values:
+                            - ocpbugs-20184
+                        topologyKey: kubernetes.io/hostname
+                      weight: 1
                 tolerations:
                 - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
                   operator: Exists
                 serviceAccountName: ocpbugs-20184
                 restartPolicy: Never
@@ -22632,6 +22645,13 @@ objects:
                 - name: ocpbugs-20184
                   image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
                   imagePullPolicy: Always
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
+                    limits:
+                      cpu: 100m
+                      memory: 100Mi
                   command:
                   - oc
                   - delete


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Updates the cronjob for ocpbugs-20184 as follows:
- Runs every 10 minutes instead of every hour. If things are working properly, the impact will be negligible, but it will fix stalled upgrades quicker.
- Allow it to schedule anywhere, but still prefer infra nodes. This will allow it to find any functional node to schedule to.
- Set resources to help with scheduling.
- Adds pod anti-affinity to prefer that if one pod gets wedged, it'll try to select a different node.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
