### PR TITLE
Add alert for controlplanemachineset has additional machines

### DIFF
--- a/deploy/sre-prometheus/100-controlplanemachineset.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-controlplanemachineset.PrometheusRule.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-control-plane-machine-set-alerts
+    role: alert-rules
+  name: sre-control-plane-machine-set-alerts
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-control-plane-machine-set-alerts
+    rules:
+        - alert: SREControlPlaneMachineSetStuck
+          expr: cpms_enabled > 0 AND (
+            count ( cluster:nodes_roles{label_node_role_kubernetes_io="master"} ) > 3
+            OR
+            count ( cluster:nodes_roles{label_node_role_kubernetes_io="control-plane"} ) > 3
+            )
+          for: 1h
+          labels:
+            severity: critical
+            namespace: openshift-monitoring
+            link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/SREControlPlaneMachineSetStuck.md"
+          annotations:
+            message: "The clusters controlplane machineset has additional nodes for more than 1 hour."
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34874,6 +34874,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-control-plane-machine-set-alerts
+          role: alert-rules
+        name: sre-control-plane-machine-set-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-control-plane-machine-set-alerts
+          rules:
+          - alert: SREControlPlaneMachineSetStuck
+            expr: cpms_enabled > 0 AND ( count ( cluster:nodes_roles{label_node_role_kubernetes_io="master"}
+              ) > 3 OR count ( cluster:nodes_roles{label_node_role_kubernetes_io="control-plane"}
+              ) > 3 )
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/SREControlPlaneMachineSetStuck.md
+            annotations:
+              message: The clusters controlplane machineset has additional nodes for
+                more than 1 hour.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-elasticsearch-jobs
           role: alert-rules
         name: sre-elasticsearch-jobs

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34874,6 +34874,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-control-plane-machine-set-alerts
+          role: alert-rules
+        name: sre-control-plane-machine-set-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-control-plane-machine-set-alerts
+          rules:
+          - alert: SREControlPlaneMachineSetStuck
+            expr: cpms_enabled > 0 AND ( count ( cluster:nodes_roles{label_node_role_kubernetes_io="master"}
+              ) > 3 OR count ( cluster:nodes_roles{label_node_role_kubernetes_io="control-plane"}
+              ) > 3 )
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/SREControlPlaneMachineSetStuck.md
+            annotations:
+              message: The clusters controlplane machineset has additional nodes for
+                more than 1 hour.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-elasticsearch-jobs
           role: alert-rules
         name: sre-elasticsearch-jobs

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34874,6 +34874,30 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-control-plane-machine-set-alerts
+          role: alert-rules
+        name: sre-control-plane-machine-set-alerts
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-control-plane-machine-set-alerts
+          rules:
+          - alert: SREControlPlaneMachineSetStuck
+            expr: cpms_enabled > 0 AND ( count ( cluster:nodes_roles{label_node_role_kubernetes_io="master"}
+              ) > 3 OR count ( cluster:nodes_roles{label_node_role_kubernetes_io="control-plane"}
+              ) > 3 )
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/SREControlPlaneMachineSetStuck.md
+            annotations:
+              message: The clusters controlplane machineset has additional nodes for
+                more than 1 hour.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-elasticsearch-jobs
           role: alert-rules
         name: sre-elasticsearch-jobs


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
adds an alert for when the controlplanemachineset  is active and the cluster has more than 3 control plane nodes for more than one hour

I put an 'OR' for the node role as we have clusters with 'master' & 'control-plane' and older ones with only 'master'.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-20595

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR https://github.com/openshift/ops-sop/pull/3101 
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```