### PR TITLE
add alert for ocm-agent pull secret invalid

### DIFF
--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -27,6 +27,14 @@ spec:
         severity: warning
         namespace: openshift-monitoring
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets"
-
       annotations:
         message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com` pull secret.
+    - alert: OCMAgentPullSecretInvalidSRE
+      expr: ocm_agent_pull_secret_invalid > 0
+      for: 15m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets"
+      annotations:
+        message: OCM Agent pull secret auth token is not valid.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34557,6 +34557,15 @@ objects:
             annotations:
               message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com`
                 pull secret.
+          - alert: OCMAgentPullSecretInvalidSRE
+            expr: ocm_agent_pull_secret_invalid > 0
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
+            annotations:
+              message: OCM Agent pull secret auth token is not valid.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34557,6 +34557,15 @@ objects:
             annotations:
               message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com`
                 pull secret.
+          - alert: OCMAgentPullSecretInvalidSRE
+            expr: ocm_agent_pull_secret_invalid > 0
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
+            annotations:
+              message: OCM Agent pull secret auth token is not valid.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34557,6 +34557,15 @@ objects:
             annotations:
               message: OCM Agent Operator cannot retrieve or parse the cluster's `cloud.openshift.com`
                 pull secret.
+          - alert: OCMAgentPullSecretInvalidSRE
+            expr: ocm_agent_pull_secret_invalid > 0
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
+            annotations:
+              message: OCM Agent pull secret auth token is not valid.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
this metric comes from https://github.com/openshift/ocm-agent/pull/74 and this PR is similar to https://github.com/openshift/managed-cluster-config/pull/1847

with this alert, SRE will be paged when a cluster's pull secret is invalid. this symptom causes many other alerts that may take longer to investigate. with this very particular alert, we will reduce investigation time and prevent other alerts from popping up.

it is possible to use the same metric later to prevent other alerts. for example: https://github.com/openshift/managed-cluster-config/pull/1848

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-20285

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
