### PR TITLE
begin scan migration, rm from FR stg/int

### DIFF
--- a/deploy/osd-scanning/config.yaml
+++ b/deploy/osd-scanning/config.yaml
@@ -5,3 +5,7 @@ selectorSyncSet:
       operator: In
       values:
         - "true"
+    - key: api.openshift.com/environment
+      operator: In
+      values:
+        - "production"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31027,6 +31027,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31027,6 +31027,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31027,6 +31027,10 @@ objects:
         operator: In
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
As part of a migration of osd-scanning to app-interface, I need to disable automated malware scanning deployments in int/stg so I can test deployments to those environments via saas file.

### Which Jira/Github issue(s) this PR fixes?
[OSD-20014](https://issues.redhat.com//browse/OSD-20014)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
