### PR TITLE
OSD-22258: need to use full kind name to avoid confusion

### DIFF
--- a/deploy/osd-curated-operatorsources-revert/01-osd-patch-subscription-source.ClusterRole.yaml
+++ b/deploy/osd-curated-operatorsources-revert/01-osd-patch-subscription-source.ClusterRole.yaml
@@ -6,7 +6,7 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
-  - subscriptions
+  - subscriptions.operators.coreos.com
   verbs:
   - patch
   - get

--- a/deploy/osd-curated-operatorsources-revert/10-osd-patch-subscription-source.CronJob.yaml
+++ b/deploy/osd-curated-operatorsources-revert/10-osd-patch-subscription-source.CronJob.yaml
@@ -44,30 +44,30 @@ spec:
               # NOTE there are loops for each source to keep the jsonpath simple and the logic easy to read
 
               echo START
-              for NS in $(oc get subscription -A -o jsonpath='{.items[?(@.spec.source=="osd-curated-redhat-operators")].metadata.namespace}');
+              for NS in $(oc get subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.spec.source=="osd-curated-redhat-operators")].metadata.namespace}');
               do
-                for SUB in $(oc -n $NS get subscription -o jsonpath='{.items[?(@.spec.source=="osd-curated-redhat-operators")].metadata.name}');
+                for SUB in $(oc -n $NS get subscriptions.operators.coreos.com -o jsonpath='{.items[?(@.spec.source=="osd-curated-redhat-operators")].metadata.name}');
                 do
                   echo "Patching subscription '$SUB' in namespace '$NS'"
-                  oc -n $NS patch subscription $SUB --patch '{"spec":{"source":"redhat-operators"}}' --type merge
+                  oc -n $NS patch subscriptions.operators.coreos.com $SUB --patch '{"spec":{"source":"redhat-operators"}}' --type merge
                 done
               done
 
-              for NS in $(oc get subscription -A -o jsonpath='{.items[?(@.spec.source=="osd-curated-certified-operators")].metadata.namespace}');
+              for NS in $(oc get subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.spec.source=="osd-curated-certified-operators")].metadata.namespace}');
               do
-                for SUB in $(oc -n $NS get subscription -o jsonpath='{.items[?(@.spec.source=="osd-curated-certified-operators")].metadata.name}');
+                for SUB in $(oc -n $NS get subscriptions.operators.coreos.com -o jsonpath='{.items[?(@.spec.source=="osd-curated-certified-operators")].metadata.name}');
                 do
                   echo "Patching subscription '$SUB' in namespace '$NS'"
-                  oc -n $NS patch subscription $SUB --patch '{"spec":{"source":"certified-operators"}}' --type merge
+                  oc -n $NS patch subscriptions.operators.coreos.com $SUB --patch '{"spec":{"source":"certified-operators"}}' --type merge
                 done
               done
 
-              for NS in $(oc get subscription -A -o jsonpath='{.items[?(@.spec.source=="osd-curated-community-operators")].metadata.namespace}');
+              for NS in $(oc get subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.spec.source=="osd-curated-community-operators")].metadata.namespace}');
               do
-                for SUB in $(oc -n $NS get subscription -o jsonpath='{.items[?(@.spec.source=="osd-curated-community-operators")].metadata.name}');
+                for SUB in $(oc -n $NS get subscriptions.operators.coreos.com -o jsonpath='{.items[?(@.spec.source=="osd-curated-community-operators")].metadata.name}');
                 do
                   echo "Patching subscription '$SUB' in namespace '$NS'"
-                  oc -n $NS patch subscription $SUB --patch '{"spec":{"source":"community-operators"}}' --type merge
+                  oc -n $NS patch subscriptions.operators.coreos.com $SUB --patch '{"spec":{"source":"community-operators"}}' --type merge
                 done
               done
               echo FINISH

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27180,7 +27180,7 @@ objects:
       - apiGroups:
         - operators.coreos.com
         resources:
-        - subscriptions
+        - subscriptions.operators.coreos.com
         verbs:
         - patch
         - get
