### PR TITLE
Fix syntax error preventing rollout

### DIFF
--- a/deploy/osd-ingress/routerreplicas-osd-20989/config.yaml
+++ b/deploy/osd-ingress/routerreplicas-osd-20989/config.yaml
@@ -6,4 +6,5 @@ selectorSyncSet:
       values: "${{ROUTER_REPLICA_ORG_IDS}}"
     - key: api.openshift.com/multi-az
       operator: In
-      values: "true"
+      values: 
+        - "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ORG_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL
@@ -28981,7 +28983,8 @@ objects:
         values: ${{ROUTER_REPLICA_ORG_IDS}}
       - key: api.openshift.com/multi-az
         operator: In
-        values: 'true'
+        values:
+        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ORG_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL
@@ -28981,7 +28983,8 @@ objects:
         values: ${{ROUTER_REPLICA_ORG_IDS}}
       - key: api.openshift.com/multi-az
         operator: In
-        values: 'true'
+        values:
+        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ORG_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL
@@ -28981,7 +28983,8 @@ objects:
         values: ${{ROUTER_REPLICA_ORG_IDS}}
       - key: api.openshift.com/multi-az
         operator: In
-        values: 'true'
+        values:
+        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: v1

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -22,6 +22,8 @@ parameters:
   required: true
 - name: ROUTER_REPLICA_CLUSTER_IDS
   required: true
+- name: ROUTER_REPLICA_ORG_IDS
+  required: true
 - name: SEGMENT_API_KEY
   required: true
 - name: RHOBS_URL


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
The rollout or #2077 is currently failing due to
```
[2024-04-11 19:49:12] [ERROR] [openshift_base.py:apply_action:864] - [hives03ue1/cluster-scope] [https://api.hives03ue1.2yi8.p1.openshiftapps.com:6443/]: The SelectorSyncSet "osd-ingress-routerreplicas-osd-20989" is invalid: 
* spec.clusterDeploymentSelector.matchExpressions[0].values: Invalid value: "string": spec.clusterDeploymentSelector.matchExpressions[0].values in body must be of type array: "string"
* spec.clusterDeploymentSelector.matchExpressions[1].values: Invalid value: "string": spec.clusterDeploymentSelector.matchExpressions[1].values in body must be of type array: "string"
```

### Which Jira/Github issue(s) this PR fixes?
[OSD-20989](https://issues.redhat.com//browse/OSD-20989)