### PR TITLE
Remove invalid permission s3:GetBucketReplication

### DIFF
--- a/resources/sts/4.14/sts_installer_core_permission_policy.json
+++ b/resources/sts/4.14/sts_installer_core_permission_policy.json
@@ -130,7 +130,6 @@
 		    "s3:GetBucketLogging",
 		    "s3:GetBucketObjectLockConfiguration",
 		    "s3:GetBucketPolicy",
-		    "s3:GetBucketReplication",
 		    "s3:GetBucketRequestPayment",
 		    "s3:GetBucketTagging",
 		    "s3:GetBucketVersioning",

--- a/resources/sts/4.14/sts_installer_permission_policy.json
+++ b/resources/sts/4.14/sts_installer_permission_policy.json
@@ -156,7 +156,6 @@
                 "s3:GetBucketLogging",
                 "s3:GetBucketObjectLockConfiguration",
                 "s3:GetBucketPolicy",
-                "s3:GetBucketReplication",
                 "s3:GetBucketRequestPayment",
                 "s3:GetBucketTagging",
                 "s3:GetBucketVersioning",


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This permission does not exist in AWS. We've been asking for it since 4.10, but if you use IAM Access Analyzer AWS will happily tell you that:

> Invalid Action: The action s3:GetBucketReplication does not exist. Did you mean s3:GetReplicationConfiguration? The API called GetBucketReplication authorizes against the IAM action s3:GetReplicationConfiguration.

Since we aren't going to refer to older 4.10-4.13 policies anymore I didn't update them in this PR, but am happy to do so if we think that's best.

### Which Jira/Github issue(s) this PR fixes?
[OSD-19685](https://issues.redhat.com//browse/OSD-19685)

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster