### PR TITLE
Disable second ingress service log on v4.13+

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
+++ b/deploy/sre-prometheus/ocm-agent/legacy-ingress/config.yaml
@@ -2,6 +2,6 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: "Sync"
   matchExpressions:
-  - key: ext-managed.openshift.io/legacy-ingress-support
-    operator: NotIn
-    values: ["false"]
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.8", "4.9", "4.10", "4.11", "4.12"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35796,10 +35796,14 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: ext-managed.openshift.io/legacy-ingress-support
-        operator: NotIn
+      - key: hive.openshift.io/version-major-minor
+        operator: In
         values:
-        - 'false'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35796,10 +35796,14 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: ext-managed.openshift.io/legacy-ingress-support
-        operator: NotIn
+      - key: hive.openshift.io/version-major-minor
+        operator: In
         values:
-        - 'false'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35796,10 +35796,14 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
       matchExpressions:
-      - key: ext-managed.openshift.io/legacy-ingress-support
-        operator: NotIn
+      - key: hive.openshift.io/version-major-minor
+        operator: In
         values:
-        - 'false'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+        - '4.11'
+        - '4.12'
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
There is a request from the BU side to _disable_ the 2nd IC service log automation on version 4.13+, instead of when the new 'managed ingress' feature is enabled.
This pull request makes the SL's `PrometheusRule` align with that idea.

[Discussion](https://redhat-internal.slack.com/archives/CCX9DB894/p1698966021083539) 
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
