### PR TITLE
[OSD-21572] feat: Add oidc-missing and sre-kubelet-debugging-handlers-enabled alerts

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-audit-webhook-cloud-watch-errors.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-audit-webhook-cloud-watch-errors.PrometheusRule.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
+    role: alert-rules
+  name: audit-webhook-error-putting-minimized-cloudwatch-log
+  namespace: openshift-observability-operator
+spec:
+  groups:
+    - name: AuditWebhookCloudWatchErrors
+      interval: 60s
+      rules:
+        - alert: AuditWebhookErrorPuttingMinimizedCloudwatchLog
+          annotations:
+            description: "The audit webhook failed to put a minimized event to cloudwatch in {{ $labels.namespace }}."
+            summary: "Audit webhook cloudwatch PutEvents failed for a minimized event"
+          # All suffixed invalidparameterexception indicate that the resend failed, which we want to alert on:
+          # This includes the following errors:
+          # - invalidparameterexception_reduce_failed
+          # - invalidparameterexception_marshal_failed
+          # - invalidparameterexception_resent_failed
+          expr: sum by (mc_name, _mc_id, sector, region, env, namespace, source, _id) (rate (splunkforwarder_audit_filter_cloudwatch_put_log_errors_total{error_code=~"invalidparameterexception_.*"}[5m])) > 0
+          for: 1m
+          labels:
+            severity: info
+            send_managed_notification: "true"
+            managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
+            namespace: "{{ $labels.namespace }}"

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: oidc-missing
+    role: alert-rules
+  name: oidc-missing
+  namespace: openshift-observability-operator
+spec:
+  groups:
+    - name: OIDCMissingFleetNotification
+      interval: 60s
+      rules:
+        - alert: OIDCMissingFleetNotification
+          annotations:
+            description: "Customer cloud environment is unreachable from the management cluster due to invalid aws credentials"
+            summary: "Cluster has invalid AWS credentials"
+          # Clusters tend to have their `hypershift_cluster_invalid_aws_creds` set to > 0 while the cluster didn't finish the installation, thus we check
+          # that the cluster is not rolling out in our expression (= hypershift_cluster_initial_rolling_out_duration_seconds does not exist)
+          # hypershift_cluster_initial_rolling_out_duration_seconds stops being emitted once the cluster is rolled out
+          expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace, source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m])) > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
+          for: 10m
+          labels:
+            severity: warning
+            send_managed_notification: "true"
+            managed_notification_template: oidc-deleted-notification
+            # We don't want the wrapper to auto resolve this, as the notification itself is setting limited support via OCM-Agent.
+            # This alert would resolve itself by firing, thus removing limited support and causing itself to flap.
+            silencing_wrapper: none
+            namespace: "{{ $labels.namespace }}"

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/config.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/config.yaml
@@ -1,0 +1,7 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37316,6 +37316,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-ocm-agent-obo-monitoring
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
+          role: alert-rules
+        name: audit-webhook-error-putting-minimized-cloudwatch-log
+        namespace: openshift-observability-operator
+      spec:
+        groups:
+        - name: AuditWebhookCloudWatchErrors
+          interval: 60s
+          rules:
+          - alert: AuditWebhookErrorPuttingMinimizedCloudwatchLog
+            annotations:
+              description: The audit webhook failed to put a minimized event to cloudwatch
+                in {{ $labels.namespace }}.
+              summary: Audit webhook cloudwatch PutEvents failed for a minimized event
+            expr: sum by (mc_name, _mc_id, sector, region, env, namespace, source,
+              _id) (rate (splunkforwarder_audit_filter_cloudwatch_put_log_errors_total{error_code=~"invalidparameterexception_.*"}[5m]))
+              > 0
+            for: 1m
+            labels:
+              severity: info
+              send_managed_notification: 'true'
+              managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: oidc-missing
+          role: alert-rules
+        name: oidc-missing
+        namespace: openshift-observability-operator
+      spec:
+        groups:
+        - name: OIDCMissingFleetNotification
+          interval: 60s
+          rules:
+          - alert: OIDCMissingFleetNotification
+            annotations:
+              description: Customer cloud environment is unreachable from the management
+                cluster due to invalid aws credentials
+              summary: Cluster has invalid AWS credentials
+            expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace,
+              source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
+              > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
+              unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
+            for: 10m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: oidc-deleted-notification
+              silencing_wrapper: none
+              namespace: '{{ $labels.namespace }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent-unsupported-logging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37316,6 +37316,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-ocm-agent-obo-monitoring
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
+          role: alert-rules
+        name: audit-webhook-error-putting-minimized-cloudwatch-log
+        namespace: openshift-observability-operator
+      spec:
+        groups:
+        - name: AuditWebhookCloudWatchErrors
+          interval: 60s
+          rules:
+          - alert: AuditWebhookErrorPuttingMinimizedCloudwatchLog
+            annotations:
+              description: The audit webhook failed to put a minimized event to cloudwatch
+                in {{ $labels.namespace }}.
+              summary: Audit webhook cloudwatch PutEvents failed for a minimized event
+            expr: sum by (mc_name, _mc_id, sector, region, env, namespace, source,
+              _id) (rate (splunkforwarder_audit_filter_cloudwatch_put_log_errors_total{error_code=~"invalidparameterexception_.*"}[5m]))
+              > 0
+            for: 1m
+            labels:
+              severity: info
+              send_managed_notification: 'true'
+              managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: oidc-missing
+          role: alert-rules
+        name: oidc-missing
+        namespace: openshift-observability-operator
+      spec:
+        groups:
+        - name: OIDCMissingFleetNotification
+          interval: 60s
+          rules:
+          - alert: OIDCMissingFleetNotification
+            annotations:
+              description: Customer cloud environment is unreachable from the management
+                cluster due to invalid aws credentials
+              summary: Cluster has invalid AWS credentials
+            expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace,
+              source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
+              > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
+              unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
+            for: 10m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: oidc-deleted-notification
+              silencing_wrapper: none
+              namespace: '{{ $labels.namespace }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent-unsupported-logging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37316,6 +37316,81 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-prometheus-ocm-agent-obo-monitoring
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
+          role: alert-rules
+        name: audit-webhook-error-putting-minimized-cloudwatch-log
+        namespace: openshift-observability-operator
+      spec:
+        groups:
+        - name: AuditWebhookCloudWatchErrors
+          interval: 60s
+          rules:
+          - alert: AuditWebhookErrorPuttingMinimizedCloudwatchLog
+            annotations:
+              description: The audit webhook failed to put a minimized event to cloudwatch
+                in {{ $labels.namespace }}.
+              summary: Audit webhook cloudwatch PutEvents failed for a minimized event
+            expr: sum by (mc_name, _mc_id, sector, region, env, namespace, source,
+              _id) (rate (splunkforwarder_audit_filter_cloudwatch_put_log_errors_total{error_code=~"invalidparameterexception_.*"}[5m]))
+              > 0
+            for: 1m
+            labels:
+              severity: info
+              send_managed_notification: 'true'
+              managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
+              namespace: '{{ $labels.namespace }}'
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
+          prometheus: oidc-missing
+          role: alert-rules
+        name: oidc-missing
+        namespace: openshift-observability-operator
+      spec:
+        groups:
+        - name: OIDCMissingFleetNotification
+          interval: 60s
+          rules:
+          - alert: OIDCMissingFleetNotification
+            annotations:
+              description: Customer cloud environment is unreachable from the management
+                cluster due to invalid aws credentials
+              summary: Cluster has invalid AWS credentials
+            expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace,
+              source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
+              > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
+              unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
+            for: 10m
+            labels:
+              severity: warning
+              send_managed_notification: 'true'
+              managed_notification_template: oidc-deleted-notification
+              silencing_wrapper: none
+              namespace: '{{ $labels.namespace }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: sre-prometheus-ocm-agent-unsupported-logging
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
To implement ocm-agent for Hypershift without RHOBS we need to enable the OBO AlertManager to receive alerts triggered by these two specific Prometheus rules and to send the alerts json payload to ocm-agent-fleet.

### Which Jira/Github issue(s) this PR fixes?
[OSD-21572](https://issues.redhat.com/browse/OSD-21572)