### PR TITLE
OCM-5315 & ACM-9127 Policy will be non-compliant until the default IngressController resource appears

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ ifndef GEN_CMO_CONFIG
 $(error GEN_CMO_CONFIG is not set; check project.mk file)
 endif
 
+POLICYGEN_VERSION=v1.12.3
+
 VOLUME_MOUNT_FLAGS = :z
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
 ifneq (,$(findstring podman,$(CONTAINER_ENGINE)))
@@ -75,7 +77,7 @@ generate-rosa-brand-logo:
 .PHONY: generate-hive-templates
 generate-hive-templates: generate-oauth-templates
 	if [ -z ${IN_CONTAINER} ]; then \
-		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi8/python-39 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.9.1/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator; chmod +x /opt/app-root/bin/PolicyGenerator; ${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; ${GEN_POLICY}; ${GEN_CMO_CONFIG}";\
+		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi8/python-39 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator; chmod +x /opt/app-root/bin/PolicyGenerator; ${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; ${GEN_POLICY}; ${GEN_CMO_CONFIG}";\
 		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi8/python-39 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; ${GEN_TEMPLATE}"; \
 	else \
 		${GEN_POLICY_CONFIG};\

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifndef GEN_CMO_CONFIG
 $(error GEN_CMO_CONFIG is not set; check project.mk file)
 endif
 
-POLICYGEN_VERSION=v1.12.3
+POLICYGEN_VERSION=v1.12.4
 
 VOLUME_MOUNT_FLAGS = :z
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)

--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -105,6 +105,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -171,6 +171,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -77,6 +77,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -31,6 +31,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -105,6 +105,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -140,6 +140,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -84,6 +84,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
@@ -359,6 +359,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
@@ -241,6 +241,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -105,6 +105,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -140,6 +140,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -143,6 +143,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -422,6 +422,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -105,6 +105,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -140,6 +140,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -45,6 +45,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -73,6 +73,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -40,6 +40,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -102,6 +102,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
@@ -62,6 +62,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
@@ -35,6 +35,7 @@ spec:
                     {{- end }}
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -59,6 +59,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -39,6 +39,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
@@ -626,6 +626,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
@@ -236,6 +236,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
@@ -70,6 +70,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
@@ -120,6 +120,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
@@ -170,6 +170,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -36,6 +36,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -95,6 +95,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -75,6 +75,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
@@ -57,6 +57,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
@@ -114,6 +114,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -347,6 +347,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -1040,6 +1040,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding-configmap.Policy.yaml
@@ -133,6 +133,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding.Policy.yaml
@@ -41,6 +41,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
@@ -6,7 +6,7 @@ metadata:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
         policy.open-cluster-management.io/standards: NIST SP 800-53
-    name: osd-user-workload-monitoring-sp
+    name: rosa-ingress-certificate-check
     namespace: openshift-acm-policies
 spec:
     disabled: false
@@ -15,47 +15,29 @@ spec:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
-                name: osd-user-workload-monitoring-sp
+                name: rosa-ingress-controller-check
             spec:
                 evaluationInterval:
                     compliant: 2h
                     noncompliant: 45s
-                namespaceSelector:
-                    exclude:
-                        - kube-*
-                        - openshift*
-                        - ops-health-monitoring
-                        - management-infra
-                        - default
-                        - logging
-                        - sre-app-check
-                    include:
-                        - '*'
                 object-templates:
-                    - complianceType: mustonlyhave
+                    - complianceType: musthave
                       metadataComplianceType: musthave
                       objectDefinition:
-                        apiVersion: rbac.authorization.k8s.io/v1
-                        kind: RoleBinding
+                        apiVersion: operator.openshift.io/v1
+                        kind: IngressController
                         metadata:
