### PR TITLE
[OSD-19769] Add ClusterMonitoringErrorBudgetBurnSRE alert

### DIFF
--- a/deploy/sre-prometheus/monitoring/100-cluster-monitoring-error-budget-burn.yaml
+++ b/deploy/sre-prometheus/monitoring/100-cluster-monitoring-error-budget-burn.yaml
@@ -1,0 +1,73 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-cluster-monitoring-error-budget-burn
+    role: alert-rules
+  name: sre-cluster-monitoring-error-budget-burn
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-cluster-monitoring-error-budget-burn
+    rules:
+    # Substitues ClusterOperatorDown{name="monitoring"} as part of https://issues.redhat.com/browse/OSD-19769
+    - alert: ClusterMonitoringErrorBudgetBurnSRE
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) ) > (14.4 * (1 - 0.99))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) ) > (14.4 * (1 - 0.99))
+      for: 2m
+      labels:
+        long_window: 1h
+        severity: critical
+        namespace: openshift-monitoring
+        source: "https://issues.redhat.com/browse/OSD-19769"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md"
+        short_window: 5m
+      annotations:
+        message: "High error budget burn for the monitoring cluster operator (current value: {{ $value }})"
+    - alert: ClusterMonitoringErrorBudgetBurnSRE
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m])) ) > (6 * (1 - 0.99))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) ) > (6 * (1 - 0.99))
+      for: 15m
+      labels:
+        long_window: 6h
+        severity: critical
+        namespace: openshift-monitoring
+        source: "https://issues.redhat.com/browse/OSD-19769"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md"
+        short_window: 30m
+      annotations:
+        message: "High error budget burn for the monitoring cluster operator (current value: {{ $value }})"
+    - alert: ClusterMonitoringErrorBudgetBurnSRE
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[2h])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[2h])) ) > (3 * (1 - 0.99))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1d])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[1d])) ) > (3 * (1 - 0.99))
+      for: 1h
+      labels:
+        long_window: 1d
+        severity: critical
+        namespace: openshift-monitoring
+        source: "https://issues.redhat.com/browse/OSD-19769"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md"
+        short_window: 2h
+      annotations:
+        message: "High error budget burn for the monitoring cluster operator (current value: {{ $value }})"
+    - alert: ClusterMonitoringErrorBudgetBurnSRE
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) ) > (1 * (1 - 0.99))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[3d])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[3d])) ) > (1 * (1 - 0.99))
+      for: 3h
+      labels:
+        long_window: 3d
+        severity: critical
+        namespace: openshift-monitoring
+        source: "https://issues.redhat.com/browse/OSD-19769"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md"
+        short_window: 6h
+      annotations:
+        message: "High error budget burn for the monitoring cluster operator (current value: {{ $value }})"

--- a/deploy/sre-prometheus/monitoring/config.yaml
+++ b/deploy/sre-prometheus/monitoring/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values:
+        - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35728,6 +35728,129 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-monitoring
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-cluster-monitoring-error-budget-burn
+          role: alert-rules
+        name: sre-cluster-monitoring-error-budget-burn
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-monitoring-error-budget-burn
+          rules:
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) )
+              > (14.4 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) )
+              > (14.4 * (1 - 0.99))
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m]))
+              ) > (6 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
+              > (6 * (1 - 0.99))
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 30m
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[2h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[2h])) )
+              > (3 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1d]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1d])) )
+              > (3 * (1 - 0.99))
+
+              '
+            for: 1h
+            labels:
+              long_window: 1d
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 2h
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
+              > (1 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[3d]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[3d])) )
+              > (1 * (1 - 0.99))
+
+              '
+            for: 3h
+            labels:
+              long_window: 3d
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 6h
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35728,6 +35728,129 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-monitoring
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-cluster-monitoring-error-budget-burn
+          role: alert-rules
+        name: sre-cluster-monitoring-error-budget-burn
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-monitoring-error-budget-burn
+          rules:
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) )
+              > (14.4 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) )
+              > (14.4 * (1 - 0.99))
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m]))
+              ) > (6 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
+              > (6 * (1 - 0.99))
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 30m
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[2h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[2h])) )
+              > (3 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1d]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1d])) )
+              > (3 * (1 - 0.99))
+
+              '
+            for: 1h
+            labels:
+              long_window: 1d
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 2h
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
+              > (1 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[3d]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[3d])) )
+              > (1 * (1 - 0.99))
+
+              '
+            for: 3h
+            labels:
+              long_window: 3d
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 6h
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35728,6 +35728,129 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-monitoring
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: sre-cluster-monitoring-error-budget-burn
+          role: alert-rules
+        name: sre-cluster-monitoring-error-budget-burn
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-cluster-monitoring-error-budget-burn
+          rules:
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) )
+              > (14.4 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) )
+              > (14.4 * (1 - 0.99))
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m]))
+              ) > (6 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
+              > (6 * (1 - 0.99))
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 30m
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[2h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[2h])) )
+              > (3 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1d]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1d])) )
+              > (3 * (1 - 0.99))
+
+              '
+            for: 1h
+            labels:
+              long_window: 1d
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 2h
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+          - alert: ClusterMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
+              > (1 * (1 - 0.99))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[3d]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring"}[3d])) )
+              > (1 * (1 - 0.99))
+
+              '
+            for: 3h
+            labels:
+              long_window: 3d
+              severity: critical
+              namespace: openshift-monitoring
+              source: https://issues.redhat.com/browse/OSD-19769
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 6h
+            annotations:
+              message: 'High error budget burn for the monitoring cluster operator
+                (current value: {{ $value }})'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

This PR aims to replace the ClusterOperatorDown alert for the cluster monitoring operator. More information on the ticket https://issues.redhat.com/browse/OSD-19769

The silence for the ClusterOperatorDown is being added on CAMO with this PR: https://github.com/openshift/configure-alertmanager-operator/pull/312. To merge after this one.
