### PR TITLE
change cmo to remoteWrite directly, using oauth2

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
@@ -8,7 +8,16 @@ data:
     enableUserWorkload: false
     prometheusK8s:
       remoteWrite:
-      - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+      - url: ${OBSERVATORIUM_URL}
+        oauth2:
+          clientId:
+            secret:
+              key: client-id
+              name: observatorium-credentials
+          clientSecret:
+            key: client-secret
+            name: observatorium-credentials
+          tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
         remoteTimeout: 30s
         writeRelabelConfigs:
         - sourceLabels:

--- a/deploy/cluster-monitoring-config-non-uwm/clusters-v4.5/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/clusters-v4.5/50-GENERATED-cluster-monitoring-config.yaml
@@ -8,7 +8,16 @@ data:
     enableUserWorkload: false
     prometheusK8s:
       remoteWrite:
-      - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+      - url: ${OBSERVATORIUM_URL}
+        oauth2:
+          clientId:
+            secret:
+              key: client-id
+              name: observatorium-credentials
+          clientSecret:
+            key: client-secret
+            name: observatorium-credentials
+          tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
         remoteTimeout: 30s
         writeRelabelConfigs:
         - sourceLabels:

--- a/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -8,7 +8,16 @@ data:
     enableUserWorkload: false
     prometheusK8s:
       remoteWrite:
-      - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+      - url: ${OBSERVATORIUM_URL}
+        oauth2:
+          clientId:
+            secret:
+              key: client-id
+              name: observatorium-credentials
+          clientSecret:
+            key: client-secret
+            name: observatorium-credentials
+          tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
         remoteTimeout: 30s
         writeRelabelConfigs:
         - sourceLabels:

--- a/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -8,7 +8,16 @@ data:
     enableUserWorkload: true
     prometheusK8s:
       remoteWrite:
-      - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+      - url: ${OBSERVATORIUM_URL}
+        oauth2:
+          clientId:
+            secret:
+              key: client-id
+              name: observatorium-credentials
+          clientSecret:
+            key: client-secret
+            name: observatorium-credentials
+          tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
         remoteTimeout: 30s
         writeRelabelConfigs:
         - sourceLabels:

--- a/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -8,7 +8,16 @@ data:
     enableUserWorkload: true
     prometheusK8s:
       remoteWrite:
-      - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+      - url: ${OBSERVATORIUM_URL}
+        oauth2:
+          clientId:
+            secret:
+              key: client-id
+              name: observatorium-credentials
+          clientSecret:
+            key: client-secret
+            name: observatorium-credentials
+          tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
         remoteTimeout: 30s
         writeRelabelConfigs:
         - sourceLabels:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -20947,7 +20947,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
-          \ - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21010,7 +21013,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21065,7 +21071,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21128,7 +21137,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21195,7 +21207,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
-          \ - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26,6 +26,8 @@ parameters:
   required: true
 - name: ENV
   required: true
+- name: OBSERVATORIUM_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -20947,7 +20947,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
-          \ - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21010,7 +21013,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21065,7 +21071,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21128,7 +21137,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21195,7 +21207,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
-          \ - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26,6 +26,8 @@ parameters:
   required: true
 - name: ENV
   required: true
+- name: OBSERVATORIUM_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -20947,7 +20947,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
-          \ - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21010,7 +21013,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21065,7 +21071,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21128,7 +21137,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
-          \  - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
@@ -21195,7 +21207,10 @@ objects:
         namespace: openshift-monitoring
       data:
         config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
-          \ - url: http://token-refresher.openshift-monitoring.svc.cluster.local\n\
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
           \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
           \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|csv_succeeded)\n\
           \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26,6 +26,8 @@ parameters:
   required: true
 - name: ENV
   required: true
+- name: OBSERVATORIUM_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:

--- a/resources/cluster-monitoring-config/config.yaml
+++ b/resources/cluster-monitoring-config/config.yaml
@@ -5,7 +5,16 @@ prometheusK8s:
 # make sure to adjust https://github.com/openshift/ops-sop/blob/master/v4/howto/observability/o11m_mst_killswitch.md
 # so that killswitch instructions point to the right file!
   remoteWrite:
-    - url: http://token-refresher.openshift-monitoring.svc.cluster.local
+    - url: ${OBSERVATORIUM_URL}
+      oauth2:
+        clientId:
+          secret:
+            key: client-id
+            name: observatorium-credentials
+        clientSecret:
+            key: client-secret
+            name: observatorium-credentials
+        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
       remoteTimeout: 30s
       writeRelabelConfigs:
       - sourceLabels: [__name__]

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -26,6 +26,8 @@ parameters:
   required: true
 - name: ENV
   required: true
+- name: OBSERVATORIUM_URL
+  required: true
 metadata:
   name: selectorsyncset-template
 objects:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
We are removing the token-refresher by using prometheus remoteWrite directly.
The secret, previously used by token-refresher, is read and used by prometheus now to do oauth2.
Removal of the tokenrefresher resources will be done in a follow up PR, once this has been validated in stage.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-18526 

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
