### PR TITLE
[OSD-18386] Only fire UpgradeConfigValidationFailedSRE after two hours of validation failure

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -12,8 +12,8 @@ spec:
     rules:
     - alert: UpgradeConfigValidationFailedSRE
       # Alert if the UpgradeConfig validation check metric has been set for a ten-minute average window
-      expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m]) == 1
-      for: 10m
+      expr: upgradeoperator_upgradeconfig_validation_failed == 1
+      for: 2h
       labels:
         severity: critical
         namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34084,9 +34084,8 @@ objects:
         - name: sre-managed-upgrade-operator-alerts
           rules:
           - alert: UpgradeConfigValidationFailedSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m])
-              == 1
-            for: 10m
+            expr: upgradeoperator_upgradeconfig_validation_failed == 1
+            for: 2h
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34084,9 +34084,8 @@ objects:
         - name: sre-managed-upgrade-operator-alerts
           rules:
           - alert: UpgradeConfigValidationFailedSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m])
-              == 1
-            for: 10m
+            expr: upgradeoperator_upgradeconfig_validation_failed == 1
+            for: 2h
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34084,9 +34084,8 @@ objects:
         - name: sre-managed-upgrade-operator-alerts
           rules:
           - alert: UpgradeConfigValidationFailedSRE
-            expr: avg_over_time(upgradeoperator_upgradeconfig_validation_failed[10m])
-              == 1
-            for: 10m
+            expr: upgradeoperator_upgradeconfig_validation_failed == 1
+            for: 2h
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

- Increase the time it takes until an UpgradeConfig validation issue alerts primary.
- Rewrite the alerting rule to make it clearer when it triggers the alert
  - Previously, the alert triggered after 30 minutes, which isn't really clear from the way the rule is written

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-18386](https://issues.redhat.com/browse/OSD-18386)_

### Validation

- Validated new rule with the following prometheus unit test case:

```yaml
rule_files:
  - rules.yml
evaluation_interval: 1m
tests:
  - interval: 1m
    input_series:
      - series: upgradeoperator_upgradeconfig_validation_failed
        # 20 minutes off, 40 minutes on, 10 minutes off, 3 hours on
        # Alert should only fire at the end
        values: 0x20 1x40 0x10 1x180

    alert_rule_test:
        # check alert not firing
      - eval_time: 20m
        alertname: UpgradeConfigValidationFailedSRE
        exp_alerts:
      - eval_time: 60m
        alertname: UpgradeConfigValidationFailedSRE
        exp_alerts:
      - eval_time: 200m
        alertname: UpgradeConfigValidationFailedSRE
        exp_alerts:
          - exp_annotations:
              summary: "Upgrade config validation failed"
```
