### PR TITLE
Add ALLOW_CORDON_WORKER_NODE_ENTITY_IDS as a feature flag for MCVW

### DIFF
--- a/deploy/customer-cordon-node-configmap/config.yaml
+++ b/deploy/customer-cordon-node-configmap/config.yaml
@@ -1,0 +1,11 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: "${{ALLOW_CORDON_WORKER_NODE_ENTITY_IDS}}"
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values:
+        - "true"

--- a/deploy/customer-cordon-node-configmap/configmap.yaml
+++ b/deploy/customer-cordon-node-configmap/configmap.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: allow-worker-node-cordon
+  namespace: openshift-validation-webhook

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -16,6 +16,8 @@ parameters:
   required: true
 - name: LOG_LINKING_ENTITY_IDS
   required: true
+- name: ALLOW_CORDON_WORKER_NODE_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
@@ -21456,6 +21458,33 @@ objects:
               overwrite: true
               path: /etc/crio/crio.conf.d/90-linked-log.conf
         osImageURL: ''
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: customer-cordon-node-configmap
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ALLOW_CORDON_WORKER_NODE_ENTITY_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: allow-worker-node-cordon
+        namespace: openshift-validation-webhook
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -16,6 +16,8 @@ parameters:
   required: true
 - name: LOG_LINKING_ENTITY_IDS
   required: true
+- name: ALLOW_CORDON_WORKER_NODE_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
@@ -21456,6 +21458,33 @@ objects:
               overwrite: true
               path: /etc/crio/crio.conf.d/90-linked-log.conf
         osImageURL: ''
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: customer-cordon-node-configmap
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ALLOW_CORDON_WORKER_NODE_ENTITY_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: allow-worker-node-cordon
+        namespace: openshift-validation-webhook
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -16,6 +16,8 @@ parameters:
   required: true
 - name: LOG_LINKING_ENTITY_IDS
   required: true
+- name: ALLOW_CORDON_WORKER_NODE_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
@@ -21456,6 +21458,33 @@ objects:
               overwrite: true
               path: /etc/crio/crio.conf.d/90-linked-log.conf
         osImageURL: ''
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: customer-cordon-node-configmap
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ALLOW_CORDON_WORKER_NODE_ENTITY_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: allow-worker-node-cordon
+        namespace: openshift-validation-webhook
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -16,6 +16,8 @@ parameters:
   required: true
 - name: LOG_LINKING_ENTITY_IDS
   required: true
+- name: ALLOW_CORDON_WORKER_NODE_ENTITY_IDS
+  required: true
 - name: ALLOWED_CIDR_BLOCKS
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS


### PR DESCRIPTION
In [OSD-20485](https://issues.redhat.com//browse/OSD-20485) we need to expedite a feature for one specific customer, this enables us to deploy a configmap to clusters owned by a specific customer and we will use it as a feature flag in
managed-cluster-validating-webhooks.

### What type of PR is this?
feature

### Which Jira/Github issue(s) this PR fixes?
[OSD-20485](https://issues.redhat.com//browse/OSD-20485)

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
