### PR TITLE
formatting conditions less permissive as requested

### DIFF
--- a/resources/sts/4.14/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
+++ b/resources/sts/4.14/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
@@ -32,7 +32,8 @@
         "s3:PutLifecycleConfiguration"
       ],
       "Resource": [
-        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}*"
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}-*",
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}"
       ],
       "Condition": {
         "StringEquals": {
@@ -51,7 +52,8 @@
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}*/*"
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}-*/*",
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}/*"
       ],
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
Changes registry operator permissions in AWS to be more restrictive regex as requested by AWS . 