### PR TITLE
Bump infra machinehealthcheck timeout to 10m

### DIFF
--- a/deploy/osd-machine-api/010-machine-api.srep-infra-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/010-machine-api.srep-infra-healthcheck.MachineHealthCheck.yaml
@@ -17,6 +17,6 @@ spec:
     timeout: "480s"
     status: "False"
   - type:    "Ready"
-    timeout: "480s"
+    timeout: "600s"
     status: "Unknown"
   maxUnhealthy: 2

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28164,7 +28164,7 @@ objects:
           timeout: 480s
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 600s
           status: Unknown
         maxUnhealthy: 2
     - apiVersion: machine.openshift.io/v1beta1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28164,7 +28164,7 @@ objects:
           timeout: 480s
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 600s
           status: Unknown
         maxUnhealthy: 2
     - apiVersion: machine.openshift.io/v1beta1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28164,7 +28164,7 @@ objects:
           timeout: 480s
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 600s
           status: Unknown
         maxUnhealthy: 2
     - apiVersion: machine.openshift.io/v1beta1


### PR DESCRIPTION
### What type of PR is this?
_bug_

Fixes: https://issues.redhat.com/browse/OSD-19449

### What this PR does / why we need it?
Increases the `srep-infra-machinehealthcheck` timeout to 600s, to avoid infra node startup delays.