### PR TITLE
Refactors the upstream PDBLimit alert

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-poddisruptionbudget
+    role: alert-rules
+  name: sre-poddisruptionbudget
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-poddisruptionbudget
+    rules:
+    - alert: PodDisruptionBudgetLimitSRE
+      # This takes the original PodDisruptionBudgetLimit alert and adjusts to filter by namespace
+      # In the first max by() statement we ONLY care about the `openshift-*` namespaces. We then
+      # do an AND on any namespaces that are NOT `openshift-logging`, `openshift-operators`,
+      # or `openshift-user-workload-monitoring`. When we join the two statements together we are
+      # left with only the openshift-* namespaces that are NOT excluded by the second statement
+      #
+      # To add more openshift-* namespaces to the exclusion list, add them to the
+      # second statement below.
+      expr: |-
+        max by(namespace, poddisruptionbudget) (
+            kube_poddisruptionbudget_status_current_healthy{namespace=~"openshift-.*"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~"openshift-.*"}
+        )
+        and
+        max by(namespace, poddisruptionbudget) (
+            kube_poddisruptionbudget_status_current_healthy{namespace!~"openshift-(logging|user-workload-monitoring|operators)"} < kube_poddisruptionbudget_status_desired_healthy{namespace!~"openshift-(logging|user-workload-monitoring|operators)"}
+        )
+      for: 15m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        message: The pod disruption budget is below the minimum disruptions allowed level and is not satisfied. The number of current healthy pods is less than the desired healthy pods.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34159,6 +34159,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-poddisruptionbudget
+          role: alert-rules
+        name: sre-poddisruptionbudget
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-poddisruptionbudget
+          rules:
+          - alert: PodDisruptionBudgetLimitSRE
+            expr: "max by(namespace, poddisruptionbudget) (\n    kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
+              openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
+              openshift-.*\"}\n)\nand\nmax by(namespace, poddisruptionbudget) (\n\
+              \    kube_poddisruptionbudget_status_current_healthy{namespace!~\"openshift-(logging|user-workload-monitoring|operators)\"\
+              } < kube_poddisruptionbudget_status_desired_healthy{namespace!~\"openshift-(logging|user-workload-monitoring|operators)\"\
+              }\n)"
+            for: 15m
+            labels:
+              severity: critical
+            annotations:
+              message: The pod disruption budget is below the minimum disruptions
+                allowed level and is not satisfied. The number of current healthy
+                pods is less than the desired healthy pods.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pruning
           role: alert-rules
         name: sre-pruning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34177,6 +34177,7 @@ objects:
             for: 15m
             labels:
               severity: critical
+              namespace: openshift-monitoring
             annotations:
               message: The pod disruption budget is below the minimum disruptions
                 allowed level and is not satisfied. The number of current healthy

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34159,6 +34159,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-poddisruptionbudget
+          role: alert-rules
+        name: sre-poddisruptionbudget
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-poddisruptionbudget
+          rules:
+          - alert: PodDisruptionBudgetLimitSRE
+            expr: "max by(namespace, poddisruptionbudget) (\n    kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
+              openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
+              openshift-.*\"}\n)\nand\nmax by(namespace, poddisruptionbudget) (\n\
+              \    kube_poddisruptionbudget_status_current_healthy{namespace!~\"openshift-(logging|user-workload-monitoring|operators)\"\
+              } < kube_poddisruptionbudget_status_desired_healthy{namespace!~\"openshift-(logging|user-workload-monitoring|operators)\"\
+              }\n)"
+            for: 15m
+            labels:
+              severity: critical
+            annotations:
+              message: The pod disruption budget is below the minimum disruptions
+                allowed level and is not satisfied. The number of current healthy
+                pods is less than the desired healthy pods.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pruning
           role: alert-rules
         name: sre-pruning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34177,6 +34177,7 @@ objects:
             for: 15m
             labels:
               severity: critical
+              namespace: openshift-monitoring
             annotations:
               message: The pod disruption budget is below the minimum disruptions
                 allowed level and is not satisfied. The number of current healthy

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34159,6 +34159,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-poddisruptionbudget
+          role: alert-rules
+        name: sre-poddisruptionbudget
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-poddisruptionbudget
+          rules:
+          - alert: PodDisruptionBudgetLimitSRE
+            expr: "max by(namespace, poddisruptionbudget) (\n    kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
+              openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
+              openshift-.*\"}\n)\nand\nmax by(namespace, poddisruptionbudget) (\n\
+              \    kube_poddisruptionbudget_status_current_healthy{namespace!~\"openshift-(logging|user-workload-monitoring|operators)\"\
+              } < kube_poddisruptionbudget_status_desired_healthy{namespace!~\"openshift-(logging|user-workload-monitoring|operators)\"\
+              }\n)"
+            for: 15m
+            labels:
+              severity: critical
+            annotations:
+              message: The pod disruption budget is below the minimum disruptions
+                allowed level and is not satisfied. The number of current healthy
+                pods is less than the desired healthy pods.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-pruning
           role: alert-rules
         name: sre-pruning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34177,6 +34177,7 @@ objects:
             for: 15m
             labels:
               severity: critical
+              namespace: openshift-monitoring
             annotations:
               message: The pod disruption budget is below the minimum disruptions
                 allowed level and is not satisfied. The number of current healthy


### PR DESCRIPTION
Refactors the upstream PDBLimit alert for SRE to be targeted to Managed Workloads.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

Feature

### What this PR does / why we need it?

This refactors the upstream PodDisruptionBudgetLimit alert to only fire for applicable SRE-managed workloads by only filtering on openshift-* and excluding openshift-logging, openshift-user-workload-monitoring and openshift-operators namespaces.  From our alert trends over the last 90 days this should result in this alert firing ~17% less when we exclude the unactionable namespaces.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-6598_

### Special notes for your reviewer:

To test this, I applied the PromRule, cordoned both worker nodes on my cluster, and deployed a simple app with a minAvailable PDB into three namespaces: `gin`, `openshift-monitoring` and `openshift-logging`. I observed the `PodDisruptionBudgetLimit` alert enter a pending state for all three namespaces, but only a single `PodDisruptionBudgetLimitSRE` alert, for the openshift-monitoring namespace.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
