### PR TITLE
XCMSTRAT-305 | feat: add list role / list attached role policies perm to hcp managed installer policy

### DIFF
--- a/resources/sts/4.15/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.15/hypershift/sts_hcp_installer_permission_policy.json
@@ -22,6 +22,8 @@
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "iam:GetOpenIDConnectProvider",
                 "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies",
                 "route53:GetHostedZone",
                 "route53:ListHostedZones",
                 "route53:ListHostedZonesByName",


### PR DESCRIPTION
… 

### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature
### What this PR does / why we need it?
Support for allowing clusters service to assume into the users' installer role to list policies attached to required cluster roles.
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
