### PR TITLE
SDCICD-1229: add additional metadata from clusterdeployments

### DIFF
--- a/deploy/osd-cluster-metadata/10-osd-cluster-metadata.openshift-config.ConfigMap.yaml
+++ b/deploy/osd-cluster-metadata/10-osd-cluster-metadata.openshift-config.ConfigMap.yaml
@@ -4,6 +4,12 @@ metadata:
   name: osd-cluster-metadata
   namespace: openshift-config
 data:
+  api.openshift.com_name: "{{ fromCDLabel \"api.openshift.com/name\" }}"
+  api.openshift.com_product: "{{ fromCDLabel \"api.openshift.com/product\" }}"
+  api.openshift.com_fedramp: "{{ fromCDLabel \"api.openshift.com/fedramp\" }}"
+  api.openshift.com_sts: "{{ fromCDLabel \"api.openshift.com/sts\" }}"
+  api.openshift.com_limited-support: "{{ fromCDLabel \"api.openshift.com/limited-support\" }}"
+  api.openshift.com_private-link: "{{ fromCDLabel \"api.openshift.com/private-link\" }}"
   api.openshift.com_ccs: "{{ fromCDLabel \"api.openshift.com/ccs\" }}"
   api.openshift.com_channel-group: "{{ fromCDLabel \"api.openshift.com/channel-group\" }}"
   api.openshift.com_environment: "{{ fromCDLabel \"api.openshift.com/environment\" }}"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26640,6 +26640,14 @@ objects:
         name: osd-cluster-metadata
         namespace: openshift-config
       data:
+        api.openshift.com_name: '{{ fromCDLabel "api.openshift.com/name" }}'
+        api.openshift.com_product: '{{ fromCDLabel "api.openshift.com/product" }}'
+        api.openshift.com_fedramp: '{{ fromCDLabel "api.openshift.com/fedramp" }}'
+        api.openshift.com_sts: '{{ fromCDLabel "api.openshift.com/sts" }}'
+        api.openshift.com_limited-support: '{{ fromCDLabel "api.openshift.com/limited-support"
+          }}'
+        api.openshift.com_private-link: '{{ fromCDLabel "api.openshift.com/private-link"
+          }}'
         api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
         api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
           }}'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26640,6 +26640,14 @@ objects:
         name: osd-cluster-metadata
         namespace: openshift-config
       data:
+        api.openshift.com_name: '{{ fromCDLabel "api.openshift.com/name" }}'
+        api.openshift.com_product: '{{ fromCDLabel "api.openshift.com/product" }}'
+        api.openshift.com_fedramp: '{{ fromCDLabel "api.openshift.com/fedramp" }}'
+        api.openshift.com_sts: '{{ fromCDLabel "api.openshift.com/sts" }}'
+        api.openshift.com_limited-support: '{{ fromCDLabel "api.openshift.com/limited-support"
+          }}'
+        api.openshift.com_private-link: '{{ fromCDLabel "api.openshift.com/private-link"
+          }}'
         api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
         api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
           }}'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26640,6 +26640,14 @@ objects:
         name: osd-cluster-metadata
         namespace: openshift-config
       data:
+        api.openshift.com_name: '{{ fromCDLabel "api.openshift.com/name" }}'
+        api.openshift.com_product: '{{ fromCDLabel "api.openshift.com/product" }}'
+        api.openshift.com_fedramp: '{{ fromCDLabel "api.openshift.com/fedramp" }}'
+        api.openshift.com_sts: '{{ fromCDLabel "api.openshift.com/sts" }}'
+        api.openshift.com_limited-support: '{{ fromCDLabel "api.openshift.com/limited-support"
+          }}'
+        api.openshift.com_private-link: '{{ fromCDLabel "api.openshift.com/private-link"
+          }}'
         api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
         api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
           }}'


### PR DESCRIPTION
Signed-off-by: Brady Pratt <bpratt@redhat.com>

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

/feature

### What this PR does / why we need it?

Add additional keys to the metadata configmap used to propogate data to a spoke
cluster

```
❯ oc describe clusterdeployment osde2e-ui79z -n uhc-staging-27h4c7p5q0t13qtk84f6c0k99qjhql66
Name:         osde2e-ui79z
Namespace:    uhc-staging-27h4c7p5q0t13qtk84f6c0k99qjhql66
Labels:       api.openshift.com/ccs=true
              api.openshift.com/channel-group=nightly
              api.openshift.com/cluster-admin=true
              api.openshift.com/environment=staging
              api.openshift.com/id=27h4c7p5q0t13qtk84f6c0k99qjhql66
              api.openshift.com/legal-entity-id=1adeEj3FFUxuhmjsUgvGWCtZJuD
              api.openshift.com/managed=true
              api.openshift.com/name=osde2e-ui79z
              api.openshift.com/product=rosa
              api.openshift.com/sts=true
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

[SDCICD-1229](https://issues.redhat.com//browse/SDCICD-1229)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
