### PR TITLE
OSD-19348: Update Dynatrace Workload Monitoring Alerts

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
@@ -1,62 +1,69 @@
-apiVersion: monitoring.rhobs/v1
+apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
     prometheus: sre-dynatrace-workloads
     role: alert-rules
   name: sre-dynatrace-workloads
-  namespace: openshift-observability-dynatrace
+  namespace: openshift-monitoring
 spec:
   groups:
   - name: sre-dynatrace-workloads-failing
     rules:
     - alert: DynatraceMonitoringStackDownSRE
       expr: |
-          sum(hypershift_hostedclusters) > 0 and (
-          kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"} == 0 or
-          kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"} == 0 or
-          kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"} == 0 or
-          kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"} == 0 or
-          kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent", namespace="dynatrace"} == 0 )
+          absent(kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"}) or
+          absent(kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}) or
+          absent(kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"}) or
+          absent(kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}) or
+          absent(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent", namespace="dynatrace"})
       for: 15m
       labels:
         namespace: dynatrace
-        severity: warning
+        severity: critical
       annotations:
-        summary: "Dynatrace Workloads are failing on the Management Cluster"
-        description: "The Dynatrace deployment on the Management Cluster has failed to be deployed for 15 mins"
+        summary: "Dynatrace Workload(s) are absent or have failed to deploy on the Management Cluster"
+        description: |
+          The following Dynatrace Workload(s) are absent or have failed to be deployed the Management Cluster for last 15 mins:
+          {{ if $labels.deployment }} {{$labels.deployment}} Deployment {{end}}
+          {{ if $labels.daemonset }} {{ $labels.daemonset }} Daemonset {{end}}
+          {{ if $labels.statefulset }} {{$labels.statefulset}} Statefulset {{end}}
+        SOP : https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceMonitoringStackDownSRE.md
 
   - name: sre-dynatrace-monitoring-stack-degraded
     rules:
     - alert: DynatraceOperatorDegradedSRE
       expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator", namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-      for: 10m
+      for: 15m
       labels:
         namespace: dynatrace
         severity: warning
       annotations:
         summary: "The Dynatrace Operator is Degraded"
-        description: "{{$value}} pods are not running out of total pods for the Dynatrace Operator"
+        description: "{{$value}} replicas are not running out of total required replicas for the Dynatrace Operator"
+        SOP : https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOperatorDegradedSRE.md
   
     - alert: DynatraceWebhookDegradedSRE
       expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook", namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-      for: 10m
+      for: 15m
       labels:
         namespace: dynatrace
         severity: warning
       annotations:
         summary: "Dynatrace Webhook is Degraded"
-        description: "{{$value}} pods are not running out of total pods for the Dynatrace Webhook"
+        description: "{{$value}} replicas are not running out of total required replicas for the Dynatrace Webhook"
+        SOP : https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceWebhookDegradedSRE.md
 
     - alert: DynatraceOpenTelemetryCollectorDegradedSRE
-      expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+      expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector", namespace="dynatrace"}) without (deployment, instance, pod)) > 0
       for: 15m
       labels:
         namespace: dynatrace
         severity: warning
       annotations:
         summary: "Dynatrace OTEL Collector is Degraded"
-        description: "{{$value}} pods are not running out of total pods for the OpenTelemetry Dynatrace Collector"
+        description: "{{$value}} replicas are not running out of total required replicas for the OpenTelemetry Dynatrace Collector"
+        SOP : https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOpenTelemetryCollectorDegradedSRE.md
 
     - alert: DynatraceActiveGateDegradedSRE
       expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate", namespace="dynatrace"}) without (deployment, instance, pod)) > 0
@@ -66,7 +73,8 @@ spec:
         severity: warning
       annotations:
         summary: "Dynatrace ActiveGate is Degraded"
-        description: "{{$value}} pods are not running out of total pods for Dynatrace ActiveGate"
+        description: "{{$value}} replicas are not running out of total required replicas for Dynatrace ActiveGate"
+        SOP : https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceActiveGateDegradedSRE.md
 
     - alert: DynatraceOneAgentDegradedSRE
       expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent", namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent", namespace="dynatrace"}) without (daemonset, instance, pod) > 0
@@ -76,7 +84,8 @@ spec:
         severity: warning
       annotations:
         summary: "Dynatrace OneAgent is Degraded"
-        description: "{{$value}} pods are not running out of total pods for Dynatrace OneAgent"  
+        description: "{{$value}} replicas are not running out of total required replicas for Dynatrace OneAgent" 
+        SOP : https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOneAgentDegradedSRE.md 
 
     - alert: DynatracePodRestartsStuckSRE
       expr: kube_pod_container_status_restarts_total{namespace="dynatrace"} > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m]) > 0
