### PR TITLE
Do not reschedule infra pods if there are already the number of infra node pods running on infra nodes

### DIFF
--- a/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
+++ b/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
@@ -105,7 +105,7 @@ data:
     # Notes: this is done as a response to an escalation in https://issues.redhat.com/browse/OSD-13621 
     # A long term fix will follow 
     # If there are already the same number of infra nodes scheduled on the infra nodes, we will skip deleting the pods.
-    # This is for the use case that customer scaled up the replicas like registry pods to handel the load
+    # This is for SUPPORTEX-16697 where >3 registry pods are needed to handle the load
     infraPodsMisscheduled(){
         NODE_TAINT="node-role.kubernetes.io=infra"
         # The 'none' at the end accounts for pods which are currently being scheduled.

--- a/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
+++ b/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
@@ -104,6 +104,8 @@ data:
     #    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution for infra nodes
     # Notes: this is done as a response to an escalation in https://issues.redhat.com/browse/OSD-13621 
     # A long term fix will follow 
+    # If there are already the same number of infra nodes scheduled on the infra nodes, we will skip deleting the pods.
+    # This is for the use case that customer scaled up the replicas like registry pods to handel the load
     infraPodsMisscheduled(){
         NODE_TAINT="node-role.kubernetes.io=infra"
         # The 'none' at the end accounts for pods which are currently being scheduled.
@@ -111,17 +113,27 @@ data:
         # the output will look like "<node1>|<node2>|none"
         infranodes_regexp="$(oc get no -l "${NODE_TAINT}" -o go-template='{{range .items}}{{.metadata.name}}{{"|"}}{{end}}')none"
         
-        # the output will look something like
-        # <namespace> | <pod> | <affinity> | <node>
-        # each pod on the list needs to be rescheduled
-        misscheduled_pods=`for ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob := index .metadata.labels "job-name"}}{{$namespace := .metadata.namespace}}{{$name := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}} | {{.spec.nodeName}} {{"\n" -}} {{end}}{{end}}{{end}}';done |grep "node-role.kubernetes.io/infra" |grep -vE ${infranodes_regexp}`
+        for ns in $@
+        do
+          echo "INFO: check infra pods miss schedule in $ns"
+          pod_number=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob := index .metadata.labels "job-name"}}{{$namespace := .metadata.namespace}}{{$name := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}} | {{.spec.nodeName}} {{"\n" -}} {{end}}{{end}}{{end}}'|grep "node-role.kubernetes.io/infra" |grep -E ${infranodes_regexp}|wc -l`
+          # if the pods number running on infra is more than the infra node count, we will skip the reschedule.
+          if (( ${pod_number} >= ${INFRA_NODE_COUNT} ));then
+            echo "INFO: there are already ${pod_number} pods running on ${INFRA_NODE_COUNT} infra nodes, skip reschedule"
+            continue
+          fi
 
-        if [ ! -z  "$misscheduled_pods" ]; then
-            # --ignore-not-found=true so that for STS clusters this doesn't fail when this can't find CIO or velero pods
+          # the output will look something like
+          # <namespace> | <pod> | <affinity> | <node>
+          # each pod on the list needs to be rescheduled
+          missscheduled_pods=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob := index .metadata.labels "job-name"}}{{$namespace := .metadata.namespace}}{{$name := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}} | {{.spec.nodeName}} {{"\n" -}} {{end}}{{end}}{{end}}'|grep "node-role.kubernetes.io/infra" |grep -vE ${infranodes_regexp}`
+          if [ ! -z  "$misscheduled_pods" ]; then
+          # --ignore-not-found=true so that for STS clusters this doesn't fail when this can't find CIO or velero pods
             while read line ; do cmd=`echo $line|awk -F'|' '{print "oc -n " $1 " delete po --ignore-not-found=true " $2}'`;echo "INFO: $cmd"; eval $cmd;done <<< "$misscheduled_pods"
-        else
-            echo "INFO: no misscheduled pods in openshift-* namespaces"
-        fi
+          else
+            echo "INFO: no misscheduled pods in $ns namespaces"
+          fi
+        done
     }
 
     echo "INFO: Rebalancing openshift-dns/dns-default Daemonset..."

--- a/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
+++ b/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
@@ -104,7 +104,7 @@ data:
     #    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution for infra nodes
     # Notes: this is done as a response to an escalation in https://issues.redhat.com/browse/OSD-13621 
     # A long term fix will follow 
