### PR TITLE
Allow HCP Installer policy to tag subnets with the tag format that k8s expects

### DIFF
--- a/resources/sts/4.15/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.15/hypershift/sts_hcp_installer_permission_policy.json
@@ -306,6 +306,23 @@
                     ]
                 }
             }
+        },
+        {
+            "Sid": "CreateTagsK8sSubnet",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:subnet/*"
+            ],
+            "Condition": {
+                "ForAllValues:StringLike": {
+                    "aws:TagKeys": [
+                        "kubernetes.io/cluster/*"
+                    ]
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-21658

Adds permissions to the HCP installer role that allows for tagging subnets with the specific format k8s expects: `kubernetes.io/cluster/$CLUSTER_ID`
