### PR TITLE
OSD-18286: Adding Prometheus Rule for Dynatrace Workload Monitoring at MC

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
@@ -1,0 +1,90 @@
+apiVersion: monitoring.rhobs/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-dynatrace-workloads
+    role: alert-rules
+  name: sre-dynatrace-workloads
+  namespace: openshift-observability-dynatrace
+spec:
+  groups:
+  - name: sre-dynatrace-workloads-failing
+    rules:
+    - alert: DynatraceMonitoringStackDownSRE
+      expr: |
+          sum(hypershift_hostedclusters) > 0 and (
+          kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"} == 0 or
+          kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"} == 0 or
+          kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"} == 0 or
+          kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"} == 0 or
+          kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent", namespace="dynatrace"} == 0 )
+      for: 15m
+      labels:
+        namespace: dynatrace
+        severity: warning
+      annotations:
+        summary: "Dynatrace Workloads are failing on the Management Cluster"
+        description: "The Dynatrace deployment on the Management Cluster has failed to be deployed for 15 mins"
+
+  - name: sre-dynatrace-monitoring-stack-degraded
+    rules:
+    - alert: DynatraceOperatorDegradedSRE
+      expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator", namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+      for: 10m
+      labels:
+        namespace: dynatrace
+        severity: warning
+      annotations:
+        summary: "The Dynatrace Operator is Degraded"
+        description: "{{$value}} pods are not running out of total pods for the Dynatrace Operator"
+  
+    - alert: DynatraceWebhookDegradedSRE
+      expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook", namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+      for: 10m
+      labels:
+        namespace: dynatrace
+        severity: warning
+      annotations:
+        summary: "Dynatrace Webhook is Degraded"
+        description: "{{$value}} pods are not running out of total pods for the Dynatrace Webhook"
+
+    - alert: DynatraceOpenTelemetryCollectorDegradedSRE
+      expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+      for: 15m
+      labels:
+        namespace: dynatrace
+        severity: warning
+      annotations:
+        summary: "Dynatrace OTEL Collector is Degraded"
+        description: "{{$value}} pods are not running out of total pods for the OpenTelemetry Dynatrace Collector"
+
+    - alert: DynatraceActiveGateDegradedSRE
+      expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate", namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+      for: 15m
+      labels:
+        namespace: dynatrace
+        severity: warning
+      annotations:
+        summary: "Dynatrace ActiveGate is Degraded"
+        description: "{{$value}} pods are not running out of total pods for Dynatrace ActiveGate"
+
+    - alert: DynatraceOneAgentDegradedSRE
+      expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent", namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent", namespace="dynatrace"}) without (daemonset, instance, pod) > 0
+      for: 15m
+      labels:
+        namespace: dynatrace
+        severity: warning
+      annotations:
+        summary: "Dynatrace OneAgent is Degraded"
+        description: "{{$value}} pods are not running out of total pods for Dynatrace OneAgent"  
+
+    - alert: DynatracePodRestartsStuckSRE
+      expr: kube_pod_container_status_restarts_total{namespace="dynatrace"} > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m]) > 0
+      for: 15m
+      labels:
+        namespace: dynatrace
+        severity: warning
+      annotations:
+        summary: "Pod Restarts Stuck Alert"
+        description: "At least one pod in the 'dynatrace' namespace has been stuck in restarts for the last 15 minutes."
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34935,6 +34935,119 @@ objects:
         - ibm-infra
     resourceApplyMode: Sync
     resources:
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-dynatrace-workloads
+          role: alert-rules
+        name: sre-dynatrace-workloads
+        namespace: openshift-observability-dynatrace
+      spec:
+        groups:
+        - name: sre-dynatrace-workloads-failing
+          rules:
+          - alert: DynatraceMonitoringStackDownSRE
+            expr: 'sum(hypershift_hostedclusters) > 0 and (
+
+              kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"}
+              == 0 or
+
+              kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}
+              == 0 or
+
+              kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"} == 0 or
+
+              kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}
+              == 0 or
+
+              kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"} == 0 )
+
+              '
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace Workloads are failing on the Management Cluster
+              description: The Dynatrace deployment on the Management Cluster has
+                failed to be deployed for 15 mins
+        - name: sre-dynatrace-monitoring-stack-degraded
+          rules:
+          - alert: DynatraceOperatorDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 10m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: The Dynatrace Operator is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the Dynatrace Operator'
+          - alert: DynatraceWebhookDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 10m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace Webhook is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the Dynatrace Webhook'
+          - alert: DynatraceOpenTelemetryCollectorDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace OTEL Collector is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the OpenTelemetry Dynatrace Collector'
+          - alert: DynatraceActiveGateDegradedSRE
+            expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace ActiveGate is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                Dynatrace ActiveGate'
+          - alert: DynatraceOneAgentDegradedSRE
+            expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent",
+              namespace="dynatrace"}) without (daemonset, instance, pod) > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace OneAgent is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                Dynatrace OneAgent'
+          - alert: DynatracePodRestartsStuckSRE
+            expr: kube_pod_container_status_restarts_total{namespace="dynatrace"}
+              > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m])
+              > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Pod Restarts Stuck Alert
+              description: At least one pod in the 'dynatrace' namespace has been
+                stuck in restarts for the last 15 minutes.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34935,6 +34935,119 @@ objects:
         - ibm-infra
     resourceApplyMode: Sync
     resources:
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-dynatrace-workloads
+          role: alert-rules
+        name: sre-dynatrace-workloads
+        namespace: openshift-observability-dynatrace
+      spec:
+        groups:
+        - name: sre-dynatrace-workloads-failing
+          rules:
+          - alert: DynatraceMonitoringStackDownSRE
+            expr: 'sum(hypershift_hostedclusters) > 0 and (
+
+              kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"}
+              == 0 or
+
+              kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}
+              == 0 or
+
+              kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"} == 0 or
+
+              kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}
+              == 0 or
+
+              kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"} == 0 )
+
+              '
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace Workloads are failing on the Management Cluster
+              description: The Dynatrace deployment on the Management Cluster has
+                failed to be deployed for 15 mins
+        - name: sre-dynatrace-monitoring-stack-degraded
+          rules:
+          - alert: DynatraceOperatorDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 10m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: The Dynatrace Operator is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the Dynatrace Operator'
+          - alert: DynatraceWebhookDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 10m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace Webhook is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the Dynatrace Webhook'
+          - alert: DynatraceOpenTelemetryCollectorDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace OTEL Collector is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the OpenTelemetry Dynatrace Collector'
+          - alert: DynatraceActiveGateDegradedSRE
+            expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace ActiveGate is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                Dynatrace ActiveGate'
+          - alert: DynatraceOneAgentDegradedSRE
+            expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent",
+              namespace="dynatrace"}) without (daemonset, instance, pod) > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace OneAgent is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                Dynatrace OneAgent'
+          - alert: DynatracePodRestartsStuckSRE
+            expr: kube_pod_container_status_restarts_total{namespace="dynatrace"}
+              > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m])
+              > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Pod Restarts Stuck Alert
+              description: At least one pod in the 'dynatrace' namespace has been
+                stuck in restarts for the last 15 minutes.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34935,6 +34935,119 @@ objects:
         - ibm-infra
     resourceApplyMode: Sync
     resources:
