### PR TITLE
The Policy will be non-compliant until the default IngressController resource appears

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -43,6 +43,14 @@ spec:
                               scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
                           {{hub- end hub}}
                     {{- end }}
+                    {{- if ne (lookup "operator.openshift.io/v1" "IngressController" "openshift-ingress-operator" "default").metadata.name "default" }}
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        kind: Namespace
+                        metadata:
+                          name: donotcreateme?
+                    {{- end }}
                 pruneObjectBehavior: None
                 remediationAction: enforce
                 severity: low

--- a/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/02-ingress-default.Policy.yaml
@@ -6,6 +6,9 @@
 #  by the change.
 # Changing the policy directly, without the ConfigMap reference will apply to ALL HCP's
 #
+# SPECIAL NOTE:
+# The Namespace enforce at the bottom has an invalid name, this is designed to make the policy non-compliant
+# whenever the openshift-ingress-operator IngressController default customResource is missing.
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
@@ -36,6 +39,14 @@ spec:
               dnsManagementPolicy: 'Managed'
               scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
           {{hub- end hub}}
+    {{- end }}
+    {{- if ne (lookup "operator.openshift.io/v1" "IngressController" "openshift-ingress-operator" "default").metadata.name "default" }}
+    - complianceType: musthave
+      metadataComplianceType: musthave
+      objectDefinition:
+        kind: Namespace
+        metadata:
+          name: donotcreateme?
     {{- end }}
   pruneObjectBehavior: None
   remediationAction: enforce

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7644,7 +7644,11 @@ objects:
                 \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
                 endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
                 \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
-                {{- end }}\n"
+                {{- end }}\n{{- if ne (lookup \"operator.openshift.io/v1\" \"IngressController\"\
+                \ \"openshift-ingress-operator\" \"default\").metadata.name \"default\"\
+                \ }}\n- complianceType: musthave\n  metadataComplianceType: musthave\n\
+                \  objectDefinition:\n    kind: Namespace\n    metadata:\n      name:\
+                \ donotcreateme?\n{{- end }}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7644,7 +7644,11 @@ objects:
                 \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
                 endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
                 \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
-                {{- end }}\n"
+                {{- end }}\n{{- if ne (lookup \"operator.openshift.io/v1\" \"IngressController\"\
+                \ \"openshift-ingress-operator\" \"default\").metadata.name \"default\"\
+                \ }}\n- complianceType: musthave\n  metadataComplianceType: musthave\n\
+                \  objectDefinition:\n    kind: Namespace\n    metadata:\n      name:\
+                \ donotcreateme?\n{{- end }}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7644,7 +7644,11 @@ objects:
                 \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
                 endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
                 \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
-                {{- end }}\n"
+                {{- end }}\n{{- if ne (lookup \"operator.openshift.io/v1\" \"IngressController\"\
+                \ \"openshift-ingress-operator\" \"default\").metadata.name \"default\"\
+                \ }}\n- complianceType: musthave\n  metadataComplianceType: musthave\n\
+                \  objectDefinition:\n    kind: Namespace\n    metadata:\n      name:\
+                \ donotcreateme?\n{{- end }}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug (regression) due to performance improvements.

### What this PR does / why we need it?
* Allows the Policy to avoid a 2hr reconcile when the default IngressController resource is missing
* This was accomplished, by trying to create an invalid resource when the default IngressController is missing
* Even if there was a Policy looking for the default IngressController, it would show as non-compliant
* Reconcile is 45s when non-compliant, so there should not be a dramatic affect on provisioning

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OCM-5315

### Special notes for your reviewer:
Make sure TLS is online and the rosa-ingress-certificate-policies and rosa-ingress-certificate-check policies are not return a large number of messages when non-compliant.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] ~Included documentation changes with PR~
- [ ] ~If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:~

