### PR TITLE
add r7i

### DIFF
--- a/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
@@ -41,6 +41,8 @@ spec:
       - "c6id.metal"
       - "i3.metal"
       - "i3en.metal"
+      - "r7i.metal-48xl"
+      - "r7i.48xlarge"
   unhealthyConditions:
   - type: "Ready"
     timeout: 8m


### PR DESCRIPTION
r7i.48xlarge as well due to really long ready time in testing

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

This adds r7i.metal-48xlarge and r7i.48xlarge to the extended timeout list so that these instances can have more time to become nodes in the cluster.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
OSD-21729

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
