### PR TITLE
OCM-6862 | feat: add tag condition when listing policies attached to roles

### DIFF
--- a/resources/sts/4.15/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.15/hypershift/sts_hcp_installer_permission_policy.json
@@ -22,8 +22,6 @@
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "iam:GetOpenIDConnectProvider",
                 "iam:GetRole",
-                "iam:ListAttachedRolePolicies",
-                "iam:ListRolePolicies",
                 "route53:GetHostedZone",
                 "route53:ListHostedZones",
                 "route53:ListHostedZonesByName",
@@ -321,6 +319,20 @@
                     "aws:TagKeys": [
                         "kubernetes.io/cluster/*"
                     ]
+                }
+            }
+        },
+        {
+            "Sid": "ListPoliciesAttachedToRoles",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListAttachedRolePolicies",
+                "iam:ListRolePolicies"
+            ],
+            "Resource": "arn:aws:iam::*:role/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
                 }
             }
         }


### PR DESCRIPTION
Follow up to thread:
https://redhat-internal.slack.com/archives/CB53T9ZHQ/p1710949371262269

**Manual Test:**
After assuming into a role with a specific policy that has the role tag conditions defined, as shown in this commit:

Assuming into role / session: "dle-stage-HCP-ROSA-Installer-Role"
![image](https://github.com/openshift/managed-cluster-config/assets/118839428/0dd2eb65-0e5d-4d5b-a7a4-ae0d0d1972ad)

Then,
Querying / listing policies attached to role: "croche-HCP-ROSA-Installer-Role"
![image](https://github.com/openshift/managed-cluster-config/assets/118839428/58fba195-f654-4ca7-890d-fd594158d222)

In the top of the image, I was able to confirm that retrieving list of policies was allowed only when the role itself carried the tag: "red-hat-managed: true"
![image](https://github.com/openshift/managed-cluster-config/assets/118839428/92cdaa39-bee0-4f4d-93a3-c57b4066b0ba)

I then removed the "red-hat-managed: true" from role, "croche-HCP-ROSA-Installer-Role"
![image](https://github.com/openshift/managed-cluster-config/assets/118839428/591cf61f-3311-4e1b-8912-afd6e42b366a)


and re-ran the same commands, to confirm the denials:
![image](https://github.com/openshift/managed-cluster-config/assets/118839428/4285260c-db8d-4484-9307-a2fee589a3c7)




### What type of PR is this?
feature

### What this PR does / why we need it?
Adding a condition to permissions (for AWS Owned - HCP Managed Installer Role Policy), IAM: ListRolePolicies and IAM: ListAttachedRolePolicies to only work on roles that carry the tag "red-hat-managed: true".

### Which Jira/Github issue(s) this PR fixes?
[OCM-6862](https://issues.redhat.com/browse/OCM-6862)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
