### PR TITLE
OSD-19800: replace ClusterOperatorDown(insights)

### DIFF
--- a/deploy/sre-prometheus/insights/100-sre-insightsoperator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/insights/100-sre-insightsoperator.PrometheusRule.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-insights-operator-alerts
+    role: alert-rules
+  name: sre-insights-operator-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-insights-operator-alerts
+    rules:
+    # Upstream alert: ClusterOperatorDown{name="insights"}
+    # https://github.com/openshift/cluster-version-operator/blob/master/install/0000_90_cluster-version-operator_02_servicemonitor.yaml#L96
+    # Redefined as part of https://issues.redhat.com/browse/OSD-19800
+    - alert: InsightsOperatorDownSRE
+      expr: |
+        max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator", name="insights"} == 0)
+      for: 3h
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: Insights operator has not been available for 3 hours.
+        description: The {{ "{{ $labels.name }}" }} operator may be down or disabled because {{ "{{ $labels.reason }}" }}, and the components it manages may be unavailable or degraded.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/insights.md"

--- a/deploy/sre-prometheus/insights/config.yaml
+++ b/deploy/sre-prometheus/insights/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+    - key: api.openshift.com/fedramp
+      # Insights operator does not exist in FedRAMP
+      # https://issues.redhat.com/browse/OSD-13685
+      operator: NotIn
+      values:
+        - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35446,6 +35446,57 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-insights
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-insights-operator-alerts
+          role: alert-rules
+        name: sre-insights-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-insights-operator-alerts
+          rules:
+          - alert: InsightsOperatorDownSRE
+            expr: 'max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator",
+              name="insights"} == 0)
+
+              '
+            for: 3h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              summary: Insights operator has not been available for 3 hours.
+              description: The {{ "{{ $labels.name }}" }} operator may be down or
+                disabled because {{ "{{ $labels.reason }}" }}, and the components
+                it manages may be unavailable or degraded.  Cluster upgrades may not
+                complete. For more information refer to 'oc get -o yaml clusteroperator
+                {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\"
+                | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}}
+                or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end
+                }}{{ end }}" }}.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/insights.md
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-legacy-ingress
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35446,6 +35446,57 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-insights
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-insights-operator-alerts
+          role: alert-rules
+        name: sre-insights-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-insights-operator-alerts
+          rules:
+          - alert: InsightsOperatorDownSRE
+            expr: 'max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator",
+              name="insights"} == 0)
+
+              '
+            for: 3h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              summary: Insights operator has not been available for 3 hours.
+              description: The {{ "{{ $labels.name }}" }} operator may be down or
+                disabled because {{ "{{ $labels.reason }}" }}, and the components
+                it manages may be unavailable or degraded.  Cluster upgrades may not
+                complete. For more information refer to 'oc get -o yaml clusteroperator
+                {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\"
+                | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}}
+                or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end
+                }}{{ end }}" }}.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/insights.md
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-legacy-ingress
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35446,6 +35446,57 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-insights
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-insights-operator-alerts
+          role: alert-rules
+        name: sre-insights-operator-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-insights-operator-alerts
+          rules:
+          - alert: InsightsOperatorDownSRE
+            expr: 'max by (namespace, name, reason) (cluster_operator_up{job="cluster-version-operator",
+              name="insights"} == 0)
+
+              '
+            for: 3h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              summary: Insights operator has not been available for 3 hours.
+              description: The {{ "{{ $labels.name }}" }} operator may be down or
+                disabled because {{ "{{ $labels.reason }}" }}, and the components
+                it manages may be unavailable or degraded.  Cluster upgrades may not
+                complete. For more information refer to 'oc get -o yaml clusteroperator
+                {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\"
+                | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}}
+                or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end
+                }}{{ end }}" }}.
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/insights.md
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-legacy-ingress
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?

This PR introduces a new alert `InsightsOperatorDownSRE` which replaces `ClusterOperatorDown` for insights. The expression is the same but needs to be triggered for 3 hours instead of 10 minutes.

`ClusterOperatorDown` for `insights` is being silenced in CAMO with this PR: https://github.com/openshift/configure-alertmanager-operator/pull/309/files.

Important notes:
- this new alert is only effective for non-fedramp, as fedramp has no insights operator
- MCC will need to be promoted before CAMO to not risk losing any alerts

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-19800 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
