### PR TITLE
added /health so console would curl lightweight health endpoint

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -103,4 +103,4 @@ spec:
       summary: "Action required: User Workload Monitoring is degraded"
       logType: Cluster Configuration
       references:
-        - "https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes"
+        - "https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html"

--- a/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.console.RouteMonitor.yaml
+++ b/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.console.RouteMonitor.yaml
@@ -7,5 +7,6 @@ spec:
   route:
     name: console
     namespace: openshift-console
+    suffix: /health
   slo:
     targetAvailabilityPercent: "99.5"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22820,7 +22820,7 @@ objects:
           summary: 'Action required: User Workload Monitoring is degraded'
           logType: Cluster Configuration
           references:
-          - https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes
+          - https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -31035,6 +31035,7 @@ objects:
         route:
           name: console
           namespace: openshift-console
+          suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22820,7 +22820,7 @@ objects:
           summary: 'Action required: User Workload Monitoring is degraded'
           logType: Cluster Configuration
           references:
-          - https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes
+          - https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -31035,6 +31035,7 @@ objects:
         route:
           name: console
           namespace: openshift-console
+          suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22820,7 +22820,7 @@ objects:
           summary: 'Action required: User Workload Monitoring is degraded'
           logType: Cluster Configuration
           references:
-          - https://docs.openshift.com/rosa/nodes/nodes/rosa-working-with-nodes
+          - https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -31035,6 +31035,7 @@ objects:
         route:
           name: console
           namespace: openshift-console
+          suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Bug
### What this PR does / why we need it?
change the URL so RMO would query the lightweight /health endpoint.Not /healthz because that would redirect to the console.
### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-22053
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
