### PR TITLE
Use internal OCM endpoint proxy for MUO on non-management clusters

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -8,7 +8,7 @@ data:
     upgradeType: OSD
     configManager:
       source: OCM
-      ocmBaseUrl: ${OCM_BASE_URL}
+      ocmBaseUrl: http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081
       watchInterval: 60
     maintenance:
       controlPlaneTime: 130

--- a/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
@@ -8,7 +8,7 @@ data:
     upgradeType: OSD
     configManager:
       source: OCM
-      ocmBaseUrl: ${OCM_BASE_URL}
+      ocmBaseUrl: http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081
       watchInterval: 60
     maintenance:
       controlPlaneTime: 130

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21731,11 +21731,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
-          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
-          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
-          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
+          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
@@ -21909,11 +21909,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
-          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
-          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
-          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
+          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21731,11 +21731,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
-          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
-          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
-          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
+          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
@@ -21909,11 +21909,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
-          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
-          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
-          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
+          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21731,11 +21731,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
-          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
-          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
-          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
+          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
@@ -21909,11 +21909,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
-          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
-          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
-          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
-          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
+          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
+          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
+          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
+          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Updates the Managed Upgrade Operator configuration to use the internal OCM endpoint proxy instead of the raw `api.openshift.com` endpoint. Not relevant (yet) to Hypershift clusters. 

Depends on https://issues.redhat.com/browse/OSD-19745, https://issues.redhat.com/browse/OSD-19232 being in stage, as well as https://github.com/openshift/ocm-agent/pull/71 to be merged. 
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-19764

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
