### PR TITLE
OSD-18436 : Workaround for bug 16655: CreateContainerError due to seccomp error

### DIFF
--- a/deploy/ocpbugs-15043/00-ocpbugs-15043.ServiceAccount.yaml
+++ b/deploy/ocpbugs-15043/00-ocpbugs-15043.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ocpbugs-15043
+  namespace: openshift-config

--- a/deploy/ocpbugs-15043/01-ocpbugs-15043.Role.yaml
+++ b/deploy/ocpbugs-15043/01-ocpbugs-15043.Role.yaml
@@ -27,6 +27,37 @@ rules:
   - get
   - list
   - delete
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ocpbugs-15043-read-configmap
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocpbugs-15043-manage-lastrun-cm
+  namespace: openshift-config
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -40,3 +71,24 @@ rules:
   verbs:
   - get
   - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ocpbugs-15043-read-clusterversion
+rules:
+- apiGroups:
+    - "config.openshift.io"
+  resources:
+    - clusterversions
+  verbs:
+    - get
+    - list
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+  verbs:
+    - get
+    - list
+    - watch

--- a/deploy/ocpbugs-15043/01-ocpbugs-15043.Role.yaml
+++ b/deploy/ocpbugs-15043/01-ocpbugs-15043.Role.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocpbugs-15043-read-pullsecret
+  namespace: openshift-config
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocpbugs-15043-delete-machines
+  namespace: openshift-machine-api
+rules:
+- apiGroups:
+  - "machine.openshift.io"
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ocpbugs-15043-inspect-pods
+rules:
+- apiGroups:
+  - 
+  resources:
+  - pods
+  verbs:
+  - get
+  - list

--- a/deploy/ocpbugs-15043/02-ocpbugs-15043.RoleBinding.yaml
+++ b/deploy/ocpbugs-15043/02-ocpbugs-15043.RoleBinding.yaml
@@ -30,6 +30,48 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: ocpbugs-15043-read-muo-configmap
+  namespace: openshift-managed-upgrade-operator
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocpbugs-15043-read-configmap
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-15043-read-oao-configmap
+  namespace: openshift-ocm-agent-operator
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocpbugs-15043-read-configmap
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-15043-manage-lastrun-cm
+  namespace: openshift-config
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocpbugs-15043-manage-lastrun-cm
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: ocpbugs-15043-inspect-pods
   namespace: openshift-sre-pruning
 subjects:
@@ -54,3 +96,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: ocpbugs-15043-inspect-pods
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-15043-read-clusterversion
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocpbugs-15043-read-clusterversion

--- a/deploy/ocpbugs-15043/02-ocpbugs-15043.RoleBinding.yaml
+++ b/deploy/ocpbugs-15043/02-ocpbugs-15043.RoleBinding.yaml
@@ -1,0 +1,56 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-15043-read-pullsecret
+  namespace: openshift-config
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocpbugs-15043-read-pullsecret
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-15043-delete-machines
+  namespace: openshift-machine-api
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocpbugs-15043-delete-machines
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-15043-inspect-pods
+  namespace: openshift-sre-pruning
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocpbugs-15043-inspect-pods
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ocpbugs-15043-inspect-pods
+  namespace: openshift-monitoring
+subjects:
+- kind: ServiceAccount
+  name: ocpbugs-15043
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ocpbugs-15043-inspect-pods

--- a/deploy/ocpbugs-15043/03-ocpbugs-15043.configmap.yaml
+++ b/deploy/ocpbugs-15043/03-ocpbugs-15043.configmap.yaml
@@ -6,29 +6,40 @@ metadata:
   namespace: openshift-config
 data:
   ocpbugs-15043.sh: |
