### PR TITLE
OHSS-29140;OHSS-28570 - Remove 'openshift-operators-redhat' namespace from UWM scraping

### DIFF
--- a/deploy/osd-namespace-labels/10-openshift-operators-redhat.patch.yaml
+++ b/deploy/osd-namespace-labels/10-openshift-operators-redhat.patch.yaml
@@ -1,0 +1,8 @@
+kind: Namespace
+apiVersion: v1
+name: openshift-operators-redhat
+applyMode: AlwaysApply
+# https://issues.redhat.com/browse/OSD-4230
+patch: |-
+  { "metadata": {"labels": {"openshift.io/user-monitoring": "false"} } }
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28547,6 +28547,13 @@ objects:
       patch: '{ "metadata": {"labels": {"name":"openshift-operator-lifecycle-manager"}
         } }'
       patchType: merge
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-operators-redhat
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"openshift.io/user-monitoring": "false"} }
+        }'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28547,6 +28547,13 @@ objects:
       patch: '{ "metadata": {"labels": {"name":"openshift-operator-lifecycle-manager"}
         } }'
       patchType: merge
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-operators-redhat
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"openshift.io/user-monitoring": "false"} }
+        }'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28547,6 +28547,13 @@ objects:
       patch: '{ "metadata": {"labels": {"name":"openshift-operator-lifecycle-manager"}
         } }'
       patchType: merge
+    - kind: Namespace
+      apiVersion: v1
+      name: openshift-operators-redhat
+      applyMode: AlwaysApply
+      patch: '{ "metadata": {"labels": {"openshift.io/user-monitoring": "false"} }
+        }'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION

### What type of PR is this?
_bug_

### What this PR does / why we need it?
Explicitly labels the `openshift-operators-redhat` namespace as one user-workload-monitoring should *not* scrape. UWM throws a warning-level alert when trying to scrape ServiceMonitors in this namespace, which has generated several OHSS tickets for Secondary. 

The suggested workaround in [this KCS](https://access.redhat.com/solutions/6992399) is to label the namespace with `openshift.io/cluster-monitoring: "true"`, however this is inappropriate for OSD/ROSA, as doing so would route alerts from this namespace to Primary.

### Which Jira/Github issue(s) this PR fixes?
- [OHSS-28570](https://issues.redhat.com/browse/OHSS-28570)
- [OHSS-29140](https://issues.redhat.com/browse/OHSS-29140)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
