### PR TITLE
SDCICD-1229: add cluster metadata cm

### DIFF
--- a/deploy/osd-cluster-metadata/10-osd-cluster-metadata.openshift-config.ConfigMap.yaml
+++ b/deploy/osd-cluster-metadata/10-osd-cluster-metadata.openshift-config.ConfigMap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-cluster-metadata
+  namespace: openshift-config
+data:
+  api.openshift.com_ccs: "{{ fromCDLabel \"api.openshift.com/ccs\" }}"
+  api.openshift.com_channel-group: "{{ fromCDLabel \"api.openshift.com/channel-group\" }}"
+  api.openshift.com_environment: "{{ fromCDLabel \"api.openshift.com/environment\" }}"
+  hive.openshift.io_cluster-platform: "{{ fromCDLabel \"hive.openshift.io/cluster-platform\" }}"
+  hive.openshift.io_cluster-region: "{{ fromCDLabel \"hive.openshift.io/cluster-region\" }}"

--- a/deploy/osd-cluster-metadata/config.yaml
+++ b/deploy/osd-cluster-metadata/config.yaml
@@ -1,0 +1,4 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  enableResourceParameters: true
+  resourceApplyMode: "Sync"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26616,6 +26616,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-metadata
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    enableResourceParameters: true
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-cluster-metadata
+        namespace: openshift-config
+      data:
+        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
+        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
+          }}'
+        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
+          }}'
+        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
+          }}'
+        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
+          }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26616,6 +26616,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-metadata
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    enableResourceParameters: true
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-cluster-metadata
+        namespace: openshift-config
+      data:
+        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
+        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
+          }}'
+        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
+          }}'
+        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
+          }}'
+        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
+          }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26616,6 +26616,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-metadata
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    enableResourceParameters: true
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-cluster-metadata
+        namespace: openshift-config
+      data:
+        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
+        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
+          }}'
+        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
+          }}'
+        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
+          }}'
+        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
+          }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -73,6 +73,9 @@ def add_sss_for(name, directory, config):
         for item in config['matchExpressions']:
             o['spec']['clusterDeploymentSelector']['matchExpressions'].append(item)
 
+    if 'enableResourceParameters' in config:
+        o['spec']['enableResourceParameters'] = config['enableResourceParameters']
+
     # Get all yaml files as array of yaml objects
     yamls = get_all_yaml_obj(get_all_yaml_files(directory))
     if len(yamls) == 0:


### PR DESCRIPTION
### What type of PR is this?

/feature
/hold

### What this PR does / why we need it?

Hive has implemented templating which allows us to propogate cluster
metadata into the cluster to be consumed by PKO and others. Additional
data can be added if there is a usecase.

Signed-off-by: Brady Pratt <bpratt@redhat.com>

### Which Jira/Github issue(s) this PR fixes?

Fixes [SDCICD-1229](https://issues.redhat.com//browse/SDCICD-1229)

### Special notes for your reviewer:

The goal is to allow for PKO to perform conditonal templating to the resources
based on the data in the configmap

We are leveraging a custom function within hive to pull labels from the
`ClusterDeployment` object

https://github.com/openshift/hive/blob/8c54fc9cac459e0c5852a55775ac570695e3b465/pkg/controller/clustersync/templates.go#L33-L37

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
