### PR TITLE
OSD-19863 add oidc deleted managedfleetnotification

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/README.md
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/README.md
@@ -2,9 +2,9 @@
 
 This location manages the distribution of the OCM Agent Operator `ManagedFleetNotification` CR to hypershift-only OCM agent running on `rhobsp02ue1`.
 
-The purpose of the `ManagedFleetNotification` CR is to define Service Log templates that map to AlertManager alerts, allowing the OCM Agent to build and send Service Logs when it is notified about those alerts.
+The purpose of the `ManagedFleetNotification` CR is to define notification templates that map to AlertManager alerts, allowing the OCM Agent to build and send notifications when it is notified about those alerts.
 
-The different to the `ManagedNotification` is that the Fleet alerts are working for hypershift.
+`ManagedNotifications` are specifically for HyperShift and are currently sent from a centralized place (`rhobsp02ue1`) to the whole fleet of HCP clusters. Furthermore, `ManagedNotifications` support notifications of type limited support by setting the `limitedSupport` field to `true`. 
 
 ## How to make changes
 

--- a/deploy/ocm-agent-operator-managedfleetnotifications/oidc-deleted-limited-support.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/oidc-deleted-limited-support.yaml
@@ -1,0 +1,14 @@
+apiVersion: ocmagent.managed.openshift.io/v1alpha1
+kind: ManagedFleetNotification
+metadata:
+  name: oidc-deleted-notification
+  namespace: openshift-ocm-agent-operator
+spec:
+  fleetNotification:
+    name: oidc-deleted-notification
+    summary: Cluster is in Limited Support due to unsupported cloud provider configuration
+    notificationMessage: |-
+      Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install. If you have deleted the associated OpenIDConnectProvider, please recreate it by executing the command: rosa create oidc-provider --mode manual --cluster $CLUSTER
+    resendWait: 0
+    severity: Info
+    limitedSupport: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22270,6 +22270,25 @@ objects:
           name: audit-webhook-error-putting-minimized-cloudwatch-log
           resendWait: 24
           severity: Info
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
+        name: oidc-deleted-notification
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: oidc-deleted-notification
+          summary: Cluster is in Limited Support due to unsupported cloud provider
+            configuration
+          notificationMessage: 'Your cluster requires you to take action because Red
+            Hat is not able to access the infrastructure with the provided credentials.
+            Please restore the credentials and permissions provided during install.
+            If you have deleted the associated OpenIDConnectProvider, please recreate
+            it by executing the command: rosa create oidc-provider --mode manual --cluster
+            $CLUSTER'
+          resendWait: 0
+          severity: Info
+          limitedSupport: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22270,6 +22270,25 @@ objects:
           name: audit-webhook-error-putting-minimized-cloudwatch-log
           resendWait: 24
           severity: Info
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
+        name: oidc-deleted-notification
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: oidc-deleted-notification
+          summary: Cluster is in Limited Support due to unsupported cloud provider
+            configuration
+          notificationMessage: 'Your cluster requires you to take action because Red
+            Hat is not able to access the infrastructure with the provided credentials.
+            Please restore the credentials and permissions provided during install.
+            If you have deleted the associated OpenIDConnectProvider, please recreate
+            it by executing the command: rosa create oidc-provider --mode manual --cluster
+            $CLUSTER'
+          resendWait: 0
+          severity: Info
+          limitedSupport: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22270,6 +22270,25 @@ objects:
           name: audit-webhook-error-putting-minimized-cloudwatch-log
           resendWait: 24
           severity: Info
+    - apiVersion: ocmagent.managed.openshift.io/v1alpha1
+      kind: ManagedFleetNotification
+      metadata:
+        name: oidc-deleted-notification
+        namespace: openshift-ocm-agent-operator
+      spec:
+        fleetNotification:
+          name: oidc-deleted-notification
+          summary: Cluster is in Limited Support due to unsupported cloud provider
+            configuration
+          notificationMessage: 'Your cluster requires you to take action because Red
+            Hat is not able to access the infrastructure with the provided credentials.
+            Please restore the credentials and permissions provided during install.
+            If you have deleted the associated OpenIDConnectProvider, please recreate
+            it by executing the command: rosa create oidc-provider --mode manual --cluster
+            $CLUSTER'
+          resendWait: 0
+          severity: Info
+          limitedSupport: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This PR adds the MFN for oidc missing, which will be used to set limited support for HyperShift clusters that have a deleted OIDC provider/config.

### Which Jira/Github issue(s) this PR fixes?

[OSD-19786](https://issues.redhat.com//browse/OSD-19786)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
