### PR TITLE
Make podman compatible with MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,16 @@ ifndef GEN_CMO_CONFIG
 $(error GEN_CMO_CONFIG is not set; check project.mk file)
 endif
 
-
+VOLUME_MOUNT_FLAGS = :z
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
-CONTAINER_RUN_FLAGS=--user : --rm -v `pwd -P`:`pwd -P`:z -w=`pwd` --platform linux/amd64
+ifneq (,$(findstring podman,$(CONTAINER_ENGINE)))
+	ifeq ($(shell uname -s), Darwin)
+		# if you're running podman on macOS, don't set the SELinux label
+		VOLUME_MOUNT_FLAGS =
+	endif
+endif
+CONTAINER_RUN_FLAGS=--user : --rm -v `pwd -P`:`pwd -P`${VOLUME_MOUNT_FLAGS} -w=`pwd` --platform linux/amd64
+
 
 ifeq ($(CONTAINER_ENGINE),)
 # Running already in a container


### PR DESCRIPTION
Seting the SELinux mount label when running on podman for macOS make the run fails with an error. So we don't set it.

Similar to https://github.com/openshift/release/pull/35997

### What type of PR is this?
bug

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?
Fixes error
```
Error: preparing container 44309ffd66e127508322ff6634ec3acd17be9bcd735210b54bd81b5e7e139ba2 for attach: lsetxattr /Users/adecorte/code/managed-cluster-config/.git: operation not supported
```
when running on MacOS

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
