### PR TITLE
Remove console routemonitor from hypershift management clusters

### DIFF
--- a/deploy/hypershift-route-monitor-operator/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
+++ b/deploy/hypershift-route-monitor-operator/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: ClusterUrlMonitor
+metadata:
+  name: api
+  namespace: openshift-route-monitor-operator
+spec:
+  prefix: https://api.
+  port: "6443"
+  suffix: /livez
+  slo:
+    targetAvailabilityPercent: "99.0"

--- a/deploy/hypershift-route-monitor-operator/OWNERS
+++ b/deploy/hypershift-route-monitor-operator/OWNERS
@@ -1,0 +1,1 @@
+reviewers:

--- a/deploy/hypershift-route-monitor-operator/README.md
+++ b/deploy/hypershift-route-monitor-operator/README.md
@@ -1,0 +1,22 @@
+# File Convention
+
+the convention is:
+```
+${NUMBER}-${NS}.${NAME}.${TYPE}.yaml
+```
+
+## Number
+a way to order the resources (if need be),
+should be a 3 digit number just in case.
+
+## Ns
+the namespace the resource is created in
+
+## Name
+the name of the resource
+
+## Type
+the type of the resource
+
+# Caveat
+the alert name will be comprised from the RouteMonitor/ClusterUrlMonitor name, so be careful when renaming || Adding

--- a/deploy/hypershift-route-monitor-operator/config.yaml
+++ b/deploy/hypershift-route-monitor-operator/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-sector
+    operator: NotIn
+    values: ["ibm-infra"]

--- a/deploy/osd-route-monitor-operator/config.yaml
+++ b/deploy/osd-route-monitor-operator/config.yaml
@@ -5,3 +5,7 @@ selectorSyncSet:
     operator: NotIn
     values:
       - "true"
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: NotIn
+    values:
+      - "management-cluster"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21875,6 +21875,44 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: ClusterUrlMonitor
+      metadata:
+        name: api
+        namespace: openshift-route-monitor-operator
+      spec:
+        prefix: https://api.
+        port: '6443'
+        suffix: /livez
+        slo:
+          targetAvailabilityPercent: '99.0'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-sre-metric-set
   spec:
     clusterDeploymentSelector:
@@ -30741,6 +30779,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21875,6 +21875,44 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: ClusterUrlMonitor
+      metadata:
+        name: api
+        namespace: openshift-route-monitor-operator
+      spec:
+        prefix: https://api.
+        port: '6443'
+        suffix: /livez
+        slo:
+          targetAvailabilityPercent: '99.0'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-sre-metric-set
   spec:
     clusterDeploymentSelector:
@@ -30741,6 +30779,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21875,6 +21875,44 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-route-monitor-operator
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: ClusterUrlMonitor
+      metadata:
+        name: api
+        namespace: openshift-route-monitor-operator
+      spec:
+        prefix: https://api.
+        port: '6443'
+        suffix: /livez
+        slo:
+          targetAvailabilityPercent: '99.0'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-sre-metric-set
   spec:
     clusterDeploymentSelector:
@@ -30741,6 +30779,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.openshift.io/v1alpha1


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Separates out management cluster RMO objects from standard cluster objects and removes console routemonitor from hypershift MCs. The intention is that this can be reverted, or the console routemonitor can be added to the new `hypershift-route-monitor-operator` directory, after [this](https://issues.redhat.com/browse/OSD-20289?focusedId=24273275&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24273275) is resolved.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
