### PR TITLE
new suricata image excluding flooding rules

### DIFF
--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14 
+        image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:

--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
+        image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14 
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:
@@ -33,7 +33,7 @@ spec:
         - mountPath: /host/var/log
           name: host-filesystem
       - name: log-cleaner
-        image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
+        image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
         volumeMounts:
         - mountPath: /host/var/log
           name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31816,7 +31816,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
+              image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -31835,7 +31835,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
+              image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31816,7 +31816,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
+              image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -31835,7 +31835,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
+              image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31816,7 +31816,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:dd08ab702198479f1e0b76df7d7f282fbad4e0254930862758e55fdc575de1c1
+              image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -31835,7 +31835,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:40f10248c444d60316a29dac29075a18eeadf5a8556a8824185b5955656005e9
+              image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This PR references the newest built versions of the suricata container and logger, minus one set of rules that are flooding Splunk.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OHSS-7141](https://issues.redhat.com//browse/OHSS-7141)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```