### PR TITLE
Add fix for private NLB resolution bug

### DIFF
--- a/deploy/osd-private-nlb-fix/00-osd-private-nlb-fix.ServiceAccount.yaml
+++ b/deploy/osd-private-nlb-fix/00-osd-private-nlb-fix.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-private-nlb-fix
+  namespace: openshift-config

--- a/deploy/osd-private-nlb-fix/10-osd-private-nlb-fix.CronJob.yaml
+++ b/deploy/osd-private-nlb-fix/10-osd-private-nlb-fix.CronJob.yaml
@@ -1,0 +1,89 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-private-nlb-fix
+  namespace: openshift-config
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: osd-private-nlb-fix
+          restartPolicy: Never
+          containers:
+          - name: osd-private-nlb-fix
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            args:
+            - /usr/bin/python
+            - -c
+            - |
+              import os
+              import json
+              import socket
+
+              def shell(command):
+                  f = os.popen(command)
+                  stdout = f.read()
+                  error = f.close()
+                  if error:
+                      print(stdout)
+                      exit(1)
+                  return stdout
+
+              out = shell("oc get ingresscontroller -n openshift-ingress-operator default -ojsonpath='{.spec.endpointPublishingStrategy.loadBalancer}'")
+              load_balancer_config = json.loads(out)
+              if not ("aws" in load_balancer_config["providerParameters"]
+                      and load_balancer_config["providerParameters"]["aws"]["type"] == "NLB"
+                      and load_balancer_config["scope"] == "Internal"):
+                  print(
+                      "Not private AWS NLB, not assigning NLB IP to router-default service"
+                  )
+                  print(
+                      "Default IngressController .spec.endpointPublishingStrategy.loadBalancer",
+                      load_balancer_config
+                  )
+
+              print("Private NLB, will patch external IP with VPC internal IP")
+              out = shell("oc get service router-default -n openshift-ingress -ojson")
+              router_default_svc = json.loads(out)
+              hostname = router_default_svc["status"]["loadBalancer"]["ingress"][0]["hostname"]
+
+              # Get NLB IP address inside VPC
+              # https://stackoverflow.com/questions/12297500/python-module-for-nslookup
+              print(f"Looking up IP by hostname {hostname}")
+              vpc_ip = socket.gethostbyname(hostname)
+              router_status_ingress = router_default_svc["status"]["loadBalancer"]["ingress"][0]
+              if "ip" in router_status_ingress and router_status_ingress["ip"] == vpc_ip:
+                  print("VPC IP matches router ingress IP, no more work needed.")
+                  exit(0)
+              try:
+                  socket.inet_aton(vpc_ip)
+                  router_default_patch = [
+                      {
+                          'op': 'replace',
+                          'path': '/status/loadBalancer/ingress/0/ip',
+                          'value': vpc_ip
+                      }
+                  ]
+                  patch_file = json.dumps(router_default_patch)
+                  out = shell(f"oc patch service router-default -n openshift-ingress --type=json --subresource=status --patch='{patch_file}'")
+                  print(out)
+              except OSError:
+                  print(f'router_default IP {router_default_svc["status"]["loadBalancer"]["ingress"][0]["hostname"]} Not a valid IPv4 address.')

--- a/deploy/osd-private-nlb-fix/10-osd-private-nlb-fix.Role.yaml
+++ b/deploy/osd-private-nlb-fix/10-osd-private-nlb-fix.Role.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-private-nlb-fix
+  namespace: openshift-ingress
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: osd-private-nlb-fix
+  namespace: openshift-ingress-operator
+rules:
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get

--- a/deploy/osd-private-nlb-fix/10-osd-private-nlb-fix.RoleBinding.yaml
+++ b/deploy/osd-private-nlb-fix/10-osd-private-nlb-fix.RoleBinding.yaml
@@ -1,0 +1,27 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-private-nlb-fix
+  namespace: openshift-ingress
+subjects:
+- kind: ServiceAccount
+  name: osd-private-nlb-fix
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-private-nlb-fix
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-private-nlb-fix
+  namespace: openshift-ingress-operator
+subjects:
+- kind: ServiceAccount
+  name: osd-private-nlb-fix
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: osd-private-nlb-fix

