### PR TITLE
Revert "ensure CPMS is disabled on 4.15 for now"

### DIFF
--- a/deploy/osd-14634-disable-cpms/config.yaml
+++ b/deploy/osd-14634-disable-cpms/config.yaml
@@ -2,14 +2,15 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: Sync
   matchExpressions:
-  # This will be removed once SDE-2149 has been completed
+  # This will be removed once OSD-14568 has been completed
   - key: hive.openshift.io/version-major-minor
     operator: In
-    values:
+    values: 
       - "4.12"
       - "4.13"
+      # Customers can continue to opt-in to keep using CIO in 4.14+, so disable CPMS on those clusters
+      # until the completion of OSD-14568
       - "4.14"
-      - "4.15"
   - key: ext-hypershift.openshift.io/cluster-type
     operator: NotIn
     values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24052,7 +24052,6 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
-        - '4.15'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24052,7 +24052,6 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
-        - '4.15'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24052,7 +24052,6 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
-        - '4.15'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: NotIn
         values:


### PR DESCRIPTION
Since this didn't make it into GA and we're in the process of enabling CPMS across the fleet, let's not work against ourselves and allow it to be present entirely on fresh-installs of 4.15+ clusters.