### PR TITLE
Templatize `NodeCondition` managed notifications 

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/node-condition/100-sre-node-condition-managed-notification.ManagedNotification.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/node-condition/100-sre-node-condition-managed-notification.ManagedNotification.yaml
@@ -6,46 +6,11 @@ metadata:
 spec:
   notifications:
     # available conditions: https://kubernetes.io/docs/reference/node/node-status/#condition 
-    # TODO convert to single notification when OCM Agent supports templatized messages: https://issues.redhat.com//browse/OSD-14130
-    - name: NodeConditionDiskPressureNotification
+    - name: NodeConditionNotification
       severity: Warning
-      summary: "Worker node is experiencing DiskPressure"
+      summary: "Worker node is experiencing ${condition}"
       activeBody: |-
-        DiskPressure condition is true for at least one worker. Consider moving application storage off the worker node and into persistent volumes. For more information, see "Configuring persistent storage" in the ROSA documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage
+        ${condition} condition is true for at least one worker.${explanation} For more information, consult the relevant ROSA documentation here: ${documentation}.
       resolvedBody: |-
-        DiskPressure condition is resolved.
+        ${condition} condition is resolved.
       resendWait: 6
-      references: 
-      - "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage"
-      logType: Capacity Management
-    - name: NodeConditionMemoryPressureNotification
-      severity: Warning
-      summary: "Worker node is experiencing MemoryPressure"
-      activeBody: |-
-        MemoryPressure condition is true for at least one worker. For more information on memory management in OpenShift applications, see "Understanding managing application memory" in the ROSA documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure
-      resolvedBody: |-
-        MemoryPressure condition is resolved.
-      resendWait: 6
-      references: 
-      - "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure"
-      logType: Capacity Management
-    - name: NodeConditionPIDPressureNotification
-      severity: Warning
-      summary: "Worker node is experiencing PIDPressure"
-      activeBody: |-
-        PIDPressure condition is true for at least one worker. This means that more than the maximum allowed number of process identifiers are consumed on one or more worker nodes. This is likely to create instability in the node, as required system services may not be able to create new processes. For more information see https://access.redhat.com/articles/7033551. Reduce the number of pods scheduled to the impacted nodes, or reduce the number of process identifiers consumed by applications on the impacted nodes.
-      resolvedBody: |-
-        PIDPressure condition is resolved.
-      resendWait: 6
-      references: 
-      - "https://access.redhat.com/articles/7033551"
-      logType: Cluster Configuration
-    - name: NodeConditionNetworkUnavailableNotification
-      severity: Warning
-      summary: "Worker node is experiencing NetworkUnavailable"
-      activeBody: |-
-        NetworkUnavailable condition is true for at least one worker. Red Hat SRE will be alerted and triage issues. If action is required, a proactive case will be opened by Red Hat.
-      resolvedBody: |-
-        NetworkUnavailable condition is resolved.
-      resendWait: 6
-      logType: Cluster Networking

--- a/deploy/sre-prometheus/ocm-agent/node-condition/100-ocm-agent-node-condition.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/node-condition/100-ocm-agent-node-condition.PrometheusRule.yaml
@@ -38,7 +38,11 @@ spec:
         severity: info
         namespace: openshift-node
         send_managed_notification: "true"