--- a/deploy/osd-private-nlb-fix/config.yaml
+++ b/deploy/osd-private-nlb-fix/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28863,6 +28863,144 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-private-nlb-fix
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-private-nlb-fix
+                restartPolicy: Never
+                containers:
+                - name: osd-private-nlb-fix
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /usr/bin/python
+                  - -c
+                  - "import os\nimport json\nimport socket\n\ndef shell(command):\n\
+                    \    f = os.popen(command)\n    stdout = f.read()\n    error =\
+                    \ f.close()\n    if error:\n        print(stdout)\n        exit(1)\n\
+                    \    return stdout\n\nout = shell(\"oc get ingresscontroller -n\
+                    \ openshift-ingress-operator default -ojsonpath='{.spec.endpointPublishingStrategy.loadBalancer}'\"\
+                    )\nload_balancer_config = json.loads(out)\nif not (\"aws\" in\
+                    \ load_balancer_config[\"providerParameters\"]\n        and load_balancer_config[\"\
+                    providerParameters\"][\"aws\"][\"type\"] == \"NLB\"\n        and\
+                    \ load_balancer_config[\"scope\"] == \"Internal\"):\n    print(\n\
+                    \        \"Not private AWS NLB, not assigning NLB IP to router-default\
+                    \ service\"\n    )\n    print(\n        \"Default IngressController\
+                    \ .spec.endpointPublishingStrategy.loadBalancer\",\n        load_balancer_config\n\
+                    \    )\n\nprint(\"Private NLB, will patch external IP with VPC\
+                    \ internal IP\")\nout = shell(\"oc get service router-default\
+                    \ -n openshift-ingress -ojson\")\nrouter_default_svc = json.loads(out)\n\
+                    hostname = router_default_svc[\"status\"][\"loadBalancer\"][\"\
+                    ingress\"][0][\"hostname\"]\n\n# Get NLB IP address inside VPC\n\
+                    # https://stackoverflow.com/questions/12297500/python-module-for-nslookup\n\
+                    print(f\"Looking up IP by hostname {hostname}\")\nvpc_ip = socket.gethostbyname(hostname)\n\
+                    router_status_ingress = router_default_svc[\"status\"][\"loadBalancer\"\
+                    ][\"ingress\"][0]\nif \"ip\" in router_status_ingress and router_status_ingress[\"\
+                    ip\"] == vpc_ip:\n    print(\"VPC IP matches router ingress IP,\
+                    \ no more work needed.\")\n    exit(0)\ntry:\n    socket.inet_aton(vpc_ip)\n\
+                    \    router_default_patch = [\n        {\n            'op': 'replace',\n\
+                    \            'path': '/status/loadBalancer/ingress/0/ip',\n  \
+                    \          'value': vpc_ip\n        }\n    ]\n    patch_file =\
+                    \ json.dumps(router_default_patch)\n    out = shell(f\"oc patch\
+                    \ service router-default -n openshift-ingress --type=json --subresource=status\
+                    \ --patch='{patch_file}'\")\n    print(out)\nexcept OSError:\n\
+                    \    print(f'router_default IP {router_default_svc[\"status\"\
+                    ][\"loadBalancer\"][\"ingress\"][0][\"hostname\"]} Not a valid\
+                    \ IPv4 address.')\n"
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - services/status
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress-operator
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - ingresscontrollers
+        verbs:
+        - get
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress
+      subjects:
+      - kind: ServiceAccount
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-private-nlb-fix
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-private-nlb-fix
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-project-request-template
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28863,6 +28863,144 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-private-nlb-fix
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-private-nlb-fix
+                restartPolicy: Never
+                containers:
+                - name: osd-private-nlb-fix
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /usr/bin/python
+                  - -c
+                  - "import os\nimport json\nimport socket\n\ndef shell(command):\n\
+                    \    f = os.popen(command)\n    stdout = f.read()\n    error =\
+                    \ f.close()\n    if error:\n        print(stdout)\n        exit(1)\n\
+                    \    return stdout\n\nout = shell(\"oc get ingresscontroller -n\
+                    \ openshift-ingress-operator default -ojsonpath='{.spec.endpointPublishingStrategy.loadBalancer}'\"\
+                    )\nload_balancer_config = json.loads(out)\nif not (\"aws\" in\
+                    \ load_balancer_config[\"providerParameters\"]\n        and load_balancer_config[\"\
+                    providerParameters\"][\"aws\"][\"type\"] == \"NLB\"\n        and\
+                    \ load_balancer_config[\"scope\"] == \"Internal\"):\n    print(\n\
+                    \        \"Not private AWS NLB, not assigning NLB IP to router-default\
+                    \ service\"\n    )\n    print(\n        \"Default IngressController\
+                    \ .spec.endpointPublishingStrategy.loadBalancer\",\n        load_balancer_config\n\
+                    \    )\n\nprint(\"Private NLB, will patch external IP with VPC\
+                    \ internal IP\")\nout = shell(\"oc get service router-default\
+                    \ -n openshift-ingress -ojson\")\nrouter_default_svc = json.loads(out)\n\
+                    hostname = router_default_svc[\"status\"][\"loadBalancer\"][\"\
+                    ingress\"][0][\"hostname\"]\n\n# Get NLB IP address inside VPC\n\
+                    # https://stackoverflow.com/questions/12297500/python-module-for-nslookup\n\
+                    print(f\"Looking up IP by hostname {hostname}\")\nvpc_ip = socket.gethostbyname(hostname)\n\
+                    router_status_ingress = router_default_svc[\"status\"][\"loadBalancer\"\
+                    ][\"ingress\"][0]\nif \"ip\" in router_status_ingress and router_status_ingress[\"\
+                    ip\"] == vpc_ip:\n    print(\"VPC IP matches router ingress IP,\
+                    \ no more work needed.\")\n    exit(0)\ntry:\n    socket.inet_aton(vpc_ip)\n\
+                    \    router_default_patch = [\n        {\n            'op': 'replace',\n\
+                    \            'path': '/status/loadBalancer/ingress/0/ip',\n  \
+                    \          'value': vpc_ip\n        }\n    ]\n    patch_file =\
+                    \ json.dumps(router_default_patch)\n    out = shell(f\"oc patch\
+                    \ service router-default -n openshift-ingress --type=json --subresource=status\
+                    \ --patch='{patch_file}'\")\n    print(out)\nexcept OSError:\n\
+                    \    print(f'router_default IP {router_default_svc[\"status\"\
+                    ][\"loadBalancer\"][\"ingress\"][0][\"hostname\"]} Not a valid\
+                    \ IPv4 address.')\n"
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - services/status
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress-operator
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - ingresscontrollers
+        verbs:
+        - get
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress
+      subjects:
+      - kind: ServiceAccount
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-private-nlb-fix
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-private-nlb-fix
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-project-request-template
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28863,6 +28863,144 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-private-nlb-fix
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-private-nlb-fix
+                restartPolicy: Never
+                containers:
+                - name: osd-private-nlb-fix
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  args:
+                  - /usr/bin/python
+                  - -c
+                  - "import os\nimport json\nimport socket\n\ndef shell(command):\n\
+                    \    f = os.popen(command)\n    stdout = f.read()\n    error =\
+                    \ f.close()\n    if error:\n        print(stdout)\n        exit(1)\n\
+                    \    return stdout\n\nout = shell(\"oc get ingresscontroller -n\
+                    \ openshift-ingress-operator default -ojsonpath='{.spec.endpointPublishingStrategy.loadBalancer}'\"\
+                    )\nload_balancer_config = json.loads(out)\nif not (\"aws\" in\
+                    \ load_balancer_config[\"providerParameters\"]\n        and load_balancer_config[\"\
+                    providerParameters\"][\"aws\"][\"type\"] == \"NLB\"\n        and\
+                    \ load_balancer_config[\"scope\"] == \"Internal\"):\n    print(\n\
+                    \        \"Not private AWS NLB, not assigning NLB IP to router-default\
+                    \ service\"\n    )\n    print(\n        \"Default IngressController\
+                    \ .spec.endpointPublishingStrategy.loadBalancer\",\n        load_balancer_config\n\
+                    \    )\n\nprint(\"Private NLB, will patch external IP with VPC\
+                    \ internal IP\")\nout = shell(\"oc get service router-default\
+                    \ -n openshift-ingress -ojson\")\nrouter_default_svc = json.loads(out)\n\
+                    hostname = router_default_svc[\"status\"][\"loadBalancer\"][\"\
+                    ingress\"][0][\"hostname\"]\n\n# Get NLB IP address inside VPC\n\
+                    # https://stackoverflow.com/questions/12297500/python-module-for-nslookup\n\
+                    print(f\"Looking up IP by hostname {hostname}\")\nvpc_ip = socket.gethostbyname(hostname)\n\
+                    router_status_ingress = router_default_svc[\"status\"][\"loadBalancer\"\
+                    ][\"ingress\"][0]\nif \"ip\" in router_status_ingress and router_status_ingress[\"\
+                    ip\"] == vpc_ip:\n    print(\"VPC IP matches router ingress IP,\
+                    \ no more work needed.\")\n    exit(0)\ntry:\n    socket.inet_aton(vpc_ip)\n\
+                    \    router_default_patch = [\n        {\n            'op': 'replace',\n\
+                    \            'path': '/status/loadBalancer/ingress/0/ip',\n  \
+                    \          'value': vpc_ip\n        }\n    ]\n    patch_file =\
+                    \ json.dumps(router_default_patch)\n    out = shell(f\"oc patch\
+                    \ service router-default -n openshift-ingress --type=json --subresource=status\
+                    \ --patch='{patch_file}'\")\n    print(out)\nexcept OSError:\n\
+                    \    print(f'router_default IP {router_default_svc[\"status\"\
+                    ][\"loadBalancer\"][\"ingress\"][0][\"hostname\"]} Not a valid\
+                    \ IPv4 address.')\n"
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - services/status
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress-operator
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - ingresscontrollers
+        verbs:
+        - get
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress
+      subjects:
+      - kind: ServiceAccount
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-private-nlb-fix
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-private-nlb-fix
+        namespace: openshift-ingress-operator
+      subjects:
+      - kind: ServiceAccount
+        name: osd-private-nlb-fix
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: osd-private-nlb-fix
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-project-request-template
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Temporary fix for https://issues.redhat.com/browse/OCPBUGS-9026
Using @gcs278's fix from https://issues.redhat.com/browse/OCPBUGS-9026?focusedId=22618127&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22618127,
this is a `CronJob` that runs every five minutes, looks up the VPC IP of the internal load balancer, and then sets the IP of the default router service to that IP. 
It only runs when a cluster is running an AWS internal private LB. 
To test: 
Run reproducer from above: 
```
To reproduce:

    Clone https://github.com/gcs278/openshift-hacks 
    cd openshift-hacks/BZ2023681/
    [./reproducer.sh](https://github.com/gcs278/openshift-hacks/blob/master/BZ2023681/reproducer.sh)
```
Create a private cluster in 4.14+
Verify `nlb-shard` does resolve in the second test. 
Edit the cronjob to reference `router-nlb-shard` and `nlb-shard` (for the service and IC respectively).
`oc apply -f ~/redhat/managed-cluster-config/deploy/osd-private-nlb-fix/`
Run the reproducer again (it should work this time). 
### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OCPBUGS-9026

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
