### PR TITLE
ITN-56: Fix OSD-21066 cronjob

### DIFF
--- a/deploy/osd-21066-camo-olm-dance/00-roles.yaml
+++ b/deploy/osd-21066-camo-olm-dance/00-roles.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-monitoring
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-monitoring

--- a/deploy/osd-21066-camo-olm-dance/01-cronjob.yaml
+++ b/deploy/osd-21066-camo-olm-dance/01-cronjob.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-monitoring
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/5 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-monitoring
+
+              # Check for the presence of CAMO v0.1.581. If it exists, do nothing. If any other version is found clean up OLM resources
+              # The resources will be re-created with the latest verseion as we are keeping the subscription around.
+              if ! oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com configure-alertmanager-operator.v0.1.581-c2526fb; then
+                oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com $(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName=="configure-alertmanager-operator")].metadata.name}') || true
+                oc -n "$NAMESPACE" delete installplan.operators.coreos.com -l operators.coreos.com/configure-alertmanager-operator.openshift-monitoring=""
+              fi
+
+              # Prevent the job from -rerunning
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/deploy/osd-21066-camo-olm-dance/README.md
+++ b/deploy/osd-21066-camo-olm-dance/README.md
@@ -1,0 +1,2 @@
+# README
+This cronjob is a fix for https://issues.redhat.com/browse/OSD-21066 and ITN-056

--- a/deploy/osd-21066-camo-olm-dance/config.yaml
+++ b/deploy/osd-21066-camo-olm-dance/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11","4.12","4.13","4.14","4.15"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24334,6 +24334,135 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-21066-camo-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-monitoring
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-monitoring\n\
+                    \n# Check for the presence of CAMO v0.1.581. If it exists, do\
+                    \ nothing. If any other version is found clean up OLM resources\n\
+                    # The resources will be re-created with the latest verseion as\
+                    \ we are keeping the subscription around.\nif ! oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com configure-alertmanager-operator.v0.1.581-c2526fb;\
+                    \ then\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"configure-alertmanager-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/configure-alertmanager-operator.openshift-monitoring=\"\
+                    \"\nfi\n\n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\"\
+                    \ delete cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete role sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\"\
+                    \ delete rolebinding sre-operator-reinstall-rb || true\noc -n\
+                    \ \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24334,6 +24334,135 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-21066-camo-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-monitoring
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-monitoring\n\
+                    \n# Check for the presence of CAMO v0.1.581. If it exists, do\
+                    \ nothing. If any other version is found clean up OLM resources\n\
+                    # The resources will be re-created with the latest verseion as\
+                    \ we are keeping the subscription around.\nif ! oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com configure-alertmanager-operator.v0.1.581-c2526fb;\
+                    \ then\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"configure-alertmanager-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/configure-alertmanager-operator.openshift-monitoring=\"\
+                    \"\nfi\n\n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\"\
+                    \ delete cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete role sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\"\
+                    \ delete rolebinding sre-operator-reinstall-rb || true\noc -n\
+                    \ \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24334,6 +24334,135 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-21066-camo-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-monitoring
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-monitoring
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/5 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-monitoring\n\
+                    \n# Check for the presence of CAMO v0.1.581. If it exists, do\
+                    \ nothing. If any other version is found clean up OLM resources\n\
+                    # The resources will be re-created with the latest verseion as\
+                    \ we are keeping the subscription around.\nif ! oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com configure-alertmanager-operator.v0.1.581-c2526fb;\
+                    \ then\n  oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"configure-alertmanager-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/configure-alertmanager-operator.openshift-monitoring=\"\
+                    \"\nfi\n\n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\"\
+                    \ delete cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete role sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\"\
+                    \ delete rolebinding sre-operator-reinstall-rb || true\noc -n\
+                    \ \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

This PR adds a cronjob for a fleet wide CAMO olm dance, which was not fully successful with https://github.com/openshift/managed-cluster-config/pull/2051. 

The previous PR had a bug that prevented CSVs from being deleted:
```
# This never works, the CSV doesn't have this label
oc -n openshift-monitoring delete clusterserviceversions.operators.coreos.com -l operators.coreos.com/configure-alertmanager-operator.openshift-monitoring=
```

The faulty olm dance is causing a lot of logs to be written in the catalog operator pod and potentially causes weird states on the clusters it ran on (according to telemetry `count(sre:operators:succeeded{name="ocm-agent-operator"})` is 1755, whereas  `count(sre:operators:succeeded{name="configure-alertmanager-operator"})`  is around 200). 

We need this olm dance to put the fleet back on the right version and resolve the excessive logging and potential high networking loads (the latter is unconfirmed to be related). 

The changes with this OLM dance compared to the previous one:
- fixed csv deletion
- keep the subscription as is, it will allow olm to get the latest version

### Which Jira/Github issue(s) this PR fixes?

Fixes ITN56

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
