### PR TITLE
OCM-2303 | [HCP] Disable ingress certificate in ACM policy if configmap parameter is true

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -38,8 +38,10 @@ spec:
                           annotations:
                             ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
                         spec:
+                          {{hub- if ne (fromConfigMap "openshift-acm-policies" .ManagedClusterName "disable-certificates") "true" hub}}
                           defaultCertificate:
                             name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+                          {{hub- end hub}}
                           {{hub- if ne (lookup "v1" "ConfigMap" "openshift-acm-policies" .ManagedClusterName).data nil hub}}
                           endpointPublishingStrategy:
                             type: LoadBalancerService
@@ -65,18 +67,20 @@ spec:
                 evaluationInterval:
                     compliant: 2h
                     noncompliant: 45s
-                object-templates:
+                object-templates-raw: |
+                    {{hub- if ne (fromConfigMap "openshift-acm-policies" .ManagedClusterName "disable-certificates") "true" hub}}
                     - complianceType: musthave
                       metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: v1
                         data:
-                            tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
-                            tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
+                          tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
+                          tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
                         kind: Secret
                         metadata:
-                            name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
-                            namespace: openshift-ingress
+                          name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+                          namespace: openshift-ingress
+                    {{hub- end hub}}
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/rosa-ingress-certificate-policies/00-ingress-default.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/00-ingress-default.Policy.yaml
@@ -26,8 +26,10 @@ spec:
           annotations:
             ingress.operator.openshift.io/auto-delete-load-balancer: 'true'
         spec:
+          {{hub- if ne (fromConfigMap "openshift-acm-policies" .ManagedClusterName "disable-certificates") "true" hub}}
           defaultCertificate:
             name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+          {{hub- end hub}}
           {{hub- if ne (lookup "v1" "ConfigMap" "openshift-acm-policies" .ManagedClusterName).data nil hub}}
           endpointPublishingStrategy:
             type: LoadBalancerService

--- a/deploy/rosa-ingress-certificate-policies/01-rosa-ingress-certificate.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/01-rosa-ingress-certificate.Policy.yaml
@@ -1,8 +1,25 @@
-apiVersion: v1
-data:
-  tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
-  tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
-kind: Secret
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
 metadata:
-  name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
-  namespace: openshift-ingress
+  name: rosa-ingress-certificate-policies
+spec:
+  evaluationInterval:
+    compliant: 2h
+    noncompliant: 45s
+  object-templates-raw: |
+    {{hub- if ne (fromConfigMap "openshift-acm-policies" .ManagedClusterName "disable-certificates") "true" hub}}
+    - complianceType: musthave
+      metadataComplianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        data:
+          tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.crt" hub}}'
+          tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName "tls.key" hub}}'
+        kind: Secret
+        metadata:
+          name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
+          namespace: openshift-ingress
+    {{hub- end hub}}
+  pruneObjectBehavior: DeleteIfCreated
+  remediationAction: enforce
+  severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7744,15 +7744,17 @@ objects:
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
                 \        ingress.operator.openshift.io/auto-delete-load-balancer:\
