### PR TITLE
Added acs-fleetshard-qe to LPSRE permissions

### DIFF
--- a/deploy/backplane/lpsre/acs/config.yaml
+++ b/deploy/backplane/lpsre/acs/config.yaml
@@ -2,3 +2,4 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchLabels:
     api.openshift.com/addon-acs-fleetshard: "true"
+    api.openshift.com/addon-acs-fleetshard-qe: "true"

--- a/deploy/backplane/lpsre/config.yaml
+++ b/deploy/backplane/lpsre/config.yaml
@@ -33,4 +33,5 @@ selectorSyncSet:
       api.openshift.com/addon-smart-events-operator: "true"
       api.openshift.com/addon-cert-manager-operator: "true"
       api.openshift.com/addon-acs-fleetshard: "true"
+      api.openshift.com/addon-acs-fleetshard-qe: "true"
   matchLabelsApplyMode: "OR"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -16675,6 +16675,258 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-addon-acs-fleetshard-qe
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-acs-fleetshard-qe: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-admins-cluster
+      aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-lpsre-admins
+            operator: In
+            values:
+            - cluster
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-cluster
+      rules:
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
+        - addonoperators
+        - addons
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-olm-project
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-monitoring-project
+      rules:
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - monitoringstacks
+        - thanosqueriers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-package-operator-cluster
+      rules:
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+        - create
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-package-operator-project
+      rules:
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+        - create
+        - delete
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-package-operator
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-package-operator-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-package-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-package-operator-project
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-addon-operator-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-addon-operator-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-monitoring-project
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-addon-operator-olm-project
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - list
+        - get
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre-mustgather
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-admins-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-acm
   spec:
     clusterDeploymentSelector:
@@ -16737,6 +16989,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         api.openshift.com/addon-acs-fleetshard: 'true'
+        api.openshift.com/addon-acs-fleetshard-qe: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -16675,6 +16675,258 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-addon-acs-fleetshard-qe
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-acs-fleetshard-qe: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-admins-cluster
+      aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-lpsre-admins
+            operator: In
+            values:
+            - cluster
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-cluster
+      rules:
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
+        - addonoperators
+        - addons
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-olm-project
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-monitoring-project
+      rules:
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - monitoringstacks
+        - thanosqueriers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-package-operator-cluster
+      rules:
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+        - create
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-package-operator-project
+      rules:
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+        - create
+        - delete
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-package-operator
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-package-operator-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-package-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-package-operator-project
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-addon-operator-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-addon-operator-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-monitoring-project
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-addon-operator-olm-project
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - list
+        - get
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre-mustgather
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-admins-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-acm
   spec:
     clusterDeploymentSelector:
@@ -16737,6 +16989,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         api.openshift.com/addon-acs-fleetshard: 'true'
+        api.openshift.com/addon-acs-fleetshard-qe: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -16675,6 +16675,258 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-lpsre-addon-acs-fleetshard-qe
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-acs-fleetshard-qe: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-admins-cluster
+      aggregationRule:
+        clusterRoleSelectors:
+        - matchExpressions:
+          - key: managed.openshift.io/aggregate-to-lpsre-admins
+            operator: In
+            values:
+            - cluster
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - pods/portforward
+        verbs:
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-monitoring
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-cluster
+      rules:
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
+        - addonoperators
+        - addons
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-addon-operator-olm-project
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - installplans
+        - subscriptions
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+        - delete
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-monitoring-project
+      rules:
+      - apiGroups:
+        - monitoring.coreos.com
+        resources:
+        - servicemonitors
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+      - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - monitoringstacks
+        - thanosqueriers
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+        - update
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-package-operator-cluster
+      rules:
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+        - create
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-lpsre-package-operator-project
+      rules:
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+        - update
+        - patch
+        - create
+        - delete
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-package-operator
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-package-operator-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-package-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-package-operator-project
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre-addon-operator-admins
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-addon-operator-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: admin
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-monitoring-project
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-lpsre-addon-operator-olm-project
+          namespacesAllowedRegex: (^openshift-addon-operator$)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - create
+        - list
+        - get
+      - apiGroups:
+        - managed.openshift.io
+        resources:
+        - mustgathers
+        verbs:
+        - create
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-lpsre-mustgather
+        namespace: openshift-must-gather-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-lpsre
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-lpsre-mustgather
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-lpsre
+        namespace: openshift-rbac-permissions
+      spec:
+        clusterPermissions:
+        - backplane-lpsre-admins-cluster
+        - backplane-readers-cluster
+        permissions:
+        - clusterRoleName: dedicated-readers
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-lpsre
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-lpsre-acm
   spec:
     clusterDeploymentSelector:
@@ -16737,6 +16989,7 @@ objects:
       matchLabels:
         api.openshift.com/managed: 'true'
         api.openshift.com/addon-acs-fleetshard: 'true'
+        api.openshift.com/addon-acs-fleetshard-qe: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: managed.openshift.io/v1alpha1


### PR DESCRIPTION
### What type of PR is this?
Grant backplane permissions to LPSRE for clusters with the `acs-fleetshard-qe` addon.

### What this PR does / why we need it?
LPSRE manages ACS clusters. Currenlty we have access to the `acs-fleetshard` addon but not the the qe version used on the stage clusters. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/MTSRE-1819

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
