### PR TITLE
Update sre-infra-resizing-alerts to critical

### DIFF
--- a/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-infra-resizing.PrometheusRule.yaml
@@ -91,7 +91,7 @@ spec:
       ## If either of the CPU or Memory resource consumption alerts (see below) fire, then trigger an alert for SRE
       - expr: (
                 count(
-                  ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE", alertstate="firing"}
+                  ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h", alertstate="firing"}
                   OR
                   ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE", alertstate="firing"}
                 ) >= 1
@@ -129,7 +129,7 @@ spec:
       ## If the CPU or Memory related "InfraNodesExcessiveResourceConsumptionSRE" alerts are firing, raise a critical ticket to SRE to scale the infra nodes up
       - alert: InfraNodesNeedResizingSRE
         expr: sre:node_infras:need_resize > 0
-        for: 2h
+        for: 5m
         labels:
           severity: critical
           namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34946,7 +34946,7 @@ objects:
               ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
-          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h",
               alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
               alertstate="firing"} ) >= 1 )
             record: sre:node_infras:need_resize
@@ -34984,7 +34984,7 @@ objects:
                 the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
             expr: sre:node_infras:need_resize > 0
-            for: 2h
+            for: 5m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34946,7 +34946,7 @@ objects:
               ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
-          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h",
               alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
               alertstate="firing"} ) >= 1 )
             record: sre:node_infras:need_resize
@@ -34984,7 +34984,7 @@ objects:
                 the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
             expr: sre:node_infras:need_resize > 0
-            for: 2h
+            for: 5m
             labels:
               severity: critical
               namespace: openshift-monitoring

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34946,7 +34946,7 @@ objects:
               ="infra"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="infra"} ) ) )
             record: sre:node_infra:excessive_consumption_memory
-          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE",
+          - expr: ( count( ALERTS{alertname="cpu-InfraNodesExcessiveResourceConsumptionSRE1h",
               alertstate="firing"} OR ALERTS{alertname="memory-InfraNodesExcessiveResourceConsumptionSRE",
               alertstate="firing"} ) >= 1 )
             record: sre:node_infras:need_resize
@@ -34984,7 +34984,7 @@ objects:
                 the existing workers. See linked SOP for details.
           - alert: InfraNodesNeedResizingSRE
             expr: sre:node_infras:need_resize > 0
-            for: 2h
+            for: 5m
             labels:
               severity: critical
               namespace: openshift-monitoring


### PR DESCRIPTION
### What type of PR is this?
Update

### What this PR does / why we need it?
Changes the sre infra resize alerts from warning to critical to enable alerting on PagerDuty

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OHSS-31514

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
