### PR TITLE
[OSD-21260] hold fire for the node condition alerts to avoid flipping notification sending

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/node-condition/100-ocm-agent-node-condition.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/node-condition/100-ocm-agent-node-condition.PrometheusRule.yaml
@@ -33,7 +33,7 @@ spec:
               * on (node) group_left(condition, machineset, status) 
               sre:node:condition{condition="DiskPressure"}
             ) > 0
-      for: 5m
+      for: 20m
       labels:
         severity: info
         namespace: openshift-node
@@ -46,7 +46,7 @@ spec:
               * on (node) group_left(condition, machineset, status) 
               sre:node:condition{condition="MemoryPressure"}
             ) > 0
-      for: 5m
+      for: 20m
       labels:
         severity: info
         namespace: openshift-node
@@ -59,7 +59,7 @@ spec:
               * on (node) group_left(condition, machineset, status) 
               sre:node:condition{condition="PIDPressure"}
             ) > 0
-      for: 5m
+      for: 20m
       labels:
         severity: info
         namespace: openshift-node
@@ -72,7 +72,7 @@ spec:
               * on (node) group_left(condition, machineset, status) 
               sre:node:condition{condition="NetworkUnavailable"}
             ) > 0
-      for: 5m
+      for: 10m
       labels:
         severity: info
         namespace: openshift-node

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37395,7 +37395,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="DiskPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37405,7 +37405,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="MemoryPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37415,7 +37415,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="PIDPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37425,7 +37425,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="NetworkUnavailable"}
               ) > 0
-            for: 5m
+            for: 10m
             labels:
               severity: info
               namespace: openshift-node

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37395,7 +37395,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="DiskPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37405,7 +37405,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="MemoryPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37415,7 +37415,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="PIDPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37425,7 +37425,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="NetworkUnavailable"}
               ) > 0
-            for: 5m
+            for: 10m
             labels:
               severity: info
               namespace: openshift-node

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37395,7 +37395,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="DiskPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37405,7 +37405,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="MemoryPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37415,7 +37415,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="PIDPressure"}
               ) > 0
-            for: 5m
+            for: 20m
             labels:
               severity: info
               namespace: openshift-node
@@ -37425,7 +37425,7 @@ objects:
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="NetworkUnavailable"}
               ) > 0
-            for: 5m
+            for: 10m
             labels:
               severity: info
               namespace: openshift-node


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
We are seeing multiple customers reported that the node condition related notification are sending and resolved before they take any action.
Update the alert to hold a bit longer before firing.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-21260](https://issues.redhat.com//browse/OSD-21260)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
