### PR TITLE
Only deploy MC alerts to STS MCs

### DIFF
--- a/deploy/sre-prometheus/management-cluster/config.yaml
+++ b/deploy/sre-prometheus/management-cluster/config.yaml
@@ -7,6 +7,9 @@ selectorSyncSet:
   - key: api.openshift.com/fedramp
     operator: NotIn
     values: ["true"]
+  - key: api.openshift.com/sts
+    operator: In
+    values: ["true"]
   - key: ext-hypershift.openshift.io/cluster-sector
     operator: NotIn
     values: ["ibm-infra"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35484,6 +35484,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
       - key: ext-hypershift.openshift.io/cluster-sector
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35484,6 +35484,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
       - key: ext-hypershift.openshift.io/cluster-sector
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35484,6 +35484,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
       - key: ext-hypershift.openshift.io/cluster-sector
         operator: NotIn
         values:


### PR DESCRIPTION
### What type of PR is this?
bug/feature

### What this PR does / why we need it?
The unique management cluster alerts https://github.com/openshift/managed-cluster-config/tree/master/deploy/sre-prometheus/management-cluster only apply to STS management clusters. For example, we are going to be enabling debugging handlers on all non-STS MCs and don't need to be alerted about that

### Which Jira/Github issue(s) this PR fixes?

[OSD-19635](https://issues.redhat.com//browse/OSD-19635)