### PR TITLE
Separates UWM and Cluster Monitoring ErrorBudgetBurn Alerts

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -78,8 +78,8 @@ spec:
       severity: Error
       summary: Workload preventing machine deletion
       logType: Cluster Configuration
-      references: 
-      - "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"
+      references:
+        - "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"
     - activeBody: |-
         Your cluster requires you to take action. The available file system inodes for a worker node are currently at or below 3% and are predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of inodes used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
       name: WorkerNodeFilesystemAlmostOutOfFiles
@@ -88,8 +88,19 @@ spec:
       summary: "Filesystem has less than 3% inodes left"
       logType: Cluster Configuration
     - activeBody: |-
-        Your cluster currently has at least one unschedulable worker node. Please troubleshoot this node using the following reference documentation: https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working.
+        Your cluster currently has at least one unschedulable worker node. Please troubleshoot this node.
       name: KubeNodeUnschedulableSRE
       resendWait: 6
       severity: Error
       summary: "Action required: a worker node is Unschedulable for more than an hour"
+      references:
+        - "https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working"
+    - activeBody: |-
+        Your cluster requires your attention. User Workload Montioring is currently degraded because unscheduleable worker nodes are preventing deployment of UWM pods. Please scale up the MachinePool for this cluster or uncordon any cordoned worker nodes.
+      name: "UnscheduleableNodesPreventingUWMDeployment"
+      resendWait: 2
+      severity: Error
+      summary: "Action required: User Workload Monitoring is degraded"
+      logType: Cluster Configuration
+      references:
+        - "https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes"

--- a/deploy/sre-prometheus/monitoring/100-cluster-monitoring-error-budget-burn.yaml
+++ b/deploy/sre-prometheus/monitoring/100-cluster-monitoring-error-budget-burn.yaml
@@ -11,11 +11,12 @@ spec:
   - name: sre-cluster-monitoring-error-budget-burn
     rules:
     # Substitues ClusterOperatorDown{name="monitoring"} as part of https://issues.redhat.com/browse/OSD-19769
+    # Specifically ignore UserWorkload as part of this alert, we will look at that in another error
     - alert: ClusterMonitoringErrorBudgetBurnSRE
       expr: |
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) ) > (14.4 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m])) ) > (14.4 * (1 - 0.983))
           and
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) ) > (14.4 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h])) ) > (14.4 * (1 - 0.983))
       for: 2m
       labels:
         long_window: 1h
@@ -28,9 +29,9 @@ spec:
         message: "High error budget burn for the monitoring cluster operator (current value: {{ $value }})"
     - alert: ClusterMonitoringErrorBudgetBurnSRE
       expr: |
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m])) ) > (6 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m])) ) > (6 * (1 - 0.983))
           and
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) ) > (6 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h])) ) > (6 * (1 - 0.983))
       for: 15m
       labels:
         long_window: 6h
@@ -41,3 +42,85 @@ spec:
         short_window: 30m
       annotations:
         message: "High error budget burn for the monitoring cluster operator (current value: {{ $value }})"
