### PR TITLE
WIP OSD-17975 : Revoke openshift-config/user-ca-bundle rbac permission

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -419,6 +419,23 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-srep
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-srep-user-ca-configmap
+                            namespace: openshift-config
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resourceNames:
+                                - user-ca-bundle
+                              resources:
+                                - configmaps
+                              verbs:
+                                - ""
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/backplane/srep/50-srep-user-ca-configmap.Role.yml
+++ b/deploy/backplane/srep/50-srep-user-ca-configmap.Role.yml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-srep-user-ca-configmap
+  namespace: openshift-config
+rules:
+# can list user-ca-bundle config map
+- apiGroups:
+  - ""
+  resourceNames:
+  - user-ca-bundle
+  resources:
+  - configmaps
+  verbs:
+  - ""

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3059,6 +3059,23 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-user-ca-configmap
+                    namespace: openshift-config
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - user-ca-bundle
+                    resources:
+                    - configmaps
+                    verbs:
+                    - ''
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -19585,6 +19602,20 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-pcap-collector
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-user-ca-configmap
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resourceNames:
+        - user-ca-bundle
+        resources:
+        - configmaps
+        verbs:
+        - ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3059,6 +3059,23 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-user-ca-configmap
+                    namespace: openshift-config
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - user-ca-bundle
+                    resources:
+                    - configmaps
+                    verbs:
+                    - ''
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -19585,6 +19602,20 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-pcap-collector
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-user-ca-configmap
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resourceNames:
+        - user-ca-bundle
+        resources:
+        - configmaps
+        verbs:
+        - ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3059,6 +3059,23 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-srep
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-srep-user-ca-configmap
+                    namespace: openshift-config
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resourceNames:
+                    - user-ca-bundle
+                    resources:
+                    - configmaps
+                    verbs:
+                    - ''
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -19585,6 +19602,20 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-srep-pcap-collector
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-srep-user-ca-configmap
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resourceNames:
+        - user-ca-bundle
+        resources:
+        - configmaps
+        verbs:
+        - ''
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature 

### What this PR does / why we need it?
Revoke cm/user-ca-bundle permission in openshift-config NS 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-17975
_Fixes #_

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