-                            name: dedicated-admins-alert-routing-edit-0
-                        roleRef:
-                            apiGroup: rbac.authorization.k8s.io
-                            kind: ClusterRole
-                            name: alert-routing-edit
-                        subjects:
-                            - apiGroup: rbac.authorization.k8s.io
-                              kind: Group
-                              name: dedicated-admins
-                pruneObjectBehavior: DeleteIfCreated
-                remediationAction: enforce
+                            name: default
+                            namespace: openshift-ingress-operator
+                pruneObjectBehavior: None
+                remediationAction: inform
                 severity: low
-    remediationAction: enforce
+    remediationAction: inform
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-    name: placement-osd-user-workload-monitoring-sp
+    name: placement-rosa-ingress-certificate-check
     namespace: openshift-acm-policies
 spec:
     clusterSelector:
@@ -68,13 +50,13 @@ spec:
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-    name: binding-osd-user-workload-monitoring-sp
+    name: binding-rosa-ingress-certificate-check
     namespace: openshift-acm-policies
 placementRef:
     apiGroup: apps.open-cluster-management.io
     kind: PlacementRule
-    name: placement-osd-user-workload-monitoring-sp
+    name: placement-rosa-ingress-certificate-check
 subjects:
     - apiGroup: policy.open-cluster-management.io
       kind: Policy
-      name: osd-user-workload-monitoring-sp
+      name: rosa-ingress-certificate-check

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -11,7 +11,13 @@ metadata:
 spec:
     disabled: false
     policy-templates:
-        - objectDefinition:
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: Policy
+              name: rosa-ingress-certificate-check
+              namespace: openshift-acm-policies
+          objectDefinition:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
@@ -21,7 +27,6 @@ spec:
                     compliant: 2h
                     noncompliant: 45s
                 object-templates-raw: |
-                    {{- if eq (lookup "operator.openshift.io/v1" "IngressController" "openshift-ingress-operator" "default").metadata.name "default" }}
                     - complianceType: musthave
                       metadataComplianceType: musthave
                       objectDefinition:
@@ -42,11 +47,16 @@ spec:
                               dnsManagementPolicy: 'Managed'
                               scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
                           {{hub- end hub}}
-                    {{- end }}
                 pruneObjectBehavior: None
                 remediationAction: enforce
                 severity: low
-        - objectDefinition:
+        - extraDependencies:
+            - apiVersion: policy.open-cluster-management.io/v1
+              compliance: Compliant
+              kind: Policy
+              name: rosa-ingress-certificate-check
+              namespace: openshift-acm-policies
+          objectDefinition:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
@@ -70,6 +80,7 @@ spec:
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low
+    remediationAction: enforce
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/deploy/hosted-uwm/config.yaml
+++ b/deploy/hosted-uwm/config.yaml
@@ -1,3 +1,3 @@
 deploymentMode: Policy
 clusterSelectors:
-  hypershift.open-cluster-management.io/hosted-cluster: true
+  'hypershift.open-cluster-management.io/hosted-cluster': 'true'

--- a/deploy/hypershift-ovn-logging/config.yaml
+++ b/deploy/hypershift-ovn-logging/config.yaml
@@ -1,6 +1,6 @@
 deploymentMode: Policy
 clusterSelectors:
-  hypershift.open-cluster-management.io/management-cluster: true
+  'hypershift.open-cluster-management.io/management-cluster': 'true'
 policy:
   destination: "acm-policies"
   complianceType: "musthave"

--- a/deploy/rosa-ingress-certificate-check/01-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-check/01-ingress-default.Policy.yaml
@@ -9,12 +9,12 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
-  name: rosa-ingress-controller-policies
+  name: rosa-ingress-controller-check
 spec:
   evaluationInterval:
-      compliant: 2h
-      noncompliant: 45s
-  object-templates-raw: |
+    compliant: 2h
+    noncompliant: 45s
+  object-templates:
     - complianceType: musthave
       metadataComplianceType: musthave
       objectDefinition:
@@ -23,18 +23,6 @@ spec:
         metadata:
           name: default
           namespace: openshift-ingress-operator
