### PR TITLE
Consolidate image registry config patches

### DIFF
--- a/deploy/osd-registry/cluster.Config.patch.yaml
+++ b/deploy/osd-registry/cluster.Config.patch.yaml
@@ -4,5 +4,5 @@ kind: Config
 name: cluster
 # patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
 # patch registry to expose default route: https://docs.openshift.com/container-platform/4.1/registry/configuring-registry-operator.html#registry-operator-default-crd_configuring-registry-operator
-patch: '{"spec":{"defaultRoute":true,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
+patch: '{"spec":{"managementState":"Managed","defaultRoute":true,"nodeSelector":null,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
 patchType: merge

--- a/deploy/osd-registry/cluster.Config.removeNodeSelector.patch.yaml
+++ b/deploy/osd-registry/cluster.Config.removeNodeSelector.patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: imageregistry.operator.openshift.io/v1
-applyMode: AlwaysApply
-kind: Config
-name: cluster
-# patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
-# patch registry to expose default route: https://docs.openshift.com/container-platform/4.1/registry/configuring-registry-operator.html#registry-operator-default-crd_configuring-registry-operator
-patch: '{"spec":{"nodeSelector": null}}'
-patchType: merge

--- a/deploy/osd-registry/config.yaml
+++ b/deploy/osd-registry/config.yaml
@@ -1,6 +1,1 @@
 deploymentMode: "SelectorSyncSet"
-selectorSyncSet:
-  matchExpressions:
-  - key: hive.openshift.io/version-major-minor
-    operator: NotIn
-    values: ["4.0","4.1","4.2","4.3","4.4"]

--- a/deploy/osd-registry/legacy/cluster.Config.patch.yaml
+++ b/deploy/osd-registry/legacy/cluster.Config.patch.yaml
@@ -1,8 +1,0 @@
-apiVersion: imageregistry.operator.openshift.io/v1
-applyMode: AlwaysApply
-kind: Config
-name: cluster
-# patch registry to deploy on infras: https://docs.openshift.com/container-platform/4.2/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets
-# patch registry to expose default route: https://docs.openshift.com/container-platform/4.1/registry/configuring-registry-operator.html#registry-operator-default-crd_configuring-registry-operator
-patch: '{"spec":{"defaultRoute":true,"nodeSelector":{"node-role.kubernetes.io/infra":""},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
-patchType: merge

--- a/deploy/osd-registry/legacy/config.yaml
+++ b/deploy/osd-registry/legacy/config.yaml
@@ -1,6 +1,0 @@
-deploymentMode: "SelectorSyncSet"
-selectorSyncSet:
-  matchExpressions:
-  - key: hive.openshift.io/version-major-minor
-    operator: In
-    values: ["4.0","4.1","4.2","4.3","4.4"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29195,57 +29195,13 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: hive.openshift.io/version-major-minor
-        operator: NotIn
-        values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
     resourceApplyMode: Sync
     patches:
     - apiVersion: imageregistry.operator.openshift.io/v1
       applyMode: AlwaysApply
       kind: Config
       name: cluster
-      patch: '{"spec":{"defaultRoute":true,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
-      patchType: merge
-    - apiVersion: imageregistry.operator.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: Config
-      name: cluster
-      patch: '{"spec":{"nodeSelector": null}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: osd-registry-legacy
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: hive.openshift.io/version-major-minor
-        operator: In
-        values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: imageregistry.operator.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: Config
-      name: cluster
-      patch: '{"spec":{"defaultRoute":true,"nodeSelector":{"node-role.kubernetes.io/infra":""},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
+      patch: '{"spec":{"managementState":"Managed","defaultRoute":true,"nodeSelector":null,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29195,57 +29195,13 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: hive.openshift.io/version-major-minor
-        operator: NotIn
-        values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
     resourceApplyMode: Sync
     patches:
     - apiVersion: imageregistry.operator.openshift.io/v1
       applyMode: AlwaysApply
       kind: Config
       name: cluster
-      patch: '{"spec":{"defaultRoute":true,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
-      patchType: merge
-    - apiVersion: imageregistry.operator.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: Config
-      name: cluster
-      patch: '{"spec":{"nodeSelector": null}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: osd-registry-legacy
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: hive.openshift.io/version-major-minor
-        operator: In
-        values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: imageregistry.operator.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: Config
-      name: cluster
-      patch: '{"spec":{"defaultRoute":true,"nodeSelector":{"node-role.kubernetes.io/infra":""},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
+      patch: '{"spec":{"managementState":"Managed","defaultRoute":true,"nodeSelector":null,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29195,57 +29195,13 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: hive.openshift.io/version-major-minor
-        operator: NotIn
-        values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
     resourceApplyMode: Sync
     patches:
     - apiVersion: imageregistry.operator.openshift.io/v1
       applyMode: AlwaysApply
       kind: Config
       name: cluster
-      patch: '{"spec":{"defaultRoute":true,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
-      patchType: merge
-    - apiVersion: imageregistry.operator.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: Config
-      name: cluster
-      patch: '{"spec":{"nodeSelector": null}}'
-      patchType: merge
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
-    name: osd-registry-legacy
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: hive.openshift.io/version-major-minor
-        operator: In
-        values:
-        - '4.0'
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-    resourceApplyMode: Sync
-    patches:
-    - apiVersion: imageregistry.operator.openshift.io/v1
-      applyMode: AlwaysApply
-      kind: Config
-      name: cluster
-      patch: '{"spec":{"defaultRoute":true,"nodeSelector":{"node-role.kubernetes.io/infra":""},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
+      patch: '{"spec":{"managementState":"Managed","defaultRoute":true,"nodeSelector":null,"affinity":{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/infra","operator":"Exists"}]},"weight":1}]}},"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/infra","operator":"Exists"}]}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
We don't support 4.4 clusters anymore, so consolidate all the image registry patches into a single patch.

### Which Jira/Github issue(s) this PR fixes?

fixes [OSD-22476](https://issues.redhat.com//browse/OSD-22476)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
