### PR TITLE
Added new instance types r7i.48xlarge and r7i.metal-48xl to longer timeout

### DIFF
--- a/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -41,6 +41,8 @@ spec:
       - "c6id.metal"
       - "i3.metal"
       - "i3en.metal"
+      - "r7i.48xlarge"
+      - "r7i.metal-48xl"
   unhealthyConditions:
   - type:    "Ready"
     timeout: "480s"

--- a/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
@@ -41,6 +41,8 @@ spec:
       - "c6id.metal"
       - "i3.metal"
       - "i3en.metal"
+      - "r7i.48xlarge"
+      - "r7i.metal-48xl"
   unhealthyConditions:
   - type: "Ready"
     timeout: 8m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29364,6 +29364,8 @@ objects:
             - c6id.metal
             - i3.metal
             - i3en.metal
+            - r7i.48xlarge
+            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -29416,6 +29418,8 @@ objects:
             - c6id.metal
             - i3.metal
             - i3en.metal
+            - r7i.48xlarge
+            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 8m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29364,6 +29364,8 @@ objects:
             - c6id.metal
             - i3.metal
             - i3en.metal
+            - r7i.48xlarge
+            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -29416,6 +29418,8 @@ objects:
             - c6id.metal
             - i3.metal
             - i3en.metal
+            - r7i.48xlarge
+            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 8m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29364,6 +29364,8 @@ objects:
             - c6id.metal
             - i3.metal
             - i3en.metal
+            - r7i.48xlarge
+            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -29416,6 +29418,8 @@ objects:
             - c6id.metal
             - i3.metal
             - i3en.metal
+            - r7i.48xlarge
+            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 8m


### PR DESCRIPTION
Added new instance types r7i.48xlarge and r7i.metal-48xl to longer time out list

### What type of PR is this?
Feature


### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-21729
