### PR TITLE
update to account for AWS ap regions

### DIFF
--- a/resources/sts/4.14/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
+++ b/resources/sts/4.14/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
@@ -27,7 +27,7 @@
         "s3:PutLifecycleConfiguration"
       ],
       "Resource": [
-        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}-*"
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}*"
       ]
     },
     {
@@ -41,7 +41,7 @@
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}-*/*"
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}*/*"
       ]
     }
   ]


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
https://github.com/openshift/cluster-image-registry-operator/blob/release-4.14/pkg/storage/util/util.go#L87-L134

This PR accounts for how the image-registry operator names buckets in
AWS, which is:

`${cluster_id}-image-registry-${aws_region}-${suffix}`

* `${cluster_id}` is 32 characters
* -image-registry- is 16 characters
* ap-northeast-1 is 14 characters
* The image-registry operator truncates the name to 62 characters

which leaves us with no suffix for these kinds of regions.

### Which Jira/Github issue(s) this PR fixes?
[OSD-19694](https://issues.redhat.com//browse/OSD-19694)

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster