### PR TITLE
osd-cluster-ready: v0.1.122-8ca3df8

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,13 +13,13 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.112-43308f7"
+                managed.openshift.io/version: "v0.1.122-8ca3df8"
         spec:
             containers:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a"
+              image: "quay.io/app-sre/osd-cluster-ready@sha256:c07cc9b8cd38d7da2abf371970d1884a720a24714a8e5761affe9359aa58572d"
               command: ["/root/main"]
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25406,11 +25406,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.112-43308f7
+              managed.openshift.io/version: v0.1.122-8ca3df8
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c07cc9b8cd38d7da2abf371970d1884a720a24714a8e5761affe9359aa58572d
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25406,11 +25406,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.112-43308f7
+              managed.openshift.io/version: v0.1.122-8ca3df8
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c07cc9b8cd38d7da2abf371970d1884a720a24714a8e5761affe9359aa58572d
               command:
               - /root/main
             restartPolicy: OnFailure

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25406,11 +25406,11 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.112-43308f7
+              managed.openshift.io/version: v0.1.122-8ca3df8
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:c6ff874eaac41fec4370c87515a4213edb0ca383246301d86dea947502c5b70a
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c07cc9b8cd38d7da2abf371970d1884a720a24714a8e5761affe9359aa58572d
               command:
               - /root/main
             restartPolicy: OnFailure


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Increments the osd-cluster-ready image https://quay.io/repository/app-sre/osd-cluster-ready

With these changes (by and large base image updates)
https://github.com/openshift/osd-cluster-ready/compare/43308f77d7b5f47f464d98eeece29cda80ba8363...8ca3df8b1188486c7440072ab39f68eb90a0c03f

[OSD-19380](https://issues.redhat.com//browse/OSD-19380)