### PR TITLE
Add prometheus rule to hive prod to create alert for CGAO

### DIFF
--- a/deploy/sre-prometheus/fedramp/hive-prod/100-cgao-inactive-heartbeatmonitor.yaml
+++ b/deploy/sre-prometheus/fedramp/hive-prod/100-cgao-inactive-heartbeatmonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: sre-cgao-inative-heartbeat
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-cgao-inactive-heartbeat
+    rules:
+    - alert: CgaoInactiveHeartbeat
+      expr: cgao_heartbeat_inactive > 0
+      for: 30m
+      labels:
+        severity: critical
+        namespace: "{{ $labels.namespace }}"
+      annotations:
+        message: "The Goalert service for cluster {{ $labels.service_name }} has inactive heartbeatmonitor for 30m and requires SRE action."

--- a/deploy/sre-prometheus/fedramp/hive-prod/config.yaml
+++ b/deploy/sre-prometheus/fedramp/hive-prod/config.yaml
@@ -1,0 +1,15 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/fedramp
+      operator: In
+      values:
+        - "true"
+    - key: ext-managed.openshift.io/hive-shard
+      operator: In
+      values:
+        - "true"
+    - key: api.openshift.com/environment
+      operator: In
+      values:
+        - "production"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35339,6 +35339,51 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-fedramp-hive-prod
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: sre-cgao-inative-heartbeat
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cgao-inactive-heartbeat
+          rules:
+          - alert: CgaoInactiveHeartbeat
+            expr: cgao_heartbeat_inactive > 0
+            for: 30m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: The Goalert service for cluster {{ $labels.service_name }}
+                has inactive heartbeatmonitor for 30m and requires SRE action.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-legacy-ingress
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35339,6 +35339,51 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-fedramp-hive-prod
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: sre-cgao-inative-heartbeat
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cgao-inactive-heartbeat
+          rules:
+          - alert: CgaoInactiveHeartbeat
+            expr: cgao_heartbeat_inactive > 0
+            for: 30m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: The Goalert service for cluster {{ $labels.service_name }}
+                has inactive heartbeatmonitor for 30m and requires SRE action.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-legacy-ingress
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35339,6 +35339,51 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-fedramp-hive-prod
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: ext-managed.openshift.io/hive-shard
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: sre-cgao-inative-heartbeat
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cgao-inactive-heartbeat
+          rules:
+          - alert: CgaoInactiveHeartbeat
+            expr: cgao_heartbeat_inactive > 0
+            for: 30m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              message: The Goalert service for cluster {{ $labels.service_name }}
+                has inactive heartbeatmonitor for 30m and requires SRE action.
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-legacy-ingress
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?
We've created a metric for configure-goalert-operator and we need to create a new alert to let fedramp srep know when there are inactive heartbeatmonitors

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18802

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