@@ -87,4 +96,5 @@ spec:
       annotations:
         summary: "Pod Restarts Stuck Alert"
         description: "At least one pod in the 'dynatrace' namespace has been stuck in restarts for the last 15 minutes."
+        SOP : https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatracePodRestartsStuckSRE.md
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35448,83 +35448,94 @@ objects:
         - ibm-infra
     resourceApplyMode: Sync
     resources:
-    - apiVersion: monitoring.rhobs/v1
+    - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: sre-dynatrace-workloads
           role: alert-rules
         name: sre-dynatrace-workloads
-        namespace: openshift-observability-dynatrace
+        namespace: openshift-monitoring
       spec:
         groups:
         - name: sre-dynatrace-workloads-failing
           rules:
           - alert: DynatraceMonitoringStackDownSRE
-            expr: 'sum(hypershift_hostedclusters) > 0 and (
+            expr: 'absent(kube_deployment_status_replicas{deployment="dynatrace-operator",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"}
-              == 0 or
+              absent(kube_deployment_status_replicas{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}
-              == 0 or
+              absent(kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
-              namespace="dynatrace"} == 0 or
+              absent(kube_statefulset_status_replicas{statefulset=~".*-activegate",
+              namespace="dynatrace"}) or
 
-              kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}
-              == 0 or
-
-              kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
-              namespace="dynatrace"} == 0 )
+              absent(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"})
 
               '
             for: 15m
             labels:
               namespace: dynatrace
-              severity: warning
+              severity: critical
             annotations:
-              summary: Dynatrace Workloads are failing on the Management Cluster
-              description: The Dynatrace deployment on the Management Cluster has
-                failed to be deployed for 15 mins
+              summary: Dynatrace Workload(s) are absent or have failed to deploy on
+                the Management Cluster
+              description: 'The following Dynatrace Workload(s) are absent or have
+                failed to be deployed the Management Cluster for last 15 mins:
+
+                {{ if $labels.deployment }} {{$labels.deployment}} Deployment {{end}}
+
+                {{ if $labels.daemonset }} {{ $labels.daemonset }} Daemonset {{end}}
+
+                {{ if $labels.statefulset }} {{$labels.statefulset}} Statefulset {{end}}
+
+                '
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceMonitoringStackDownSRE.md
         - name: sre-dynatrace-monitoring-stack-degraded
           rules:
           - alert: DynatraceOperatorDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator",
               namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-            for: 10m
+            for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: The Dynatrace Operator is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the Dynatrace Operator'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the Dynatrace Operator'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOperatorDegradedSRE.md
           - alert: DynatraceWebhookDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook",
               namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-            for: 10m
+            for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: Dynatrace Webhook is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the Dynatrace Webhook'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the Dynatrace Webhook'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceWebhookDegradedSRE.md
           - alert: DynatraceOpenTelemetryCollectorDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector",
-              namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
             for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: Dynatrace OTEL Collector is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the OpenTelemetry Dynatrace Collector'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the OpenTelemetry Dynatrace Collector'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOpenTelemetryCollectorDegradedSRE.md
           - alert: DynatraceActiveGateDegradedSRE
             expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate",
@@ -35535,8 +35546,9 @@ objects:
               severity: warning
             annotations:
               summary: Dynatrace ActiveGate is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                Dynatrace ActiveGate'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for Dynatrace ActiveGate'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceActiveGateDegradedSRE.md
           - alert: DynatraceOneAgentDegradedSRE
             expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
               namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent",
@@ -35547,8 +35559,9 @@ objects:
               severity: warning
             annotations:
               summary: Dynatrace OneAgent is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                Dynatrace OneAgent'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for Dynatrace OneAgent'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOneAgentDegradedSRE.md
           - alert: DynatracePodRestartsStuckSRE
             expr: kube_pod_container_status_restarts_total{namespace="dynatrace"}
               > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m])
@@ -35561,6 +35574,7 @@ objects:
               summary: Pod Restarts Stuck Alert
               description: At least one pod in the 'dynatrace' namespace has been
                 stuck in restarts for the last 15 minutes.
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatracePodRestartsStuckSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35448,83 +35448,94 @@ objects:
         - ibm-infra
     resourceApplyMode: Sync
     resources:
-    - apiVersion: monitoring.rhobs/v1
+    - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: sre-dynatrace-workloads
           role: alert-rules
         name: sre-dynatrace-workloads
-        namespace: openshift-observability-dynatrace
+        namespace: openshift-monitoring
       spec:
         groups:
         - name: sre-dynatrace-workloads-failing
           rules:
           - alert: DynatraceMonitoringStackDownSRE
