### PR TITLE
Update worker machinehealthcheck timeout to 10m

### DIFF
--- a/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -46,7 +46,7 @@ spec:
     timeout: "480s"
     status: "False"
   - type:    "Ready"
-    timeout: "480s"
+    timeout: "600s"
     status: "Unknown"
   maxUnhealthy: 3
   nodeStartupTimeout: 25m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28215,7 +28215,7 @@ objects:
           timeout: 480s
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 600s
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 25m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28215,7 +28215,7 @@ objects:
           timeout: 480s
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 600s
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 25m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28215,7 +28215,7 @@ objects:
           timeout: 480s
           status: 'False'
         - type: Ready
-          timeout: 480s
+          timeout: 600s
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 25m


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Increases the `srep-worker-machinehealthcheck` timeout to 600s, to avoid worker node startup delays.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-19449

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
