### PR TITLE
[OSD-20486] Adding an automated SL when KubeNodeUnschedulableSRE alerting and changing the alert severity to Warning

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -87,3 +87,9 @@ spec:
       severity: Error
       summary: "Filesystem has less than 3% inodes left"
       logType: Cluster Configuration
+    - activeBody: |-
+        Your cluster is currently alerting with 'KubeNodeUnschedulableSRE' because a worker node '${node}' can not drain. This is not an actionable alert for the SRE team. Please troubleshoot the node using this reference documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.
+      name: KubeNodeUnschedulableSRE
+      resendWait: 1
+      severity: Error
+      summary: "Action required: a worker node is Unschedulable for more than an hour"

--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -88,8 +88,8 @@ spec:
       summary: "Filesystem has less than 3% inodes left"
       logType: Cluster Configuration
     - activeBody: |-
-        Your cluster is currently alerting with 'KubeNodeUnschedulableSRE' because a worker node '${node}' can not drain. This is not an actionable alert for the SRE team. Please troubleshoot the node using this reference documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.
+        Your cluster currently has at least one unschedulable worker node. Please troubleshoot this node using the following reference documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.
       name: KubeNodeUnschedulableSRE
-      resendWait: 1
+      resendWait: 6
       severity: Error
       summary: "Action required: a worker node is Unschedulable for more than an hour"

--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         severity: Warning
         namespace: openshift-monitoring
+        send_managed_notification: "true"
+        managed_notification_template: "KubeNodeUnschedulableSRE"  
       annotations:
         message: "The node {{ $labels.node }} has been unschedulable for more than an hour."
     - alert: ControlPlaneNodeUnschedulableSRE

--- a/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-unschedulable.PrometheusRule.yaml
@@ -14,7 +14,7 @@ spec:
       expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
       for: 61m
       labels:
-        severity: critical
+        severity: Warning
         namespace: openshift-monitoring
       annotations:
         message: "The node {{ $labels.node }} has been unschedulable for more than an hour."

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -144,11 +144,4 @@ spec:
         namespace: openshift-monitoring
         managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
         send_managed_notification: "true"
-    - alert: KubeNodeUnschedulableSRE
-      # KubeNodeUnschedulableSRE alert firing).
-      expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-      labels:
-        severity: Info
-        namespace: openshift-monitoring
-        send_managed_notification: "true"
-        managed_notification_template: "KubeNodeUnschedulableSRE"    
+    

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -10,6 +10,7 @@ spec:
   groups:
   - name: sre-managed-notification-alerts
     rules:
+    
     - alert: KubePersistentVolumeFillingUpSRE
     # KubePersistentVolumeFillingUp alert firing in openshift-user-workload-monitoring namespace (could be extended to other namespaces if needed).
       expr: count by (namespace, persistentvolumeclaim) (ALERTS{alertname="KubePersistentVolumeFillingUp", alertstate="firing", namespace="openshift-user-workload-monitoring"}) >= 1
@@ -143,3 +144,11 @@ spec:
         namespace: openshift-monitoring
         managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
         send_managed_notification: "true"
+    - alert: KubeNodeUnschedulableSRE
+      # KubeNodeUnschedulableSRE alert firing).
+      expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"}) or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service) sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+      labels:
+        severity: Info
+        namespace: openshift-monitoring
+        send_managed_notification: "true"
+        managed_notification_template: "KubeNodeUnschedulableSRE"    

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37280,15 +37280,6 @@ objects:
               namespace: openshift-monitoring
               managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
               send_managed_notification: 'true'
-          - alert: KubeNodeUnschedulableSRE
-            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
-              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
-              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-            labels:
-              severity: Info
-              namespace: openshift-monitoring
-              send_managed_notification: 'true'
-              managed_notification_template: KubeNodeUnschedulableSRE
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35449,6 +35449,8 @@ objects:
             labels:
               severity: Warning
               namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: KubeNodeUnschedulableSRE
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22591,12 +22591,11 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
-        - activeBody: 'Your cluster is currently alerting with ''KubeNodeUnschedulableSRE''
-            because a worker node ''${node}'' can not drain. This is not an actionable
-            alert for the SRE team. Please troubleshoot the node using this reference
-            documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
+        - activeBody: 'Your cluster currently has at least one unschedulable worker
+            node. Please troubleshoot this node using the following reference documentation:
+            https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
           name: KubeNodeUnschedulableSRE
-          resendWait: 1
+          resendWait: 6
           severity: Error
           summary: 'Action required: a worker node is Unschedulable for more than
             an hour'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22591,6 +22591,15 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
+        - activeBody: 'Your cluster is currently alerting with ''KubeNodeUnschedulableSRE''
+            because a worker node ''${node}'' can not drain. This is not an actionable
+            alert for the SRE team. Please troubleshoot the node using this reference
+            documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
+          name: KubeNodeUnschedulableSRE
+          resendWait: 1
+          severity: Error
+          summary: 'Action required: a worker node is Unschedulable for more than
+            an hour'
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -35438,7 +35447,7 @@ objects:
               sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
             for: 61m
             labels:
-              severity: critical
+              severity: Warning
               namespace: openshift-monitoring
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
@@ -37269,6 +37278,15 @@ objects:
               namespace: openshift-monitoring
               managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
               send_managed_notification: 'true'