-            expr: 'sum(hypershift_hostedclusters) > 0 and (
+            expr: 'absent(kube_deployment_status_replicas{deployment="dynatrace-operator",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"}
-              == 0 or
+              absent(kube_deployment_status_replicas{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}
-              == 0 or
+              absent(kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
-              namespace="dynatrace"} == 0 or
+              absent(kube_statefulset_status_replicas{statefulset=~".*-activegate",
+              namespace="dynatrace"}) or
 
-              kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}
-              == 0 or
-
-              kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
-              namespace="dynatrace"} == 0 )
+              absent(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"})
 
               '
             for: 15m
             labels:
               namespace: dynatrace
-              severity: warning
+              severity: critical
             annotations:
-              summary: Dynatrace Workloads are failing on the Management Cluster
-              description: The Dynatrace deployment on the Management Cluster has
-                failed to be deployed for 15 mins
+              summary: Dynatrace Workload(s) are absent or have failed to deploy on
+                the Management Cluster
+              description: 'The following Dynatrace Workload(s) are absent or have
+                failed to be deployed the Management Cluster for last 15 mins:
+
+                {{ if $labels.deployment }} {{$labels.deployment}} Deployment {{end}}
+
+                {{ if $labels.daemonset }} {{ $labels.daemonset }} Daemonset {{end}}
+
+                {{ if $labels.statefulset }} {{$labels.statefulset}} Statefulset {{end}}
+
+                '
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceMonitoringStackDownSRE.md
         - name: sre-dynatrace-monitoring-stack-degraded
           rules:
           - alert: DynatraceOperatorDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator",
               namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-            for: 10m
+            for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: The Dynatrace Operator is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the Dynatrace Operator'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the Dynatrace Operator'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOperatorDegradedSRE.md
           - alert: DynatraceWebhookDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook",
               namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-            for: 10m
+            for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: Dynatrace Webhook is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the Dynatrace Webhook'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the Dynatrace Webhook'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceWebhookDegradedSRE.md
           - alert: DynatraceOpenTelemetryCollectorDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector",
-              namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
             for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: Dynatrace OTEL Collector is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the OpenTelemetry Dynatrace Collector'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the OpenTelemetry Dynatrace Collector'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOpenTelemetryCollectorDegradedSRE.md
           - alert: DynatraceActiveGateDegradedSRE
             expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate",
@@ -35535,8 +35546,9 @@ objects:
               severity: warning
             annotations:
               summary: Dynatrace ActiveGate is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                Dynatrace ActiveGate'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for Dynatrace ActiveGate'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceActiveGateDegradedSRE.md
           - alert: DynatraceOneAgentDegradedSRE
             expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
               namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent",
@@ -35547,8 +35559,9 @@ objects:
               severity: warning
             annotations:
               summary: Dynatrace OneAgent is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                Dynatrace OneAgent'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for Dynatrace OneAgent'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOneAgentDegradedSRE.md
           - alert: DynatracePodRestartsStuckSRE
             expr: kube_pod_container_status_restarts_total{namespace="dynatrace"}
               > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m])
@@ -35561,6 +35574,7 @@ objects:
               summary: Pod Restarts Stuck Alert
               description: At least one pod in the 'dynatrace' namespace has been
                 stuck in restarts for the last 15 minutes.
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatracePodRestartsStuckSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35448,83 +35448,94 @@ objects:
         - ibm-infra
     resourceApplyMode: Sync
     resources:
-    - apiVersion: monitoring.rhobs/v1
+    - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: sre-dynatrace-workloads
           role: alert-rules
         name: sre-dynatrace-workloads
-        namespace: openshift-observability-dynatrace
+        namespace: openshift-monitoring
       spec:
         groups:
         - name: sre-dynatrace-workloads-failing
           rules:
           - alert: DynatraceMonitoringStackDownSRE
-            expr: 'sum(hypershift_hostedclusters) > 0 and (
+            expr: 'absent(kube_deployment_status_replicas{deployment="dynatrace-operator",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="dynatrace-operator", namespace="dynatrace"}
-              == 0 or
+              absent(kube_deployment_status_replicas{deployment="dynatrace-webhook",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="dynatrace-webhook", namespace="dynatrace"}
-              == 0 or
+              absent(kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
+              namespace="dynatrace"}) or
 
-              kube_deployment_status_replicas{deployment="opentelemetry-dynatrace-collector",
-              namespace="dynatrace"} == 0 or
+              absent(kube_statefulset_status_replicas{statefulset=~".*-activegate",
+              namespace="dynatrace"}) or
 
