### PR TITLE
updates muo config for FR to add stage

### DIFF
--- a/deploy/osd-fedramp-managed-upgrade-operator-config/int/config.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/int/config.yaml
@@ -11,5 +11,7 @@ selectorSyncSet:
     - key: api.openshift.com/environment
       operator: In
       values:
-        - "integration"        
+        - "integration"
+        - "staging"
+        - "stage"  
   resourceApplyMode: Upsert

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27268,6 +27268,8 @@ objects:
         operator: In
         values:
         - integration
+        - staging
+        - stage
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27268,6 +27268,8 @@ objects:
         operator: In
         values:
         - integration
+        - staging
+        - stage
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27268,6 +27268,8 @@ objects:
         operator: In
         values:
         - integration
+        - staging
+        - stage
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

feature

### What this PR does / why we need it?

Updates MUO in FedRAMP staging to use OCM instead of local configs. This has been validated in Integration as part of testing OCM-1606, and the fix has been rolled out to stage. This will enable upgrading clusters using rosa in stage

### Which Jira/Github issue(s) this PR fixes?

For [OSD-18886](https://issues.redhat.com//browse/OSD-18886)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
