### PR TITLE
update scanning and suricata images for CVE patching

### DIFF
--- a/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
+++ b/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           value: /certs/tls.key
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
+        image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
         name: logger
         ports:
         - containerPort: 8443
@@ -69,7 +69,7 @@ spec:
           value: "@rpc.pod.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+        image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
         name: pod-printer
         resources:
           limits:
@@ -85,7 +85,7 @@ spec:
           value: "@rpc.scan.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+        image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
         name: scan-printer
         resources:
           limits:

--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -24,7 +24,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+        image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
         name: clamsig-puller
         resources:
           limits:
@@ -43,7 +43,7 @@ spec:
           value: "false"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
+        image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
         name: clamd
         resources:
           limits:
@@ -67,7 +67,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/container-info@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
+        image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
         name: info
         resources:
           limits:
@@ -111,7 +111,7 @@ spec:
           value: '@rpc.sock'
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+        image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
         name: watcher
         resources:
           limits:
@@ -165,7 +165,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+        image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
         name: scheduler
         resources:
           limits:
@@ -199,7 +199,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+        image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
         name: init-clamsig-puller
         resources:
           limits:

--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
+        image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:
@@ -33,7 +33,7 @@ spec:
         - mountPath: /host/var/log
           name: host-filesystem
       - name: log-cleaner
-        image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
+        image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
         volumeMounts:
         - mountPath: /host/var/log
           name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29966,7 +29966,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
+              image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
               name: logger
               ports:
               - containerPort: 8443
@@ -29991,7 +29991,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
               name: pod-printer
               resources:
                 limits:
@@ -30007,7 +30007,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
               name: scan-printer
               resources:
                 limits:
@@ -30072,7 +30072,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
               name: clamsig-puller
               resources:
                 limits:
@@ -30091,7 +30091,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
+              image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
               name: clamd
               resources:
                 limits:
@@ -30115,7 +30115,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
+              image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
               name: info
               resources:
                 limits:
@@ -30159,7 +30159,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
               name: watcher
               resources:
                 limits:
@@ -30213,7 +30213,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
               name: scheduler
               resources:
                 limits:
@@ -30247,7 +30247,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
               name: init-clamsig-puller
               resources:
                 limits:
@@ -30765,7 +30765,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
+              image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -30784,7 +30784,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
+              image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29966,7 +29966,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
+              image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
               name: logger
               ports:
               - containerPort: 8443
@@ -29991,7 +29991,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
               name: pod-printer
               resources:
                 limits:
@@ -30007,7 +30007,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
               name: scan-printer
               resources:
                 limits:
@@ -30072,7 +30072,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
               name: clamsig-puller
               resources:
                 limits:
@@ -30091,7 +30091,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
+              image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
               name: clamd
               resources:
                 limits:
@@ -30115,7 +30115,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
+              image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
               name: info
               resources:
                 limits:
@@ -30159,7 +30159,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
               name: watcher
               resources:
                 limits:
@@ -30213,7 +30213,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
               name: scheduler
               resources:
                 limits:
@@ -30247,7 +30247,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
               name: init-clamsig-puller
               resources:
                 limits:
@@ -30765,7 +30765,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
+              image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -30784,7 +30784,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
+              image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29966,7 +29966,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:b9a90f58dece020ec0abe0865160d3dd8248d34ae916a495f9a70ba5fba118ef
+              image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
               name: logger
               ports:
               - containerPort: 8443
@@ -29991,7 +29991,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
               name: pod-printer
               resources:
                 limits:
@@ -30007,7 +30007,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:a421a1adc563f1c1081e9bb194f92ba712d1df9989f8a85aeb222b6eb8b54772
+              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
               name: scan-printer
               resources:
                 limits:
@@ -30072,7 +30072,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
               name: clamsig-puller
               resources:
                 limits:
@@ -30091,7 +30091,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:aa5fbc941535c8c5dbd55e32eaadb73be894fab116da32e1a64c080f77ef1dd1
+              image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
               name: clamd
               resources:
                 limits:
@@ -30115,7 +30115,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:8fa6eca92a2fbd1c6b14aee8472a509ea14cae68b69390d0811532e57fc509fd
+              image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
               name: info
               resources:
                 limits:
@@ -30159,7 +30159,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
               name: watcher
               resources:
                 limits:
@@ -30213,7 +30213,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:4a873a2063603a61835963d21a79e6c63eec1ffb96d114bb5349ff738ce93ebe
+              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
               name: scheduler
               resources:
                 limits:
@@ -30247,7 +30247,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:4830b1ff47d92f1d485115724d8a06e50d99802fcba968154a02e1085f123d53
+              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
               name: init-clamsig-puller
               resources:
                 limits:
@@ -30765,7 +30765,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:4b7b4ff88311cd2a55699d8fda8491fdf46cb70c9edded29fff0c8dd6889849e
+              image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -30784,7 +30784,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:3ded368be76bf83c64ab2d239ccff5a8aff60ccf89f2758d93cdebc22b58a015
+              image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

Patches CVE's in base images for scanning and suricata images (used in FedRAMP)

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-20019](https://issues.redhat.com//browse/OSD-20019)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
