### PR TITLE
Always permit managed-scripts to use the restricted-v2 SCC

### DIFF
--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -46,6 +46,23 @@ spec:
                       metadataComplianceType: musthave
                       objectDefinition:
                         apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: restricted-scc-user
+                            namespace: openshift-backplane-managed-scripts
+                        rules:
+                            - apiGroups:
+                                - security.openshift.io
+                              resourceNames:
+                                - restricted-v2
+                              resources:
+                                - securitycontextconstraints
+                              verbs:
+                                - use
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRoleBinding
                         metadata:
                             name: openshift-backplane-managed-scripts-reader
@@ -53,6 +70,21 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: ClusterRole
                             name: openshift-backplane-managed-scripts-reader
+                        subjects:
+                            - kind: Group
+                              name: system:serviceaccounts:openshift-backplane-managed-scripts
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: restricted-scc-user
+                            namespace: openshift-backplane-managed-scripts
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: restricted-scc-user
                         subjects:
                             - kind: Group
                               name: system:serviceaccounts:openshift-backplane-managed-scripts

--- a/deploy/osd-backplane-managed-scripts/10-openshift-backplane-managed-scripts.Role.yml
+++ b/deploy/osd-backplane-managed-scripts/10-openshift-backplane-managed-scripts.Role.yml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: restricted-scc-user
+  namespace: openshift-backplane-managed-scripts
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - "restricted-v2"
+  verbs:
+  - use

--- a/deploy/osd-backplane-managed-scripts/20-openshift-backplane-managed-scripts.RoleBinding.yml
+++ b/deploy/osd-backplane-managed-scripts/20-openshift-backplane-managed-scripts.RoleBinding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: restricted-scc-user
+  namespace: openshift-backplane-managed-scripts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: restricted-scc-user
+subjects:
+- kind: Group
+  name: system:serviceaccounts:openshift-backplane-managed-scripts

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -3970,6 +3970,23 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: restricted-scc-user
+                    namespace: openshift-backplane-managed-scripts
+                  rules:
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - restricted-v2
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
@@ -3977,6 +3994,21 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: ClusterRole
                     name: openshift-backplane-managed-scripts-reader
+                  subjects:
+                  - kind: Group
+                    name: system:serviceaccounts:openshift-backplane-managed-scripts
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: restricted-scc-user
+                    namespace: openshift-backplane-managed-scripts
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: restricted-scc-user
                   subjects:
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-managed-scripts
@@ -24861,6 +24893,20 @@ objects:
       metadata:
         name: openshift-backplane-managed-scripts-reader
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: restricted-scc-user
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        resourceNames:
+        - restricted-v2
+        verbs:
+        - use
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         name: openshift-backplane-managed-scripts-reader
@@ -24868,6 +24914,18 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: openshift-backplane-managed-scripts-reader
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: restricted-scc-user
+        namespace: openshift-backplane-managed-scripts
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: restricted-scc-user
       subjects:
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-managed-scripts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -3970,6 +3970,23 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: restricted-scc-user
+                    namespace: openshift-backplane-managed-scripts
+                  rules:
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - restricted-v2
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
@@ -3977,6 +3994,21 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: ClusterRole
                     name: openshift-backplane-managed-scripts-reader
+                  subjects:
+                  - kind: Group
+                    name: system:serviceaccounts:openshift-backplane-managed-scripts
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: restricted-scc-user
+                    namespace: openshift-backplane-managed-scripts
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: restricted-scc-user
                   subjects:
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-managed-scripts
@@ -24861,6 +24893,20 @@ objects:
       metadata:
         name: openshift-backplane-managed-scripts-reader
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: restricted-scc-user
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        resourceNames:
+        - restricted-v2
+        verbs:
+        - use
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         name: openshift-backplane-managed-scripts-reader
@@ -24868,6 +24914,18 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: openshift-backplane-managed-scripts-reader
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: restricted-scc-user
+        namespace: openshift-backplane-managed-scripts
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: restricted-scc-user
       subjects:
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-managed-scripts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -3970,6 +3970,23 @@ objects:
                 metadataComplianceType: musthave
                 objectDefinition:
                   apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: restricted-scc-user
+                    namespace: openshift-backplane-managed-scripts
+                  rules:
+                  - apiGroups:
+                    - security.openshift.io
+                    resourceNames:
+                    - restricted-v2
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - use
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRoleBinding
                   metadata:
                     name: openshift-backplane-managed-scripts-reader
@@ -3977,6 +3994,21 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: ClusterRole
                     name: openshift-backplane-managed-scripts-reader
+                  subjects:
+                  - kind: Group
+                    name: system:serviceaccounts:openshift-backplane-managed-scripts
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: restricted-scc-user
+                    namespace: openshift-backplane-managed-scripts
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: restricted-scc-user
                   subjects:
                   - kind: Group
                     name: system:serviceaccounts:openshift-backplane-managed-scripts
@@ -24861,6 +24893,20 @@ objects:
       metadata:
         name: openshift-backplane-managed-scripts-reader
     - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: restricted-scc-user
+        namespace: openshift-backplane-managed-scripts
+      rules:
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        resourceNames:
+        - restricted-v2
+        verbs:
+        - use
+    - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
         name: openshift-backplane-managed-scripts-reader
@@ -24868,6 +24914,18 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: openshift-backplane-managed-scripts-reader
+      subjects:
+      - kind: Group
+        name: system:serviceaccounts:openshift-backplane-managed-scripts
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: restricted-scc-user
+        namespace: openshift-backplane-managed-scripts
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: restricted-scc-user
       subjects:
       - kind: Group
         name: system:serviceaccounts:openshift-backplane-managed-scripts


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Ensures that managed-scripts always have permissions to run as restricted-v2

### Which Jira/Github issue(s) this PR fixes?
ref [OSD-21055](https://issues.redhat.com//browse/OSD-21055)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
