### PR TITLE
[OSD-20168] remove red-hat-managed tag condition from permission to create ec2 SecurityGroup in HCP

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
@@ -117,12 +117,7 @@
       ],
       "Resource": [
         "arn:aws:ec2:*:*:security-group/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/red-hat-managed": "true"
-        }
-      }
+      ]
     },
     {
       "Sid": "CreateSecurityGroupVpc",

--- a/resources/sts/4.13/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
+++ b/resources/sts/4.13/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
@@ -117,12 +117,7 @@
       ],
       "Resource": [
         "arn:aws:ec2:*:*:security-group/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/red-hat-managed": "true"
-        }
-      }
+      ]
     },
     {
       "Sid": "CreateSecurityGroupVpc",

--- a/resources/sts/4.14/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
+++ b/resources/sts/4.14/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
@@ -118,12 +118,7 @@
       ],
       "Resource": [
         "arn:aws:ec2:*:*:security-group/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/red-hat-managed": "true"
-        }
-      }
+      ]
     },
     {
       "Sid": "CreateSecurityGroupVpc",


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
without the removal of this condition, customer can only create `Service` of type `LoadBalancer` if it has this tag (`red-hat-managed: "true"`).

IIUC, this eventually lands in the `ROSAKubeControllerPolicy` managed policy.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-20168