+  - name: sre-user-workload-monitoring-error-budget-burn
+    rules:
+    # We want to specifically look at UserWorkloadMonitoring ErrorBudgetBurn here
+    - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m])) ) > (14.4 * (1 - 0.983))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h])) ) > (14.4 * (1 - 0.983))
+          and
+          # check for unscheduleable customer worker nodes that do not have running workload monitoring pods.
+          # if a unscheduleable worker node has running uwm pods then this budget burn is not due to potential customer cordons and should be investigated
+          count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"}) unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"}) == 0
+      for: 2m
+      labels:
+        long_window: 1h
+        severity: critical
+        namespace: openshift-monitoring
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md"
+        short_window: 5m
+      annotations:
+        message: "High error budget burn for User Workload Monitoring (current value: {{ $value }})"
+    - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m])) ) > (6 * (1 - 0.983))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h])) ) > (6 * (1 - 0.983))
+          and
+          # check for unscheduleable customer worker nodes that do not have running workload monitoring pods.
+          # if a unscheduleable worker node has running uwm pods then this budget burn is not due to potential customer cordons and should be investigated
+          count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"}) unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"}) == 0
+      for: 15m
+      labels:
+        long_window: 6h
+        severity: critical
+        namespace: openshift-monitoring
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md"
+        short_window: 30m
+      annotations:
+        message: "High error budget burn for User Workload Monitoring (current value: {{ $value }})"
+
+  - name: customer-user-workload-monitoring-error-budget-burn
+    rules:
+    # We want to specifically look at UserWorkloadMonitoring ErrorBudgetBurn here
+    # This is tweaked to send to the customer when unscheduleable due to cordoned nodes
+    # The initial alert is a warning alert so that it shows up for the customer.
+    # The longer-window alert is what fires a SL to the customer
+    - alert: UnscheduleableNodesPreventingUWMDeployment
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m])) ) > (14.4 * (1 - 0.983))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h])) ) > (14.4 * (1 - 0.983))
+          and
+          # check for unscheduleable customer worker nodes that do not have running workload monitoring pods.
+          count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"}) unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"}) > 0
+      for: 2m
+      labels:
+        long_window: 1h
+        severity: warning
+        namespace: openshift-monitoring
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md"
+        short_window: 5m
+      annotations:
+        message: "High error budget burn for User Workload Monitoring (current value: {{ $value }})"
+    - alert: UnscheduleableNodesPreventingUWMDeployment
+      expr: |
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m])) ) > (6 * (1 - 0.983))
+          and
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h])) ) > (6 * (1 - 0.983))
+          and
+          # check for unscheduleable customer worker nodes that do not have running workload monitoring pods.
+          # if a unscheduleable worker node has running uwm pods then this budget burn is not due to potential customer cordons and should be investigated
+          count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"}) unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"}) > 0
+      for: 15m
+      labels:
+        long_window: 6h
+        severity: critical
+        namespace: openshift-monitoring
+        short_window: 30m
+        send_managed_notification: "true"
+        managed_notifcation_template: "UnscheduleableNodesPreventingUWMDeployment"
+      annotations:
+        message: "High error budget burn for User Workload Monitoring (current value: {{ $value }})"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22801,14 +22801,26 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
-        - activeBody: 'Your cluster currently has at least one unschedulable worker
-            node. Please troubleshoot this node using the following reference documentation:
-            https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working.'
+        - activeBody: Your cluster currently has at least one unschedulable worker
+            node. Please troubleshoot this node.
           name: KubeNodeUnschedulableSRE
           resendWait: 6
           severity: Error
           summary: 'Action required: a worker node is Unschedulable for more than
             an hour'
+          references:
+          - https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working
+        - activeBody: Your cluster requires your attention. User Workload Montioring
+            is currently degraded because unscheduleable worker nodes are preventing
+            deployment of UWM pods. Please scale up the MachinePool for this cluster
+            or uncordon any cordoned worker nodes.
+          name: UnscheduleableNodesPreventingUWMDeployment
+          resendWait: 2
+          severity: Error
+          summary: 'Action required: User Workload Monitoring is degraded'
+          logType: Cluster Configuration
+          references:
+          - https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -37132,15 +37144,15 @@ objects:
         - name: sre-cluster-monitoring-error-budget-burn
           rules:
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) )
-              > (14.4 * (1 - 0.983))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) )
-              > (14.4 * (1 - 0.983))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
 
               '
             for: 2m
@@ -37155,15 +37167,15 @@ objects:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
               ) > (6 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
-              > (6 * (1 - 0.983))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
 
               '
             for: 15m
@@ -37177,6 +37189,144 @@ objects:
             annotations:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
+        - name: sre-user-workload-monitoring-error-budget-burn
+          rules:
+          - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              == 0
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+          - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              == 0
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 30m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+        - name: customer-user-workload-monitoring-error-budget-burn
+          rules:
+          - alert: UnscheduleableNodesPreventingUWMDeployment
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              > 0
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+          - alert: UnscheduleableNodesPreventingUWMDeployment
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              > 0
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              short_window: 30m
+              send_managed_notification: 'true'
+              managed_notifcation_template: UnscheduleableNodesPreventingUWMDeployment
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22801,14 +22801,26 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
-        - activeBody: 'Your cluster currently has at least one unschedulable worker
-            node. Please troubleshoot this node using the following reference documentation:
-            https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working.'
+        - activeBody: Your cluster currently has at least one unschedulable worker
+            node. Please troubleshoot this node.
           name: KubeNodeUnschedulableSRE
           resendWait: 6
           severity: Error
           summary: 'Action required: a worker node is Unschedulable for more than
             an hour'
+          references:
+          - https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working
+        - activeBody: Your cluster requires your attention. User Workload Montioring
+            is currently degraded because unscheduleable worker nodes are preventing
+            deployment of UWM pods. Please scale up the MachinePool for this cluster
+            or uncordon any cordoned worker nodes.
+          name: UnscheduleableNodesPreventingUWMDeployment
+          resendWait: 2
+          severity: Error
+          summary: 'Action required: User Workload Monitoring is degraded'
+          logType: Cluster Configuration
+          references:
+          - https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -37132,15 +37144,15 @@ objects:
         - name: sre-cluster-monitoring-error-budget-burn
           rules:
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) )
-              > (14.4 * (1 - 0.983))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) )
-              > (14.4 * (1 - 0.983))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
 
               '
             for: 2m