-          annotations:
-            ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
-        spec:
-          defaultCertificate:
-            name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
-          {{hub- if ne (lookup "v1" "ConfigMap" "openshift-acm-policies" .ManagedClusterName).data nil hub}}
-          endpointPublishingStrategy:
-            type: LoadBalancerService
-            loadBalancer:
-              dnsManagementPolicy: 'Managed'
-              scope: '{{hub- if eq (fromConfigMap "openshift-acm-policies" .ManagedClusterName "endpoint-publishing-strategy") "internal" -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'
-          {{hub- end hub}}
   pruneObjectBehavior: None
-  remediationAction: enforce
+  remediationAction: inform
   severity: low

--- a/deploy/rosa-ingress-certificate-check/config.yaml
+++ b/deploy/rosa-ingress-certificate-check/config.yaml
@@ -1,0 +1,5 @@
+deploymentMode: Policy
+clusterSelectors:
+  'hypershift.open-cluster-management.io/hosted-cluster': 'true'
+policy:
+  complianceType: "musthave"

--- a/deploy/rosa-ingress-certificate-policies/config.yaml
+++ b/deploy/rosa-ingress-certificate-policies/config.yaml
@@ -1,6 +1,7 @@
 deploymentMode: Policy
 clusterSelectors:
-  hypershift.open-cluster-management.io/hosted-cluster: true
+  'hypershift.open-cluster-management.io/hosted-cluster': 'true'
 policy:
   destination: "acm-policies"
   complianceType: "musthave"
+  extraDependencies:  [{'name': 'rosa-ingress-certificate-check', 'compliance': 'Compliant'}]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -732,6 +732,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -929,6 +930,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1032,6 +1034,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1089,6 +1092,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1220,6 +1224,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1386,6 +1391,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1496,6 +1502,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1881,6 +1888,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2148,6 +2156,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2279,6 +2288,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2445,6 +2455,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2614,6 +2625,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3062,6 +3074,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3193,6 +3206,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3359,6 +3373,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3430,6 +3445,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3529,6 +3545,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3595,6 +3612,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3723,6 +3741,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3811,6 +3830,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3865,6 +3885,7 @@ objects:
                 \ '{ \"deny\": \"info\" }'\n{{- end }}\n{{- end }}\n"
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3950,6 +3971,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4015,6 +4037,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4667,6 +4690,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4895,6 +4919,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4991,6 +5016,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5137,6 +5163,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5333,6 +5360,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5395,6 +5423,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5516,6 +5545,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5617,6 +5647,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5700,6 +5731,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5776,6 +5808,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5916,6 +5949,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -6289,6 +6323,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7355,6 +7390,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7515,6 +7551,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7582,6 +7619,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7614,7 +7652,7 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
         disabled: false
@@ -7623,14 +7661,77 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+              name: rosa-ingress-controller-check
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
+              pruneObjectBehavior: None
+              remediationAction: inform
+              severity: low
+        remediationAction: inform
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-ingress-certificate-check
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-ingress-certificate-check
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-ingress-certificate-check
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-ingress-certificate-check
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-ingress-certificate-policies
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            compliance: Compliant
+            kind: Policy
+            name: rosa-ingress-certificate-check
+            namespace: openshift-acm-policies
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
               name: rosa-ingress-controller-policies
             spec:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates-raw: "{{- if eq (lookup \"operator.openshift.io/v1\"\
-                \ \"IngressController\" \"openshift-ingress-operator\" \"default\"\
-                ).metadata.name \"default\" }}\n- complianceType: musthave\n  metadataComplianceType:\
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
                 \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
@@ -7643,12 +7744,17 @@ objects:
                 \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
                 \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
                 endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
