### PR TITLE
temporarily reverting the validation config from crc clusters

### DIFF
--- a/deploy/osd-fedramp-machineconfig/prod/pre-4.13/config.yaml
+++ b/deploy/osd-fedramp-machineconfig/prod/pre-4.13/config.yaml
@@ -12,3 +12,6 @@ selectorSyncSet:
     - key: hive.openshift.io/version-major-minor
       operator: In
       values: ["4.11", "4.12"]
+    - key: api.openshift.com/name
+      operator: NotIn
+      values: ["crcfrs01ugw1", "crcfrp01ugw1"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28075,6 +28075,11 @@ objects:
         values:
         - '4.11'
         - '4.12'
+      - key: api.openshift.com/name
+        operator: NotIn
+        values:
+        - crcfrs01ugw1
+        - crcfrp01ugw1
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28075,6 +28075,11 @@ objects:
         values:
         - '4.11'
         - '4.12'
+      - key: api.openshift.com/name
+        operator: NotIn
+        values:
+        - crcfrs01ugw1
+        - crcfrp01ugw1
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28075,6 +28075,11 @@ objects:
         values:
         - '4.11'
         - '4.12'
+      - key: api.openshift.com/name
+        operator: NotIn
+        values:
+        - crcfrs01ugw1
+        - crcfrp01ugw1
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
temporarily reverting the validation config from crc clusters to unbreak patching them

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

Currently Insights team is unable to patch an operator due to signature validation and has a strict timeline. reverting this change to allow them to validate CVE patching and satisfy CONMON while we continue to test in integration

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

N/A

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
