### PR TITLE
updates images for suricata/scanning in FedRAMP to patch CVE's

### DIFF
--- a/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
+++ b/deploy/osd-scanning/20-osd-scanning-logger-Daemonset.yaml
@@ -44,7 +44,7 @@ spec:
           value: /certs/tls.key
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
+        image: quay.io/app-sre/pod-logger@sha256:ff4c3f88486b0e5ea86a9e555408be770f7059680fbf3941f136517014acaa3c
         name: logger
         ports:
         - containerPort: 8443
@@ -69,7 +69,7 @@ spec:
           value: "@rpc.pod.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+        image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
         name: pod-printer
         resources:
           limits:
@@ -85,7 +85,7 @@ spec:
           value: "@rpc.scan.sock"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+        image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
         name: scan-printer
         resources:
           limits:

--- a/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
+++ b/deploy/osd-scanning/30-osd-scanning-scanner-Daemonset.yaml
@@ -24,7 +24,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+        image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
         name: clamsig-puller
         resources:
           limits:
@@ -43,7 +43,7 @@ spec:
           value: "false"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
+        image: quay.io/app-sre/clamd@sha256:9adf08032b8d7a6f722444695ed4dbc8233480380e1a5c5bacff7a1571099acb
         name: clamd
         resources:
           limits:
@@ -67,7 +67,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
+        image: quay.io/app-sre/container-info@sha256:1816eb093b3855e1d374c29ddf935bb35474a1315f344ff062169b5b5cecc60d
         name: info
         resources:
           limits:
@@ -111,7 +111,7 @@ spec:
           value: '@rpc.sock'
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+        image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
         name: watcher
         resources:
           limits:
@@ -165,7 +165,7 @@ spec:
           value: /host
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+        image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
         name: scheduler
         resources:
           limits:
@@ -199,7 +199,7 @@ spec:
           value: "/secrets/clam_update_config.json"
         - name: OPENSSL_FORCE_FIPS_MODE
           value: "1"
-        image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+        image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
         name: init-clamsig-puller
         resources:
           limits:

--- a/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
+++ b/deploy/osd-suricata/20-osd-suricata-Daemonset.yaml
@@ -16,7 +16,7 @@ spec:
       - env:
         - name: OO_PAUSE_ON_START
           value: "false"
-        image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
+        image: quay.io/app-sre/suricata@sha256:69f79f15ed54d710fcfa24fe4031112f82f5c4dc68abba5d1f5a0cc0fa568d0c
         imagePullPolicy: IfNotPresent
         name: suricata
         resources:
@@ -33,7 +33,7 @@ spec:
         - mountPath: /host/var/log
           name: host-filesystem
       - name: log-cleaner
-        image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
+        image: quay.io/app-sre/log-cleaner@sha256:78ea446c88abb07e474f939f72ab73616f5915f166355f8810aee4c1468a3278
         volumeMounts:
         - mountPath: /host/var/log
           name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31097,7 +31097,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
+              image: quay.io/app-sre/pod-logger@sha256:ff4c3f88486b0e5ea86a9e555408be770f7059680fbf3941f136517014acaa3c
               name: logger
               ports:
               - containerPort: 8443
@@ -31122,7 +31122,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+              image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
               name: pod-printer
               resources:
                 limits:
@@ -31138,7 +31138,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+              image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
               name: scan-printer
               resources:
                 limits:
@@ -31203,7 +31203,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+              image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
               name: clamsig-puller
               resources:
                 limits:
@@ -31222,7 +31222,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
+              image: quay.io/app-sre/clamd@sha256:9adf08032b8d7a6f722444695ed4dbc8233480380e1a5c5bacff7a1571099acb
               name: clamd
               resources:
                 limits:
@@ -31246,7 +31246,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
+              image: quay.io/app-sre/container-info@sha256:1816eb093b3855e1d374c29ddf935bb35474a1315f344ff062169b5b5cecc60d
               name: info
               resources:
                 limits:
@@ -31290,7 +31290,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+              image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
               name: watcher
               resources:
                 limits:
@@ -31344,7 +31344,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+              image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
               name: scheduler
               resources:
                 limits:
@@ -31378,7 +31378,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+              image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
               name: init-clamsig-puller
               resources:
                 limits:
@@ -31903,7 +31903,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
+              image: quay.io/app-sre/suricata@sha256:69f79f15ed54d710fcfa24fe4031112f82f5c4dc68abba5d1f5a0cc0fa568d0c
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -31922,7 +31922,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
+              image: quay.io/app-sre/log-cleaner@sha256:78ea446c88abb07e474f939f72ab73616f5915f166355f8810aee4c1468a3278
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31097,7 +31097,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
+              image: quay.io/app-sre/pod-logger@sha256:ff4c3f88486b0e5ea86a9e555408be770f7059680fbf3941f136517014acaa3c
               name: logger
               ports:
               - containerPort: 8443
@@ -31122,7 +31122,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+              image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
               name: pod-printer
               resources:
                 limits:
@@ -31138,7 +31138,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+              image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
               name: scan-printer
               resources:
                 limits:
@@ -31203,7 +31203,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+              image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
               name: clamsig-puller
               resources:
                 limits:
@@ -31222,7 +31222,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
+              image: quay.io/app-sre/clamd@sha256:9adf08032b8d7a6f722444695ed4dbc8233480380e1a5c5bacff7a1571099acb
               name: clamd
               resources:
                 limits:
