### PR TITLE
Add `iam:GetPolicyVersion` to the OCM admin role

### DIFF
--- a/resources/sts/4.11/sts_ocm_admin_permission_policy.json
+++ b/resources/sts/4.11/sts_ocm_admin_permission_policy.json
@@ -15,6 +15,7 @@
         "iam:DetachRolePolicy",
         "iam:GetOpenIDConnectProvider",
         "iam:GetPolicy",
+        "iam:GetPolicyVersion",
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListPolicies",

--- a/resources/sts/4.12/sts_ocm_admin_permission_policy.json
+++ b/resources/sts/4.12/sts_ocm_admin_permission_policy.json
@@ -15,6 +15,7 @@
         "iam:DetachRolePolicy",
         "iam:GetOpenIDConnectProvider",
         "iam:GetPolicy",
+        "iam:GetPolicyVersion",
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListPolicies",

--- a/resources/sts/4.13/sts_ocm_admin_permission_policy.json
+++ b/resources/sts/4.13/sts_ocm_admin_permission_policy.json
@@ -15,6 +15,7 @@
         "iam:DetachRolePolicy",
         "iam:GetOpenIDConnectProvider",
         "iam:GetPolicy",
+        "iam:GetPolicyVersion",
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListPolicies",

--- a/resources/sts/4.14/sts_ocm_admin_permission_policy.json
+++ b/resources/sts/4.14/sts_ocm_admin_permission_policy.json
@@ -15,6 +15,7 @@
         "iam:DetachRolePolicy",
         "iam:GetOpenIDConnectProvider",
         "iam:GetPolicy",
+        "iam:GetPolicyVersion",
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListPolicies",


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
For the auto admin flow, the backend creates the operator roles for the user.
In the case of shared VPC, we need to validate existing ingress operator policies to make sure not to override an existing shared VPC role ARN. Therefore, we need to fetch the policy document via the API call `GetPolicyVersion`.

### Which Jira/Github issue(s) this PR fixes?
Related: [OCM-4267](https://issues.redhat.com//browse/OCM-4267)

### Special notes for your reviewer:
Related PR for the OCM backend is in progress, going to rely on this permission or return an error
to the user to add permission.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