+    - apiVersion: monitoring.rhobs/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-dynatrace-workloads
+          role: alert-rules
+        name: sre-dynatrace-workloads
+        namespace: openshift-observability-dynatrace
+      spec:
+        groups:
+        - name: sre-dynatrace-workloads-failing
+          rules:
+          - alert: DynatraceMonitoringStackDownSRE
+            expr: 'sum(hypershift_hostedclusters) > 0 and (
+
+              kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"}
+              == 0 or
+
+              kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}
+              == 0 or
+
+              kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"} == 0 or
+
+              kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}
+              == 0 or
+
+              kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"} == 0 )
+
+              '
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace Workloads are failing on the Management Cluster
+              description: The Dynatrace deployment on the Management Cluster has
+                failed to be deployed for 15 mins
+        - name: sre-dynatrace-monitoring-stack-degraded
+          rules:
+          - alert: DynatraceOperatorDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 10m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: The Dynatrace Operator is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the Dynatrace Operator'
+          - alert: DynatraceWebhookDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 10m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace Webhook is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the Dynatrace Webhook'
+          - alert: DynatraceOpenTelemetryCollectorDegradedSRE
+            expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace OTEL Collector is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                the OpenTelemetry Dynatrace Collector'
+          - alert: DynatraceActiveGateDegradedSRE
+            expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate",
+              namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate",
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace ActiveGate is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                Dynatrace ActiveGate'
+          - alert: DynatraceOneAgentDegradedSRE
+            expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent",
+              namespace="dynatrace"}) without (daemonset, instance, pod) > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Dynatrace OneAgent is Degraded
+              description: '{{$value}} pods are not running out of total pods for
+                Dynatrace OneAgent'
+          - alert: DynatracePodRestartsStuckSRE
+            expr: kube_pod_container_status_restarts_total{namespace="dynatrace"}
+              > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m])
+              > 0
+            for: 15m
+            labels:
+              namespace: dynatrace
+              severity: warning
+            annotations:
+              summary: Pod Restarts Stuck Alert
+              description: At least one pod in the 'dynatrace' namespace has been
+                stuck in restarts for the last 15 minutes.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION


### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
This PR closes [OSD-18286](https://issues.redhat.com//browse/OSD-18286). It add Prometheus Rule for Dynatrace Workload Monitoring at Management Cluster Level.
It is a combination of two alerts - DynatraceMonitoringStackDownSRE and DynatraceComponentDegradedSRE

Ref - [doc](https://docs.google.com/document/d/1Ph69hzglhb3nidFcZIem1koqi-dj1YxKdo8yc_jiVFs/edit) for discussion and further details on these alerts

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_[OSD-18286](https://issues.redhat.com//browse/OSD-18286)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
