### PR TITLE
Remove r7i.metal-48xl from the metal machine healthcheck based on QE …

### DIFF
--- a/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml
@@ -42,7 +42,6 @@ spec:
       - "i3.metal"
       - "i3en.metal"
       - "r7i.48xlarge"
-      - "r7i.metal-48xl"
   unhealthyConditions:
   - type:    "Ready"
     timeout: "480s"

--- a/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/012-machine-api.srep-metal-worker-healthcheck.MachineHealthCheck.yaml
@@ -42,7 +42,6 @@ spec:
       - "i3.metal"
       - "i3en.metal"
       - "r7i.48xlarge"
-      - "r7i.metal-48xl"
   unhealthyConditions:
   - type: "Ready"
     timeout: 8m

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29499,7 +29499,6 @@ objects:
             - i3.metal
             - i3en.metal
             - r7i.48xlarge
-            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -29553,7 +29552,6 @@ objects:
             - i3.metal
             - i3en.metal
             - r7i.48xlarge
-            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 8m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29499,7 +29499,6 @@ objects:
             - i3.metal
             - i3en.metal
             - r7i.48xlarge
-            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -29553,7 +29552,6 @@ objects:
             - i3.metal
             - i3en.metal
             - r7i.48xlarge
-            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 8m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29499,7 +29499,6 @@ objects:
             - i3.metal
             - i3en.metal
             - r7i.48xlarge
-            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 480s
@@ -29553,7 +29552,6 @@ objects:
             - i3.metal
             - i3en.metal
             - r7i.48xlarge
-            - r7i.metal-48xl
         unhealthyConditions:
         - type: Ready
           timeout: 8m


### PR DESCRIPTION
…test failure

### What type of PR is this?
cleanup

### What this PR does / why we need it?
Removes r7i.metal-48xl from metal machine healthcheck as QE showed it fails. 
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-21729