@@ -27240,27 +27240,28 @@ objects:
                     \ for each subscription having a curated source\n# patch the source\n\
                     # NOTE there are loops for each source to keep the jsonpath simple\
                     \ and the logic easy to read\n\necho START\nfor NS in $(oc get\
-                    \ subscription -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-redhat-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.spec.source==\"\
+                    osd-curated-redhat-operators\")].metadata.namespace}');\ndo\n\
+                    \  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-redhat-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"redhat-operators\"}}' --type\
-                    \ merge\n  done\ndone\n\nfor NS in $(oc get subscription -A -o\
-                    \ jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"redhat-operators\"}}'\
+                    \ --type merge\n  done\ndone\n\nfor NS in $(oc get subscriptions.operators.coreos.com\
+                    \ -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
+                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"certified-operators\"}}' --type\
-                    \ merge\n  done\ndone\n\nfor NS in $(oc get subscription -A -o\
-                    \ jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"certified-operators\"\
+                    }}' --type merge\n  done\ndone\n\nfor NS in $(oc get subscriptions.operators.coreos.com\
+                    \ -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
+                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"community-operators\"}}' --type\
-                    \ merge\n  done\ndone\necho FINISH\n"
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"community-operators\"\
+                    }}' --type merge\n  done\ndone\necho FINISH\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27180,7 +27180,7 @@ objects:
       - apiGroups:
         - operators.coreos.com
         resources:
-        - subscriptions
+        - subscriptions.operators.coreos.com
         verbs:
         - patch
         - get
@@ -27240,27 +27240,28 @@ objects:
                     \ for each subscription having a curated source\n# patch the source\n\
                     # NOTE there are loops for each source to keep the jsonpath simple\
                     \ and the logic easy to read\n\necho START\nfor NS in $(oc get\
-                    \ subscription -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-redhat-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.spec.source==\"\
+                    osd-curated-redhat-operators\")].metadata.namespace}');\ndo\n\
+                    \  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-redhat-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"redhat-operators\"}}' --type\
-                    \ merge\n  done\ndone\n\nfor NS in $(oc get subscription -A -o\
-                    \ jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"redhat-operators\"}}'\
+                    \ --type merge\n  done\ndone\n\nfor NS in $(oc get subscriptions.operators.coreos.com\
+                    \ -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
+                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"certified-operators\"}}' --type\
-                    \ merge\n  done\ndone\n\nfor NS in $(oc get subscription -A -o\
-                    \ jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"certified-operators\"\
+                    }}' --type merge\n  done\ndone\n\nfor NS in $(oc get subscriptions.operators.coreos.com\
+                    \ -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
+                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"community-operators\"}}' --type\
-                    \ merge\n  done\ndone\necho FINISH\n"
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"community-operators\"\
+                    }}' --type merge\n  done\ndone\necho FINISH\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27180,7 +27180,7 @@ objects:
       - apiGroups:
         - operators.coreos.com
         resources:
-        - subscriptions
+        - subscriptions.operators.coreos.com
         verbs:
         - patch
         - get
@@ -27240,27 +27240,28 @@ objects:
                     \ for each subscription having a curated source\n# patch the source\n\
                     # NOTE there are loops for each source to keep the jsonpath simple\
                     \ and the logic easy to read\n\necho START\nfor NS in $(oc get\
-                    \ subscription -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-redhat-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ subscriptions.operators.coreos.com -A -o jsonpath='{.items[?(@.spec.source==\"\
+                    osd-curated-redhat-operators\")].metadata.namespace}');\ndo\n\
+                    \  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-redhat-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"redhat-operators\"}}' --type\
-                    \ merge\n  done\ndone\n\nfor NS in $(oc get subscription -A -o\
-                    \ jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"redhat-operators\"}}'\
+                    \ --type merge\n  done\ndone\n\nfor NS in $(oc get subscriptions.operators.coreos.com\
+                    \ -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
+                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-certified-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"certified-operators\"}}' --type\
-                    \ merge\n  done\ndone\n\nfor NS in $(oc get subscription -A -o\
-                    \ jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
-                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscription\
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"certified-operators\"\
+                    }}' --type merge\n  done\ndone\n\nfor NS in $(oc get subscriptions.operators.coreos.com\
+                    \ -A -o jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
+                    )].metadata.namespace}');\ndo\n  for SUB in $(oc -n $NS get subscriptions.operators.coreos.com\
                     \ -o jsonpath='{.items[?(@.spec.source==\"osd-curated-community-operators\"\
                     )].metadata.name}');\n  do\n    echo \"Patching subscription '$SUB'\
-                    \ in namespace '$NS'\"\n    oc -n $NS patch subscription $SUB\
-                    \ --patch '{\"spec\":{\"source\":\"community-operators\"}}' --type\
-                    \ merge\n  done\ndone\necho FINISH\n"
+                    \ in namespace '$NS'\"\n    oc -n $NS patch subscriptions.operators.coreos.com\
+                    \ $SUB --patch '{\"spec\":{\"source\":\"community-operators\"\
+                    }}' --type merge\n  done\ndone\necho FINISH\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
subscriptions.operators.coreos.com kind should be used to not make confusion when other subscriptions kind are defined

### Which Jira/Github issue(s) this PR fixes?

_Fixes OCPBUGS-32102_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