+          - alert: KubeNodeUnschedulableSRE
+            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+            labels:
+              severity: Info
+              namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: KubeNodeUnschedulableSRE
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37280,15 +37280,6 @@ objects:
               namespace: openshift-monitoring
               managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
               send_managed_notification: 'true'
-          - alert: KubeNodeUnschedulableSRE
-            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
-              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
-              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-            labels:
-              severity: Info
-              namespace: openshift-monitoring
-              send_managed_notification: 'true'
-              managed_notification_template: KubeNodeUnschedulableSRE
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35449,6 +35449,8 @@ objects:
             labels:
               severity: Warning
               namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: KubeNodeUnschedulableSRE
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22591,12 +22591,11 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
-        - activeBody: 'Your cluster is currently alerting with ''KubeNodeUnschedulableSRE''
-            because a worker node ''${node}'' can not drain. This is not an actionable
-            alert for the SRE team. Please troubleshoot the node using this reference
-            documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
+        - activeBody: 'Your cluster currently has at least one unschedulable worker
+            node. Please troubleshoot this node using the following reference documentation:
+            https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
           name: KubeNodeUnschedulableSRE
-          resendWait: 1
+          resendWait: 6
           severity: Error
           summary: 'Action required: a worker node is Unschedulable for more than
             an hour'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22591,6 +22591,15 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
+        - activeBody: 'Your cluster is currently alerting with ''KubeNodeUnschedulableSRE''
+            because a worker node ''${node}'' can not drain. This is not an actionable
+            alert for the SRE team. Please troubleshoot the node using this reference
+            documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
+          name: KubeNodeUnschedulableSRE
+          resendWait: 1
+          severity: Error
+          summary: 'Action required: a worker node is Unschedulable for more than
+            an hour'
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -35438,7 +35447,7 @@ objects:
               sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
             for: 61m
             labels:
-              severity: critical
+              severity: Warning
               namespace: openshift-monitoring
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
@@ -37269,6 +37278,15 @@ objects:
               namespace: openshift-monitoring
               managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
               send_managed_notification: 'true'
+          - alert: KubeNodeUnschedulableSRE
+            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+            labels:
+              severity: Info
+              namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: KubeNodeUnschedulableSRE
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37280,15 +37280,6 @@ objects:
               namespace: openshift-monitoring
               managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
               send_managed_notification: 'true'
-          - alert: KubeNodeUnschedulableSRE
-            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
-              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
-              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
-            labels:
-              severity: Info
-              namespace: openshift-monitoring
-              send_managed_notification: 'true'
-              managed_notification_template: KubeNodeUnschedulableSRE
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35449,6 +35449,8 @@ objects:
             labels:
               severity: Warning
               namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: KubeNodeUnschedulableSRE
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
                 than an hour.

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22591,12 +22591,11 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
-        - activeBody: 'Your cluster is currently alerting with ''KubeNodeUnschedulableSRE''
-            because a worker node ''${node}'' can not drain. This is not an actionable
-            alert for the SRE team. Please troubleshoot the node using this reference
-            documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
+        - activeBody: 'Your cluster currently has at least one unschedulable worker
+            node. Please troubleshoot this node using the following reference documentation:
+            https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
           name: KubeNodeUnschedulableSRE
-          resendWait: 1
+          resendWait: 6
           severity: Error
           summary: 'Action required: a worker node is Unschedulable for more than
             an hour'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22591,6 +22591,15 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
+        - activeBody: 'Your cluster is currently alerting with ''KubeNodeUnschedulableSRE''
+            because a worker node ''${node}'' can not drain. This is not an actionable
+            alert for the SRE team. Please troubleshoot the node using this reference
+            documentation: https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes.'
+          name: KubeNodeUnschedulableSRE
+          resendWait: 1
+          severity: Error
+          summary: 'Action required: a worker node is Unschedulable for more than
+            an hour'
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -35438,7 +35447,7 @@ objects:
               sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
             for: 61m
             labels:
-              severity: critical
+              severity: Warning
               namespace: openshift-monitoring
             annotations:
               message: The node {{ $labels.node }} has been unschedulable for more
@@ -37269,6 +37278,15 @@ objects:
               namespace: openshift-monitoring
               managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
               send_managed_notification: 'true'
+          - alert: KubeNodeUnschedulableSRE
+            expr: (kube_node_spec_unschedulable > 0 and on(node) kube_node_role{role="master"})
+              or (kube_node_spec_unschedulable > 0 unless ignoring(node,container,endpoint,job,namespace,service)
+              sum(mapi_machine_set_status_replicas{name=~".*upgrade$"}) > 0)
+            labels:
+              severity: Info
+              namespace: openshift-monitoring
+              send_managed_notification: 'true'
+              managed_notification_template: KubeNodeUnschedulableSRE
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
Adding an automated SL when KubeNodeUnschedulableSRE alerting and changing the alert severity to Warning

https://issues.redhat.com/browse/OSD-20486

### What type of PR is this?

feature 
https://issues.redhat.com/browse/SDE-3667

Documentation is updated in https://issues.redhat.com/browse/OSDOCS-9404

SOP is updated in https://github.com/openshift/ops-sop/pull/3042

