### PR TITLE
add addon-acs-fleetshard-qa perm which is used for ACS staging env clusters

### DIFF
--- a/deploy/backplane/acs/config.yaml
+++ b/deploy/backplane/acs/config.yaml
@@ -2,5 +2,6 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchLabels:
     api.openshift.com/addon-acs-fleetshard: "true"
+    api.openshift.com/addon-acs-fleetshard-qa: "true"
     api.openshift.com/addon-acs-fleetshard-dev: "true"
   matchLabelsApplyMode: "OR"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8005,12 +8005,12 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: backplane-acs-addon-acs-fleetshard-dev
+    name: backplane-acs-addon-acs-fleetshard-qa
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/addon-acs-fleetshard-dev: 'true'
+        api.openshift.com/addon-acs-fleetshard-qa: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -8087,12 +8087,12 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: backplane-acs-addon-acs-fleetshard-qa
+    name: backplane-acs-addon-acs-fleetshard-dev
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/addon-acs-fleetshard-qa: 'true'
+        api.openshift.com/addon-acs-fleetshard-dev: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8087,6 +8087,88 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-acs-addon-acs-fleetshard-qa
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-acs-fleetshard-qa: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-addon-acs-fleet-shard
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-acs-admins-project
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: view
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-acs-admins-project
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-acs-admins-project
+      rules:
+      - apiGroups:
+        - platform.stackrox.io
+        resources:
+        - centrals
+        - securedclusters
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - pods/log
+        verbs:
+        - get
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - create
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments/scale
+        verbs:
+        - patch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8005,12 +8005,12 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: backplane-acs-addon-acs-fleetshard-dev
+    name: backplane-acs-addon-acs-fleetshard-qa
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/addon-acs-fleetshard-dev: 'true'
+        api.openshift.com/addon-acs-fleetshard-qa: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -8087,12 +8087,12 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: backplane-acs-addon-acs-fleetshard-qa
+    name: backplane-acs-addon-acs-fleetshard-dev
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/addon-acs-fleetshard-qa: 'true'
+        api.openshift.com/addon-acs-fleetshard-dev: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8087,6 +8087,88 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-acs-addon-acs-fleetshard-qa
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-acs-fleetshard-qa: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-addon-acs-fleet-shard
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-acs-admins-project
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: view
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-acs-admins-project
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-acs-admins-project
+      rules:
+      - apiGroups:
+        - platform.stackrox.io
+        resources:
+        - centrals
+        - securedclusters
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - pods/log
+        verbs:
+        - get
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - create
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments/scale
+        verbs:
+        - patch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8005,12 +8005,12 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: backplane-acs-addon-acs-fleetshard-dev
+    name: backplane-acs-addon-acs-fleetshard-qa
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/addon-acs-fleetshard-dev: 'true'
+        api.openshift.com/addon-acs-fleetshard-qa: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -8087,12 +8087,12 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: backplane-acs-addon-acs-fleetshard-qa
+    name: backplane-acs-addon-acs-fleetshard-dev
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-        api.openshift.com/addon-acs-fleetshard-qa: 'true'
+        api.openshift.com/addon-acs-fleetshard-dev: 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8087,6 +8087,88 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: backplane-acs-addon-acs-fleetshard-qa
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+        api.openshift.com/addon-acs-fleetshard-qa: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane-addon-acs-fleet-shard
+    - apiVersion: managed.openshift.io/v1alpha1
+      kind: SubjectPermission
+      metadata:
+        name: backplane-acs-admins-project
+        namespace: openshift-rbac-permissions
+      spec:
+        permissions:
+        - clusterRoleName: view
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        - clusterRoleName: backplane-acs-admins-project
+          namespacesAllowedRegex: (^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*)
+          namespacesDeniedRegex: openshift-backplane-cluster-admin
+        subjectKind: Group
+        subjectName: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: backplane-acs-admins-project
+      rules:
+      - apiGroups:
+        - platform.stackrox.io
+        resources:
+        - centrals
+        - securedclusters
+        verbs:
+        - get
+        - list
+        - watch
+        - patch
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        - pods/log
+        verbs:
+        - get
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - pods
+        verbs:
+        - create
+      - apiGroups:
+        - apps
+        resources:
+        - statefulsets
+        - deployments
+        verbs:
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments/scale
+        verbs:
+        - patch
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: backplane-addon-connectors-addon-connectors-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
…

### What type of PR is this?
_feature_

### What this PR does / why we need it?

to avoid error 
```
Error from server (Forbidden): pods is forbidden: User "system:serviceaccount:openshift-backplane-addon-acs-fleet-shard:866e0f78f261aa98eee4de393f97049e" cannot list resource "pods" in API group "" in the namespace "rhacs"
```
for ACS clusters where  clusterdeployment  .items[].metadata.labels has  "api.openshift.com/addon-acs-fleetshard-qe": "true",

### Which Jira/Github issue(s) this PR fixes?

Part of bigger push to get ACS backplane access to their clusters [ROX-23556](https://issues.redhat.com/browse/ROX-23556)
