### PR TITLE
OSD-19183: add sre-cluster-version-operator PrometheusRule

### DIFF
--- a/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-cluster-version-operator
+    role: alert-rules
+  name: sre-cluster-version-operator
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-cluster-version-operator
+    rules:
+    - alert: ClusterOperatorDegradedSRE
+      annotations:
+        summary: Cluster operator has been degraded for 1 day.
+        description: The {{ "{{ $labels.name }}" }} operator is degraded because {{ "{{ $labels.reason }}" }}, and the components it manages may have reduced quality of service.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+      expr: |
+        max by (namespace, name, reason)
+        (
+          (
+            cluster_operator_conditions{job="cluster-version-operator", condition="Degraded", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"}
+            or on (namespace, name)
+            group by (namespace, name) (cluster_operator_up{job="cluster-version-operator", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"})
+          ) == 1
+        )
+      for: 1d
+      labels:
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md"
+        namespace: openshift-monitoring
+        needs_attention: "true"
+        severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33748,6 +33748,39 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cluster-version-operator
+          role: alert-rules
+        name: sre-cluster-version-operator
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-version-operator
+          rules:
+          - alert: ClusterOperatorDegradedSRE
+            annotations:
+              summary: Cluster operator has been degraded for 1 day.
+              description: The {{ "{{ $labels.name }}" }} operator is degraded because
+                {{ "{{ $labels.reason }}" }}, and the components it manages may have
+                reduced quality of service.  Cluster upgrades may not complete. For
+                more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
+                }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if
+                ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
+                (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+            expr: "max by (namespace, name, reason)\n(\n  (\n    cluster_operator_conditions{job=\"\
+              cluster-version-operator\", condition=\"Degraded\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
+              }\n    or on (namespace, name)\n    group by (namespace, name) (cluster_operator_up{job=\"\
+              cluster-version-operator\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
+              })\n  ) == 1\n)\n"
+            for: 1d
+            labels:
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+              namespace: openshift-monitoring
+              needs_attention: 'true'
+              severity: warning
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-configure-alertmanager-operator-offline-alerts
           role: alert-rules
         name: sre-configure-alertmanager-operator-offline-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33748,6 +33748,39 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cluster-version-operator
+          role: alert-rules
+        name: sre-cluster-version-operator
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-version-operator
+          rules:
+          - alert: ClusterOperatorDegradedSRE
+            annotations:
+              summary: Cluster operator has been degraded for 1 day.
+              description: The {{ "{{ $labels.name }}" }} operator is degraded because
+                {{ "{{ $labels.reason }}" }}, and the components it manages may have
+                reduced quality of service.  Cluster upgrades may not complete. For
+                more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
+                }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if
+                ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
+                (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+            expr: "max by (namespace, name, reason)\n(\n  (\n    cluster_operator_conditions{job=\"\
+              cluster-version-operator\", condition=\"Degraded\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
+              }\n    or on (namespace, name)\n    group by (namespace, name) (cluster_operator_up{job=\"\
+              cluster-version-operator\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
+              })\n  ) == 1\n)\n"
+            for: 1d
+            labels:
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+              namespace: openshift-monitoring
+              needs_attention: 'true'
+              severity: warning
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-configure-alertmanager-operator-offline-alerts
           role: alert-rules
         name: sre-configure-alertmanager-operator-offline-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33748,6 +33748,39 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-cluster-version-operator
+          role: alert-rules
+        name: sre-cluster-version-operator
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-version-operator
+          rules:
+          - alert: ClusterOperatorDegradedSRE
+            annotations:
+              summary: Cluster operator has been degraded for 1 day.
+              description: The {{ "{{ $labels.name }}" }} operator is degraded because
+                {{ "{{ $labels.reason }}" }}, and the components it manages may have
+                reduced quality of service.  Cluster upgrades may not complete. For
+                more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
+                }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if
+                ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
+                (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+            expr: "max by (namespace, name, reason)\n(\n  (\n    cluster_operator_conditions{job=\"\
+              cluster-version-operator\", condition=\"Degraded\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
+              }\n    or on (namespace, name)\n    group by (namespace, name) (cluster_operator_up{job=\"\
+              cluster-version-operator\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
+              })\n  ) == 1\n)\n"
+            for: 1d
+            labels:
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+              namespace: openshift-monitoring
+              needs_attention: 'true'
+              severity: warning
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-configure-alertmanager-operator-offline-alerts
           role: alert-rules
         name: sre-configure-alertmanager-operator-offline-alerts


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
It will create new  ClusterOperatorDegraded alerts for kube-* operators when the events last 1day, with special need_attention label to specify that this warning alert should not be deleted as it rquires atten

### Which Jira/Github issue(s) this PR fixes?

[OSD-19183](https://issues.redhat.com//browse/OSD-19183)

As mentioned in [OSD-18336 study](https://issues.redhat.com/browse/OSD-18336), activating those alerts when issue last more than 24h should raise in average 1 alert per week, that we'd better look at.