### PR TITLE
Remove log linking workaround in 4.15

### DIFF
--- a/deploy/crio-loglinking/config.yaml
+++ b/deploy/crio-loglinking/config.yaml
@@ -3,8 +3,8 @@ selectorSyncSet:
   resourceApplyMode: Sync
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
-      operator: NotIn
-      values: ["4.0","4.1","4.2","4.3","4.4","4.5","4.6","4.7","4.8","4.9","4.10","4.11","4.12"]
+      operator: In
+      values: ["4.13","4.14"]
     - key: hive.openshift.io/version-major-minor-patch
       operator: NotIn
       values: ["4.13.0","4.13.1","4.13.2","4.13.3"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21455,21 +21455,10 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: NotIn
+        operator: In
         values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '4.5'
-        - '4.6'
-        - '4.7'
-        - '4.8'
-        - '4.9'
-        - '4.10'
-        - '4.11'
-        - '4.12'
+        - '4.13'
+        - '4.14'
       - key: hive.openshift.io/version-major-minor-patch
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21455,21 +21455,10 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: NotIn
+        operator: In
         values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '4.5'
-        - '4.6'
-        - '4.7'
-        - '4.8'
-        - '4.9'
-        - '4.10'
-        - '4.11'
-        - '4.12'
+        - '4.13'
+        - '4.14'
       - key: hive.openshift.io/version-major-minor-patch
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21455,21 +21455,10 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: hive.openshift.io/version-major-minor
-        operator: NotIn
+        operator: In
         values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '4.5'
-        - '4.6'
-        - '4.7'
-        - '4.8'
-        - '4.9'
-        - '4.10'
-        - '4.11'
-        - '4.12'
+        - '4.13'
+        - '4.14'
       - key: hive.openshift.io/version-major-minor-patch
         operator: NotIn
         values:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This removes the specific log linking workaround implemented here from 4.15+, as this feature will GA and not require this configuration

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
