### PR TITLE
Add ec2:DescribeDhcpOptions to CAPA controller for HCP

### DIFF
--- a/resources/sts/4.14/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.14/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -4,6 +4,7 @@
     {
       "Sid": "ReadPermissions",      
       "Action": [
+        "ec2:DescribeDhcpOptions",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
         "ec2:DescribeInternetGateways",

--- a/resources/sts/4.15/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.15/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -4,6 +4,7 @@
     {
       "Sid": "ReadPermissions",      
       "Action": [
+        "ec2:DescribeDhcpOptions",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
         "ec2:DescribeInternetGateways",

--- a/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -4,6 +4,7 @@
     {
       "Sid": "ReadPermissions",      
       "Action": [
+        "ec2:DescribeDhcpOptions",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
         "ec2:DescribeInternetGateways",


### PR DESCRIPTION
### What this PR does / why we need it?
Addes ec2:DescribeDhcpOptions to the HCP managed policies. This permission has been added upstream and needs to be reflected here. 
https://issues.redhat.com/browse/OCPBUGS-29391
https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4841
https://github.com/openshift/hypershift/pull/3779

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-22325


### Special notes for your reviewer:
NOTE, THIS IS JUST TRACKING FOR SUBMISSION TO AWS. This PR being merged does NOT mean the permission is available for HCP yet. 