### PR TITLE
Enable cpms with canary rollout in eu-west-2

### DIFF
--- a/deploy/osd-20594-enable-cpms/config.yaml
+++ b/deploy/osd-20594-enable-cpms/config.yaml
@@ -1,0 +1,13 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchLabels:
+    api.openshift.com/managed: "true"
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]
+  - key: hive.openshift.io/cluster-region
+    operator: In
+    values:
+      - "eu-west-3"

--- a/deploy/osd-20594-enable-cpms/config.yaml
+++ b/deploy/osd-20594-enable-cpms/config.yaml
@@ -11,3 +11,6 @@ selectorSyncSet:
     operator: In
     values:
       - "eu-west-2"
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.12", "4.13", "4.14", "4.15"]

--- a/deploy/osd-20594-enable-cpms/config.yaml
+++ b/deploy/osd-20594-enable-cpms/config.yaml
@@ -10,4 +10,4 @@ selectorSyncSet:
   - key: hive.openshift.io/cluster-region
     operator: In
     values:
-      - "eu-west-3"
+      - "eu-west-2"

--- a/deploy/osd-20594-enable-cpms/cpms-cluster.state.patch.yaml
+++ b/deploy/osd-20594-enable-cpms/cpms-cluster.state.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+name: cluster
+namespace: openshift-machine-api
+patch: '{"spec":{"state": "Active"}}'
+patchType: merge
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23567,6 +23567,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-20594-enable-cpms
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: hive.openshift.io/cluster-region
+        operator: In
+        values:
+        - eu-west-3
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      name: cluster
+      namespace: openshift-machine-api
+      patch: '{"spec":{"state": "Active"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23581,6 +23581,13 @@ objects:
         operator: In
         values:
         - eu-west-2
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     patches:
     - apiVersion: machine.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23580,7 +23580,7 @@ objects:
       - key: hive.openshift.io/cluster-region
         operator: In
         values:
-        - eu-west-3
+        - eu-west-2
     resourceApplyMode: Sync
     patches:
     - apiVersion: machine.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23567,6 +23567,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-20594-enable-cpms
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: hive.openshift.io/cluster-region
+        operator: In
+        values:
+        - eu-west-3
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      name: cluster
+      namespace: openshift-machine-api
+      patch: '{"spec":{"state": "Active"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23581,6 +23581,13 @@ objects:
         operator: In
         values:
         - eu-west-2
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     patches:
     - apiVersion: machine.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23580,7 +23580,7 @@ objects:
       - key: hive.openshift.io/cluster-region
         operator: In
         values:
-        - eu-west-3
+        - eu-west-2
     resourceApplyMode: Sync
     patches:
     - apiVersion: machine.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23567,6 +23567,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-20594-enable-cpms
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: hive.openshift.io/cluster-region
+        operator: In
+        values:
+        - eu-west-3
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machine.openshift.io/v1
+      kind: ControlPlaneMachineSet
+      name: cluster
+      namespace: openshift-machine-api
+      patch: '{"spec":{"state": "Active"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23581,6 +23581,13 @@ objects:
         operator: In
         values:
         - eu-west-2
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     patches:
     - apiVersion: machine.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23580,7 +23580,7 @@ objects:
       - key: hive.openshift.io/cluster-region
         operator: In
         values:
-        - eu-west-3
+        - eu-west-2
     resourceApplyMode: Sync
     patches:
     - apiVersion: machine.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
 Enables ControlplaneMachineSet in a region with few clusters. If there are no further issues, we will enable it across the fleet.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-20594

### Special notes for your reviewer:

I excluded fedramp for now.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