@@ -31246,7 +31246,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
+              image: quay.io/app-sre/container-info@sha256:1816eb093b3855e1d374c29ddf935bb35474a1315f344ff062169b5b5cecc60d
               name: info
               resources:
                 limits:
@@ -31290,7 +31290,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+              image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
               name: watcher
               resources:
                 limits:
@@ -31344,7 +31344,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+              image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
               name: scheduler
               resources:
                 limits:
@@ -31378,7 +31378,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+              image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
               name: init-clamsig-puller
               resources:
                 limits:
@@ -31903,7 +31903,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
+              image: quay.io/app-sre/suricata@sha256:69f79f15ed54d710fcfa24fe4031112f82f5c4dc68abba5d1f5a0cc0fa568d0c
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -31922,7 +31922,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
+              image: quay.io/app-sre/log-cleaner@sha256:78ea446c88abb07e474f939f72ab73616f5915f166355f8810aee4c1468a3278
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31097,7 +31097,7 @@ objects:
                 value: /certs/tls.key
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/pod-logger@sha256:0563bb3e356ff4e2bb4d9192cb82cf8210d5e27990d91ceb1c5098b4e178215f
+              image: quay.io/app-sre/pod-logger@sha256:ff4c3f88486b0e5ea86a9e555408be770f7059680fbf3941f136517014acaa3c
               name: logger
               ports:
               - containerPort: 8443
@@ -31122,7 +31122,7 @@ objects:
                 value: '@rpc.pod.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+              image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
               name: pod-printer
               resources:
                 limits:
@@ -31138,7 +31138,7 @@ objects:
                 value: '@rpc.scan.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/log-printer@sha256:d86cad6bf5790dcd6e686aedb53f9f89eca48872bec8159af0713fa4fae83397
+              image: quay.io/app-sre/log-printer@sha256:df90865edadc4627a093b7e4234b81d2c643598b4f72c27893b8322afdfc3338
               name: scan-printer
               resources:
                 limits:
@@ -31203,7 +31203,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+              image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
               name: clamsig-puller
               resources:
                 limits:
@@ -31222,7 +31222,7 @@ objects:
                 value: 'false'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamd@sha256:eb8dfb989f4178364f077cc78fb51cb422e417e7f792b4f0d0f6dbe487b99765
+              image: quay.io/app-sre/clamd@sha256:9adf08032b8d7a6f722444695ed4dbc8233480380e1a5c5bacff7a1571099acb
               name: clamd
               resources:
                 limits:
@@ -31246,7 +31246,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/container-info@sha256:c58e2729e14022ae471b815b72dd78eec1fad6417be018255fb3df86e672aeb2
+              image: quay.io/app-sre/container-info@sha256:1816eb093b3855e1d374c29ddf935bb35474a1315f344ff062169b5b5cecc60d
               name: info
               resources:
                 limits:
@@ -31290,7 +31290,7 @@ objects:
                 value: '@rpc.sock'
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+              image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
               name: watcher
               resources:
                 limits:
@@ -31344,7 +31344,7 @@ objects:
                 value: /host
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/watcher@sha256:451b8cdd8d142cc119c3a297b12aab3eb40a2833b8696155224fd33938e9d5b1
+              image: quay.io/app-sre/watcher@sha256:530d380a64602531ff0e15f5825cb87d68aa493b8abf064aa85a0313e606cfe3
               name: scheduler
               resources:
                 limits:
@@ -31378,7 +31378,7 @@ objects:
                 value: /secrets/clam_update_config.json
               - name: OPENSSL_FORCE_FIPS_MODE
                 value: '1'
-              image: quay.io/app-sre/clamsig-puller@sha256:3713028c15bb6b9ac7c7714f155dc37534aeb1173e502dce0ab79cac61aa8d03
+              image: quay.io/app-sre/clamsig-puller@sha256:909cbdeafd028778b6d92adf92b9e63c95bc4a11d7f3c168a61db6ae87c1fc1c
               name: init-clamsig-puller
               resources:
                 limits:
@@ -31903,7 +31903,7 @@ objects:
             - env:
               - name: OO_PAUSE_ON_START
                 value: 'false'
-              image: quay.io/app-sre/suricata@sha256:526dc72bb1ed5cbd323fe57ef9a89bda71083419f8f314f522df6c15dd362c14
+              image: quay.io/app-sre/suricata@sha256:69f79f15ed54d710fcfa24fe4031112f82f5c4dc68abba5d1f5a0cc0fa568d0c
               imagePullPolicy: IfNotPresent
               name: suricata
               resources:
@@ -31922,7 +31922,7 @@ objects:
               - mountPath: /host/var/log
                 name: host-filesystem
             - name: log-cleaner
-              image: quay.io/app-sre/log-cleaner@sha256:e4dfd82ab2b1a99a6b29a4a3a95cf3bc906069fac93ea703113a914e35d5ada7
+              image: quay.io/app-sre/log-cleaner@sha256:78ea446c88abb07e474f939f72ab73616f5915f166355f8810aee4c1468a3278
               volumeMounts:
               - mountPath: /host/var/log
                 name: host-filesystem


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

Patch CVE's in base images for Scanning/Suricata services in FedRAMP

### Which Jira/Github issue(s) this PR fixes?

For [OSD-21522](https://issues.redhat.com//browse/OSD-21522)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
