### PR TITLE
[OCPBUGS-15043] fix cronjob failing to detect seccomp issues

### DIFF
--- a/deploy/ocpbugs-15043/01-ocpbugs-15043.Role.yaml
+++ b/deploy/ocpbugs-15043/01-ocpbugs-15043.Role.yaml
@@ -68,9 +68,11 @@ rules:
   - 
   resources:
   - pods
+  - events
   verbs:
   - get
   - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22692,9 +22692,11 @@ objects:
         - null
         resources:
         - pods
+        - events
         verbs:
         - get
         - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22692,9 +22692,11 @@ objects:
         - null
         resources:
         - pods
+        - events
         verbs:
         - get
         - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22692,9 +22692,11 @@ objects:
         - null
         resources:
         - pods
+        - events
         verbs:
         - get
         - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
- Currently, the cronjob for detecting the seccomp issue can't read the events for a particular pod, causing it to not detect the condition properly
- This pr adds permissions to list, get and watch events for the cronjob

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
