### PR TITLE
Install AWS SSM Agent to HCP MC workers

### DIFF
--- a/deploy/aws-ssm-agent/01-machineconfig.yaml
+++ b/deploy/aws-ssm-agent/01-machineconfig.yaml
@@ -1,0 +1,27 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-install-aws-ssm-agent
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - name: 99-install-aws-ssm-agent.service
+        enabled: true
+        contents: |
+          [Unit]
+          Description=Install and launch the AWS Systems Manager (SSM) Agent.
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/bin/rpm-ostree install --apply-live https://s3.us-east-1.amazonaws.com/amazon-ssm-us-east-1/latest/linux_amd64/amazon-ssm-agent.rpm
+          ExecStart=/usr/sbin/restorecon /etc/systemd/system/amazon-ssm-agent.service
+          ExecStart=/usr/bin/systemctl daemon-reload
+          ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
+
+          [Install]
+          WantedBy=multi-user.target

--- a/deploy/aws-ssm-agent/README.md
+++ b/deploy/aws-ssm-agent/README.md
@@ -1,0 +1,10 @@
+# ROSA HCP Management Clusters and AWS SSM Agent
+
+Kubelet debugging handlers are disabled on ROSA HCP management clusters via the [enableDebuggingHandlers](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration) flag. Among other things, this means that we lose the ability to exec into containers, causing `oc debug` to not function.
+
+[AWS SSM Agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html) is software that will allow SREs to connect to EC2 instances underlying the management cluster directly to replace workflows requiring `oc debug`.
+
+## References
+
+* [OSD-19613](https://issues.redhat.com/browse/OSD-19613)
+* [OSD-19654](https://issues.redhat.com/browse/OSD-19654)

--- a/deploy/aws-ssm-agent/config.yaml
+++ b/deploy/aws-ssm-agent/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-sector
+    operator: NotIn
+    values: ["ibm-infra"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7720,6 +7720,70 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: aws-ssm-agent
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-install-aws-ssm-agent
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          systemd:
+            units:
+            - name: 99-install-aws-ssm-agent.service
+              enabled: true
+              contents: '[Unit]
+
+                Description=Install and launch the AWS Systems Manager (SSM) Agent.
+
+
+                [Service]
+
+                Type=oneshot
+
+                ExecStart=/usr/bin/rpm-ostree install --apply-live https://s3.us-east-1.amazonaws.com/amazon-ssm-us-east-1/latest/linux_amd64/amazon-ssm-agent.rpm
+
+                ExecStart=/usr/sbin/restorecon /etc/systemd/system/amazon-ssm-agent.service
+
+                ExecStart=/usr/bin/systemctl daemon-reload
+
+                ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
+
+
+                [Install]
+
+                WantedBy=multi-user.target
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7720,6 +7720,70 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: aws-ssm-agent
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-install-aws-ssm-agent
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          systemd:
+            units:
+            - name: 99-install-aws-ssm-agent.service
+              enabled: true
+              contents: '[Unit]
+
+                Description=Install and launch the AWS Systems Manager (SSM) Agent.
+
+
+                [Service]
+
+                Type=oneshot
+
+                ExecStart=/usr/bin/rpm-ostree install --apply-live https://s3.us-east-1.amazonaws.com/amazon-ssm-us-east-1/latest/linux_amd64/amazon-ssm-agent.rpm
+
+                ExecStart=/usr/sbin/restorecon /etc/systemd/system/amazon-ssm-agent.service
+
+                ExecStart=/usr/bin/systemctl daemon-reload
+
+                ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
+
+
+                [Install]
+
+                WantedBy=multi-user.target
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7720,6 +7720,70 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: aws-ssm-agent
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-install-aws-ssm-agent
+      spec:
+        config:
+          ignition:
+            version: 3.2.0
+          systemd:
+            units:
+            - name: 99-install-aws-ssm-agent.service
+              enabled: true
+              contents: '[Unit]
+
+                Description=Install and launch the AWS Systems Manager (SSM) Agent.
+
+
+                [Service]
+
+                Type=oneshot
+
+                ExecStart=/usr/bin/rpm-ostree install --apply-live https://s3.us-east-1.amazonaws.com/amazon-ssm-us-east-1/latest/linux_amd64/amazon-ssm-agent.rpm
+
+                ExecStart=/usr/sbin/restorecon /etc/systemd/system/amazon-ssm-agent.service
+
+                ExecStart=/usr/bin/systemctl daemon-reload
+
+                ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
+
+
+                [Install]
+
+                WantedBy=multi-user.target
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Kubelet debugging handlers are disabled on ROSA HCP management clusters via the [enableDebuggingHandlers](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration) flag. Among other things, this means that we lose the ability to exec into containers, causing `oc debug` to not function.

[AWS SSM Agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html) is software that will allow SREs to connect to EC2 instances underlying the management cluster directly to replace workflows requiring `oc debug`.

### Which Jira/Github issue(s) this PR fixes?
[OSD-19654](https://issues.redhat.com//browse/OSD-19654)