-        managed_notification_template: "NodeConditionDiskPressureNotification"
+        managed_notification_template: "NodeConditionNotification"
+      annotations:
+        condition: "DiskPressure"
+        explanation: " Consider moving application storage off the worker node and into persistent volumes."
+        documentation: "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage"
     - alert: NodeConditionMemoryPressureNotificationSRE
       expr: count by (machineset, condition, status)
             (
@@ -51,7 +55,11 @@ spec:
         severity: info
         namespace: openshift-node
         send_managed_notification: "true"
-        managed_notification_template: "NodeConditionMemoryPressureNotification"
+        managed_notification_template: "NodeConditionNotification"
+      annotations:
+        condition: "MemoryPressure"
+        explanation: ""
+        documentation: "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure"
     - alert: NodeConditionPIDPressureNotificationSRE
       expr: count by (machineset, condition, status)
             (
@@ -64,7 +72,11 @@ spec:
         severity: info
         namespace: openshift-node
         send_managed_notification: "true"
-        managed_notification_template: "NodeConditionPIDPressureNotification"
+        managed_notification_template: "NodeConditionNotification"
+      annotations:
+        condition: "PIDPressure"
+        explanation: " This means that more than the maximum allowed number of process identifiers are consumed on one or more worker nodes. This is likely to create instability in the node, as required system services may not be able to create new processes."
+        documentation: "https://access.redhat.com/articles/7033551"
     - alert: NodeConditionNetworkUnavailableNotificationSRE
       expr: count by (machineset, condition, status)
             (
@@ -77,4 +89,8 @@ spec:
         severity: info
         namespace: openshift-node
         send_managed_notification: "true"
-        managed_notification_template: "NodeConditionNetworkUnavailableNotification"
+        managed_notification_template: "NodeConditionNotification"
+      annotations:
+        condition: "NetworkUnavailable"
+        explanation: " Red Hat SRE will be alerted and triage issues. If action is required, a proactive case will be opened by Red Hat."
+        documentation: "https://docs.openshift.com/rosa/rosa_planning/rosa-cloud-expert-prereq-checklist.html#networking-prerequisites"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22719,54 +22719,13 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
-        - name: NodeConditionDiskPressureNotification
+        - name: NodeConditionNotification
           severity: Warning
-          summary: Worker node is experiencing DiskPressure
-          activeBody: 'DiskPressure condition is true for at least one worker. Consider
-            moving application storage off the worker node and into persistent volumes.
-            For more information, see "Configuring persistent storage" in the ROSA
-            documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage'
-          resolvedBody: DiskPressure condition is resolved.
+          summary: Worker node is experiencing ${condition}
+          activeBody: '${condition} condition is true for at least one worker.${explanation}
+            For more information, consult the relevant ROSA documentation here: ${documentation}.'
+          resolvedBody: ${condition} condition is resolved.
           resendWait: 6
-          references:
-          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage
-          logType: Capacity Management
-        - name: NodeConditionMemoryPressureNotification
-          severity: Warning
-          summary: Worker node is experiencing MemoryPressure
-          activeBody: 'MemoryPressure condition is true for at least one worker. For
-            more information on memory management in OpenShift applications, see "Understanding
-            managing application memory" in the ROSA documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure'
-          resolvedBody: MemoryPressure condition is resolved.
-          resendWait: 6
-          references:
-          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure
-          logType: Capacity Management
-        - name: NodeConditionPIDPressureNotification
-          severity: Warning
-          summary: Worker node is experiencing PIDPressure
-          activeBody: PIDPressure condition is true for at least one worker. This
-            means that more than the maximum allowed number of process identifiers
-            are consumed on one or more worker nodes. This is likely to create instability
-            in the node, as required system services may not be able to create new
-            processes. For more information see https://access.redhat.com/articles/7033551.
-            Reduce the number of pods scheduled to the impacted nodes, or reduce the
-            number of process identifiers consumed by applications on the impacted
-            nodes.
-          resolvedBody: PIDPressure condition is resolved.
-          resendWait: 6
-          references:
-          - https://access.redhat.com/articles/7033551
-          logType: Cluster Configuration
-        - name: NodeConditionNetworkUnavailableNotification
-          severity: Warning
-          summary: Worker node is experiencing NetworkUnavailable
-          activeBody: NetworkUnavailable condition is true for at least one worker.
-            Red Hat SRE will be alerted and triage issues. If action is required,
-            a proactive case will be opened by Red Hat.
-          resolvedBody: NetworkUnavailable condition is resolved.
-          resendWait: 6
-          logType: Cluster Networking
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -37297,7 +37256,12 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionDiskPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: DiskPressure
+              explanation: ' Consider moving application storage off the worker node
+                and into persistent volumes.'
+              documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage
           - alert: NodeConditionMemoryPressureNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="MemoryPressure"}
@@ -37307,7 +37271,11 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionMemoryPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: MemoryPressure
+              explanation: ''
+              documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure
           - alert: NodeConditionPIDPressureNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="PIDPressure"}
@@ -37317,7 +37285,14 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionPIDPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: PIDPressure
+              explanation: ' This means that more than the maximum allowed number
+                of process identifiers are consumed on one or more worker nodes. This
+                is likely to create instability in the node, as required system services
+                may not be able to create new processes.'
+              documentation: https://access.redhat.com/articles/7033551
           - alert: NodeConditionNetworkUnavailableNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="NetworkUnavailable"}
@@ -37327,7 +37302,12 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionNetworkUnavailableNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: NetworkUnavailable
+              explanation: ' Red Hat SRE will be alerted and triage issues. If action
+                is required, a proactive case will be opened by Red Hat.'
+              documentation: https://docs.openshift.com/rosa/rosa_planning/rosa-cloud-expert-prereq-checklist.html#networking-prerequisites
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22719,54 +22719,13 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
-        - name: NodeConditionDiskPressureNotification
+        - name: NodeConditionNotification
           severity: Warning
