### PR TITLE
OSD-18515: Handling the KubePersistentVolumeFillingUp alerts on 'openshift-user-workload-monitoring' namespace with the ocm-agent operator

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -13,6 +13,12 @@ spec:
       summary: "Multiple ingress controllers detected"
       logType: Cluster Configuration
     - activeBody: |-
+        Your cluster is currently alerting with 'KubePersistentVolumeFillingUp' in '${namespace}' for PVC '${persistentvolumeclaim}'. This is not an actionable alert for the SRE team. Please address this capacity issue using this reference documentation: https://docs.openshift.com/container-platform/latest/storage/expanding-persistent-volumes.html.
+      name: KubePersistentVolumeFillingUp
+      resendWait: 1
+      severity: Error
+      summary: "Action required: Persistent Volume filling"
+    - activeBody: |-
         Your cluster requires you to take action as its ElasticSearch cluster logging deployment has been detected as reaching a high disk usage threshold. Red Hat SRE strongly recommends reducing application logging on your cluster to ensure logging continues to function. If logging disk consumption exceeds 95%, data will be at risk of becoming unavailable or lost and the stability of your ElasticSearch deployment may be impacted.
       name: LoggingVolumeFillingUp
       resendWait: 24

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -10,6 +10,15 @@ spec:
   groups:
   - name: sre-managed-notification-alerts
     rules:
+    - alert: KubePersistentVolumeFillingUpSRE
+    # KubePersistentVolumeFillingUp alert firing in openshift-user-workload-monitoring namespace (could be extended to other namespaces if needed).
+      expr: count by (namespace, persistentvolumeclaim) (ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-user-workload-monitoring"}) >= 1
+      for: 30m
+      labels:
+        severity: Info
+        namespace: "{{ $labels.namespace }}"
+        send_managed_notification: "true"
+        managed_notification_template: "KubePersistentVolumeFillingUp"
     - alert: LoggingVolumeFillingUpNotificationSRE
     # KubePersistentVolumeFillingUp alert firing in openshift-logging Namespace.
       expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-logging"}) >= 1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22163,6 +22163,14 @@ objects:
           severity: Info
           summary: Multiple ingress controllers detected
           logType: Cluster Configuration
+        - activeBody: "Your cluster is currently alerting with 'KubePersistentVolumeFillingUp'\
+            \ in '${namespace}' for PVC '${persistentvolumeclaim}'. This is not an\
+            \ actionable alert for the SRE team. Please address this capacity issue\
+            \ using this reference documentation:\_https://docs.openshift.com/container-platform/latest/storage/expanding-persistent-volumes.html."
+          name: KubePersistentVolumeFillingUp
+          resendWait: 1
+          severity: Error
+          summary: 'Action required: Persistent Volume filling'
         - activeBody: Your cluster requires you to take action as its ElasticSearch
             cluster logging deployment has been detected as reaching a high disk usage
             threshold. Red Hat SRE strongly recommends reducing application logging
@@ -36804,6 +36812,16 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
+          - alert: KubePersistentVolumeFillingUpSRE
+            expr: count by (namespace, persistentvolumeclaim) (ALERTS{alertname="KubePersistentVolumeFillingUp",
+              alertstate="firing", namespace="openshift-user-workload-monitoring"})
+              >= 1
+            for: 30m
+            labels:
+              severity: Info
+              namespace: '{{ $labels.namespace }}'
+              send_managed_notification: 'true'
+              managed_notification_template: KubePersistentVolumeFillingUp
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22163,6 +22163,14 @@ objects:
           severity: Info
           summary: Multiple ingress controllers detected
           logType: Cluster Configuration
+        - activeBody: "Your cluster is currently alerting with 'KubePersistentVolumeFillingUp'\
+            \ in '${namespace}' for PVC '${persistentvolumeclaim}'. This is not an\
+            \ actionable alert for the SRE team. Please address this capacity issue\
+            \ using this reference documentation:\_https://docs.openshift.com/container-platform/latest/storage/expanding-persistent-volumes.html."
+          name: KubePersistentVolumeFillingUp
+          resendWait: 1
+          severity: Error
+          summary: 'Action required: Persistent Volume filling'
         - activeBody: Your cluster requires you to take action as its ElasticSearch
             cluster logging deployment has been detected as reaching a high disk usage
             threshold. Red Hat SRE strongly recommends reducing application logging
@@ -36804,6 +36812,16 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
+          - alert: KubePersistentVolumeFillingUpSRE
+            expr: count by (namespace, persistentvolumeclaim) (ALERTS{alertname="KubePersistentVolumeFillingUp",
+              alertstate="firing", namespace="openshift-user-workload-monitoring"})
+              >= 1
+            for: 30m
+            labels:
+              severity: Info
+              namespace: '{{ $labels.namespace }}'
+              send_managed_notification: 'true'
+              managed_notification_template: KubePersistentVolumeFillingUp
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22163,6 +22163,14 @@ objects:
           severity: Info
           summary: Multiple ingress controllers detected
           logType: Cluster Configuration
+        - activeBody: "Your cluster is currently alerting with 'KubePersistentVolumeFillingUp'\
+            \ in '${namespace}' for PVC '${persistentvolumeclaim}'. This is not an\
+            \ actionable alert for the SRE team. Please address this capacity issue\
+            \ using this reference documentation:\_https://docs.openshift.com/container-platform/latest/storage/expanding-persistent-volumes.html."
+          name: KubePersistentVolumeFillingUp
+          resendWait: 1
+          severity: Error
+          summary: 'Action required: Persistent Volume filling'
         - activeBody: Your cluster requires you to take action as its ElasticSearch
             cluster logging deployment has been detected as reaching a high disk usage
             threshold. Red Hat SRE strongly recommends reducing application logging
@@ -36804,6 +36812,16 @@ objects:
         groups:
         - name: sre-managed-notification-alerts
           rules:
+          - alert: KubePersistentVolumeFillingUpSRE
+            expr: count by (namespace, persistentvolumeclaim) (ALERTS{alertname="KubePersistentVolumeFillingUp",
+              alertstate="firing", namespace="openshift-user-workload-monitoring"})
+              >= 1
+            for: 30m
+            labels:
+              severity: Info
+              namespace: '{{ $labels.namespace }}'
+              send_managed_notification: 'true'
+              managed_notification_template: KubePersistentVolumeFillingUp
           - alert: LoggingVolumeFillingUpNotificationSRE
             expr: count(ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing",
               namespace="openshift-logging"}) >= 1


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR makes sure that `KubePersistentVolumeFilling` alerts on `openshift-user-workload-monitoring` will now automatically handled by the `ocm-agent` operator.
This will avoid paging primary on-call through Pagerduty for alerts that should be actioned by the customer.

### Which Jira/Github issue(s) this PR fixes?

Contributes to [OSD-18515](https://issues.redhat.com//browse/OSD-18515)

### Special notes for your reviewer:
**Do not merge yet!**
The following PR needs to be merged first:
https://github.com/openshift/ocm-agent/pull/68

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
