### PR TITLE
reverts fr prod01 MUO config, minor fix to container sig checks

### DIFF
--- a/deploy/osd-fedramp-machineconfig/stg/pre-4.13/config.yaml
+++ b/deploy/osd-fedramp-machineconfig/stg/pre-4.13/config.yaml
@@ -9,6 +9,7 @@ selectorSyncSet:
       operator: In
       values:
         - "staging"
+        - "stage"
     - key: hive.openshift.io/version-major-minor
       operator: In
       values: ["4.11", "4.12"]

--- a/deploy/osd-fedramp-managed-upgrade-operator-config/hive-prod01/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/hive-prod01/10-managed-upgrade-operator-configmap.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: managed-upgrade-operator-config
+  namespace: openshift-managed-upgrade-operator
+data:
+  config.yaml: |
+    upgradeType: OSD
+    configManager:
+      source: LOCAL
+      localConfigName: managed-upgrade-config
+      watchInterval: 60
+    maintenance:
+      controlPlaneTime: 130
+      ignoredAlerts:
+        controlPlaneCriticals:
+        # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300
+        - ClusterOperatorDown
+    scale:
+      timeOut: 30
+    upgradeWindow:
+      delayTrigger: 30
+      timeOut: 120
+    nodeDrain:
+      timeOut: 45
+      expectedNodeDrainTime: 8
+    healthCheck:
+      ignoredCriticals:
+      - DNSErrors05MinSRE
+      - MetricsClientSendFailingSRE
+      - UpgradeNodeScalingFailedSRE
+      - UpgradeClusterCheckFailedSRE
+      - PruningCronjobErrorSRE
+      - PrometheusRuleFailures
+      - CannotRetrieveUpdates
+      - FluentdNodeDown
+      # OSD-11927
+      - ClusterProxyCAExpiringSRE
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1986981
+      - PrometheusRemoteWriteBehind
+      - KubePersistentVolumeErrors
+      - PrometheusBadConfig
+      - PrometheusRemoteStorageFailures
+      - AlertmanagerMembersInconsistent
+      - AlertmanagerClusterFailedToSendAlerts
+      - AlertmanagerConfigInconsistent
+      - AlertmanagerClusterDown
+      - KubeStateMetricsListErrors
+      - KubeStateMetricsWatchErrors
+      - ThanosRuleSenderIsFailingAlerts
+      - ThanosRuleHighRuleEvaluationFailures
+      - ThanosNoRuleEvaluations
+      ignoredNamespaces:
+      - openshift-logging
+      - openshift-redhat-marketplace
+      - openshift-operators
+      - openshift-customer-monitoring
+      - openshift-cnv
+      - openshift-route-monitoring-operator
+      - openshift-user-workload-monitoring
+      - openshift-pipelines
+    environment:
+      fedramp: true

--- a/deploy/osd-fedramp-managed-upgrade-operator-config/hive-prod01/config.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/hive-prod01/config.yaml
@@ -6,7 +6,7 @@ selectorSyncSet:
       values:
         - "true"
     - key: hive-prod01
-      operator: NotIn
+      operator: In
       values:
-      - "true"         
+      - "true"            
   resourceApplyMode: Upsert

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27430,6 +27430,7 @@ objects:
         operator: In
         values:
         - staging
+        - stage
       - key: hive.openshift.io/version-major-minor
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27490,6 +27490,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: hive-prod01
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -27517,6 +27521,54 @@ objects:
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
           \      \nenvironment:\n  fedramp: true\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-hive-prod01
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: hive-prod01
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: LOCAL\n  localConfigName:\
+          \ managed-upgrade-config\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nenvironment:\n  fedramp: true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27430,6 +27430,7 @@ objects:
         operator: In
         values:
         - staging
+        - stage
       - key: hive.openshift.io/version-major-minor
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27490,6 +27490,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: hive-prod01
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -27517,6 +27521,54 @@ objects:
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
           \      \nenvironment:\n  fedramp: true\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-hive-prod01
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: hive-prod01
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: LOCAL\n  localConfigName:\
+          \ managed-upgrade-config\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nenvironment:\n  fedramp: true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27430,6 +27430,7 @@ objects:
         operator: In
         values:
         - staging
+        - stage
       - key: hive.openshift.io/version-major-minor
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27490,6 +27490,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: hive-prod01
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -27517,6 +27521,54 @@ objects:
           \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
           \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
           \      \nenvironment:\n  fedramp: true\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-hive-prod01
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: hive-prod01
+        operator: In
+        values:
+        - 'true'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: LOCAL\n  localConfigName:\
+          \ managed-upgrade-config\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\
+          \  - UpgradeClusterCheckFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
+          \  - CannotRetrieveUpdates\n  - FluentdNodeDown\n  # OSD-11927\n  - ClusterProxyCAExpiringSRE\n\
+          \  # https://bugzilla.redhat.com/show_bug.cgi?id=1986981\n  - PrometheusRemoteWriteBehind\n\
+          \  - KubePersistentVolumeErrors\n  - PrometheusBadConfig\n  - PrometheusRemoteStorageFailures\n\
+          \  - AlertmanagerMembersInconsistent\n  - AlertmanagerClusterFailedToSendAlerts\n\
+          \  - AlertmanagerConfigInconsistent\n  - AlertmanagerClusterDown\n  - KubeStateMetricsListErrors\n\
+          \  - KubeStateMetricsWatchErrors\n  - ThanosRuleSenderIsFailingAlerts\n\
+          \  - ThanosRuleHighRuleEvaluationFailures\n  - ThanosNoRuleEvaluations\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nenvironment:\n  fedramp: true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

1) The FedRAMP Prod01 Hive is in the process of decommission as its a snowflake cluster and is not importable to OCM. Since the cluster is not listed in OCM, using the OCM MUO config fails since it can't get upgrade policies. Reverting the MUO changes made in https://github.com/openshift/managed-cluster-config/pull/1978 to revert the change only for this cluster. All other clusters are fine. Once we fully decommission this hive, these configs can be removed.

2) The label for clusters in FedRAMP staging is "stage", updated the selector added in https://github.com/openshift/managed-cluster-config/pull/1969 to cover both potential labels to allow for testing anywhere, and we are hoping to get the label added to clusters updated. This would prevent deletion from stage clusters when/if that occurred

### Which Jira/Github issue(s) this PR fixes?

Related to  [OSD-18887](https://issues.redhat.com//browse/OSD-18887) and [OSD-19620](https://issues.redhat.com/browse/OSD-19620)


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