@@ -37155,15 +37167,15 @@ objects:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
               ) > (6 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
-              > (6 * (1 - 0.983))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
 
               '
             for: 15m
@@ -37177,6 +37189,144 @@ objects:
             annotations:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
+        - name: sre-user-workload-monitoring-error-budget-burn
+          rules:
+          - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              == 0
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+          - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              == 0
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 30m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+        - name: customer-user-workload-monitoring-error-budget-burn
+          rules:
+          - alert: UnscheduleableNodesPreventingUWMDeployment
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              > 0
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+          - alert: UnscheduleableNodesPreventingUWMDeployment
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              > 0
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              short_window: 30m
+              send_managed_notification: 'true'
+              managed_notifcation_template: UnscheduleableNodesPreventingUWMDeployment
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22801,14 +22801,26 @@ objects:
           severity: Error
           summary: Filesystem has less than 3% inodes left
           logType: Cluster Configuration
-        - activeBody: 'Your cluster currently has at least one unschedulable worker
-            node. Please troubleshoot this node using the following reference documentation:
-            https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working.'
+        - activeBody: Your cluster currently has at least one unschedulable worker
+            node. Please troubleshoot this node.
           name: KubeNodeUnschedulableSRE
           resendWait: 6
           severity: Error
           summary: 'Action required: a worker node is Unschedulable for more than
             an hour'
+          references:
+          - https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working
+        - activeBody: Your cluster requires your attention. User Workload Montioring
+            is currently degraded because unscheduleable worker nodes are preventing
+            deployment of UWM pods. Please scale up the MachinePool for this cluster
+            or uncordon any cordoned worker nodes.
+          name: UnscheduleableNodesPreventingUWMDeployment
+          resendWait: 2
+          severity: Error
+          summary: 'Action required: User Workload Monitoring is degraded'
+          logType: Cluster Configuration
+          references:
+          - https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -37132,15 +37144,15 @@ objects:
         - name: sre-cluster-monitoring-error-budget-burn
           rules:
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[5m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[5m])) )
-              > (14.4 * (1 - 0.983))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[1h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[1h])) )
-              > (14.4 * (1 - 0.983))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
 
               '
             for: 2m
@@ -37155,15 +37167,15 @@ objects:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[30m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[30m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
               ) > (6 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring"}[6h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring"}[6h])) )
-              > (6 * (1 - 0.983))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
 
               '
             for: 15m
@@ -37177,6 +37189,144 @@ objects:
             annotations:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
+        - name: sre-user-workload-monitoring-error-budget-burn
+          rules:
+          - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              == 0
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+          - alert: UserWorkloadMonitoringErrorBudgetBurnSRE
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              == 0
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 30m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+        - name: customer-user-workload-monitoring-error-budget-burn
+          rules:
+          - alert: UnscheduleableNodesPreventingUWMDeployment
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[5m]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[1h]))
+              ) > (14.4 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              > 0
+
+              '
+            for: 2m
+            labels:
+              long_window: 1h
+              severity: warning
+              namespace: openshift-monitoring
+              link: https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/clusteroperators/monitoring.md
+              short_window: 5m
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
+          - alert: UnscheduleableNodesPreventingUWMDeployment
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[30m]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason=~"UserWorkload.*"}[6h]))
+              ) > (6 * (1 - 0.983))
+
+              and
+
+              # check for unscheduleable customer worker nodes that do not have running
+              workload monitoring pods.
+
+              # if a unscheduleable worker node has running uwm pods then this budget
+              burn is not due to potential customer cordons and should be investigated
+
+              count ((kube_node_spec_unschedulable > 0 and on (node) cluster:nodes_roles{label_node_role_kubernetes_io!~"infra|master|control-plane"})
+              unless on (node) kube_pod_info{namespace="openshift-user-workload-monitoring"})
+              > 0
+
+              '
+            for: 15m
+            labels:
+              long_window: 6h
+              severity: critical
+              namespace: openshift-monitoring
+              short_window: 30m
+              send_managed_notification: 'true'
+              managed_notifcation_template: UnscheduleableNodesPreventingUWMDeployment
+            annotations:
+              message: 'High error budget burn for User Workload Monitoring (current
+                value: {{ $value }})'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
Feature

### What this PR does / why we need it?

This separates the UWM and Cluster Monitoring Error Budget Burn alerts so that we can notify customers automatically when a cordoned worker node is preventing UWM rollout.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-20673_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