-                \ 'true'\n    spec:\n      defaultCertificate:\n        name: '{{hub\
-                \ (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName) hub}}'\n\
-                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
-                \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
-                \        type: LoadBalancerService\n        loadBalancer:\n      \
-                \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
-                \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
-                endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
+                \ 'true'\n    spec:\n      {{hub- if ne (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"disable-certificates\") \"true\" hub}}\n \
+                \     defaultCertificate:\n        name: '{{hub (printf \"%s-primary-cert-bundle-secret\"\
+                \ .ManagedClusterName) hub}}'\n      {{hub- end hub}}\n      {{hub-\
+                \ if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\" .ManagedClusterName).data\
+                \ nil hub}}\n      endpointPublishingStrategy:\n        type: LoadBalancerService\n\
+                \        loadBalancer:\n          dnsManagementPolicy: 'Managed'\n\
+                \          scope: '{{hub- if eq (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"endpoint-publishing-strategy\") \"internal\"\
+                \ -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'\n\
+                \      {{hub- end hub}}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
@@ -7771,21 +7773,15 @@ objects:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates:
-              - complianceType: musthave
-                metadataComplianceType: musthave
-                objectDefinition:
-                  apiVersion: v1
-                  data:
-                    tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
-                      "tls.crt" hub}}'
-                    tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
-                      "tls.key" hub}}'
-                  kind: Secret
-                  metadata:
-                    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
-                      hub}}'
-                    namespace: openshift-ingress
+              object-templates-raw: "{{hub- if ne (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"disable-certificates\") \"true\" hub}}\n-\
+                \ complianceType: musthave\n  metadataComplianceType: musthave\n \
+                \ objectDefinition:\n    apiVersion: v1\n    data:\n      tls.crt:\
+                \ '{{hub fromSecret \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"tls.crt\" hub}}'\n      tls.key: '{{hub fromSecret \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"tls.key\" hub}}'\n    kind: Secret\n    metadata:\n\
+                \      name: '{{hub (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName)\
+                \ hub}}'\n      namespace: openshift-ingress\n{{hub- end hub}}\n"
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7744,15 +7744,17 @@ objects:
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
                 \        ingress.operator.openshift.io/auto-delete-load-balancer:\
-                \ 'true'\n    spec:\n      defaultCertificate:\n        name: '{{hub\
-                \ (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName) hub}}'\n\
-                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
-                \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
-                \        type: LoadBalancerService\n        loadBalancer:\n      \
-                \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
-                \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
-                endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
+                \ 'true'\n    spec:\n      {{hub- if ne (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"disable-certificates\") \"true\" hub}}\n \
+                \     defaultCertificate:\n        name: '{{hub (printf \"%s-primary-cert-bundle-secret\"\
+                \ .ManagedClusterName) hub}}'\n      {{hub- end hub}}\n      {{hub-\
+                \ if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\" .ManagedClusterName).data\
+                \ nil hub}}\n      endpointPublishingStrategy:\n        type: LoadBalancerService\n\
+                \        loadBalancer:\n          dnsManagementPolicy: 'Managed'\n\
+                \          scope: '{{hub- if eq (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"endpoint-publishing-strategy\") \"internal\"\
+                \ -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'\n\
+                \      {{hub- end hub}}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
@@ -7771,21 +7773,15 @@ objects:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates:
-              - complianceType: musthave
-                metadataComplianceType: musthave
-                objectDefinition:
-                  apiVersion: v1
-                  data:
-                    tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
-                      "tls.crt" hub}}'
-                    tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
-                      "tls.key" hub}}'
-                  kind: Secret
-                  metadata:
-                    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
-                      hub}}'
-                    namespace: openshift-ingress
+              object-templates-raw: "{{hub- if ne (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"disable-certificates\") \"true\" hub}}\n-\
+                \ complianceType: musthave\n  metadataComplianceType: musthave\n \
+                \ objectDefinition:\n    apiVersion: v1\n    data:\n      tls.crt:\
+                \ '{{hub fromSecret \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"tls.crt\" hub}}'\n      tls.key: '{{hub fromSecret \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"tls.key\" hub}}'\n    kind: Secret\n    metadata:\n\
+                \      name: '{{hub (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName)\
+                \ hub}}'\n      namespace: openshift-ingress\n{{hub- end hub}}\n"
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7744,15 +7744,17 @@ objects:
                 \    kind: IngressController\n    metadata:\n      name: default\n\
                 \      namespace: openshift-ingress-operator\n      annotations:\n\
                 \        ingress.operator.openshift.io/auto-delete-load-balancer:\
