### PR TITLE
Skip Makefile from the broken links check

### DIFF
--- a/scripts/checklinks.sh
+++ b/scripts/checklinks.sh
@@ -7,7 +7,7 @@ IGNORE_REPOS=(
     "https://jira.coreos.com"
     "https://grafana"
 )
-find . -type f -not -path '*/\.*' -print | while read -r file; do
+find . -type f -not -path '*/\.*' -not -path './Makefile' -print | while read -r file; do
     grep -shEo "(http|https)://[a-zA-Z0-9./?=_-]*" "$file" | sort -u | while IFS= read -r URL; do
         skip=false
         for repo in "${IGNORE_REPOS[@]}"; do


### PR DESCRIPTION
### What type of PR is this?
_make target_

### What this PR does / why we need it?
skip Makefile from the broken links check as it contains some programmatic URLs that cannot be accessed with curl.

### Which Jira/Github issue(s) this PR fixes?
[SDCICD-1162](https://issues.redhat.com/browse/SDCICD-1162)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
