### PR TITLE
Modify promrule so it doesn't deploy to int/stg hive

### DIFF
--- a/deploy/sre-prometheus/fedramp/hive-prod/config.yaml
+++ b/deploy/sre-prometheus/fedramp/hive-prod/config.yaml
@@ -13,3 +13,8 @@ selectorSyncSet:
       operator: In
       values:
         - "production"
+    - key: api.openshift.com/id
+      operator: NotIn
+      values:
+        - "1un6q99vtt3g1ujlqbuok3arlnd41flm"
+        - "1un6r65bn36fhtl0o5ai0vsoqoicm4qf"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35414,6 +35414,11 @@ objects:
         operator: In
         values:
         - production
+      - key: api.openshift.com/id
+        operator: NotIn
+        values:
+        - 1un6q99vtt3g1ujlqbuok3arlnd41flm
+        - 1un6r65bn36fhtl0o5ai0vsoqoicm4qf
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35414,6 +35414,11 @@ objects:
         operator: In
         values:
         - production
+      - key: api.openshift.com/id
+        operator: NotIn
+        values:
+        - 1un6q99vtt3g1ujlqbuok3arlnd41flm
+        - 1un6r65bn36fhtl0o5ai0vsoqoicm4qf
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35414,6 +35414,11 @@ objects:
         operator: In
         values:
         - production
+      - key: api.openshift.com/id
+        operator: NotIn
+        values:
+        - 1un6q99vtt3g1ujlqbuok3arlnd41flm
+        - 1un6r65bn36fhtl0o5ai0vsoqoicm4qf
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18802

_Fixes #_
PrometheusRule created previously deployed to int/stg hive since they were labeled as production environments. This PR skips these 2 hives

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