-                \ 'true'\n    spec:\n      defaultCertificate:\n        name: '{{hub\
-                \ (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName) hub}}'\n\
-                \      {{hub- if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\"\
-                \ .ManagedClusterName).data nil hub}}\n      endpointPublishingStrategy:\n\
-                \        type: LoadBalancerService\n        loadBalancer:\n      \
-                \    dnsManagementPolicy: 'Managed'\n          scope: '{{hub- if eq\
-                \ (fromConfigMap \"openshift-acm-policies\" .ManagedClusterName \"\
-                endpoint-publishing-strategy\") \"internal\" -hub}} Internal {{hub-\
-                \ else -hub}} External {{hub- end -hub}}'\n      {{hub- end hub}}\n"
+                \ 'true'\n    spec:\n      {{hub- if ne (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"disable-certificates\") \"true\" hub}}\n \
+                \     defaultCertificate:\n        name: '{{hub (printf \"%s-primary-cert-bundle-secret\"\
+                \ .ManagedClusterName) hub}}'\n      {{hub- end hub}}\n      {{hub-\
+                \ if ne (lookup \"v1\" \"ConfigMap\" \"openshift-acm-policies\" .ManagedClusterName).data\
+                \ nil hub}}\n      endpointPublishingStrategy:\n        type: LoadBalancerService\n\
+                \        loadBalancer:\n          dnsManagementPolicy: 'Managed'\n\
+                \          scope: '{{hub- if eq (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"endpoint-publishing-strategy\") \"internal\"\
+                \ -hub}} Internal {{hub- else -hub}} External {{hub- end -hub}}'\n\
+                \      {{hub- end hub}}\n"
               pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
@@ -7771,21 +7773,15 @@ objects:
               evaluationInterval:
                 compliant: 2h
                 noncompliant: 45s
-              object-templates:
-              - complianceType: musthave
-                metadataComplianceType: musthave
-                objectDefinition:
-                  apiVersion: v1
-                  data:
-                    tls.crt: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
-                      "tls.crt" hub}}'
-                    tls.key: '{{hub fromSecret "openshift-acm-policies" .ManagedClusterName
-                      "tls.key" hub}}'
-                  kind: Secret
-                  metadata:
-                    name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName)
-                      hub}}'
-                    namespace: openshift-ingress
+              object-templates-raw: "{{hub- if ne (fromConfigMap \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"disable-certificates\") \"true\" hub}}\n-\
+                \ complianceType: musthave\n  metadataComplianceType: musthave\n \
+                \ objectDefinition:\n    apiVersion: v1\n    data:\n      tls.crt:\
+                \ '{{hub fromSecret \"openshift-acm-policies\" .ManagedClusterName\
+                \ \"tls.crt\" hub}}'\n      tls.key: '{{hub fromSecret \"openshift-acm-policies\"\
+                \ .ManagedClusterName \"tls.key\" hub}}'\n    kind: Secret\n    metadata:\n\
+                \      name: '{{hub (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName)\
+                \ hub}}'\n      namespace: openshift-ingress\n{{hub- end hub}}\n"
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low


### PR DESCRIPTION
Ingress in HCP are configured by an ACM policy and configuration are passed in a configmap written by OCM.

In local environment, certificates are not generated, so specifying them in the ingress config make the operator degraded, as the relevant secret does not exist. To fix this, we added a new parameter in the CM to skip certificates.

With this change, the policy will read the parameter and exclude any certificate related config/object if it is true. If it is false or not present, we will behave as before (so reference the certificates). So backward compatibility is guaranteed. No impact expected in standard integration/staging/production clusters.

Tested the changes in an integration Service Cluster.

CC @cdoan1 for awareness

### What type of PR is this?
Bug fixing for local development environment

### What this PR does / why we need it?
Allows having compliant policies and proper setup when certificate are not available

### Which Jira/Github issue(s) this PR fixes?
[OCM-2303](https://issues.redhat.com//browse/OCM-2303)

### Special notes for your reviewer:
To be monitored that default ingress controller gets certificates in integration/staging.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