-          summary: Worker node is experiencing DiskPressure
-          activeBody: 'DiskPressure condition is true for at least one worker. Consider
-            moving application storage off the worker node and into persistent volumes.
-            For more information, see "Configuring persistent storage" in the ROSA
-            documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage'
-          resolvedBody: DiskPressure condition is resolved.
+          summary: Worker node is experiencing ${condition}
+          activeBody: '${condition} condition is true for at least one worker.${explanation}
+            For more information, consult the relevant ROSA documentation here: ${documentation}.'
+          resolvedBody: ${condition} condition is resolved.
           resendWait: 6
-          references:
-          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage
-          logType: Capacity Management
-        - name: NodeConditionMemoryPressureNotification
-          severity: Warning
-          summary: Worker node is experiencing MemoryPressure
-          activeBody: 'MemoryPressure condition is true for at least one worker. For
-            more information on memory management in OpenShift applications, see "Understanding
-            managing application memory" in the ROSA documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure'
-          resolvedBody: MemoryPressure condition is resolved.
-          resendWait: 6
-          references:
-          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure
-          logType: Capacity Management
-        - name: NodeConditionPIDPressureNotification
-          severity: Warning
-          summary: Worker node is experiencing PIDPressure
-          activeBody: PIDPressure condition is true for at least one worker. This
-            means that more than the maximum allowed number of process identifiers
-            are consumed on one or more worker nodes. This is likely to create instability
-            in the node, as required system services may not be able to create new
-            processes. For more information see https://access.redhat.com/articles/7033551.
-            Reduce the number of pods scheduled to the impacted nodes, or reduce the
-            number of process identifiers consumed by applications on the impacted
-            nodes.
-          resolvedBody: PIDPressure condition is resolved.
-          resendWait: 6
-          references:
-          - https://access.redhat.com/articles/7033551
-          logType: Cluster Configuration
-        - name: NodeConditionNetworkUnavailableNotification
-          severity: Warning
-          summary: Worker node is experiencing NetworkUnavailable
-          activeBody: NetworkUnavailable condition is true for at least one worker.
-            Red Hat SRE will be alerted and triage issues. If action is required,
-            a proactive case will be opened by Red Hat.
-          resolvedBody: NetworkUnavailable condition is resolved.
-          resendWait: 6
-          logType: Cluster Networking
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -37297,7 +37256,12 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionDiskPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: DiskPressure
+              explanation: ' Consider moving application storage off the worker node
+                and into persistent volumes.'
+              documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage
           - alert: NodeConditionMemoryPressureNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="MemoryPressure"}
@@ -37307,7 +37271,11 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionMemoryPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: MemoryPressure
+              explanation: ''
+              documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure
           - alert: NodeConditionPIDPressureNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="PIDPressure"}
@@ -37317,7 +37285,14 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionPIDPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: PIDPressure
+              explanation: ' This means that more than the maximum allowed number
+                of process identifiers are consumed on one or more worker nodes. This
+                is likely to create instability in the node, as required system services
+                may not be able to create new processes.'
+              documentation: https://access.redhat.com/articles/7033551
           - alert: NodeConditionNetworkUnavailableNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="NetworkUnavailable"}
@@ -37327,7 +37302,12 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionNetworkUnavailableNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: NetworkUnavailable
+              explanation: ' Red Hat SRE will be alerted and triage issues. If action
+                is required, a proactive case will be opened by Red Hat.'
+              documentation: https://docs.openshift.com/rosa/rosa_planning/rosa-cloud-expert-prereq-checklist.html#networking-prerequisites
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22719,54 +22719,13 @@ objects:
         namespace: openshift-ocm-agent-operator
       spec:
         notifications:
-        - name: NodeConditionDiskPressureNotification
+        - name: NodeConditionNotification
           severity: Warning
-          summary: Worker node is experiencing DiskPressure
-          activeBody: 'DiskPressure condition is true for at least one worker. Consider
-            moving application storage off the worker node and into persistent volumes.
-            For more information, see "Configuring persistent storage" in the ROSA
-            documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage'
-          resolvedBody: DiskPressure condition is resolved.
+          summary: Worker node is experiencing ${condition}
+          activeBody: '${condition} condition is true for at least one worker.${explanation}
+            For more information, consult the relevant ROSA documentation here: ${documentation}.'
+          resolvedBody: ${condition} condition is resolved.
           resendWait: 6
