### PR TITLE
Migrate OADP prometheusrules to openshift-monitoring

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-oadp-monitoring.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-oadp-monitoring.PrometheusRule.yaml
@@ -1,8 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: oadp-backup-alerts
-  namespace: openshift-adp-operator
+  name: sre-oadp-alerts
+  namespace: openshift-monitoring
 spec:
   groups:
   - name: oadp-backup-alerts
@@ -16,7 +16,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-        namespace: openshift-adp-operator
+        namespace: openshift-monitoring
     - alert: OADPDailyBackupFailing
       annotations:
         description: OADP had {{$value | humanize}} daily backup failures over the last 24 hours.
@@ -26,7 +26,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-        namespace: openshift-adp-operator
+        namespace: openshift-monitoring
     - alert: OADPBackupDeletionFailing
       annotations:
         description: OADP had {{$value | humanize}} backup deletion failures over the last 24 hours
@@ -36,4 +36,4 @@ spec:
       for: 5m
       labels:
         severity: warning
-        namespace: openshift-adp-operator
+        namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36128,8 +36128,8 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: oadp-backup-alerts
-        namespace: openshift-adp-operator
+        name: sre-oadp-alerts
+        namespace: openshift-monitoring
       spec:
         groups:
         - name: oadp-backup-alerts
@@ -36146,7 +36146,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
           - alert: OADPDailyBackupFailing
             annotations:
               description: OADP had {{$value | humanize}} daily backup failures over
@@ -36159,7 +36159,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
           - alert: OADPBackupDeletionFailing
             annotations:
               description: OADP had {{$value | humanize}} backup deletion failures
@@ -36171,7 +36171,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36128,8 +36128,8 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: oadp-backup-alerts
-        namespace: openshift-adp-operator
+        name: sre-oadp-alerts
+        namespace: openshift-monitoring
       spec:
         groups:
         - name: oadp-backup-alerts
@@ -36146,7 +36146,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
           - alert: OADPDailyBackupFailing
             annotations:
               description: OADP had {{$value | humanize}} daily backup failures over
@@ -36159,7 +36159,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
           - alert: OADPBackupDeletionFailing
             annotations:
               description: OADP had {{$value | humanize}} backup deletion failures
@@ -36171,7 +36171,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36128,8 +36128,8 @@ objects:
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
-        name: oadp-backup-alerts
-        namespace: openshift-adp-operator
+        name: sre-oadp-alerts
+        namespace: openshift-monitoring
       spec:
         groups:
         - name: oadp-backup-alerts
@@ -36146,7 +36146,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
           - alert: OADPDailyBackupFailing
             annotations:
               description: OADP had {{$value | humanize}} daily backup failures over
@@ -36159,7 +36159,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
           - alert: OADPBackupDeletionFailing
             annotations:
               description: OADP had {{$value | humanize}} backup deletion failures
@@ -36171,7 +36171,7 @@ objects:
             for: 5m
             labels:
               severity: warning
-              namespace: openshift-adp-operator
+              namespace: openshift-monitoring
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Migrates the OADP prometheusrules to `openshift-monitoring` so they can be included in upstream forwarding to promlens/grafana without having to add `openshift-adp-operator` to our managed-namespaces list, which has wide-ranging side-effects.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-19703

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