-    # If there are already the same number of infra nodes scheduled on the infra nodes, we will skip deleting the pods.
+    # If there are already the same number of infra pods scheduled on the infra nodes, we will skip deleting the pods.
     # This is for SUPPORTEX-16697 where >3 registry pods are needed to handle the load
     infraPodsMisscheduled(){
         NODE_TAINT="node-role.kubernetes.io=infra"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29274,29 +29274,43 @@ objects:
           \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
           \ for infra nodes\n# Notes: this is done as a response to an escalation\
           \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
-          \ follow \ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
+          \ follow \n# If there are already the same number of infra nodes scheduled\
+          \ on the infra nodes, we will skip deleting the pods.\n# This is for the\
+          \ use case that customer scaled up the replicas like registry pods to handel\
+          \ the load\ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
           \n    # The 'none' at the end accounts for pods which are currently being\
           \ scheduled.\n    # we do not want to reschedule them before knowing where\
           \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
           \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
-          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    # the output\
-          \ will look something like\n    # <namespace> | <pod> | <affinity> | <node>\n\
-          \    # each pod on the list needs to be rescheduled\n    misscheduled_pods=`for\
-          \ ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    for ns in\
+          \ $@\n    do\n      echo \"INFO: check infra pods miss schedule in $ns\"\
+          \n      pod_number=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
           \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
           \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
           \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
-          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}';done |grep \"\
-          node-role.kubernetes.io/infra\" |grep -vE ${infranodes_regexp}`\n\n    if\
-          \ [ ! -z  \"$misscheduled_pods\" ]; then\n        # --ignore-not-found=true\
-          \ so that for STS clusters this doesn't fail when this can't find CIO or\
-          \ velero pods\n        while read line ; do cmd=`echo $line|awk -F'|' '{print\
-          \ \"oc -n \" $1 \" delete po --ignore-not-found=true \" $2}'`;echo \"INFO:\
-          \ $cmd\"; eval $cmd;done <<< \"$misscheduled_pods\"\n    else\n        echo\
-          \ \"INFO: no misscheduled pods in openshift-* namespaces\"\n    fi\n}\n\n\
-          echo \"INFO: Rebalancing openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled\
-          \ \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\
-          \necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
+          \ |grep -E ${infranodes_regexp}|wc -l`\n      # if the pods number running\
+          \ on infra is more than the infra node count, we will skip the reschedule.\n\
+          \      if (( ${pod_number} >= ${INFRA_NODE_COUNT} ));then\n        echo\
+          \ \"INFO: there are already ${pod_number} pods running on ${INFRA_NODE_COUNT}\
+          \ infra nodes, skip reschedule\"\n        continue\n      fi\n\n      #\
+          \ the output will look something like\n      # <namespace> | <pod> | <affinity>\
+          \ | <node>\n      # each pod on the list needs to be rescheduled\n     \
+          \ missscheduled_pods=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
+          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
+          \ |grep -vE ${infranodes_regexp}`\n      if [ ! -z  \"$misscheduled_pods\"\
+          \ ]; then\n      # --ignore-not-found=true so that for STS clusters this\
+          \ doesn't fail when this can't find CIO or velero pods\n        while read\
+          \ line ; do cmd=`echo $line|awk -F'|' '{print \"oc -n \" $1 \" delete po\
+          \ --ignore-not-found=true \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<<\
+          \ \"$misscheduled_pods\"\n      else\n        echo \"INFO: no misscheduled\
+          \ pods in $ns namespaces\"\n      fi\n    done\n}\n\necho \"INFO: Rebalancing\
+          \ openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled \"\
+          openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\n\
+          echo \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
           \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
           \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
           \ app prometheus-user-workload-db\n\necho \"INFO: Rebalancing alertmanager\

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29274,19 +29274,19 @@ objects:
           \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
           \ for infra nodes\n# Notes: this is done as a response to an escalation\
           \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
-          \ follow \n# If there are already the same number of infra nodes scheduled\
-          \ on the infra nodes, we will skip deleting the pods.\n# This is for the\
-          \ use case that customer scaled up the replicas like registry pods to handel\
-          \ the load\ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
-          \n    # The 'none' at the end accounts for pods which are currently being\
-          \ scheduled.\n    # we do not want to reschedule them before knowing where\
-          \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
-          \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
-          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    for ns in\
-          \ $@\n    do\n      echo \"INFO: check infra pods miss schedule in $ns\"\
-          \n      pod_number=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
-          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
-          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ follow \n# If there are already the same number of infra pods scheduled\
+          \ on the infra nodes, we will skip deleting the pods.\n# This is for SUPPORTEX-16697\
+          \ where >3 registry pods are needed to handle the load\ninfraPodsMisscheduled(){\n\
+          \    NODE_TAINT=\"node-role.kubernetes.io=infra\"\n    # The 'none' at the\
+          \ end accounts for pods which are currently being scheduled.\n    # we do\
+          \ not want to reschedule them before knowing where they landed\n    # the\
+          \ output will look like \"<node1>|<node2>|none\"\n    infranodes_regexp=\"\
+          $(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range .items}}{{.metadata.name}}{{\"\
+          |\"}}{{end}}')none\"\n    \n    for ns in $@\n    do\n      echo \"INFO:\
+          \ check infra pods miss schedule in $ns\"\n      pod_number=`oc -n $ns get\
+          \ po -o go-template='{{range .items}}{{$isjob := index .metadata.labels\
+          \ \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name := .metadata.name}}{{$affinity\
+          \ := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
           \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
           \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
           \ |grep -E ${infranodes_regexp}|wc -l`\n      # if the pods number running\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29274,29 +29274,43 @@ objects:
           \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
           \ for infra nodes\n# Notes: this is done as a response to an escalation\
           \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
-          \ follow \ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
+          \ follow \n# If there are already the same number of infra nodes scheduled\
+          \ on the infra nodes, we will skip deleting the pods.\n# This is for the\
+          \ use case that customer scaled up the replicas like registry pods to handel\
+          \ the load\ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
           \n    # The 'none' at the end accounts for pods which are currently being\
           \ scheduled.\n    # we do not want to reschedule them before knowing where\
           \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
           \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
-          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    # the output\
-          \ will look something like\n    # <namespace> | <pod> | <affinity> | <node>\n\
-          \    # each pod on the list needs to be rescheduled\n    misscheduled_pods=`for\
-          \ ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    for ns in\
+          \ $@\n    do\n      echo \"INFO: check infra pods miss schedule in $ns\"\
+          \n      pod_number=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
           \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
           \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
           \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
-          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}';done |grep \"\
-          node-role.kubernetes.io/infra\" |grep -vE ${infranodes_regexp}`\n\n    if\
-          \ [ ! -z  \"$misscheduled_pods\" ]; then\n        # --ignore-not-found=true\
-          \ so that for STS clusters this doesn't fail when this can't find CIO or\
-          \ velero pods\n        while read line ; do cmd=`echo $line|awk -F'|' '{print\
-          \ \"oc -n \" $1 \" delete po --ignore-not-found=true \" $2}'`;echo \"INFO:\
-          \ $cmd\"; eval $cmd;done <<< \"$misscheduled_pods\"\n    else\n        echo\
-          \ \"INFO: no misscheduled pods in openshift-* namespaces\"\n    fi\n}\n\n\
-          echo \"INFO: Rebalancing openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled\
-          \ \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\
-          \necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
+          \ |grep -E ${infranodes_regexp}|wc -l`\n      # if the pods number running\
+          \ on infra is more than the infra node count, we will skip the reschedule.\n\
+          \      if (( ${pod_number} >= ${INFRA_NODE_COUNT} ));then\n        echo\
+          \ \"INFO: there are already ${pod_number} pods running on ${INFRA_NODE_COUNT}\
+          \ infra nodes, skip reschedule\"\n        continue\n      fi\n\n      #\
+          \ the output will look something like\n      # <namespace> | <pod> | <affinity>\
+          \ | <node>\n      # each pod on the list needs to be rescheduled\n     \
+          \ missscheduled_pods=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
+          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
+          \ |grep -vE ${infranodes_regexp}`\n      if [ ! -z  \"$misscheduled_pods\"\
+          \ ]; then\n      # --ignore-not-found=true so that for STS clusters this\
+          \ doesn't fail when this can't find CIO or velero pods\n        while read\
+          \ line ; do cmd=`echo $line|awk -F'|' '{print \"oc -n \" $1 \" delete po\
+          \ --ignore-not-found=true \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<<\
+          \ \"$misscheduled_pods\"\n      else\n        echo \"INFO: no misscheduled\
+          \ pods in $ns namespaces\"\n      fi\n    done\n}\n\necho \"INFO: Rebalancing\
+          \ openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled \"\
+          openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\n\
+          echo \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
           \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
           \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
           \ app prometheus-user-workload-db\n\necho \"INFO: Rebalancing alertmanager\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29274,19 +29274,19 @@ objects:
           \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
           \ for infra nodes\n# Notes: this is done as a response to an escalation\
           \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
-          \ follow \n# If there are already the same number of infra nodes scheduled\
-          \ on the infra nodes, we will skip deleting the pods.\n# This is for the\
-          \ use case that customer scaled up the replicas like registry pods to handel\
-          \ the load\ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
-          \n    # The 'none' at the end accounts for pods which are currently being\
-          \ scheduled.\n    # we do not want to reschedule them before knowing where\
-          \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
-          \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
-          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    for ns in\
-          \ $@\n    do\n      echo \"INFO: check infra pods miss schedule in $ns\"\
-          \n      pod_number=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
-          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
-          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ follow \n# If there are already the same number of infra pods scheduled\
+          \ on the infra nodes, we will skip deleting the pods.\n# This is for SUPPORTEX-16697\
+          \ where >3 registry pods are needed to handle the load\ninfraPodsMisscheduled(){\n\
+          \    NODE_TAINT=\"node-role.kubernetes.io=infra\"\n    # The 'none' at the\
+          \ end accounts for pods which are currently being scheduled.\n    # we do\
+          \ not want to reschedule them before knowing where they landed\n    # the\
+          \ output will look like \"<node1>|<node2>|none\"\n    infranodes_regexp=\"\
+          $(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range .items}}{{.metadata.name}}{{\"\
+          |\"}}{{end}}')none\"\n    \n    for ns in $@\n    do\n      echo \"INFO:\
+          \ check infra pods miss schedule in $ns\"\n      pod_number=`oc -n $ns get\
+          \ po -o go-template='{{range .items}}{{$isjob := index .metadata.labels\
+          \ \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name := .metadata.name}}{{$affinity\
+          \ := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
           \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
           \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
           \ |grep -E ${infranodes_regexp}|wc -l`\n      # if the pods number running\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29274,29 +29274,43 @@ objects:
           \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
           \ for infra nodes\n# Notes: this is done as a response to an escalation\
           \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
-          \ follow \ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
+          \ follow \n# If there are already the same number of infra nodes scheduled\
+          \ on the infra nodes, we will skip deleting the pods.\n# This is for the\
+          \ use case that customer scaled up the replicas like registry pods to handel\
+          \ the load\ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
           \n    # The 'none' at the end accounts for pods which are currently being\
           \ scheduled.\n    # we do not want to reschedule them before knowing where\
           \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
           \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
-          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    # the output\
-          \ will look something like\n    # <namespace> | <pod> | <affinity> | <node>\n\
-          \    # each pod on the list needs to be rescheduled\n    misscheduled_pods=`for\
-          \ ns in $@; do oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    for ns in\
+          \ $@\n    do\n      echo \"INFO: check infra pods miss schedule in $ns\"\
+          \n      pod_number=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
           \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
           \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
           \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
-          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}';done |grep \"\
-          node-role.kubernetes.io/infra\" |grep -vE ${infranodes_regexp}`\n\n    if\
-          \ [ ! -z  \"$misscheduled_pods\" ]; then\n        # --ignore-not-found=true\
-          \ so that for STS clusters this doesn't fail when this can't find CIO or\
-          \ velero pods\n        while read line ; do cmd=`echo $line|awk -F'|' '{print\
-          \ \"oc -n \" $1 \" delete po --ignore-not-found=true \" $2}'`;echo \"INFO:\
-          \ $cmd\"; eval $cmd;done <<< \"$misscheduled_pods\"\n    else\n        echo\
-          \ \"INFO: no misscheduled pods in openshift-* namespaces\"\n    fi\n}\n\n\
-          echo \"INFO: Rebalancing openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled\
-          \ \"openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\
-          \necho \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
+          \ |grep -E ${infranodes_regexp}|wc -l`\n      # if the pods number running\
+          \ on infra is more than the infra node count, we will skip the reschedule.\n\
+          \      if (( ${pod_number} >= ${INFRA_NODE_COUNT} ));then\n        echo\
+          \ \"INFO: there are already ${pod_number} pods running on ${INFRA_NODE_COUNT}\
+          \ infra nodes, skip reschedule\"\n        continue\n      fi\n\n      #\
+          \ the output will look something like\n      # <namespace> | <pod> | <affinity>\
+          \ | <node>\n      # each pod on the list needs to be rescheduled\n     \
+          \ missscheduled_pods=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
+          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
+          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
+          \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
+          \ |grep -vE ${infranodes_regexp}`\n      if [ ! -z  \"$misscheduled_pods\"\
+          \ ]; then\n      # --ignore-not-found=true so that for STS clusters this\
+          \ doesn't fail when this can't find CIO or velero pods\n        while read\
+          \ line ; do cmd=`echo $line|awk -F'|' '{print \"oc -n \" $1 \" delete po\
+          \ --ignore-not-found=true \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<<\
+          \ \"$misscheduled_pods\"\n      else\n        echo \"INFO: no misscheduled\
+          \ pods in $ns namespaces\"\n      fi\n    done\n}\n\necho \"INFO: Rebalancing\
+          \ openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled \"\
+          openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\n\
+          echo \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
           \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
           \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
           \ app prometheus-user-workload-db\n\necho \"INFO: Rebalancing alertmanager\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29274,19 +29274,19 @@ objects:
           \ \n#    but have nodeaffinity preferredDuringSchedulingIgnoredDuringExecution\
           \ for infra nodes\n# Notes: this is done as a response to an escalation\
           \ in https://issues.redhat.com/browse/OSD-13621 \n# A long term fix will\
-          \ follow \n# If there are already the same number of infra nodes scheduled\
-          \ on the infra nodes, we will skip deleting the pods.\n# This is for the\
-          \ use case that customer scaled up the replicas like registry pods to handel\
-          \ the load\ninfraPodsMisscheduled(){\n    NODE_TAINT=\"node-role.kubernetes.io=infra\"\
-          \n    # The 'none' at the end accounts for pods which are currently being\
-          \ scheduled.\n    # we do not want to reschedule them before knowing where\
-          \ they landed\n    # the output will look like \"<node1>|<node2>|none\"\n\
-          \    infranodes_regexp=\"$(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range\
-          \ .items}}{{.metadata.name}}{{\"|\"}}{{end}}')none\"\n    \n    for ns in\
-          \ $@\n    do\n      echo \"INFO: check infra pods miss schedule in $ns\"\
-          \n      pod_number=`oc -n $ns get po -o go-template='{{range .items}}{{$isjob\
-          \ := index .metadata.labels \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name\
-          \ := .metadata.name}}{{$affinity := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
+          \ follow \n# If there are already the same number of infra pods scheduled\
+          \ on the infra nodes, we will skip deleting the pods.\n# This is for SUPPORTEX-16697\
+          \ where >3 registry pods are needed to handle the load\ninfraPodsMisscheduled(){\n\
+          \    NODE_TAINT=\"node-role.kubernetes.io=infra\"\n    # The 'none' at the\
+          \ end accounts for pods which are currently being scheduled.\n    # we do\
+          \ not want to reschedule them before knowing where they landed\n    # the\
+          \ output will look like \"<node1>|<node2>|none\"\n    infranodes_regexp=\"\
+          $(oc get no -l \"${NODE_TAINT}\" -o go-template='{{range .items}}{{.metadata.name}}{{\"\
+          |\"}}{{end}}')none\"\n    \n    for ns in $@\n    do\n      echo \"INFO:\
+          \ check infra pods miss schedule in $ns\"\n      pod_number=`oc -n $ns get\
+          \ po -o go-template='{{range .items}}{{$isjob := index .metadata.labels\
+          \ \"job-name\"}}{{$namespace := .metadata.namespace}}{{$name := .metadata.name}}{{$affinity\
+          \ := .spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution\
           \ }}{{if not $isjob}}{{if $affinity}}{{- $namespace }} | {{$name}} | {{$affinity}}\
           \ | {{.spec.nodeName}} {{\"\\n\" -}} {{end}}{{end}}{{end}}'|grep \"node-role.kubernetes.io/infra\"\
           \ |grep -E ${infranodes_regexp}|wc -l`\n      # if the pods number running\


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
https://issues.redhat.com/browse/OSD-15340
### What this PR does / why we need it?
Do not reschedule infra pods if there are already the number of infra node pods running on infra nodes
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
