### PR TITLE
AUTH-478: osd-suricata - add proper pod-security labels

### DIFF
--- a/deploy/osd-ids-tester/100-ids-tester.Namespace.yaml
+++ b/deploy/osd-ids-tester/100-ids-tester.Namespace.yaml
@@ -2,3 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-suricata
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest

--- a/deploy/osd-suricata/00-osd-suricata-Namespace.yaml
+++ b/deploy/osd-suricata/00-osd-suricata-Namespace.yaml
@@ -2,3 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-suricata
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest

--- a/deploy/osd-suricata/hypershift-management-cluster/00-osd-suricata-Namespace.yaml
+++ b/deploy/osd-suricata/hypershift-management-cluster/00-osd-suricata-Namespace.yaml
@@ -2,3 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-suricata
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28397,6 +28397,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31448,6 +31448,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -31587,6 +31594,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28397,6 +28397,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31448,6 +31448,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -31587,6 +31594,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28397,6 +28397,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31448,6 +31448,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
@@ -31587,6 +31594,13 @@ objects:
       kind: Namespace
       metadata:
         name: openshift-suricata
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
     - apiVersion: v1
       kind: ServiceAccount
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

cleanup

### What this PR does / why we need it?

The [pod security](https://cloud.redhat.com/blog/pod-security-admission-in-openshift-4.11) level is not set for this namespace. It entered the top 10 of violating openshift namespaces.

You can look it up on thanos when searching for `alerts{alertname="PodSecurityViolation"}`.

In a future update, we will enforce the pod security level and this namespace won't work anymore, without the labels set as the global config will enforce `restricted`.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/AUTH-478

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
