### PR TITLE
Revert "Use internal OCM endpoint proxy for MUO on non-management clusters"

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -8,7 +8,7 @@ data:
     upgradeType: OSD
     configManager:
       source: OCM
-      ocmBaseUrl: http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081
+      ocmBaseUrl: ${OCM_BASE_URL}
       watchInterval: 60
     maintenance:
       controlPlaneTime: 130

--- a/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/hypershift-mc/10-managed-upgrade-operator-configmap.yaml
@@ -8,7 +8,7 @@ data:
     upgradeType: OSD
     configManager:
       source: OCM
-      ocmBaseUrl: http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081
+      ocmBaseUrl: ${OCM_BASE_URL}
       watchInterval: 60
     maintenance:
       controlPlaneTime: 130

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21850,11 +21850,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
-          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
@@ -22028,11 +22028,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
-          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21850,11 +21850,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
-          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
@@ -22028,11 +22028,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
-          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21850,11 +21850,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
-          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\nhealthCheck:\n  ignoredCriticals:\n  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n\
           \  - UpgradeNodeScalingFailedSRE\n  - PruningCronjobErrorSRE\n  - PrometheusRuleFailures\n\
@@ -22028,11 +22028,11 @@ objects:
         namespace: openshift-managed-upgrade-operator
       data:
         config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
-          \ http://ocm-agent.openshift-ocm-agent-operator.svc.cluster.local:8081\n\
-          \  watchInterval: 60\nmaintenance:\n  controlPlaneTime: 130\n  ignoredAlerts:\n\
-          \    controlPlaneCriticals:\n    # ClusterOperatorDown - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n\
-          \    - ClusterOperatorDown\n    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n\
-          \    - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    # ClusterOperatorDown\
+          \ - https://bugzilla.redhat.com/show_bug.cgi?id=1955300\n    - ClusterOperatorDown\n\
+          \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
+          \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
           \ 8\n  disableDrainStrategies: true\nhealthCheck:\n  ignoredCriticals:\n\
           \  - DNSErrors05MinSRE\n  - MetricsClientSendFailingSRE\n  - UpgradeNodeScalingFailedSRE\n\


### PR DESCRIPTION
Reverts openshift/managed-cluster-config#1948

This pull request caused an incident, due to it assuming that production changes in Managed upgrade operator had propagated, resulting in a flood of `CannotRetrieveUpdatesSRE`. See incident channel here: https://redhat.enterprise.slack.com/archives/C06EEJJPUTU
