### PR TITLE
Add patch for default ingress router replicas to 3, based on the Org ID of the ClusterDeployment

### DIFF
--- a/deploy/osd-ingress/routerreplicas-osd-20989/10-routerreplics.ingresscontroller.yaml
+++ b/deploy/osd-ingress/routerreplicas-osd-20989/10-routerreplics.ingresscontroller.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: IngressController
+name: default
+namespace: openshift-ingress-operator
+applyMode: AlwaysApply
+patch: '{"spec":{"replicas":3}}'
+patchType: merge

--- a/deploy/osd-ingress/routerreplicas-osd-20989/config.yaml
+++ b/deploy/osd-ingress/routerreplicas-osd-20989/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/legal-entity-id
+      operator: In
+      values: "${{ROUTER_REPLICA_ORG_IDS}}"
+    - key: api.openshift.com/multi-az
+      operator: In
+      values: "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28887,6 +28887,34 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-ingress-routerreplicas-osd-20989
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ROUTER_REPLICA_ORG_IDS}}
+      - key: api.openshift.com/multi-az
+        operator: In
+        values: 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-legacy-ingress-feature-labeller
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28887,6 +28887,34 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-ingress-routerreplicas-osd-20989
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ROUTER_REPLICA_ORG_IDS}}
+      - key: api.openshift.com/multi-az
+        operator: In
+        values: 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-legacy-ingress-feature-labeller
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28887,6 +28887,34 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-ingress-routerreplicas-osd-20989
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/legal-entity-id
+        operator: In
+        values: ${{ROUTER_REPLICA_ORG_IDS}}
+      - key: api.openshift.com/multi-az
+        operator: In
+        values: 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: v1
+      kind: IngressController
+      name: default
+      namespace: openshift-ingress-operator
+      applyMode: AlwaysApply
+      patch: '{"spec":{"replicas":3}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-legacy-ingress-feature-labeller
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Copies OSD-8028, but instead of cluster ID, based on org ID

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-20989