### PR TITLE
ignore KubeletDown during OCP upgrades

### DIFF
--- a/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
@@ -16,6 +16,8 @@ data:
         controlPlaneCriticals:
         # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300
         - ClusterOperatorDown
+        # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201
+        - KubeletDown
     scale:
       timeOut: 30
     upgradeWindow:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21856,12 +21856,14 @@ objects:
           \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
           \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
           \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\n  disableDrainStrategies:\
-          \ true\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
-          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  #\
+          \ https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
           \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
           \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21856,12 +21856,14 @@ objects:
           \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
           \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
           \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\n  disableDrainStrategies:\
-          \ true\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
-          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  #\
+          \ https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
           \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
           \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21856,12 +21856,14 @@ objects:
           \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
           \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
           \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
-          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\n  disableDrainStrategies:\
-          \ true\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
-          \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
-          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
-          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
+          \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n  - CannotRetrieveUpdates\n\
+          \  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n  #\
+          \ https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
           \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
           \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
           \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\


### PR DESCRIPTION
### What this PR does / why we need it?
KubeletDown can fire when the DNS clusteroperator is upgrading, however the kubelet is not actually down. This PR extends #1898 to also include our HCP management clusters

### Which Jira/Github issue(s) this PR fixes?

[OSD-19002](https://issues.redhat.com//browse/OSD-19002)