-                {{- end }}\n"
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
-        - objectDefinition:
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            compliance: Compliant
+            kind: Policy
+            name: rosa-ingress-certificate-check
+            namespace: openshift-acm-policies
+          objectDefinition:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
@@ -7675,6 +7781,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -732,6 +732,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -929,6 +930,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1032,6 +1034,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1089,6 +1092,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1220,6 +1224,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1386,6 +1391,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1496,6 +1502,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1881,6 +1888,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2148,6 +2156,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2279,6 +2288,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2445,6 +2455,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2614,6 +2625,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3062,6 +3074,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3193,6 +3206,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3359,6 +3373,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3430,6 +3445,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3529,6 +3545,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3595,6 +3612,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3723,6 +3741,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3811,6 +3830,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3865,6 +3885,7 @@ objects:
                 \ '{ \"deny\": \"info\" }'\n{{- end }}\n{{- end }}\n"
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3950,6 +3971,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4015,6 +4037,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4667,6 +4690,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4895,6 +4919,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4991,6 +5016,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5137,6 +5163,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5333,6 +5360,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5395,6 +5423,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5516,6 +5545,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5617,6 +5647,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5700,6 +5731,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5776,6 +5808,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5916,6 +5949,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -6289,6 +6323,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7355,6 +7390,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7515,6 +7551,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7582,6 +7619,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7614,7 +7652,7 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
         disabled: false
@@ -7623,14 +7661,77 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+              name: rosa-ingress-controller-check
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
+              pruneObjectBehavior: None
+              remediationAction: inform
+              severity: low
+        remediationAction: inform
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-ingress-certificate-check
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-ingress-certificate-check
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-ingress-certificate-check
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-ingress-certificate-check
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-ingress-certificate-policies
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            compliance: Compliant
+            kind: Policy
+            name: rosa-ingress-certificate-check
+            namespace: openshift-acm-policies
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
               name: rosa-ingress-controller-policies
             spec:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates-raw: "{{- if eq (lookup \"operator.openshift.io/v1\"\
-                \ \"IngressController\" \"openshift-ingress-operator\" \"default\"\
-                ).metadata.name \"default\" }}\n- complianceType: musthave\n  metadataComplianceType:\
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
                 \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
@@ -7643,12 +7744,17 @@ objects:
                 \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
                 \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
                 endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
-                {{- end }}\n"
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
-        - objectDefinition:
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            compliance: Compliant
+            kind: Policy
+            name: rosa-ingress-certificate-check
+            namespace: openshift-acm-policies
+          objectDefinition:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
@@ -7675,6 +7781,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -732,6 +732,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -929,6 +930,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1032,6 +1034,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1089,6 +1092,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1220,6 +1224,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1386,6 +1391,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1496,6 +1502,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -1881,6 +1888,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2148,6 +2156,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2279,6 +2288,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2445,6 +2455,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -2614,6 +2625,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3062,6 +3074,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3193,6 +3206,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3359,6 +3373,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3430,6 +3445,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3529,6 +3545,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3595,6 +3612,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3723,6 +3741,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3811,6 +3830,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3865,6 +3885,7 @@ objects:
                 \ '{ \"deny\": \"info\" }'\n{{- end }}\n{{- end }}\n"
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -3950,6 +3971,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4015,6 +4037,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4667,6 +4690,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4895,6 +4919,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -4991,6 +5016,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5137,6 +5163,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5333,6 +5360,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5395,6 +5423,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5516,6 +5545,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5617,6 +5647,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5700,6 +5731,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5776,6 +5808,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -5916,6 +5949,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -6289,6 +6323,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7355,6 +7390,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7515,6 +7551,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7582,6 +7619,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:
@@ -7614,7 +7652,7 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
-        name: rosa-ingress-certificate-policies
+        name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
         disabled: false
