### PR TITLE
OSD-20859 - Use insecure probes for console to avoid failures from redirects

### DIFF
--- a/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.console.RouteMonitor.yaml
+++ b/deploy/osd-route-monitor-operator/100-openshift-route-monitor-operator.console.RouteMonitor.yaml
@@ -10,3 +10,5 @@ spec:
     suffix: /health
   slo:
     targetAvailabilityPercent: "99.5"
+  # Remove once https://issues.redhat.com/browse/OSD-20859 is promoted
+  insecureSkipTLSVerify: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29289,6 +29289,7 @@ objects:
           suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
+        insecureSkipTLSVerify: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29289,6 +29289,7 @@ objects:
           suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
+        insecureSkipTLSVerify: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29289,6 +29289,7 @@ objects:
           suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
+        insecureSkipTLSVerify: true
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION

### What type of PR is this?
_bug_

### What this PR does / why we need it?

Provides a "stop-gap" solution to the problem of blackbox probes failing when the console pods return a 301. This http code is returned when customers set custom console URLs, as it redirects the probe to use that URL instead of the one configured by the routemonitor object.

### Which Jira/Github issue(s) this PR fixes?

Related to https://issues.redhat.com/browse/OSD-20859 (this is a stop-gap solution, it does not fix the root cause)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
