### PR TITLE
Update the OBO prometheus rules

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-audit-webhook-cloud-watch-errors.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-audit-webhook-cloud-watch-errors.PrometheusRule.yaml
@@ -1,12 +1,12 @@
 ---
-apiVersion: monitoring.coreos.com/v1
+apiVersion: monitoring.rhobs/v1
 kind: PrometheusRule
 metadata:
   labels:
     prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
     role: alert-rules
   name: audit-webhook-error-putting-minimized-cloudwatch-log
-  namespace: openshift-observability-operator
+  namespace: openshift-observability-rhobs
 spec:
   groups:
     - name: AuditWebhookCloudWatchErrors

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
@@ -1,12 +1,12 @@
 ---
-apiVersion: monitoring.coreos.com/v1
+apiVersion: monitoring.rhobs/v1
 kind: PrometheusRule
 metadata:
   labels:
     prometheus: oidc-missing
     role: alert-rules
   name: oidc-missing
-  namespace: openshift-observability-operator
+  namespace: openshift-observability-rhobs
 spec:
   groups:
     - name: OIDCMissingFleetNotification

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37558,14 +37558,14 @@ objects:
         - management-cluster
     resourceApplyMode: Sync
     resources:
-    - apiVersion: monitoring.coreos.com/v1
+    - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
           role: alert-rules
         name: audit-webhook-error-putting-minimized-cloudwatch-log
-        namespace: openshift-observability-operator
+        namespace: openshift-observability-rhobs
       spec:
         groups:
         - name: AuditWebhookCloudWatchErrors
@@ -37585,14 +37585,14 @@ objects:
               send_managed_notification: 'true'
               managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
               namespace: '{{ $labels.namespace }}'
-    - apiVersion: monitoring.coreos.com/v1
+    - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: oidc-missing
           role: alert-rules
         name: oidc-missing
-        namespace: openshift-observability-operator
+        namespace: openshift-observability-rhobs
       spec:
         groups:
         - name: OIDCMissingFleetNotification

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37558,14 +37558,14 @@ objects:
         - management-cluster
     resourceApplyMode: Sync
     resources:
-    - apiVersion: monitoring.coreos.com/v1
+    - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
           role: alert-rules
         name: audit-webhook-error-putting-minimized-cloudwatch-log
-        namespace: openshift-observability-operator
+        namespace: openshift-observability-rhobs
       spec:
         groups:
         - name: AuditWebhookCloudWatchErrors
@@ -37585,14 +37585,14 @@ objects:
               send_managed_notification: 'true'
               managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
               namespace: '{{ $labels.namespace }}'
-    - apiVersion: monitoring.coreos.com/v1
+    - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: oidc-missing
           role: alert-rules
         name: oidc-missing
-        namespace: openshift-observability-operator
+        namespace: openshift-observability-rhobs
       spec:
         groups:
         - name: OIDCMissingFleetNotification

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37558,14 +37558,14 @@ objects:
         - management-cluster
     resourceApplyMode: Sync
     resources:
-    - apiVersion: monitoring.coreos.com/v1
+    - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: audit-webhook-error-putting-minimized-cloudwatch-log
           role: alert-rules
         name: audit-webhook-error-putting-minimized-cloudwatch-log
-        namespace: openshift-observability-operator
+        namespace: openshift-observability-rhobs
       spec:
         groups:
         - name: AuditWebhookCloudWatchErrors
@@ -37585,14 +37585,14 @@ objects:
               send_managed_notification: 'true'
               managed_notification_template: audit-webhook-error-putting-minimized-cloudwatch-log
               namespace: '{{ $labels.namespace }}'
-    - apiVersion: monitoring.coreos.com/v1
+    - apiVersion: monitoring.rhobs/v1
       kind: PrometheusRule
       metadata:
         labels:
           prometheus: oidc-missing
           role: alert-rules
         name: oidc-missing
-        namespace: openshift-observability-operator
+        namespace: openshift-observability-rhobs
       spec:
         groups:
         - name: OIDCMissingFleetNotification


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Update the prometheus rules to specifiy the namespace as `openshift-observability-rhobs` which has the label `hypershift.openshift.io/monitoring=true` to enable rule reload.

More context in [slack thread here](https://redhat-internal.slack.com/archives/C03FR4B5MS7/p1712128223276259)