### PR TITLE
No more customer kube-node-unscheduleables

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -60,7 +60,7 @@ spec:
       summary: Worker node is predicted to run out of inodes in 4 hours
     - activeBody: |-
         Your cluster requires you to take action. A workload is been preventing a machine from deleting. The name of the workload can be found by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not taking action can result in higher compute costs as the instance won't terminate until the workload has been moved.
-      name: CustomerWorkloadPrecventingDrain
+      name: CustomerWorkloadPreventingDrain
       resendWait: 1
       severity: Error
       summary: Workload preventing machine deletion

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -58,3 +58,9 @@ spec:
       resendWait: 24
       severity: Info
       summary: Worker node is predicted to run out of inodes in 4 hours
+    - activeBody: |-
+        Your cluster requires you to take action. A workload is been preventing a machine from deleting. The name of the workload can be found by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not taking action can result in higher compute costs as the instance won't terminate until the workload has been moved.
+      name: CustomerWorkloadPrecventingDrain
+      resendWait: 1
+      severity: Error
+      summary: Workload preventing machine deletion

--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -12,9 +12,24 @@ spec:
     rules:
     - alert: KubeNodeUnschedulableSRE
       expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-      for: 60m
+      for: 61m
       labels:
         severity: critical
         namespace: openshift-monitoring
       annotations:
         message: "The node {{ $labels.node }} has been unschedulable for more than an hour."
+    - alert: ControlPlaneNodeUnschedulableSRE
+      expr: |-
+        (
+        kube_node_spec_unschedulable > 0
+        unless
+        ignoring(node,container,endpoint,job,namespace,service)
+        sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0
+        )
+        and on (node) (kube_node_role{role=~"infra|control-plane|master"})
+      for: 60m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        message: "The managed node {{ $labels.node }} has been unschedulable for more than an hour."

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -84,3 +84,31 @@ spec:
         send_managed_notification: "true"
       annotations:
         message: "Filesystem is predicted to run out of inodes within the next 4 hours."
+    - alert: CustomerWorkloadPreventingDrainSRE
+      # This alert will fire when a node is unscheduleable and is failing to drain for an extended period of time based on a customer workload that's failing to drain
+      # This alert will NOT fire if there is an ongoing upgrade, or if the node is not deleting.
+      expr: |-
+        (
+          (
+            kube_node_spec_unschedulable > 0
+            unless
+            ignoring(node,container,endpoint,job,namespace,service)
+            sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0
+          )
+          * on (node)
+          group_right ()group by (node)
+            (pods_preventing_node_drain)
+        )
+        * on (node)
+        group_left ()group by (node)
+          (kube_node_role{role!~"infra|control-plane|master"})
+        unless group by(node)
+          (kube_node_role{role=~"infra|control-plane|master"})
+      for: 30m # KubeNodeUnscheduleableSRE fires at 1h, but since this is specific to customer workloads we can shorten the feedback loop here.
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: CustomerWorkloadPreventingDrain
+        send_managed_notification: "true"
+      annotations:
+        message: "A non-openshift workload is preventing a node from draining."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34261,13 +34261,34 @@ objects:
             expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
               sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-            for: 60m
+            for: 61m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.
+          - alert: ControlPlaneNodeUnschedulableSRE
+            expr: '(
+
+              kube_node_spec_unschedulable > 0
+
+              unless
+
+              ignoring(node,container,endpoint,job,namespace,service)
+
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0
+
+              )
+
+              and on (node) (kube_node_role{role=~"infra|control-plane|master"})'
+            for: 60m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The managed node {{ $labels.node }} has been unschedulable
+                for more than an hour.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -35782,6 +35803,21 @@ objects:
             annotations:
               message: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+          - alert: CustomerWorkloadPreventingDrainSRE
+            expr: "(\n  (\n    kube_node_spec_unschedulable > 0\n    unless\n    ignoring(node,container,endpoint,job,namespace,service)\n\
+              \    sum(mapi_machine_set_status_replicas{name=~\".*upgrade$\"}) > 0\n\
+              \  )\n  * on (node)\n  group_right ()group by (node)\n    (pods_preventing_node_drain)\n\
+              )\n* on (node)\ngroup_left ()group by (node)\n  (kube_node_role{role!~\"\
+              infra|control-plane|master\"})\nunless group by(node)\n  (kube_node_role{role=~\"\
+              infra|control-plane|master\"})"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: CustomerWorkloadPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: A non-openshift workload is preventing a node from draining.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22053,7 +22053,7 @@ objects:
             by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
             taking action can result in higher compute costs as the instance won't
             terminate until the workload has been moved.
-          name: CustomerWorkloadPrecventingDrain
+          name: CustomerWorkloadPreventingDrain
           resendWait: 1
           severity: Error
           summary: Workload preventing machine deletion

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22048,6 +22048,15 @@ objects:
           resendWait: 24
           severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
+        - activeBody: Your cluster requires you to take action. A workload is been
+            preventing a machine from deleting. The name of the workload can be found
+            by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
+            taking action can result in higher compute costs as the instance won't
+            terminate until the workload has been moved.
+          name: CustomerWorkloadPrecventingDrain
+          resendWait: 1
+          severity: Error
+          summary: Workload preventing machine deletion
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34261,13 +34261,34 @@ objects:
             expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
               sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-            for: 60m
