### PR TITLE
OSD-20989 Router Replica Count By Org For Multi-Az

### DIFF
--- a/deploy/osd-router-replicas-by-entity-id/10-routerreplics.ingresscontroller.yaml
+++ b/deploy/osd-router-replicas-by-entity-id/10-routerreplics.ingresscontroller.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: IngressController
+name: default
+namespace: openshift-ingress-operator
+applyMode: AlwaysApply
+patch: '{"spec":{"replicas":3}}'
+patchType: merge

--- a/deploy/osd-router-replicas-by-entity-id/config.yaml
+++ b/deploy/osd-router-replicas-by-entity-id/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/multi-az
+      operator: In
+      values: "true"
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: "${{ROUTER_REPLICA_ENTITY_IDS}}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ENTITY_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL
@@ -30599,6 +30601,34 @@ objects:
           namespace: openshift-console
         slo:
           targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-router-replicas-by-entity-id
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/multi-az
+        operator: In
+        values: 'true'
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ROUTER_REPLICA_ENTITY_IDS}}
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ENTITY_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL
@@ -30599,6 +30601,34 @@ objects:
           namespace: openshift-console
         slo:
           targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-router-replicas-by-entity-id
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/multi-az
+        operator: In
+        values: 'true'
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ROUTER_REPLICA_ENTITY_IDS}}
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ENTITY_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL
@@ -30599,6 +30601,34 @@ objects:
           namespace: openshift-console
         slo:
           targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-router-replicas-by-entity-id
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/multi-az
+        operator: In
+        values: 'true'
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ROUTER_REPLICA_ENTITY_IDS}}
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ENTITY_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL


### PR DESCRIPTION
Support patching default IngressController router replicas by Organization ID only for Multi-AZ clusters to match infra node counts.

### What type of PR is this?
_Feature_

### Which Jira/Github issue(s) this PR fixes?
[OSD-20989](https://issues.redhat.com//browse/OSD-20989)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