-              kube_statefulset_status_replicas{statefulset=~".*-activegate", namespace="dynatrace"}
-              == 0 or
-
-              kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
-              namespace="dynatrace"} == 0 )
+              absent(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
+              namespace="dynatrace"})
 
               '
             for: 15m
             labels:
               namespace: dynatrace
-              severity: warning
+              severity: critical
             annotations:
-              summary: Dynatrace Workloads are failing on the Management Cluster
-              description: The Dynatrace deployment on the Management Cluster has
-                failed to be deployed for 15 mins
+              summary: Dynatrace Workload(s) are absent or have failed to deploy on
+                the Management Cluster
+              description: 'The following Dynatrace Workload(s) are absent or have
+                failed to be deployed the Management Cluster for last 15 mins:
+
+                {{ if $labels.deployment }} {{$labels.deployment}} Deployment {{end}}
+
+                {{ if $labels.daemonset }} {{ $labels.daemonset }} Daemonset {{end}}
+
+                {{ if $labels.statefulset }} {{$labels.statefulset}} Statefulset {{end}}
+
+                '
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceMonitoringStackDownSRE.md
         - name: sre-dynatrace-monitoring-stack-degraded
           rules:
           - alert: DynatraceOperatorDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-operator",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-operator",
               namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-            for: 10m
+            for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: The Dynatrace Operator is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the Dynatrace Operator'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the Dynatrace Operator'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOperatorDegradedSRE.md
           - alert: DynatraceWebhookDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="dynatrace-webhook",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="dynatrace-webhook",
               namespace="dynatrace"}) without (deployment, instance, pod)) > 0
-            for: 10m
+            for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: Dynatrace Webhook is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the Dynatrace Webhook'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the Dynatrace Webhook'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceWebhookDegradedSRE.md
           - alert: DynatraceOpenTelemetryCollectorDegradedSRE
             expr: (sum(kube_deployment_spec_replicas{deployment="opentelemetry-dynatrace-collector",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_deployment_status_replicas_available{deployment="opentelemetry-dynatrace-collector",
-              namespace="dynatrace"}) without (deployment, instance, pod)) == 0
+              namespace="dynatrace"}) without (deployment, instance, pod)) > 0
             for: 15m
             labels:
               namespace: dynatrace
               severity: warning
             annotations:
               summary: Dynatrace OTEL Collector is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                the OpenTelemetry Dynatrace Collector'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for the OpenTelemetry Dynatrace Collector'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOpenTelemetryCollectorDegradedSRE.md
           - alert: DynatraceActiveGateDegradedSRE
             expr: (sum(kube_statefulset_status_replicas{statefulset=~".*-activegate",
               namespace="dynatrace"}) without (deployment, instance, pod)) - (sum(kube_statefulset_status_replicas_ready{statefulset=~".*-activegate",
@@ -35535,8 +35546,9 @@ objects:
               severity: warning
             annotations:
               summary: Dynatrace ActiveGate is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                Dynatrace ActiveGate'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for Dynatrace ActiveGate'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceActiveGateDegradedSRE.md
           - alert: DynatraceOneAgentDegradedSRE
             expr: sum(kube_daemonset_status_desired_number_scheduled{daemonset=~".*-oneagent",
               namespace="dynatrace"}) without (daemonset, instance, pod) - sum(kube_daemonset_status_number_ready{daemonset=~".*-oneagent",
@@ -35547,8 +35559,9 @@ objects:
               severity: warning
             annotations:
               summary: Dynatrace OneAgent is Degraded
-              description: '{{$value}} pods are not running out of total pods for
-                Dynatrace OneAgent'
+              description: '{{$value}} replicas are not running out of total required
+                replicas for Dynatrace OneAgent'
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatraceOneAgentDegradedSRE.md
           - alert: DynatracePodRestartsStuckSRE
             expr: kube_pod_container_status_restarts_total{namespace="dynatrace"}
               > 0 and increase(kube_pod_container_status_restarts_total{namespace="dynatrace"}[15m])
@@ -35561,6 +35574,7 @@ objects:
               summary: Pod Restarts Stuck Alert
               description: At least one pod in the 'dynatrace' namespace has been
                 stuck in restarts for the last 15 minutes.
+              SOP: https://github.com/openshift/ops-sop/blob/master/dynatrace/alerts/DynatracePodRestartsStuckSRE.md
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR updates the `100-dynatrace-workloads-monitoring` i.e Dynatrace Workload Monitoring based on discussions and validations tracked in the [osd-19348](https://issues.redhat.com//browse/osd-19348)

- Changes the apiVersion from OBO to CAMO
- Fixes OTELDegraded Alert Condition
- Updates expression for Dynatrace Monitoring Stack Down Alert as well as increases the severity to critical
- Add links of SOP for the alerts

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_[OSD-19348](https://issues.redhat.com//browse/OSD-19348)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