-    #!/usr/bin/env bash
-    check_ns=(
+    #!/bin/bash
+
+    set -euo pipefail
+
+    CHECKED_NAMESPACES=(
         "openshift-sre-pruning"
         "openshift-monitoring"
     )
+
+    LAST_SL_CONFIGMAP="ocpbugs-15043-last-sl-sent"
+    LAST_RUN_ANNOTATION="lasttimestamp"
+    DELAY_BETWEEN_SEND_SECONDS="86400"
+
     NODES=()
 
-    for current_ns in "${check_ns[@]}"; do
+    MACHINE_API_NAMESPACE="openshift-machine-api"
+
+    for current_ns in "${CHECKED_NAMESPACES[@]}"; do
         readarray -t failedPods < <(oc -n "$current_ns" get pods -owide | grep "CreateContainerError" | awk '{print $1}')
         for pod in "${failedPods[@]}"; do
+            echo "Found pod $pod failing."
             podDescribe="$(oc -n "$current_ns" describe pod "$pod")"
+
             if ! echo "$podDescribe" | grep "error loading seccomp filter into kernel" >/dev/null; then
+                echo -e "\t$pod is failing for another reason. Ignoring"
                 continue
             fi
+
             node="$(echo "$podDescribe" | grep Node: | awk '{print $2}' | cut -d "/" -f 1)"
+            echo -e "\t$pod on $node having seccomp issues"
             if echo "${NODES[@]}" | grep "$node" >/dev/null; then
                 continue
             fi
-            if oc get node "$node" | grep master >/dev/null; then
-                echo "Found node $node, however master nodes must be fixed manually by restarting the instance in ec2."
-            else
-                NODES+=("$node")
-            fi
+            NODES+=("$node")
         done
     done
 
@@ -37,35 +48,97 @@ data:
         exit 0
     fi
 
-    echo "Found:"
-    echo "${NODES[@]}"
-    echo ""
+    # print affected nodes and 
 
     for NODE in "${NODES[@]}"; do
-        RESULT=$(oc debug -n default "node/$NODE" -- chroot /host cat /proc/vmallocinfo | grep bpf_jit | awk '{s+=$2} END {print s}')
+        nodeJson="$(oc get node "$NODE" -ojson)"
 
-        echo " "
-        echo "The vmallocinfo value on $NODE for bpf_jit is $RESULT the clusterversion is"
-        oc get clusterversion version
+        # make sure we only restart infra nodes
+        if ! jq -e '.metadata.labels."node-role.kubernetes.io/infra"' <<< "$nodeJson" > /dev/null ; then
+          echo "Found node '$node', however control-plane and worker nodes must be restarted manually"
+          continue
+        fi
+
+        echo "Found node '$node'. Checking associated machine cr"
+
+        MACHINE="$(jq -r '.metadata.annotations."machine.openshift.io/machine"' <<< "$nodeJson" | cut -d '/' -f2)"
+        if [[ $MACHINE = "" ]]; then
+          echo "Couldn't find Machine for node $node. Skipping"
+          continue
+        fi
+
+        echo "Found machine '$MACHINE' for node '$node'. Removing it..."
+        oc -n "$MACHINE_API_NAMESPACE" delete machine "$MACHINE" --wait
+        echo "Machine removed successfully. Waiting for all machines to be in Running state again"
+        oc -n "$MACHINE_API_NAMESPACE" wait --all --for=jsonpath='{.status.phase}'=Running --timeout=5m machines
+        echo "All Machines are running again. Waiting for all nodes to become ready."
+        oc wait --all --for=condition=Ready=true --timeout=5m nodes
+        echo "All nodes are Ready. Continuing."
     done
 
-    date
-    echo "In case the cluster is at 4.12.z Please reach out on Slack with the following message and wait a few min for a response:"
-    echo "@Viktor Malik, @Arnaldo Melo, @raquini - we have a case of OCPBUGS-15043 bpf limits"
 
-    echo ""
-    echo "Replacing the nodes will reset the memory leak, the following machines will be instantly deleted (use your judgement when deleting more than 1 at a time)."
-    echo "${NODES[@]}"
-    read -r -p "Continue with machine reprovisioning (y/n)?" choice
+    currentTimestamp=$(date -u +%s)
 
-    if [[ ! $choice =~ ^[yY]$ ]]; then
-        echo "ok, skipping"
-        exit 0
+    if oc get cm "$LAST_SL_CONFIGMAP" > /dev/null; then 
+      if oc get cm "$LAST_SL_CONFIGMAP" -ojson | jq -e ".metadata.annotations.$LAST_RUN_ANNOTATION" > /dev/null; then
+        lastSentTimestamp=$(oc get cm "$LAST_SL_CONFIGMAP" -ojson | jq -r ".metadata.annotations.$LAST_RUN_ANNOTATION")
+        if [[ $(( currentTimestamp - lastSentTimestamp )) -lt $DELAY_BETWEEN_SEND_SECONDS ]]; then 
+          echo "An SL was already sent recently. Skipping it this time."
+          exit 0
+        fi
+      fi
     fi
 
-    for NODE in "${NODES[@]}"; do
-        oc get machine -n openshift-machine-api -o wide | grep "$NODE" | awk '{print $1}' | grep -v master | xargs oc delete machine -n openshift-machine-api
-    done
+    echo "Retrieving pull secret"
+    SECRET=$(oc -n openshift-config get secret pull-secret -ojson | jq -r '.data.".dockerconfigjson" | @base64d ' | jq -r '.auths."cloud.openshift.com".auth')
+    echo "Pull secret retrieved"
 
-    osdctl servicelog post "$(oc get clusterversion version -o json | jq -r .spec.clusterID)" -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/OCPBUGS-16655-remediation-please-upgrade.json
+    echo "Retrieving cluster uuid"
+    EXTERNAL_CLUSTER_ID=$( oc get clusterversion version -o json | jq -r '.spec.clusterID' )
+    echo "Cluster UUID is: $EXTERNAL_CLUSTER_ID"
 
+    echo "Getting OCM Base Url"
+    OAO_CONFIGMAP="ocm-agent-cm"
+    OAO_NAMESPACE="openshift-ocm-agent-operator"
+
+    MUO_CONFIGMAP="managed-upgrade-operator-config"
+    MUO_NAMESPACE="openshift-managed-upgrade-operator"
+    if oc get configmap -n "$OAO_NAMESPACE" "$OAO_CONFIGMAP"; then
+      OCM_BASE_URL=$(oc get configmap -n "$OAO_NAMESPACE" "$OAO_CONFIGMAP" -o json | jq -r '.data.ocmBaseURL')
+    elif oc get configmap -n "$MUO_NAMESPACE" "$MUO_CONFIGMAP"; then
+      OCM_BASE_URL=$(oc get configmap -n "$MUO_NAMESPACE" "$MUO_CONFIGMAP" -o json | jq -r '.data."config.yaml"' | grep ocmBaseUrl | awk '{print $2;}')
+    else 
+      echo "Couldn't determin OCM BASE URL. Won't send a servicelog"
+    fi
+    echo "OCM Base URL is: $OCM_BASE_URL"
+
+
+    SL_URL="${OCM_BASE_URL}/api/service_logs/v1/cluster_logs"
+
+
+    SL_POST_DATA=$(cat << EOF
+    {
+      "cluster_uuid": "$EXTERNAL_CLUSTER_ID",
+      "severity": "Warning",
+      "service_name": "SREManualAction",
+      "summary": "Cluster impacted by OCPBUGS-16655, upgrade recommended",
+      "description": "Your cluster is impacted by https://issues.redhat.com/browse/OCPBUGS-16655, which results in nodes periodically being unable to run containers. Red Hat SRE has responded to and temporarily remediated impacts of this bug on this cluster and recommends that the cluster be upgraded to 4.13.10 or later as soon as convenient.",
+      "internal_only": false,
+      "_tags": [
+        "sop_PruningCronjobErrorSRE"
+      ]
+    }
+    EOF
+    )
+
+    echo "SENDING SL: $SL_POST_DATA"
+
+    curl -v -m 20 -X POST \
+      -d "$SL_POST_DATA" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: AccessToken $EXTERNAL_CLUSTER_ID:$SECRET" "$SL_URL"
+
+    echo "Annotation configmap with timestamp"
+
+    oc create configmap "$LAST_SL_CONFIGMAP" || true
+    oc annotate configmap --overwrite "$LAST_SL_CONFIGMAP" "${LAST_RUN_ANNOTATION}=${currentTimestamp}"

--- a/deploy/ocpbugs-15043/03-ocpbugs-15043.configmap.yaml
+++ b/deploy/ocpbugs-15043/03-ocpbugs-15043.configmap.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocpbugs-15043-script
+  namespace: openshift-config
+data:
+  ocpbugs-15043.sh: |
+    #!/usr/bin/env bash
+    check_ns=(
+        "openshift-sre-pruning"
+        "openshift-monitoring"
+    )
+    NODES=()
+
+    for current_ns in "${check_ns[@]}"; do
+        readarray -t failedPods < <(oc -n "$current_ns" get pods -owide | grep "CreateContainerError" | awk '{print $1}')
+        for pod in "${failedPods[@]}"; do
+            podDescribe="$(oc -n "$current_ns" describe pod "$pod")"
+            if ! echo "$podDescribe" | grep "error loading seccomp filter into kernel" >/dev/null; then
+                continue
+            fi
+            node="$(echo "$podDescribe" | grep Node: | awk '{print $2}' | cut -d "/" -f 1)"
+            if echo "${NODES[@]}" | grep "$node" >/dev/null; then
+                continue
+            fi
+            if oc get node "$node" | grep master >/dev/null; then
+                echo "Found node $node, however master nodes must be fixed manually by restarting the instance in ec2."
+            else
+                NODES+=("$node")
+            fi
+        done
+    done
+
+    if [ ${#NODES[@]} -eq 0 ]; then
+        echo "No affected nodes."
+        exit 0
+    fi
+
+    echo "Found:"
+    echo "${NODES[@]}"
+    echo ""
+
+    for NODE in "${NODES[@]}"; do
+        RESULT=$(oc debug -n default "node/$NODE" -- chroot /host cat /proc/vmallocinfo | grep bpf_jit | awk '{s+=$2} END {print s}')
+
+        echo " "
+        echo "The vmallocinfo value on $NODE for bpf_jit is $RESULT the clusterversion is"
+        oc get clusterversion version
+    done
+
+    date
+    echo "In case the cluster is at 4.12.z Please reach out on Slack with the following message and wait a few min for a response:"
+    echo "@Viktor Malik, @Arnaldo Melo, @raquini - we have a case of OCPBUGS-15043 bpf limits"
+
+    echo ""
+    echo "Replacing the nodes will reset the memory leak, the following machines will be instantly deleted (use your judgement when deleting more than 1 at a time)."
+    echo "${NODES[@]}"
+    read -r -p "Continue with machine reprovisioning (y/n)?" choice
+
+    if [[ ! $choice =~ ^[yY]$ ]]; then
+        echo "ok, skipping"
+        exit 0
+    fi
+
+    for NODE in "${NODES[@]}"; do
+        oc get machine -n openshift-machine-api -o wide | grep "$NODE" | awk '{print $1}' | grep -v master | xargs oc delete machine -n openshift-machine-api
+    done
+
+    osdctl servicelog post "$(oc get clusterversion version -o json | jq -r .spec.clusterID)" -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/OCPBUGS-16655-remediation-please-upgrade.json
+

--- a/deploy/ocpbugs-15043/10-ocpbugs-15043.CronJob.yaml
+++ b/deploy/ocpbugs-15043/10-ocpbugs-15043.CronJob.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ocpbugs-15043
+  namespace: openshift-config
+spec:
+  failedJobsHistoryLimit: 2
+  successfulJobsHistoryLimit: 2
+  concurrencyPolicy: Forbid
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 3600
+      template:
+        metadata:
+          labels:
+            app: ocpbugs-15043
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              operator: Exists
+          serviceAccountName: ocpbugs-15043
+          restartPolicy: Never
+          volumes:
+            - name: scriptconfigmap
+              configMap:
+                name: ocpbugs-15043-script
+                items:
+                  - key: ocpbugs-15043.sh
+                    path: script
+            - name: pull-secret
+              secret:
+                secretName: pull-secret
+          containers:
+          - name: ocpbugs-15043
+            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+            imagePullPolicy: Always
+            resources:
+              requests:
+                cpu: 100m
+                memory: 100Mi
+              limits:
+                cpu: 100m
+                memory: 100Mi
+            command:
+            - /bin/bash
+            - -c
+            - |
+                  chmod +x /etc/config/script/ocpbugs-15043.sh
+                  /etc/config/script/ocpbugs-15043.sh

--- a/deploy/ocpbugs-15043/10-ocpbugs-15043.CronJob.yaml
+++ b/deploy/ocpbugs-15043/10-ocpbugs-15043.CronJob.yaml
@@ -33,10 +33,11 @@ spec:
           volumes:
             - name: scriptconfigmap
               configMap:
+                defaultMode: 493
                 name: ocpbugs-15043-script
                 items:
                   - key: ocpbugs-15043.sh
-                    path: script
+                    path: ocpbugs-15043.sh
             - name: pull-secret
               secret:
                 secretName: pull-secret
@@ -44,6 +45,10 @@ spec:
           - name: ocpbugs-15043
             image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
             imagePullPolicy: Always
+            volumeMounts:
+              - mountPath: "/tmp/config/"
+                name: scriptconfigmap
+                readOnly: false
             resources:
               requests:
                 cpu: 100m
@@ -52,8 +57,4 @@ spec:
                 cpu: 100m
                 memory: 100Mi
             command:
-            - /bin/bash
-            - -c
-            - |
-                  chmod +x /etc/config/script/ocpbugs-15043.sh
-                  /etc/config/script/ocpbugs-15043.sh
+              - /tmp/config/ocpbugs-15043.sh

--- a/deploy/ocpbugs-15043/config.yaml
+++ b/deploy/ocpbugs-15043/config.yaml
@@ -1,0 +1,17 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version
+    operator: In
+    values: 
+      - 4.13.0
+      - 4.13.1
+      - 4.13.2
+      - 4.13.3
+      - 4.13.4
+      - 4.13.5
+      - 4.13.6
+      - 4.13.7
+      - 4.13.8
+      - 4.13.9

--- a/deploy/ocpbugs-15043/script.sh
+++ b/deploy/ocpbugs-15043/script.sh
@@ -1,25 +1,37 @@
 #!/bin/bash
 
-check_ns=(
+set -euo pipefail
+
+CHECKED_NAMESPACES=(
     "openshift-sre-pruning"
     "openshift-monitoring"
 )
+
+LAST_SL_CONFIGMAP="ocpbugs-15043-last-sl-sent"
+LAST_RUN_ANNOTATION="lasttimestamp"
+DELAY_BETWEEN_SEND_SECONDS="86400"
 
 NODES=()
 
 MACHINE_API_NAMESPACE="openshift-machine-api"
 
-for current_ns in "${check_ns[@]}"; do
+for current_ns in "${CHECKED_NAMESPACES[@]}"; do
     readarray -t failedPods < <(oc -n "$current_ns" get pods -owide | grep "CreateContainerError" | awk '{print $1}')
     for pod in "${failedPods[@]}"; do
+        echo "Found pod $pod failing."
         podDescribe="$(oc -n "$current_ns" describe pod "$pod")"
+
         if ! echo "$podDescribe" | grep "error loading seccomp filter into kernel" >/dev/null; then
+            echo -e "\t$pod is failing for another reason. Ignoring"
             continue
         fi
+
         node="$(echo "$podDescribe" | grep Node: | awk '{print $2}' | cut -d "/" -f 1)"
+        echo -e "\t$pod on $node having seccomp issues"
         if echo "${NODES[@]}" | grep "$node" >/dev/null; then
             continue
         fi
+        NODES+=("$node")
     done
 done
 
@@ -34,14 +46,14 @@ for NODE in "${NODES[@]}"; do
     nodeJson="$(oc get node "$NODE" -ojson)"
 
     # make sure we only restart infra nodes
-    if ! jq -e '.metadata.labels."node-role.kubernetes.io/infra"' <<< "$nodeJson"; then
+    if ! jq -e '.metadata.labels."node-role.kubernetes.io/infra"' <<< "$nodeJson" > /dev/null ; then
       echo "Found node '$node', however control-plane and worker nodes must be restarted manually"
       continue
     fi
 
     echo "Found node '$node'. Checking associated machine cr"
 
-    MACHINE="$(jq -r '.metadata.annotations."machine.openshift.io/machine"' <<< "$nodeJson" )"
+    MACHINE="$(jq -r '.metadata.annotations."machine.openshift.io/machine"' <<< "$nodeJson" | cut -d '/' -f2)"
     if [[ $MACHINE = "" ]]; then
       echo "Couldn't find Machine for node $node. Skipping"
       continue
@@ -52,9 +64,73 @@ for NODE in "${NODES[@]}"; do
     echo "Machine removed successfully. Waiting for all machines to be in Running state again"
     oc -n "$MACHINE_API_NAMESPACE" wait --all --for=jsonpath='{.status.phase}'=Running --timeout=5m machines
     echo "All Machines are running again. Waiting for all nodes to become ready."
-    oc wait --all --for=condition=Ready=false --timeout=5m nodes
+    oc wait --all --for=condition=Ready=true --timeout=5m nodes
     echo "All nodes are Ready. Continuing."
 done
 
-# rewrite to use pull secret
-osdctl servicelog post "$(oc get clusterversion version -o json | jq -r .spec.clusterID)" -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/OCPBUGS-16655-remediation-please-upgrade.json
+
+currentTimestamp=$(date -u +%s)
+
+if oc get cm "$LAST_SL_CONFIGMAP" > /dev/null; then 
+  if oc get cm "$LAST_SL_CONFIGMAP" -ojson | jq -e ".metadata.annotations.$LAST_RUN_ANNOTATION" > /dev/null; then
+    lastSentTimestamp=$(oc get cm "$LAST_SL_CONFIGMAP" -ojson | jq -r ".metadata.annotations.$LAST_RUN_ANNOTATION")
+    if [[ $(( currentTimestamp - lastSentTimestamp )) -lt $DELAY_BETWEEN_SEND_SECONDS ]]; then 
+      echo "An SL was already sent recently. Skipping it this time."
+      exit 0
+    fi
+  fi
+fi
+
+echo "Retrieving pull secret"
+SECRET=$(oc -n openshift-config get secret pull-secret -ojson | jq -r '.data.".dockerconfigjson" | @base64d ' | jq -r '.auths."cloud.openshift.com".auth')
+echo "Pull secret retrieved"
+
+echo "Retrieving cluster uuid"
+EXTERNAL_CLUSTER_ID=$( oc get clusterversion version -o json | jq -r '.spec.clusterID' )
+echo "Cluster UUID is: $EXTERNAL_CLUSTER_ID"
+
+echo "Getting OCM Base Url"
+OAO_CONFIGMAP="ocm-agent-cm"
+OAO_NAMESPACE="openshift-ocm-agent-operator"
+
+MUO_CONFIGMAP="managed-upgrade-operator-config"
+MUO_NAMESPACE="openshift-managed-upgrade-operator"
+if oc get configmap -n "$OAO_NAMESPACE" "$OAO_CONFIGMAP"; then
+  OCM_BASE_URL=$(oc get configmap -n "$OAO_NAMESPACE" "$OAO_CONFIGMAP" -o json | jq -r '.data.ocmBaseURL')
+elif oc get configmap -n "$MUO_NAMESPACE" "$MUO_CONFIGMAP"; then
+  OCM_BASE_URL=$(oc get configmap -n "$MUO_NAMESPACE" "$MUO_CONFIGMAP" -o json | jq -r '.data."config.yaml"' | grep ocmBaseUrl | awk '{print $2;}')
+else 
+  echo "Couldn't determin OCM BASE URL. Won't send a servicelog"
+fi
+echo "OCM Base URL is: $OCM_BASE_URL"
+
+
+SL_URL="${OCM_BASE_URL}/api/service_logs/v1/cluster_logs"
+
+
+SL_POST_DATA=$(cat << EOF
+{
+  "cluster_uuid": "$EXTERNAL_CLUSTER_ID",
+  "severity": "Warning",
+  "service_name": "SREManualAction",
+  "summary": "Cluster impacted by OCPBUGS-16655, upgrade recommended",
+  "description": "Your cluster is impacted by https://issues.redhat.com/browse/OCPBUGS-16655, which results in nodes periodically being unable to run containers. Red Hat SRE has responded to and temporarily remediated impacts of this bug on this cluster and recommends that the cluster be upgraded to 4.13.10 or later as soon as convenient.",
+  "internal_only": false,
+  "_tags": [
+    "sop_PruningCronjobErrorSRE"
+  ]
+}
+EOF
+)
+
+echo "SENDING SL: $SL_POST_DATA"
+
+curl -v -m 20 -X POST \
+  -d "$SL_POST_DATA" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: AccessToken $EXTERNAL_CLUSTER_ID:$SECRET" "$SL_URL"
+
+echo "Annotation configmap with timestamp"
+
+oc create configmap "$LAST_SL_CONFIGMAP" || true
+oc annotate configmap --overwrite "$LAST_SL_CONFIGMAP" "${LAST_RUN_ANNOTATION}=${currentTimestamp}"

--- a/deploy/ocpbugs-15043/script.sh
+++ b/deploy/ocpbugs-15043/script.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+check_ns=(
+    "openshift-sre-pruning"
+    "openshift-monitoring"
+)
+
+NODES=()
+
+MACHINE_API_NAMESPACE="openshift-machine-api"
+
+for current_ns in "${check_ns[@]}"; do
+    readarray -t failedPods < <(oc -n "$current_ns" get pods -owide | grep "CreateContainerError" | awk '{print $1}')
+    for pod in "${failedPods[@]}"; do
+        podDescribe="$(oc -n "$current_ns" describe pod "$pod")"
+        if ! echo "$podDescribe" | grep "error loading seccomp filter into kernel" >/dev/null; then
+            continue
+        fi
+        node="$(echo "$podDescribe" | grep Node: | awk '{print $2}' | cut -d "/" -f 1)"
+        if echo "${NODES[@]}" | grep "$node" >/dev/null; then
+            continue
+        fi
+    done
+done
+
+if [ ${#NODES[@]} -eq 0 ]; then
+    echo "No affected nodes."
+    exit 0
+fi
+
+# print affected nodes and 
+
+for NODE in "${NODES[@]}"; do
+    nodeJson="$(oc get node "$NODE" -ojson)"
+
+    # make sure we only restart infra nodes
+    if ! jq -e '.metadata.labels."node-role.kubernetes.io/infra"' <<< "$nodeJson"; then
+      echo "Found node '$node', however control-plane and worker nodes must be restarted manually"
+      continue
+    fi
+
+    echo "Found node '$node'. Checking associated machine cr"
+
+    MACHINE="$(jq -r '.metadata.annotations."machine.openshift.io/machine"' <<< "$nodeJson" )"
+    if [[ $MACHINE = "" ]]; then
+      echo "Couldn't find Machine for node $node. Skipping"
+      continue
+    fi
+
+    echo "Found machine '$MACHINE' for node '$node'. Removing it..."
+    oc -n "$MACHINE_API_NAMESPACE" delete machine "$MACHINE" --wait
+    echo "Machine removed successfully. Waiting for all machines to be in Running state again"
+    oc -n "$MACHINE_API_NAMESPACE" wait --all --for=jsonpath='{.status.phase}'=Running --timeout=5m machines
+    echo "All Machines are running again. Waiting for all nodes to become ready."
+    oc wait --all --for=condition=Ready=false --timeout=5m nodes
+    echo "All nodes are Ready. Continuing."
+done
+
+# rewrite to use pull secret
+osdctl servicelog post "$(oc get clusterversion version -o json | jq -r .spec.clusterID)" -t https://raw.githubusercontent.com/openshift/managed-notifications/master/osd/OCPBUGS-16655-remediation-please-upgrade.json

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22701,6 +22701,366 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-15043
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version
+        operator: In
+        values:
+        - 4.13.0
+        - 4.13.1
+        - 4.13.2
+        - 4.13.3
+        - 4.13.4
+        - 4.13.5
+        - 4.13.6
+        - 4.13.7
+        - 4.13.8
+        - 4.13.9
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocpbugs-15043
+        namespace: openshift-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-read-pullsecret
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-delete-machines
+        namespace: openshift-machine-api
+      rules:
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machines
+        verbs:
+        - get
+        - list
+        - delete
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-read-configmap
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-manage-lastrun-cm
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+        - create
+        - update
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+      rules:
+      - apiGroups:
+        - null
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-read-clusterversion
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - get
+        - list
+        - watch
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-pullsecret
+        namespace: openshift-config
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-read-pullsecret
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-delete-machines
+        namespace: openshift-machine-api
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-delete-machines
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-muo-configmap
+        namespace: openshift-managed-upgrade-operator
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-configmap
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-oao-configmap
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-configmap
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-manage-lastrun-cm
+        namespace: openshift-config
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-manage-lastrun-cm
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+        namespace: openshift-sre-pruning
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-inspect-pods
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-inspect-pods
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-clusterversion
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-clusterversion
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ocpbugs-15043-script
+        namespace: openshift-config
+      data:
+        ocpbugs-15043.sh: "#!/bin/bash\n\nset -euo pipefail\n\nCHECKED_NAMESPACES=(\n\
+          \    \"openshift-sre-pruning\"\n    \"openshift-monitoring\"\n)\n\nLAST_SL_CONFIGMAP=\"\
+          ocpbugs-15043-last-sl-sent\"\nLAST_RUN_ANNOTATION=\"lasttimestamp\"\nDELAY_BETWEEN_SEND_SECONDS=\"\
+          86400\"\n\nNODES=()\n\nMACHINE_API_NAMESPACE=\"openshift-machine-api\"\n\
+          \nfor current_ns in \"${CHECKED_NAMESPACES[@]}\"; do\n    readarray -t failedPods\
+          \ < <(oc -n \"$current_ns\" get pods -owide | grep \"CreateContainerError\"\
+          \ | awk '{print $1}')\n    for pod in \"${failedPods[@]}\"; do\n       \
+          \ echo \"Found pod $pod failing.\"\n        podDescribe=\"$(oc -n \"$current_ns\"\
+          \ describe pod \"$pod\")\"\n\n        if ! echo \"$podDescribe\" | grep\
+          \ \"error loading seccomp filter into kernel\" >/dev/null; then\n      \
+          \      echo -e \"\\t$pod is failing for another reason. Ignoring\"\n   \
+          \         continue\n        fi\n\n        node=\"$(echo \"$podDescribe\"\
+          \ | grep Node: | awk '{print $2}' | cut -d \"/\" -f 1)\"\n        echo -e\
+          \ \"\\t$pod on $node having seccomp issues\"\n        if echo \"${NODES[@]}\"\
+          \ | grep \"$node\" >/dev/null; then\n            continue\n        fi\n\
+          \        NODES+=(\"$node\")\n    done\ndone\n\nif [ ${#NODES[@]} -eq 0 ];\
+          \ then\n    echo \"No affected nodes.\"\n    exit 0\nfi\n\n# print affected\
+          \ nodes and \n\nfor NODE in \"${NODES[@]}\"; do\n    nodeJson=\"$(oc get\
+          \ node \"$NODE\" -ojson)\"\n\n    # make sure we only restart infra nodes\n\
+          \    if ! jq -e '.metadata.labels.\"node-role.kubernetes.io/infra\"' <<<\
+          \ \"$nodeJson\" > /dev/null ; then\n      echo \"Found node '$node', however\
+          \ control-plane and worker nodes must be restarted manually\"\n      continue\n\
+          \    fi\n\n    echo \"Found node '$node'. Checking associated machine cr\"\
+          \n\n    MACHINE=\"$(jq -r '.metadata.annotations.\"machine.openshift.io/machine\"\
+          ' <<< \"$nodeJson\" | cut -d '/' -f2)\"\n    if [[ $MACHINE = \"\" ]]; then\n\
+          \      echo \"Couldn't find Machine for node $node. Skipping\"\n      continue\n\
+          \    fi\n\n    echo \"Found machine '$MACHINE' for node '$node'. Removing\
+          \ it...\"\n    oc -n \"$MACHINE_API_NAMESPACE\" delete machine \"$MACHINE\"\
+          \ --wait\n    echo \"Machine removed successfully. Waiting for all machines\
+          \ to be in Running state again\"\n    oc -n \"$MACHINE_API_NAMESPACE\" wait\
+          \ --all --for=jsonpath='{.status.phase}'=Running --timeout=5m machines\n\
+          \    echo \"All Machines are running again. Waiting for all nodes to become\
+          \ ready.\"\n    oc wait --all --for=condition=Ready=true --timeout=5m nodes\n\
+          \    echo \"All nodes are Ready. Continuing.\"\ndone\n\n\ncurrentTimestamp=$(date\
+          \ -u +%s)\n\nif oc get cm \"$LAST_SL_CONFIGMAP\" > /dev/null; then \n  if\
+          \ oc get cm \"$LAST_SL_CONFIGMAP\" -ojson | jq -e \".metadata.annotations.$LAST_RUN_ANNOTATION\"\
+          \ > /dev/null; then\n    lastSentTimestamp=$(oc get cm \"$LAST_SL_CONFIGMAP\"\
+          \ -ojson | jq -r \".metadata.annotations.$LAST_RUN_ANNOTATION\")\n    if\
+          \ [[ $(( currentTimestamp - lastSentTimestamp )) -lt $DELAY_BETWEEN_SEND_SECONDS\
+          \ ]]; then \n      echo \"An SL was already sent recently. Skipping it this\
+          \ time.\"\n      exit 0\n    fi\n  fi\nfi\n\necho \"Retrieving pull secret\"\
+          \nSECRET=$(oc -n openshift-config get secret pull-secret -ojson | jq -r\
+          \ '.data.\".dockerconfigjson\" | @base64d ' | jq -r '.auths.\"cloud.openshift.com\"\
+          .auth')\necho \"Pull secret retrieved\"\n\necho \"Retrieving cluster uuid\"\
+          \nEXTERNAL_CLUSTER_ID=$( oc get clusterversion version -o json | jq -r '.spec.clusterID'\
+          \ )\necho \"Cluster UUID is: $EXTERNAL_CLUSTER_ID\"\n\necho \"Getting OCM\
+          \ Base Url\"\nOAO_CONFIGMAP=\"ocm-agent-cm\"\nOAO_NAMESPACE=\"openshift-ocm-agent-operator\"\
+          \n\nMUO_CONFIGMAP=\"managed-upgrade-operator-config\"\nMUO_NAMESPACE=\"\
+          openshift-managed-upgrade-operator\"\nif oc get configmap -n \"$OAO_NAMESPACE\"\
+          \ \"$OAO_CONFIGMAP\"; then\n  OCM_BASE_URL=$(oc get configmap -n \"$OAO_NAMESPACE\"\
+          \ \"$OAO_CONFIGMAP\" -o json | jq -r '.data.ocmBaseURL')\nelif oc get configmap\
+          \ -n \"$MUO_NAMESPACE\" \"$MUO_CONFIGMAP\"; then\n  OCM_BASE_URL=$(oc get\
+          \ configmap -n \"$MUO_NAMESPACE\" \"$MUO_CONFIGMAP\" -o json | jq -r '.data.\"\
+          config.yaml\"' | grep ocmBaseUrl | awk '{print $2;}')\nelse \n  echo \"\
+          Couldn't determin OCM BASE URL. Won't send a servicelog\"\nfi\necho \"OCM\
+          \ Base URL is: $OCM_BASE_URL\"\n\n\nSL_URL=\"${OCM_BASE_URL}/api/service_logs/v1/cluster_logs\"\
+          \n\n\nSL_POST_DATA=$(cat << EOF\n{\n  \"cluster_uuid\": \"$EXTERNAL_CLUSTER_ID\"\
+          ,\n  \"severity\": \"Warning\",\n  \"service_name\": \"SREManualAction\"\
+          ,\n  \"summary\": \"Cluster impacted by OCPBUGS-16655, upgrade recommended\"\
+          ,\n  \"description\": \"Your cluster is impacted by https://issues.redhat.com/browse/OCPBUGS-16655,\
+          \ which results in nodes periodically being unable to run containers. Red\
+          \ Hat SRE has responded to and temporarily remediated impacts of this bug\
+          \ on this cluster and recommends that the cluster be upgraded to 4.13.10\
+          \ or later as soon as convenient.\",\n  \"internal_only\": false,\n  \"\
+          _tags\": [\n    \"sop_PruningCronjobErrorSRE\"\n  ]\n}\nEOF\n)\n\necho \"\
+          SENDING SL: $SL_POST_DATA\"\n\ncurl -v -m 20 -X POST \\\n  -d \"$SL_POST_DATA\"\
+          \ \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization:\
+          \ AccessToken $EXTERNAL_CLUSTER_ID:$SECRET\" \"$SL_URL\"\n\necho \"Annotation\
+          \ configmap with timestamp\"\n\noc create configmap \"$LAST_SL_CONFIGMAP\"\
+          \ || true\noc annotate configmap --overwrite \"$LAST_SL_CONFIGMAP\" \"${LAST_RUN_ANNOTATION}=${currentTimestamp}\"\
+          \n"
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ocpbugs-15043
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 2
+        successfulJobsHistoryLimit: 2
+        concurrencyPolicy: Forbid
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 3600
+            template:
+              metadata:
+                labels:
+                  app: ocpbugs-15043
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  operator: Exists
+                serviceAccountName: ocpbugs-15043
+                restartPolicy: Never
+                volumes:
+                - name: scriptconfigmap
+                  configMap:
+                    defaultMode: 493
+                    name: ocpbugs-15043-script
+                    items:
+                    - key: ocpbugs-15043.sh
+                      path: ocpbugs-15043.sh
+                - name: pull-secret
+                  secret:
+                    secretName: pull-secret
+                containers:
+                - name: ocpbugs-15043
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  volumeMounts:
+                  - mountPath: /tmp/config/
+                    name: scriptconfigmap
+                    readOnly: false
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
+                    limits:
+                      cpu: 100m
+                      memory: 100Mi
+                  command:
+                  - /tmp/config/ocpbugs-15043.sh
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-20184
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22701,6 +22701,366 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-15043
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version
+        operator: In
+        values:
+        - 4.13.0
+        - 4.13.1
+        - 4.13.2
+        - 4.13.3
+        - 4.13.4
+        - 4.13.5
+        - 4.13.6
+        - 4.13.7
+        - 4.13.8
+        - 4.13.9
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocpbugs-15043
+        namespace: openshift-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-read-pullsecret
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-delete-machines
+        namespace: openshift-machine-api
+      rules:
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machines
+        verbs:
+        - get
+        - list
+        - delete
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-read-configmap
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-manage-lastrun-cm
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+        - create
+        - update
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+      rules:
+      - apiGroups:
+        - null
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-read-clusterversion
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - get
+        - list
+        - watch
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-pullsecret
+        namespace: openshift-config
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-read-pullsecret
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-delete-machines
+        namespace: openshift-machine-api
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-delete-machines
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-muo-configmap
+        namespace: openshift-managed-upgrade-operator
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-configmap
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-oao-configmap
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-configmap
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-manage-lastrun-cm
+        namespace: openshift-config
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-manage-lastrun-cm
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+        namespace: openshift-sre-pruning
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-inspect-pods
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-inspect-pods
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-clusterversion
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-clusterversion
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ocpbugs-15043-script
+        namespace: openshift-config
+      data:
+        ocpbugs-15043.sh: "#!/bin/bash\n\nset -euo pipefail\n\nCHECKED_NAMESPACES=(\n\
+          \    \"openshift-sre-pruning\"\n    \"openshift-monitoring\"\n)\n\nLAST_SL_CONFIGMAP=\"\
+          ocpbugs-15043-last-sl-sent\"\nLAST_RUN_ANNOTATION=\"lasttimestamp\"\nDELAY_BETWEEN_SEND_SECONDS=\"\
+          86400\"\n\nNODES=()\n\nMACHINE_API_NAMESPACE=\"openshift-machine-api\"\n\
+          \nfor current_ns in \"${CHECKED_NAMESPACES[@]}\"; do\n    readarray -t failedPods\
+          \ < <(oc -n \"$current_ns\" get pods -owide | grep \"CreateContainerError\"\
+          \ | awk '{print $1}')\n    for pod in \"${failedPods[@]}\"; do\n       \
+          \ echo \"Found pod $pod failing.\"\n        podDescribe=\"$(oc -n \"$current_ns\"\
+          \ describe pod \"$pod\")\"\n\n        if ! echo \"$podDescribe\" | grep\
+          \ \"error loading seccomp filter into kernel\" >/dev/null; then\n      \
+          \      echo -e \"\\t$pod is failing for another reason. Ignoring\"\n   \
+          \         continue\n        fi\n\n        node=\"$(echo \"$podDescribe\"\
+          \ | grep Node: | awk '{print $2}' | cut -d \"/\" -f 1)\"\n        echo -e\
+          \ \"\\t$pod on $node having seccomp issues\"\n        if echo \"${NODES[@]}\"\
+          \ | grep \"$node\" >/dev/null; then\n            continue\n        fi\n\
+          \        NODES+=(\"$node\")\n    done\ndone\n\nif [ ${#NODES[@]} -eq 0 ];\
+          \ then\n    echo \"No affected nodes.\"\n    exit 0\nfi\n\n# print affected\
+          \ nodes and \n\nfor NODE in \"${NODES[@]}\"; do\n    nodeJson=\"$(oc get\
+          \ node \"$NODE\" -ojson)\"\n\n    # make sure we only restart infra nodes\n\
+          \    if ! jq -e '.metadata.labels.\"node-role.kubernetes.io/infra\"' <<<\
+          \ \"$nodeJson\" > /dev/null ; then\n      echo \"Found node '$node', however\
+          \ control-plane and worker nodes must be restarted manually\"\n      continue\n\
+          \    fi\n\n    echo \"Found node '$node'. Checking associated machine cr\"\
+          \n\n    MACHINE=\"$(jq -r '.metadata.annotations.\"machine.openshift.io/machine\"\
+          ' <<< \"$nodeJson\" | cut -d '/' -f2)\"\n    if [[ $MACHINE = \"\" ]]; then\n\
+          \      echo \"Couldn't find Machine for node $node. Skipping\"\n      continue\n\
+          \    fi\n\n    echo \"Found machine '$MACHINE' for node '$node'. Removing\
+          \ it...\"\n    oc -n \"$MACHINE_API_NAMESPACE\" delete machine \"$MACHINE\"\
+          \ --wait\n    echo \"Machine removed successfully. Waiting for all machines\
+          \ to be in Running state again\"\n    oc -n \"$MACHINE_API_NAMESPACE\" wait\
+          \ --all --for=jsonpath='{.status.phase}'=Running --timeout=5m machines\n\
+          \    echo \"All Machines are running again. Waiting for all nodes to become\
+          \ ready.\"\n    oc wait --all --for=condition=Ready=true --timeout=5m nodes\n\
+          \    echo \"All nodes are Ready. Continuing.\"\ndone\n\n\ncurrentTimestamp=$(date\
+          \ -u +%s)\n\nif oc get cm \"$LAST_SL_CONFIGMAP\" > /dev/null; then \n  if\
+          \ oc get cm \"$LAST_SL_CONFIGMAP\" -ojson | jq -e \".metadata.annotations.$LAST_RUN_ANNOTATION\"\
+          \ > /dev/null; then\n    lastSentTimestamp=$(oc get cm \"$LAST_SL_CONFIGMAP\"\
+          \ -ojson | jq -r \".metadata.annotations.$LAST_RUN_ANNOTATION\")\n    if\
+          \ [[ $(( currentTimestamp - lastSentTimestamp )) -lt $DELAY_BETWEEN_SEND_SECONDS\
+          \ ]]; then \n      echo \"An SL was already sent recently. Skipping it this\
+          \ time.\"\n      exit 0\n    fi\n  fi\nfi\n\necho \"Retrieving pull secret\"\
+          \nSECRET=$(oc -n openshift-config get secret pull-secret -ojson | jq -r\
+          \ '.data.\".dockerconfigjson\" | @base64d ' | jq -r '.auths.\"cloud.openshift.com\"\
+          .auth')\necho \"Pull secret retrieved\"\n\necho \"Retrieving cluster uuid\"\
+          \nEXTERNAL_CLUSTER_ID=$( oc get clusterversion version -o json | jq -r '.spec.clusterID'\
+          \ )\necho \"Cluster UUID is: $EXTERNAL_CLUSTER_ID\"\n\necho \"Getting OCM\
+          \ Base Url\"\nOAO_CONFIGMAP=\"ocm-agent-cm\"\nOAO_NAMESPACE=\"openshift-ocm-agent-operator\"\
+          \n\nMUO_CONFIGMAP=\"managed-upgrade-operator-config\"\nMUO_NAMESPACE=\"\
+          openshift-managed-upgrade-operator\"\nif oc get configmap -n \"$OAO_NAMESPACE\"\
+          \ \"$OAO_CONFIGMAP\"; then\n  OCM_BASE_URL=$(oc get configmap -n \"$OAO_NAMESPACE\"\
+          \ \"$OAO_CONFIGMAP\" -o json | jq -r '.data.ocmBaseURL')\nelif oc get configmap\
+          \ -n \"$MUO_NAMESPACE\" \"$MUO_CONFIGMAP\"; then\n  OCM_BASE_URL=$(oc get\
+          \ configmap -n \"$MUO_NAMESPACE\" \"$MUO_CONFIGMAP\" -o json | jq -r '.data.\"\
+          config.yaml\"' | grep ocmBaseUrl | awk '{print $2;}')\nelse \n  echo \"\
+          Couldn't determin OCM BASE URL. Won't send a servicelog\"\nfi\necho \"OCM\
+          \ Base URL is: $OCM_BASE_URL\"\n\n\nSL_URL=\"${OCM_BASE_URL}/api/service_logs/v1/cluster_logs\"\
+          \n\n\nSL_POST_DATA=$(cat << EOF\n{\n  \"cluster_uuid\": \"$EXTERNAL_CLUSTER_ID\"\
+          ,\n  \"severity\": \"Warning\",\n  \"service_name\": \"SREManualAction\"\
+          ,\n  \"summary\": \"Cluster impacted by OCPBUGS-16655, upgrade recommended\"\
+          ,\n  \"description\": \"Your cluster is impacted by https://issues.redhat.com/browse/OCPBUGS-16655,\
+          \ which results in nodes periodically being unable to run containers. Red\
+          \ Hat SRE has responded to and temporarily remediated impacts of this bug\
+          \ on this cluster and recommends that the cluster be upgraded to 4.13.10\
+          \ or later as soon as convenient.\",\n  \"internal_only\": false,\n  \"\
+          _tags\": [\n    \"sop_PruningCronjobErrorSRE\"\n  ]\n}\nEOF\n)\n\necho \"\
+          SENDING SL: $SL_POST_DATA\"\n\ncurl -v -m 20 -X POST \\\n  -d \"$SL_POST_DATA\"\
+          \ \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization:\
+          \ AccessToken $EXTERNAL_CLUSTER_ID:$SECRET\" \"$SL_URL\"\n\necho \"Annotation\
+          \ configmap with timestamp\"\n\noc create configmap \"$LAST_SL_CONFIGMAP\"\
+          \ || true\noc annotate configmap --overwrite \"$LAST_SL_CONFIGMAP\" \"${LAST_RUN_ANNOTATION}=${currentTimestamp}\"\
+          \n"
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ocpbugs-15043
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 2
+        successfulJobsHistoryLimit: 2
+        concurrencyPolicy: Forbid
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 3600
+            template:
+              metadata:
+                labels:
+                  app: ocpbugs-15043
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  operator: Exists
+                serviceAccountName: ocpbugs-15043
+                restartPolicy: Never
+                volumes:
+                - name: scriptconfigmap
+                  configMap:
+                    defaultMode: 493
+                    name: ocpbugs-15043-script
+                    items:
+                    - key: ocpbugs-15043.sh
+                      path: ocpbugs-15043.sh
+                - name: pull-secret
+                  secret:
+                    secretName: pull-secret
+                containers:
+                - name: ocpbugs-15043
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  volumeMounts:
+                  - mountPath: /tmp/config/
+                    name: scriptconfigmap
+                    readOnly: false
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
+                    limits:
+                      cpu: 100m
+                      memory: 100Mi
+                  command:
+                  - /tmp/config/ocpbugs-15043.sh
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-20184
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22701,6 +22701,366 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-15043
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version
+        operator: In
+        values:
+        - 4.13.0
+        - 4.13.1
+        - 4.13.2
+        - 4.13.3
+        - 4.13.4
+        - 4.13.5
+        - 4.13.6
+        - 4.13.7
+        - 4.13.8
+        - 4.13.9
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: ocpbugs-15043
+        namespace: openshift-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-read-pullsecret
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-delete-machines
+        namespace: openshift-machine-api
+      rules:
+      - apiGroups:
+        - machine.openshift.io
+        resources:
+        - machines
+        verbs:
+        - get
+        - list
+        - delete
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-read-configmap
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: ocpbugs-15043-manage-lastrun-cm
+        namespace: openshift-config
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - configmaps
+        verbs:
+        - get
+        - list
+        - create
+        - update
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+      rules:
+      - apiGroups:
+        - null
+        resources:
+        - pods
+        verbs:
+        - get
+        - list
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: ocpbugs-15043-read-clusterversion
+      rules:
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - clusterversions
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - get
+        - list
+        - watch
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-pullsecret
+        namespace: openshift-config
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-read-pullsecret
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-delete-machines
+        namespace: openshift-machine-api
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-delete-machines
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-muo-configmap
+        namespace: openshift-managed-upgrade-operator
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-configmap
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-oao-configmap
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-configmap
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-manage-lastrun-cm
+        namespace: openshift-config
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: ocpbugs-15043-manage-lastrun-cm
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+        namespace: openshift-sre-pruning
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-inspect-pods
+    - kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-inspect-pods
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-inspect-pods
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ocpbugs-15043-read-clusterversion
+      subjects:
+      - kind: ServiceAccount
+        name: ocpbugs-15043
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: ocpbugs-15043-read-clusterversion
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: ocpbugs-15043-script
+        namespace: openshift-config
+      data:
+        ocpbugs-15043.sh: "#!/bin/bash\n\nset -euo pipefail\n\nCHECKED_NAMESPACES=(\n\
+          \    \"openshift-sre-pruning\"\n    \"openshift-monitoring\"\n)\n\nLAST_SL_CONFIGMAP=\"\
+          ocpbugs-15043-last-sl-sent\"\nLAST_RUN_ANNOTATION=\"lasttimestamp\"\nDELAY_BETWEEN_SEND_SECONDS=\"\
+          86400\"\n\nNODES=()\n\nMACHINE_API_NAMESPACE=\"openshift-machine-api\"\n\
+          \nfor current_ns in \"${CHECKED_NAMESPACES[@]}\"; do\n    readarray -t failedPods\
+          \ < <(oc -n \"$current_ns\" get pods -owide | grep \"CreateContainerError\"\
+          \ | awk '{print $1}')\n    for pod in \"${failedPods[@]}\"; do\n       \
+          \ echo \"Found pod $pod failing.\"\n        podDescribe=\"$(oc -n \"$current_ns\"\
+          \ describe pod \"$pod\")\"\n\n        if ! echo \"$podDescribe\" | grep\
+          \ \"error loading seccomp filter into kernel\" >/dev/null; then\n      \
+          \      echo -e \"\\t$pod is failing for another reason. Ignoring\"\n   \
+          \         continue\n        fi\n\n        node=\"$(echo \"$podDescribe\"\
+          \ | grep Node: | awk '{print $2}' | cut -d \"/\" -f 1)\"\n        echo -e\
+          \ \"\\t$pod on $node having seccomp issues\"\n        if echo \"${NODES[@]}\"\
+          \ | grep \"$node\" >/dev/null; then\n            continue\n        fi\n\
+          \        NODES+=(\"$node\")\n    done\ndone\n\nif [ ${#NODES[@]} -eq 0 ];\
+          \ then\n    echo \"No affected nodes.\"\n    exit 0\nfi\n\n# print affected\
+          \ nodes and \n\nfor NODE in \"${NODES[@]}\"; do\n    nodeJson=\"$(oc get\
+          \ node \"$NODE\" -ojson)\"\n\n    # make sure we only restart infra nodes\n\
+          \    if ! jq -e '.metadata.labels.\"node-role.kubernetes.io/infra\"' <<<\
+          \ \"$nodeJson\" > /dev/null ; then\n      echo \"Found node '$node', however\
+          \ control-plane and worker nodes must be restarted manually\"\n      continue\n\
+          \    fi\n\n    echo \"Found node '$node'. Checking associated machine cr\"\
+          \n\n    MACHINE=\"$(jq -r '.metadata.annotations.\"machine.openshift.io/machine\"\
+          ' <<< \"$nodeJson\" | cut -d '/' -f2)\"\n    if [[ $MACHINE = \"\" ]]; then\n\
+          \      echo \"Couldn't find Machine for node $node. Skipping\"\n      continue\n\
+          \    fi\n\n    echo \"Found machine '$MACHINE' for node '$node'. Removing\
+          \ it...\"\n    oc -n \"$MACHINE_API_NAMESPACE\" delete machine \"$MACHINE\"\
+          \ --wait\n    echo \"Machine removed successfully. Waiting for all machines\
+          \ to be in Running state again\"\n    oc -n \"$MACHINE_API_NAMESPACE\" wait\
+          \ --all --for=jsonpath='{.status.phase}'=Running --timeout=5m machines\n\
+          \    echo \"All Machines are running again. Waiting for all nodes to become\
+          \ ready.\"\n    oc wait --all --for=condition=Ready=true --timeout=5m nodes\n\
+          \    echo \"All nodes are Ready. Continuing.\"\ndone\n\n\ncurrentTimestamp=$(date\
+          \ -u +%s)\n\nif oc get cm \"$LAST_SL_CONFIGMAP\" > /dev/null; then \n  if\
+          \ oc get cm \"$LAST_SL_CONFIGMAP\" -ojson | jq -e \".metadata.annotations.$LAST_RUN_ANNOTATION\"\
+          \ > /dev/null; then\n    lastSentTimestamp=$(oc get cm \"$LAST_SL_CONFIGMAP\"\
+          \ -ojson | jq -r \".metadata.annotations.$LAST_RUN_ANNOTATION\")\n    if\
+          \ [[ $(( currentTimestamp - lastSentTimestamp )) -lt $DELAY_BETWEEN_SEND_SECONDS\
+          \ ]]; then \n      echo \"An SL was already sent recently. Skipping it this\
+          \ time.\"\n      exit 0\n    fi\n  fi\nfi\n\necho \"Retrieving pull secret\"\
+          \nSECRET=$(oc -n openshift-config get secret pull-secret -ojson | jq -r\
+          \ '.data.\".dockerconfigjson\" | @base64d ' | jq -r '.auths.\"cloud.openshift.com\"\
+          .auth')\necho \"Pull secret retrieved\"\n\necho \"Retrieving cluster uuid\"\
+          \nEXTERNAL_CLUSTER_ID=$( oc get clusterversion version -o json | jq -r '.spec.clusterID'\
+          \ )\necho \"Cluster UUID is: $EXTERNAL_CLUSTER_ID\"\n\necho \"Getting OCM\
+          \ Base Url\"\nOAO_CONFIGMAP=\"ocm-agent-cm\"\nOAO_NAMESPACE=\"openshift-ocm-agent-operator\"\
+          \n\nMUO_CONFIGMAP=\"managed-upgrade-operator-config\"\nMUO_NAMESPACE=\"\
+          openshift-managed-upgrade-operator\"\nif oc get configmap -n \"$OAO_NAMESPACE\"\
+          \ \"$OAO_CONFIGMAP\"; then\n  OCM_BASE_URL=$(oc get configmap -n \"$OAO_NAMESPACE\"\
+          \ \"$OAO_CONFIGMAP\" -o json | jq -r '.data.ocmBaseURL')\nelif oc get configmap\
+          \ -n \"$MUO_NAMESPACE\" \"$MUO_CONFIGMAP\"; then\n  OCM_BASE_URL=$(oc get\
+          \ configmap -n \"$MUO_NAMESPACE\" \"$MUO_CONFIGMAP\" -o json | jq -r '.data.\"\
+          config.yaml\"' | grep ocmBaseUrl | awk '{print $2;}')\nelse \n  echo \"\
+          Couldn't determin OCM BASE URL. Won't send a servicelog\"\nfi\necho \"OCM\
+          \ Base URL is: $OCM_BASE_URL\"\n\n\nSL_URL=\"${OCM_BASE_URL}/api/service_logs/v1/cluster_logs\"\
+          \n\n\nSL_POST_DATA=$(cat << EOF\n{\n  \"cluster_uuid\": \"$EXTERNAL_CLUSTER_ID\"\
+          ,\n  \"severity\": \"Warning\",\n  \"service_name\": \"SREManualAction\"\
+          ,\n  \"summary\": \"Cluster impacted by OCPBUGS-16655, upgrade recommended\"\
+          ,\n  \"description\": \"Your cluster is impacted by https://issues.redhat.com/browse/OCPBUGS-16655,\
+          \ which results in nodes periodically being unable to run containers. Red\
+          \ Hat SRE has responded to and temporarily remediated impacts of this bug\
+          \ on this cluster and recommends that the cluster be upgraded to 4.13.10\
+          \ or later as soon as convenient.\",\n  \"internal_only\": false,\n  \"\
+          _tags\": [\n    \"sop_PruningCronjobErrorSRE\"\n  ]\n}\nEOF\n)\n\necho \"\
+          SENDING SL: $SL_POST_DATA\"\n\ncurl -v -m 20 -X POST \\\n  -d \"$SL_POST_DATA\"\
+          \ \\\n  -H \"Content-Type: application/json\" \\\n  -H \"Authorization:\
+          \ AccessToken $EXTERNAL_CLUSTER_ID:$SECRET\" \"$SL_URL\"\n\necho \"Annotation\
+          \ configmap with timestamp\"\n\noc create configmap \"$LAST_SL_CONFIGMAP\"\
+          \ || true\noc annotate configmap --overwrite \"$LAST_SL_CONFIGMAP\" \"${LAST_RUN_ANNOTATION}=${currentTimestamp}\"\
+          \n"
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: ocpbugs-15043
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 2
+        successfulJobsHistoryLimit: 2
+        concurrencyPolicy: Forbid
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 3600
+            template:
+              metadata:
+                labels:
+                  app: ocpbugs-15043
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/master
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  operator: Exists
+                serviceAccountName: ocpbugs-15043
+                restartPolicy: Never
+                volumes:
+                - name: scriptconfigmap
+                  configMap:
+                    defaultMode: 493
+                    name: ocpbugs-15043-script
+                    items:
+                    - key: ocpbugs-15043.sh
+                      path: ocpbugs-15043.sh
+                - name: pull-secret
+                  secret:
+                    secretName: pull-secret
+                containers:
+                - name: ocpbugs-15043
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  volumeMounts:
+                  - mountPath: /tmp/config/
+                    name: scriptconfigmap
+                    readOnly: false
+                  resources:
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
+                    limits:
+                      cpu: 100m
+                      memory: 100Mi
+                  command:
+                  - /tmp/config/ocpbugs-15043.sh
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-20184
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What this PR does / why we need it?

- Deploys a CronJob to clusters affected by https://issues.redhat.com/browse/OCPBUGS-16655
- That cronjob checks if nodes are affected by the bug
- If so, the machines are deleted and the node is recreated
- Also, an SL is sent to the CU

However, some restrictions apply:
- Only infra nodes are recreated
- SL is only sent if there hasn't been an SL sent in the last 24 hours (by this cronjob)

Here's a rough outline over the steps in the script:
1. Check namespaces in `$CHECKED_NAMESPACES` for failing pods
2. Check if those pods fail with a seccomp error and save the nodes those pods are running on
3. For every node identified, Check if it's an infra node.
4. If so, get the machine CR and delete it
5. wait for the new machine to be ready and the new node to become ready
6. After all nodes have been handled, a servicelog is sent and the current timestamp is saved in a configmap annotation. This annotation is then used to check if we already sent a servicelog today.

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-18436](https://issues.redhat.com//browse/OSD-18436)_

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
