### PR TITLE
Add 4.15 version gates

### DIFF
--- a/deploy/osd-cluster-acks/sts/4.15/config.yaml
+++ b/deploy/osd-cluster-acks/sts/4.15/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.14"]
+  - key: api.openshift.com/gate-sts
+    operator: In
+    values: ["4.15"]
+  - key: api.openshift.com/sts
+    operator: In
+    values: ["true"]

--- a/deploy/osd-cluster-acks/sts/4.15/osd-sts-ack_CloudCredential.yaml
+++ b/deploy/osd-cluster-acks/sts/4.15/osd-sts-ack_CloudCredential.yaml
@@ -1,0 +1,6 @@
+apiVersion: operator.openshift.io/v1
+kind: CloudCredential
+name: cluster
+applyMode: AlwaysApply
+patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25671,6 +25671,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-sts-4.15
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.14'
+      - key: api.openshift.com/gate-sts
+        operator: In
+        values:
+        - '4.15'
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: CloudCredential
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-sts-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25671,6 +25671,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-sts-4.15
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.14'
+      - key: api.openshift.com/gate-sts
+        operator: In
+        values:
+        - '4.15'
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: CloudCredential
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-sts-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25671,6 +25671,39 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-sts-4.15
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.14'
+      - key: api.openshift.com/gate-sts
+        operator: In
+        values:
+        - '4.15'
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: CloudCredential
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-sts-4.9
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Adds 4.15 version gates to enable 4.15 upgrades. 


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:
https://issues.redhat.com/browse/OSD-20068

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