@@ -7623,14 +7661,77 @@ objects:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
+              name: rosa-ingress-controller-check
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: operator.openshift.io/v1
+                  kind: IngressController
+                  metadata:
+                    name: default
+                    namespace: openshift-ingress-operator
+              pruneObjectBehavior: None
+              remediationAction: inform
+              severity: low
+        remediationAction: inform
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-ingress-certificate-check
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-ingress-certificate-check
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-ingress-certificate-check
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-ingress-certificate-check
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-ingress-certificate-policies
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            compliance: Compliant
+            kind: Policy
+            name: rosa-ingress-certificate-check
+            namespace: openshift-acm-policies
+          objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
               name: rosa-ingress-controller-policies
             spec:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates-raw: "{{- if eq (lookup \"operator.openshift.io/v1\"\
-                \ \"IngressController\" \"openshift-ingress-operator\" \"default\"\
-                ).metadata.name \"default\" }}\n- complianceType: musthave\n  metadataComplianceType:\
+              object-templates-raw: "- complianceType: musthave\n  metadataComplianceType:\
                 \ musthave\n  objectDefinition:\n    apiVersion: operator.openshift.io/v1\n\
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
@@ -7643,12 +7744,17 @@ objects:
                 \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
                 \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
                 endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n\
-                {{- end }}\n"
+                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
-        - objectDefinition:
+        - extraDependencies:
+          - apiVersion: policy.open-cluster-management.io/v1
+            compliance: Compliant
+            kind: Policy
+            name: rosa-ingress-certificate-check
+            namespace: openshift-acm-policies
+          objectDefinition:
             apiVersion: policy.open-cluster-management.io/v1
             kind: ConfigurationPolicy
             metadata:
@@ -7675,6 +7781,7 @@ objects:
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
+        remediationAction: enforce
     - apiVersion: apps.open-cluster-management.io/v1
       kind: PlacementRule
       metadata:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -40,6 +40,7 @@ directories = [
         'rosa-console-branding',
         'rosa-console-branding-configmap',
         'rosa-ingress-certificate-policies',
+        'rosa-ingress-certificate-check',
         ]
 policy_generator_config = './scripts/policy-generator-config.yaml'
 config_filename = "config.yaml"
@@ -83,7 +84,9 @@ for directory in sorted(directories, key=str.casefold):
                 policy_template['policyDefaults']['complianceType'] = config['policy']['complianceType'].lower()
             if 'metadataComplianceType' in config['policy'].keys() and config['policy']['metadataComplianceType'] != '' : 
                 policy_template['policyDefaults']['metadataComplianceType'] = config['policy']['metadataComplianceType'].lower()
-       
+            if 'extraDependencies' in config['policy'].keys() and config['policy']['extraDependencies'] != '' : 
+                policy_template['policyDefaults']['extraDependencies'] = config['policy']['extraDependencies']
+
     for p in policy_template['policies']:
         p['name'] = policy_name
         for m in p['manifests']:

--- a/scripts/generate-policy.sh
+++ b/scripts/generate-policy.sh
@@ -6,7 +6,7 @@ ROOT_DIR=$PWD
 for dir in $DIRECTORY; do
     echo $dir
     cd $dir
-    name=$(grep "\- name:" $FILENAME | cut -d: -f2- | xargs)
+    name=$(grep "^\- name:" $FILENAME | cut -d: -f2- | xargs)
     echo $name
     PolicyGenerator $FILENAME > $ROOT_DIR/deploy/acm-policies/50-GENERATED-$name.Policy.yaml
     cd $ROOT_DIR


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
**bug** (regression) due to performance improvements.

### What this PR does / why we need it?

* Allows the Policy to avoid a 2hr reconcile when the default IngressController resource is missing
* This was accomplished, by creating a new dependency that looks for the default IngressController resource
* We then put an extraDependencies check on the rosa-ingress-certificate-policies Policy so that it doesn't run until the resource exists
* Reconcile is 45s when non-compliant (default ingressController resource is missing), so there should not be a dramatic affect on provisioning

### Which Jira/Github issue(s) this PR fixes?

Fixes # https://issues.redhat.com/browse/OCM-5315

### Special notes for your reviewer:
Make sure TLS is online and the rosa-ingress-certificate-policies and rosa-ingress-certificate-check policies are not return a large number of messages when non-compliant.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] ~Included documentation changes with PR~
- [ ] ~If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:~
