### PR TITLE
Restrict iam:PassRole for classic 4.14

### DIFF
--- a/resources/sts/4.14/openshift_machine_api_aws_cloud_credentials_policy.json
+++ b/resources/sts/4.14/openshift_machine_api_aws_cloud_credentials_policy.json
@@ -2,6 +2,21 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "PassRoleToNodes",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": [
+            "ec2.amazonaws.com"
+          ]
+        }
+      }
+    },
+    {
       "Effect": "Allow",
       "Action": [
         "ec2:CreateTags",
@@ -23,7 +38,6 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:RegisterTargets",
         "elasticloadbalancing:DeregisterTargets",
-        "iam:PassRole",
         "iam:CreateServiceLinkedRole"
       ],
       "Resource": "*"

--- a/resources/sts/4.14/sts_installer_core_permission_policy.json
+++ b/resources/sts/4.14/sts_installer_core_permission_policy.json
@@ -1,6 +1,24 @@
 {
     "Version": "2012-10-17",
     "Statement": [
+		{
+			"Sid": "PassRoleToNodes",
+			"Action": [
+				"iam:PassRole"
+			],
+			"Effect": "Allow",
+			"Resource": [
+				"arn:*:iam::*:role/*-ControlPlane-Role",
+				"arn:*:iam::*:role/*-Worker-Role"
+			],
+			"Condition": {
+				"StringEquals": {
+					"iam:PassedToService": [
+						"ec2.amazonaws.com"
+					]
+				}
+			}
+		},
         {
             "Effect": "Allow",
             "Action": [
@@ -103,7 +121,6 @@
 		    "iam:ListRoles",
 		    "iam:ListUserPolicies",
 		    "iam:ListUsers",
-		    "iam:PassRole",
 		    "iam:RemoveRoleFromInstanceProfile",
 		    "iam:SimulatePrincipalPolicy",
 		    "iam:TagRole",

--- a/resources/sts/4.14/sts_installer_permission_policy.json
+++ b/resources/sts/4.14/sts_installer_permission_policy.json
@@ -2,6 +2,24 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "PassRoleToNodes",
+            "Action": [
+                "iam:PassRole"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:*:iam::*:role/*-ControlPlane-Role",
+                "arn:*:iam::*:role/*-Worker-Role"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": [
+                        "ec2.amazonaws.com"
+                    ]
+                }
+            }
+        },
+        {
             "Effect": "Allow",
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
@@ -128,7 +146,6 @@
                 "iam:ListRoles",
                 "iam:ListUserPolicies",
                 "iam:ListUsers",
-                "iam:PassRole",
                 "iam:RemoveRoleFromInstanceProfile",
                 "iam:SimulatePrincipalPolicy",
                 "iam:TagRole",


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Minimizes the scope of how the installer and MAPI are allowed to use `iam:PassRole`:

* Installer: allow passing the `ControlPlane-Role` and `Worker-Role` to `ec2.amazonaws.com`
* MAPI: allow passing roles to`ec2.amazonaws.com`

### Which Jira/Github issue(s) this PR fixes?
[OSD-19684](https://issues.redhat.com//browse/OSD-19684)

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster