### PR TITLE
updates base images for Suricata and ClamAV in fedRAMP

### DIFF
--- a/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
+++ b/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           value: /certs/tls.key
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
+        image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
         name: logger
         ports:
         - containerPort: 8443
@@ -69,7 +69,7 @@ spec:
           value: "@rpc.pod.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+        image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
         name: pod-printer
         resources:
           limits:
@@ -85,7 +85,7 @@ spec:
           value: "@rpc.scan.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+        image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
         name: scan-printer
         resources:
           limits:

--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -24,7 +24,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+        image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
         name: clamsig-puller
         resources:
           limits:
@@ -43,7 +43,7 @@ spec:
           value: "false"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
+        image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
         name: clamd
         resources:
           limits:
@@ -67,7 +67,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
+        image: quay.io/app-sre/container-info@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
         name: info
         resources:
           limits:
@@ -111,7 +111,7 @@ spec:
           value: '@rpc.sock'
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+        image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
         name: watcher
         resources:
           limits:
@@ -165,7 +165,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+        image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
         name: scheduler
         resources:
           limits:
@@ -199,7 +199,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+        image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
         name: init-clamsig-puller
         resources:
           limits:

--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:d437c8cf14cec7a3b215a4f318c604d9df6062e37a738b35253f52b093f4447f
+        image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:
@@ -33,7 +33,7 @@ spec:
         - mountPath: /host/var/log
           name: host-filesystem
       - name: log-cleaner
-        image: quay.io/app-sre/log-cleaner@sha256:eaebbfc805800f6f284b33e75686f137e607dca19370d9db11f1577ccf492fdb
+        image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
         volumeMounts:
         - mountPath: /host/var/log
           name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29835,7 +29835,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
+              image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
               name: logger
               ports:
               - containerPort: 8443
@@ -29860,7 +29860,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
               name: pod-printer
               resources:
                 limits:
@@ -29876,7 +29876,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
               name: scan-printer
               resources:
                 limits:
@@ -29941,7 +29941,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
               name: clamsig-puller
               resources:
                 limits:
@@ -29960,7 +29960,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
+              image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
               name: clamd
               resources:
                 limits:
@@ -29984,7 +29984,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
+              image: quay.io/app-sre/container-info@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
               name: info
               resources:
                 limits:
@@ -30028,7 +30028,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+              image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
               name: watcher
               resources:
                 limits:
@@ -30082,7 +30082,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+              image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
               name: scheduler
               resources:
                 limits:
@@ -30116,7 +30116,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
               name: init-clamsig-puller
               resources:
                 limits:
@@ -30634,7 +30634,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:d437c8cf14cec7a3b215a4f318c604d9df6062e37a738b35253f52b093f4447f
+              image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -30653,7 +30653,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:eaebbfc805800f6f284b33e75686f137e607dca19370d9db11f1577ccf492fdb
+              image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29835,7 +29835,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
+              image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
               name: logger
               ports:
               - containerPort: 8443
@@ -29860,7 +29860,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
               name: pod-printer
               resources:
                 limits:
@@ -29876,7 +29876,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
               name: scan-printer
               resources:
                 limits:
@@ -29941,7 +29941,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
               name: clamsig-puller
               resources:
                 limits:
@@ -29960,7 +29960,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
+              image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
               name: clamd
               resources:
                 limits:
@@ -29984,7 +29984,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
+              image: quay.io/app-sre/container-info@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
               name: info
               resources:
                 limits:
@@ -30028,7 +30028,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+              image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
               name: watcher
               resources:
                 limits:
@@ -30082,7 +30082,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+              image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
               name: scheduler
               resources:
                 limits:
@@ -30116,7 +30116,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
               name: init-clamsig-puller
               resources:
                 limits:
@@ -30634,7 +30634,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:d437c8cf14cec7a3b215a4f318c604d9df6062e37a738b35253f52b093f4447f
+              image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -30653,7 +30653,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:eaebbfc805800f6f284b33e75686f137e607dca19370d9db11f1577ccf492fdb
+              image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29835,7 +29835,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:1743c1dade77a0a70ad72d1c06633554f2f70dcde6ae212558bbeb98c14d66a2
+              image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
               name: logger
               ports:
               - containerPort: 8443
@@ -29860,7 +29860,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
               name: pod-printer
               resources:
                 limits:
@@ -29876,7 +29876,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:348371caccd2e36618ec0eddc313ad393307fd5d04cb28e566f7b98216cf7b43
+              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
               name: scan-printer
               resources:
                 limits:
@@ -29941,7 +29941,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
               name: clamsig-puller
               resources:
                 limits:
@@ -29960,7 +29960,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:ccb819c5699318f12f154ae967d4a000eb831c0bc6357523737fca650df9acb8
+              image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
               name: clamd
               resources:
                 limits:
@@ -29984,7 +29984,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:d3baebe489000b930ecd63526ba2ae12478293c1f80b1ed303f62d41c9730618
+              image: quay.io/app-sre/container-info@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
               name: info
               resources:
                 limits:
@@ -30028,7 +30028,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+              image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
               name: watcher
               resources:
                 limits:
@@ -30082,7 +30082,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:7b54c31bc5eff1d3ef048526624c42e656d240d9973e02cc57438d1fdd267c2b
+              image: quay.io/app-sre/watcher@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
               name: scheduler
               resources:
                 limits:
@@ -30116,7 +30116,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:29ee889009b7cbb2e2dbd9a85efab63644a4019e3e5b05113cbe59e72b585995
+              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
               name: init-clamsig-puller
               resources:
                 limits:
@@ -30634,7 +30634,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:d437c8cf14cec7a3b215a4f318c604d9df6062e37a738b35253f52b093f4447f
+              image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -30653,7 +30653,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:eaebbfc805800f6f284b33e75686f137e607dca19370d9db11f1577ccf492fdb
+              image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

Updates the base images for malware scanning and suricata in FedRAMP for CVE patching

### Which Jira/Github issue(s) this PR fixes?

For https://issues.redhat.com/browse/OSD-19389

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
