### PR TITLE
Fix references to be an array

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -78,7 +78,8 @@ spec:
       severity: Error
       summary: Workload preventing machine deletion
       logType: Cluster Configuration
-      references: "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"
+      references: 
+      - "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"
     - activeBody: |-
         Your cluster requires you to take action. The available file system inodes for a worker node are currently at or below 3% and are predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of inodes used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
       name: WorkerNodeFilesystemAlmostOutOfFiles

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22419,7 +22419,8 @@ objects:
           severity: Error
           summary: Workload preventing machine deletion
           logType: Cluster Configuration
-          references: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
+          references:
+          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
         - activeBody: Your cluster requires you to take action. The available file
             system inodes for a worker node are currently at or below 3% and are predicted
             to be fully exhausted soon. Without action, this could impact the usability

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22419,7 +22419,8 @@ objects:
           severity: Error
           summary: Workload preventing machine deletion
           logType: Cluster Configuration
-          references: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
+          references:
+          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
         - activeBody: Your cluster requires you to take action. The available file
             system inodes for a worker node are currently at or below 3% and are predicted
             to be fully exhausted soon. Without action, this could impact the usability

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22419,7 +22419,8 @@ objects:
           severity: Error
           summary: Workload preventing machine deletion
           logType: Cluster Configuration
-          references: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
+          references:
+          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
         - activeBody: Your cluster requires you to take action. The available file
             system inodes for a worker node are currently at or below 3% and are predicted
             to be fully exhausted soon. Without action, this could impact the usability


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
SyncSet failure, this needs to be an array of strings (see e.g. the [managed-notification for node failures](https://github.com/openshift/managed-cluster-config/blob/dac2a883f964335455aeb944ec5a80d16d9ac711/deploy/ocm-agent-operator-managednotifications/node-condition/100-sre-node-condition-managed-notification.ManagedNotification.yaml#L41) and [API](https://github.com/openshift/ocm-agent-operator/blob/804612e7e6a2b86c9fc0704c44b20f16cf3dcdd7/api/v1alpha1/managednotification_types.go#L58))
```
        Resource: "ocmagent.managed.openshift.io/v1alpha1, Resource=managednotifications", GroupVersionKind: "ocmagent.managed.openshift.io/v1alpha1, Kind=ManagedNotification"
        Name: "sre-managed-notifications", Namespace: "openshift-ocm-agent-operator"
        for: "object": ManagedNotification.ocmagent.managed.openshift.io "sre-managed-notifications" is invalid: spec.notifications[8].references: Invalid value: "string": spec.notifications[8].references in body must be of type array: "string"
```


### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