+            for: 61m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.
+          - alert: ControlPlaneNodeUnschedulableSRE
+            expr: '(
+
+              kube_node_spec_unschedulable > 0
+
+              unless
+
+              ignoring(node,container,endpoint,job,namespace,service)
+
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0
+
+              )
+
+              and on (node) (kube_node_role{role=~"infra|control-plane|master"})'
+            for: 60m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The managed node {{ $labels.node }} has been unschedulable
+                for more than an hour.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -35782,6 +35803,21 @@ objects:
             annotations:
               message: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+          - alert: CustomerWorkloadPreventingDrainSRE
+            expr: "(\n  (\n    kube_node_spec_unschedulable > 0\n    unless\n    ignoring(node,container,endpoint,job,namespace,service)\n\
+              \    sum(mapi_machine_set_status_replicas{name=~\".*upgrade$\"}) > 0\n\
+              \  )\n  * on (node)\n  group_right ()group by (node)\n    (pods_preventing_node_drain)\n\
+              )\n* on (node)\ngroup_left ()group by (node)\n  (kube_node_role{role!~\"\
+              infra|control-plane|master\"})\nunless group by(node)\n  (kube_node_role{role=~\"\
+              infra|control-plane|master\"})"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: CustomerWorkloadPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: A non-openshift workload is preventing a node from draining.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22053,7 +22053,7 @@ objects:
             by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
             taking action can result in higher compute costs as the instance won't
             terminate until the workload has been moved.
-          name: CustomerWorkloadPrecventingDrain
+          name: CustomerWorkloadPreventingDrain
           resendWait: 1
           severity: Error
           summary: Workload preventing machine deletion

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22048,6 +22048,15 @@ objects:
           resendWait: 24
           severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
+        - activeBody: Your cluster requires you to take action. A workload is been
+            preventing a machine from deleting. The name of the workload can be found
+            by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
+            taking action can result in higher compute costs as the instance won't
+            terminate until the workload has been moved.
+          name: CustomerWorkloadPrecventingDrain
+          resendWait: 1
+          severity: Error
+          summary: Workload preventing machine deletion
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34261,13 +34261,34 @@ objects:
             expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
               or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
               sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-            for: 60m
+            for: 61m
             labels:
               severity: critical
               namespace: openshift-monitoring
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.
+          - alert: ControlPlaneNodeUnschedulableSRE
+            expr: '(
+
+              kube_node_spec_unschedulable > 0
+
+              unless
+
+              ignoring(node,container,endpoint,job,namespace,service)
+
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0
+
+              )
+
+              and on (node) (kube_node_role{role=~"infra|control-plane|master"})'
+            for: 60m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: The managed node {{ $labels.node }} has been unschedulable
+                for more than an hour.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -35782,6 +35803,21 @@ objects:
             annotations:
               message: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+          - alert: CustomerWorkloadPreventingDrainSRE
+            expr: "(\n  (\n    kube_node_spec_unschedulable > 0\n    unless\n    ignoring(node,container,endpoint,job,namespace,service)\n\
+              \    sum(mapi_machine_set_status_replicas{name=~\".*upgrade$\"}) > 0\n\
+              \  )\n  * on (node)\n  group_right ()group by (node)\n    (pods_preventing_node_drain)\n\
+              )\n* on (node)\ngroup_left ()group by (node)\n  (kube_node_role{role!~\"\
+              infra|control-plane|master\"})\nunless group by(node)\n  (kube_node_role{role=~\"\
+              infra|control-plane|master\"})"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: CustomerWorkloadPreventingDrain
+              send_managed_notification: 'true'
+            annotations:
+              message: A non-openshift workload is preventing a node from draining.
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22053,7 +22053,7 @@ objects:
             by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
             taking action can result in higher compute costs as the instance won't
             terminate until the workload has been moved.
-          name: CustomerWorkloadPrecventingDrain
+          name: CustomerWorkloadPreventingDrain
           resendWait: 1
           severity: Error
           summary: Workload preventing machine deletion

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22048,6 +22048,15 @@ objects:
           resendWait: 24
           severity: Info
           summary: Worker node is predicted to run out of inodes in 4 hours
+        - activeBody: Your cluster requires you to take action. A workload is been
+            preventing a machine from deleting. The name of the workload can be found
+            by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
+            taking action can result in higher compute costs as the instance won't
+            terminate until the workload has been moved.
+          name: CustomerWorkloadPrecventingDrain
+          resendWait: 1
+          severity: Error
+          summary: Workload preventing machine deletion
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:


### PR DESCRIPTION
Send Customer KubeNodeUnscheduleable Alerts to OCM Agent Operator and ensure infra/control plane alerts are handled.

I've kept the original KubeNodeUnscheduleable alert around for now, but it should fire 1m after the ControlPlane version of this alert, so that we get the Control Plane version first and the KubeNodeUnscheduleable gets grouped into that PD alert - as we gain confidence that this alert is not missing anything then we can remove the original KubeNodeUnscheuldeable.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

Feature

### What this PR does / why we need it?

Send Customer KubeNodeUnscheduleable Alerts to OCM Agent Operator and ensure infra/control plane alerts are handled.

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-18411](https://issues.redhat.com/browse/OSD-18411)_

### Special notes for your reviewer:

I've kept the original KubeNodeUnscheduleable alert around for now, but it should fire 1m after the ControlPlane version of this alert, so that we get the Control Plane version first and the KubeNodeUnscheduleable gets grouped into that PD alert - as we gain confidence that this alert is not missing anything then we can remove the original KubeNodeUnscheuldeable.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
