### PR TITLE
ocm-agent: Fix wrong alert label

### DIFF
--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: OCMAgentResponseFailureServiceLogsSRE
       # Alert if the OCM agent response failure metric has been set for an hour average window
-      expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m]) == 1
+      expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m]) == 1
       for: 60m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34405,7 +34405,7 @@ objects:
         - name: sre-ocm-agent-operator-alerts
           rules:
           - alert: OCMAgentResponseFailureServiceLogsSRE
-            expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m])
+            expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m])
               == 1
             for: 60m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34405,7 +34405,7 @@ objects:
         - name: sre-ocm-agent-operator-alerts
           rules:
           - alert: OCMAgentResponseFailureServiceLogsSRE
-            expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m])
+            expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m])
               == 1
             for: 60m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34405,7 +34405,7 @@ objects:
         - name: sre-ocm-agent-operator-alerts
           rules:
           - alert: OCMAgentResponseFailureServiceLogsSRE
-            expr: avg_over_time(ocm_agent_response_failure{service="service_logs"}[60m])
+            expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m])
               == 1
             for: 60m
             labels:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This alert has never fired because of the wrong label. We need the alert to work as ocm-agent is supporting templates now.

Context: Found this when doing doc updates for ocm-agent for https://issues.redhat.com/browse/OSD-19692 
Corresponding updates for troubleshooting in https://github.com/openshift/ops-sop/pull/2968 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-20080 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR: Added corresponding changes in ops-sop
 - [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