-          references:
-          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage
-          logType: Capacity Management
-        - name: NodeConditionMemoryPressureNotification
-          severity: Warning
-          summary: Worker node is experiencing MemoryPressure
-          activeBody: 'MemoryPressure condition is true for at least one worker. For
-            more information on memory management in OpenShift applications, see "Understanding
-            managing application memory" in the ROSA documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure'
-          resolvedBody: MemoryPressure condition is resolved.
-          resendWait: 6
-          references:
-          - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure
-          logType: Capacity Management
-        - name: NodeConditionPIDPressureNotification
-          severity: Warning
-          summary: Worker node is experiencing PIDPressure
-          activeBody: PIDPressure condition is true for at least one worker. This
-            means that more than the maximum allowed number of process identifiers
-            are consumed on one or more worker nodes. This is likely to create instability
-            in the node, as required system services may not be able to create new
-            processes. For more information see https://access.redhat.com/articles/7033551.
-            Reduce the number of pods scheduled to the impacted nodes, or reduce the
-            number of process identifiers consumed by applications on the impacted
-            nodes.
-          resolvedBody: PIDPressure condition is resolved.
-          resendWait: 6
-          references:
-          - https://access.redhat.com/articles/7033551
-          logType: Cluster Configuration
-        - name: NodeConditionNetworkUnavailableNotification
-          severity: Warning
-          summary: Worker node is experiencing NetworkUnavailable
-          activeBody: NetworkUnavailable condition is true for at least one worker.
-            Red Hat SRE will be alerted and triage issues. If action is required,
-            a proactive case will be opened by Red Hat.
-          resolvedBody: NetworkUnavailable condition is resolved.
-          resendWait: 6
-          logType: Cluster Networking
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -37297,7 +37256,12 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionDiskPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: DiskPressure
+              explanation: ' Consider moving application storage off the worker node
+                and into persistent volumes.'
+              documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/storage/configuring-persistent-storage
           - alert: NodeConditionMemoryPressureNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="MemoryPressure"}
@@ -37307,7 +37271,11 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionMemoryPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: MemoryPressure
+              explanation: ''
+              documentation: https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/cluster_administration/nodes#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure
           - alert: NodeConditionPIDPressureNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="PIDPressure"}
@@ -37317,7 +37285,14 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionPIDPressureNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: PIDPressure
+              explanation: ' This means that more than the maximum allowed number
+                of process identifiers are consumed on one or more worker nodes. This
+                is likely to create instability in the node, as required system services
+                may not be able to create new processes.'
+              documentation: https://access.redhat.com/articles/7033551
           - alert: NodeConditionNetworkUnavailableNotificationSRE
             expr: count by (machineset, condition, status) ( count by(node) (cluster:cpu_core_node_labels{label_node_role_kubernetes_io_infra="",label_node_role_kubernetes_io_master=""})
               * on (node) group_left(condition, machineset, status) sre:node:condition{condition="NetworkUnavailable"}
@@ -37327,7 +37302,12 @@ objects:
               severity: info
               namespace: openshift-node
               send_managed_notification: 'true'
-              managed_notification_template: NodeConditionNetworkUnavailableNotification
+              managed_notification_template: NodeConditionNotification
+            annotations:
+              condition: NetworkUnavailable
+              explanation: ' Red Hat SRE will be alerted and triage issues. If action
+                is required, a proactive case will be opened by Red Hat.'
+              documentation: https://docs.openshift.com/rosa/rosa_planning/rosa-cloud-expert-prereq-checklist.html#networking-prerequisites
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
- Combine the four node condition (https://kubernetes.io/docs/reference/node/node-status/#condition) managed notifications (`PIDPressure`, `MemoryPressure`, `NetworkUnavailable`, `DiskPressure`) into a single dynamic template, `NodeConditionNotification`. 
- The notification's description body uses `${condition} condition is true for at least one worker.${explanation}` format. This is because we need to handle `${explanation}` being blank (as seen in the `MemoryPressure` alert). Each `${explanation}` begins with a space before the sentence starts. 
- Use [replacePlaceHoldersInString](https://github.com/openshift/ocm-agent/blob/a05f232bf553f92fba5b06fca75fcc873d900a73/pkg/ocm/ocm.go#L53) function from `ocm-agent` to insert alert annotations into managed notification summary and active/resolved body. 
- Tested to work on stage OSD/ROSA clusters without any extra code changes to `ocm-agent` [link](https://docs.google.com/document/d/1tOL7-vLLb-KDp1-uCBi4NSFcLDLwdoQvGlHzW9JNeYI/edit?usp=sharing)
### Which Jira/Github issue(s) this PR fixes?
_Fixes #_
https://issues.redhat.com/browse/OSD-18447

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
