### PR TITLE
OSD-19663: drop CSRPendingLongDurationSRE from critical to warning

### DIFF
--- a/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-pending-csr.PrometheusRule.yaml
@@ -17,7 +17,7 @@ spec:
           expr: sum(mapi_current_pending_csr) > 1
           for: 15m
           labels:
-            severity: critical
+            severity: warning
             namespace: openshift-monitoring
           annotations:
             message: "MAPI CSR requests have been pending for more then 15 minutes. This can indicate that orphaned VMs are being created and requires immeditate remediation."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34363,7 +34363,7 @@ objects:
             expr: sum(mapi_current_pending_csr) > 1
             for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: MAPI CSR requests have been pending for more then 15 minutes.

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34363,7 +34363,7 @@ objects:
             expr: sum(mapi_current_pending_csr) > 1
             for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: MAPI CSR requests have been pending for more then 15 minutes.

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34363,7 +34363,7 @@ objects:
             expr: sum(mapi_current_pending_csr) > 1
             for: 15m
             labels:
-              severity: critical
+              severity: warning
               namespace: openshift-monitoring
             annotations:
               message: MAPI CSR requests have been pending for more then 15 minutes.


### PR DESCRIPTION
### What type of PR is this?
change

### What this PR does / why we need it?
This PR drops CSRPendingLongDurationSRE's severity to warning, disabling the pages from it.

### Which Jira/Github issue(s) this PR fixes?

_Fixes https://issues.redhat.com/browse/OSD-19663_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
