### PR TITLE
OCMAgentServiceLogsSentExceedingLimit Feature

### DIFF
--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -43,7 +43,6 @@ spec:
     # Alert SRE if the OCM agent service log metric has been sent more than 10 within a 3-day period.
     - alert: OCMAgentServiceLogsSentExceedingLimit
       expr: sum(increase(ocm_agent_service_log_sent_total[3d])) > 10
-      for: 1m
       labels:
         severity: warning
         namespace: openshift-monitoring

--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -40,9 +40,9 @@ spec:
         message: OCM Agent pull secret auth token is not valid.
 
 
-    # Alert SRE if the OCM agent service log metric has been sent more than 20 within a 24-hour period.
+    # Alert SRE if the OCM agent service log metric has been sent more than 10 within a 3-day period.
     - alert: OCMAgentServiceLogsSentExceedingLimit
-      expr: sum(increase(ocm_agent_service_log_sent_total[1d])) > 20
+      expr: sum(increase(ocm_agent_service_log_sent_total[3d])) > 10
       for: 1m
       labels:
         severity: warning

--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -38,3 +38,15 @@ spec:
         link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets"
       annotations:
         message: OCM Agent pull secret auth token is not valid.
+
+
+    # Alert SRE if the OCM agent service log metric has been sent more than 20 within a 24-hour period.
+    - alert: OCMAgentServiceLogsSentExceedingLimit
+      expr: sum(increase(ocm_agent_service_log_sent_total[1d])) > 20
+      for: 1m
+      labels:
+        severity: warning
+        namespace: openshift-monitoring
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentServiceLogsSentExceedingLimit.md"
+      annotations:
+        message: OCM Agent has sent an excessive number of service logs, potentially indicating an issue. Immediate investigation may be required.

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent-proxy.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent-proxy.PrometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         severity: Info
         namespace: openshift-monitoring
-        managed_notification_template: "AdditionalTrustBundleCAExpiring"
+        managed_notification_template: "AdditionalTrust BundleCAExpiring"
         send_managed_notification: "true"
       annotations:
         message: "Additional Trust Bundle CA certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degradation and/or unavailability"

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent-proxy.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent-proxy.PrometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         severity: Info
         namespace: openshift-monitoring
-        managed_notification_template: "AdditionalTrust BundleCAExpiring"
+        managed_notification_template: "AdditionalTrustBundleCAExpiring"
         send_managed_notification: "true"
       annotations:
         message: "Additional Trust Bundle CA certificate will expire in {{ $value | humanizeDuration }}. Ensure new certificate is provided prior to expiration to avoid cluster degradation and/or unavailability"

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -145,3 +145,4 @@ spec:
         managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
         send_managed_notification: "true"
     
+ 

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -144,5 +144,3 @@ spec:
         namespace: openshift-monitoring
         managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
         send_managed_notification: "true"
-    
- 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35608,6 +35608,15 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
             annotations:
               message: OCM Agent pull secret auth token is not valid.
+          - alert: OCMAgentServiceLogsSentExceedingLimit
+            expr: sum(increase(ocm_agent_service_log_sent_total[3d])) > 10
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentServiceLogsSentExceedingLimit.md
+            annotations:
+              message: OCM Agent has sent an excessive number of service logs, potentially
+                indicating an issue. Immediate investigation may be required.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37171,7 +37180,7 @@ objects:
             labels:
               severity: Info
               namespace: openshift-monitoring
-              managed_notification_template: AdditionalTrustBundleCAExpiring
+              managed_notification_template: AdditionalTrust BundleCAExpiring
               send_managed_notification: 'true'
             annotations:
               message: Additional Trust Bundle CA certificate will expire in {{ $value

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37180,7 +37180,7 @@ objects:
             labels:
               severity: Info
               namespace: openshift-monitoring
-              managed_notification_template: AdditionalTrust BundleCAExpiring
+              managed_notification_template: AdditionalTrustBundleCAExpiring
               send_managed_notification: 'true'
             annotations:
               message: Additional Trust Bundle CA certificate will expire in {{ $value

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35608,6 +35608,15 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
             annotations:
               message: OCM Agent pull secret auth token is not valid.
+          - alert: OCMAgentServiceLogsSentExceedingLimit
+            expr: sum(increase(ocm_agent_service_log_sent_total[3d])) > 10
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentServiceLogsSentExceedingLimit.md
+            annotations:
+              message: OCM Agent has sent an excessive number of service logs, potentially
+                indicating an issue. Immediate investigation may be required.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37171,7 +37180,7 @@ objects:
             labels:
               severity: Info
               namespace: openshift-monitoring
-              managed_notification_template: AdditionalTrustBundleCAExpiring
+              managed_notification_template: AdditionalTrust BundleCAExpiring
               send_managed_notification: 'true'
             annotations:
               message: Additional Trust Bundle CA certificate will expire in {{ $value

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37180,7 +37180,7 @@ objects:
             labels:
               severity: Info
               namespace: openshift-monitoring
-              managed_notification_template: AdditionalTrust BundleCAExpiring
+              managed_notification_template: AdditionalTrustBundleCAExpiring
               send_managed_notification: 'true'
             annotations:
               message: Additional Trust Bundle CA certificate will expire in {{ $value

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35608,6 +35608,15 @@ objects:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentResponseFailureServiceLogsSRE.md#verify-cluster-pull-secrets
             annotations:
               message: OCM Agent pull secret auth token is not valid.
+          - alert: OCMAgentServiceLogsSentExceedingLimit
+            expr: sum(increase(ocm_agent_service_log_sent_total[3d])) > 10
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/OCMAgentServiceLogsSentExceedingLimit.md
+            annotations:
+              message: OCM Agent has sent an excessive number of service logs, potentially
+                indicating an issue. Immediate investigation may be required.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37171,7 +37180,7 @@ objects:
             labels:
               severity: Info
               namespace: openshift-monitoring
-              managed_notification_template: AdditionalTrustBundleCAExpiring
+              managed_notification_template: AdditionalTrust BundleCAExpiring
               send_managed_notification: 'true'
             annotations:
               message: Additional Trust Bundle CA certificate will expire in {{ $value

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37180,7 +37180,7 @@ objects:
             labels:
               severity: Info
               namespace: openshift-monitoring
-              managed_notification_template: AdditionalTrust BundleCAExpiring
+              managed_notification_template: AdditionalTrustBundleCAExpiring
               send_managed_notification: 'true'
             annotations:
               message: Additional Trust Bundle CA certificate will expire in {{ $value


### PR DESCRIPTION
### What type of PR is this?
_Feature_

### What this PR does / why we need it?
This PR contains a alerting rule for the ocm_service_log_sent metric.
It alerts SRE if a more than 10 Sevice logs have been sent to a customer in the span of 3 days

### Which Jira/Github issue(s) this PR fixes?
[OSD-12237]-(https://issues.redhat.com/browse/OSD-12237) - Alert if the rate of OAO service logs sent is too high

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
