### PR TITLE
Fix bug with kms:DescribeKey and break out describe actions

### DIFF
--- a/resources/sts/4.14/sts_instance_controlplane_permission_policy.json
+++ b/resources/sts/4.14/sts_instance_controlplane_permission_policy.json
@@ -49,6 +49,9 @@
             "Action": [
                 "kms:DescribeKey"
             ],
+            "Resource": [
+                "*"
+            ],
             "Condition": {
                 "StringEquals": {
                     "aws:ResourceTag/red-hat": "true"

--- a/resources/sts/4.15/sts_instance_controlplane_permission_policy.json
+++ b/resources/sts/4.15/sts_instance_controlplane_permission_policy.json
@@ -2,6 +2,42 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "ReadPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInstances",
+                "ec2:DescribeRouteTables",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeVpcs",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeLoadBalancerPolicies"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+          "Sid": "KMSDescribeKey",
+          "Effect": "Allow",
+          "Action": [
+              "kms:DescribeKey"
+          ],
+          "Resource": [
+              "*"
+          ],
+          "Condition": {
+              "StringEquals": {
+                  "aws:ResourceTag/red-hat": "true"
+              }
+          }
+        },
+        {
             "Effect": "Allow",
             "Action": [
                 "ec2:AttachVolume",
@@ -11,7 +47,6 @@
                 "ec2:CreateVolume",
                 "ec2:DeleteSecurityGroup",
                 "ec2:DeleteVolume",
-                "ec2:Describe*",
                 "ec2:DetachVolume",
                 "ec2:ModifyInstanceAttribute",
                 "ec2:ModifyVolume",
@@ -31,7 +66,6 @@
                 "elasticloadbalancing:DeleteTargetGroup",
                 "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
                 "elasticloadbalancing:DeregisterTargets",
-                "elasticloadbalancing:Describe*",
                 "elasticloadbalancing:DetachLoadBalancerFromSubnets",
                 "elasticloadbalancing:ModifyListener",
                 "elasticloadbalancing:ModifyLoadBalancerAttributes",
@@ -43,18 +77,6 @@
                 "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
             ],
             "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "kms:DescribeKey"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "aws:ResourceTag/red-hat": "true"
-                }
-            }
         }
-
     ]
 }


### PR DESCRIPTION
### What type of PR is this?
bug/feature

### What this PR does / why we need it?
The sts_instance_controlplane_permission_policy is needed for performing
cloud-controller-manager actions, on AWS this is done with
https://github.com/kubernetes/cloud-provider-aws/tree/master

This PR expands the `ec2` and `elasticloadbalancing:Describe*` actions to
align with cloud-provider-aws documentation as well as adds a missing
resource block to the `kms:DescribeKey` action.

### Which Jira/Github issue(s) this PR fixes?
[OSD-20503](https://issues.redhat.com//browse/OSD-20503)

The permissions policy blocks also align with the corresponding ROSA HCP managed policy: https://github.com/openshift/managed-cluster-config/blob/master/resources/sts/4.15/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json