### PR TITLE
OSD-19703 - Add inital alerts for OADP on MCs

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-oadp-monitoring.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-oadp-monitoring.PrometheusRule.yaml
@@ -1,0 +1,39 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oadp-backup-alerts
+  namespace: openshift-adp-operator
+spec:
+  groups:
+  - name: oadp-backup-alerts
+    rules:
+    - alert: OADPHourlyBackupFailing
+      annotations:
+        description: OADP had {{$value | humanize}} hourly backup failures over the last 2 hours.
+        summary: OADP has issues creating hourly backups
+      expr: |
+        increase(velero_backup_failure_total{schedule="hourly-full-backup"}[2h]) > 0
+      for: 5m
+      labels:
+        severity: warning
+        namespace: openshift-adp-operator
+    - alert: OADPDailyBackupFailing
+      annotations:
+        description: OADP had {{$value | humanize}} daily backup failures over the last 24 hours.
+        summary: OADP has issues creating daily backups
+      expr: |
+        increase(velero_backup_failure_total{schedule="daily-full-backup"}[24h]) > 0
+      for: 5m
+      labels:
+        severity: warning
+        namespace: openshift-adp-operator
+    - alert: OADPBackupDeletionFailing
+      annotations:
+        description: OADP had {{$value | humanize}} backup deletion failures over the last 24 hours
+        summary: OADP has issues removing backups
+      expr: |
+        increase(velero_backup_deletion_failure_total[24h]) > 0
+      for: 5m
+      labels:
+        severity: warning
+        namespace: openshift-adp-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35812,6 +35812,53 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md
             annotations:
               message: A machine on a management cluster is older than 28 days.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: oadp-backup-alerts
+        namespace: openshift-adp-operator
+      spec:
+        groups:
+        - name: oadp-backup-alerts
+          rules:
+          - alert: OADPHourlyBackupFailing
+            annotations:
+              description: OADP had {{$value | humanize}} hourly backup failures over
+                the last 2 hours.
+              summary: OADP has issues creating hourly backups
+            expr: 'increase(velero_backup_failure_total{schedule="hourly-full-backup"}[2h])
+              > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
+          - alert: OADPDailyBackupFailing
+            annotations:
+              description: OADP had {{$value | humanize}} daily backup failures over
+                the last 24 hours.
+              summary: OADP has issues creating daily backups
+            expr: 'increase(velero_backup_failure_total{schedule="daily-full-backup"}[24h])
+              > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
+          - alert: OADPBackupDeletionFailing
+            annotations:
+              description: OADP had {{$value | humanize}} backup deletion failures
+                over the last 24 hours
+              summary: OADP has issues removing backups
+            expr: 'increase(velero_backup_deletion_failure_total[24h]) > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35812,6 +35812,53 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md
             annotations:
               message: A machine on a management cluster is older than 28 days.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: oadp-backup-alerts
+        namespace: openshift-adp-operator
+      spec:
+        groups:
+        - name: oadp-backup-alerts
+          rules:
+          - alert: OADPHourlyBackupFailing
+            annotations:
+              description: OADP had {{$value | humanize}} hourly backup failures over
+                the last 2 hours.
+              summary: OADP has issues creating hourly backups
+            expr: 'increase(velero_backup_failure_total{schedule="hourly-full-backup"}[2h])
+              > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
+          - alert: OADPDailyBackupFailing
+            annotations:
+              description: OADP had {{$value | humanize}} daily backup failures over
+                the last 24 hours.
+              summary: OADP has issues creating daily backups
+            expr: 'increase(velero_backup_failure_total{schedule="daily-full-backup"}[24h])
+              > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
+          - alert: OADPBackupDeletionFailing
+            annotations:
+              description: OADP had {{$value | humanize}} backup deletion failures
+                over the last 24 hours
+              summary: OADP has issues removing backups
+            expr: 'increase(velero_backup_deletion_failure_total[24h]) > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35812,6 +35812,53 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/hypershift/MachineOutOfCompliance.md
             annotations:
               message: A machine on a management cluster is older than 28 days.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        name: oadp-backup-alerts
+        namespace: openshift-adp-operator
+      spec:
+        groups:
+        - name: oadp-backup-alerts
+          rules:
+          - alert: OADPHourlyBackupFailing
+            annotations:
+              description: OADP had {{$value | humanize}} hourly backup failures over
+                the last 2 hours.
+              summary: OADP has issues creating hourly backups
+            expr: 'increase(velero_backup_failure_total{schedule="hourly-full-backup"}[2h])
+              > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
+          - alert: OADPDailyBackupFailing
+            annotations:
+              description: OADP had {{$value | humanize}} daily backup failures over
+                the last 24 hours.
+              summary: OADP has issues creating daily backups
+            expr: 'increase(velero_backup_failure_total{schedule="daily-full-backup"}[24h])
+              > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
+          - alert: OADPBackupDeletionFailing
+            annotations:
+              description: OADP had {{$value | humanize}} backup deletion failures
+                over the last 24 hours
+              summary: OADP has issues removing backups
+            expr: 'increase(velero_backup_deletion_failure_total[24h]) > 0
+
+              '
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-adp-operator
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Adds an initial set of warning-level alerts indicating whether OADP can create new and rotate out old backups. 

### Which Jira/Github issue(s) this PR fixes?


_Fixes #_ https://issues.redhat.com/browse/OSD-19703

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
