### PR TITLE
[MTSRE-1684] enable backplane-acs-admins-cluster role 

### DIFF
--- a/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
@@ -1,9 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: backplane-acs-admins-cluster-aggregate
-  labels:
-    managed.openshift.io/aggregate-to-acs-admins: "cluster"
+  name: backplane-acs-admins-cluster
 rules:
 # ACS Eng can manage projects
 - apiGroups:

--- a/deploy/backplane/acs/02-acs-admins.SubjectPermission.yaml
+++ b/deploy/backplane/acs/02-acs-admins.SubjectPermission.yaml
@@ -4,6 +4,8 @@ metadata:
   name: backplane-acs-admins-project
   namespace: openshift-rbac-permissions
 spec:
+  clusterPermissions:
+  - backplane-acs-admins-cluster
   permissions:
   - clusterRoleName: view
     namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)

--- a/docs/backplane/requirements/acs/10-acs-managed-service.md
+++ b/docs/backplane/requirements/acs/10-acs-managed-service.md
@@ -27,15 +27,17 @@ Process is captured [ROX-22017: Harden Network Security API Permissions](https:/
 label selectors:
 * labels
 - `api.openshift.com/addon-acs-fleetshard: "true"` OR
-- `api.openshift.com/addon-acs-fleetshard-qa: "true"` OR
-- `api.openshift.com/addon-acs-fleetshard-dev: "true"` 
+- `api.openshift.com/addon-acs-fleetshard-qe: "true"` OR
+- `api.openshift.com/addon-acs-fleetshard-dev: "true"`
 
 For where access is applied
+
+Permissions are applied via `backplane-acs-admins-project` SubjectPermission.
 
 These permissions are a baseline access for the ACS:CS team across OSD/ROSA infra.  Scope of permissions are the Red Hat servers hosting ACS Central (fleetshard) and not to end-customer clusters.
 
 ## backplane-acs-admins-cluster: `cluster`
-Permissions at cluster scope. 
+Permissions at cluster scope.
 
 * view projects
 * view nodes

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7926,9 +7926,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -8158,6 +8156,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)
@@ -8374,9 +8374,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -8606,6 +8604,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)
@@ -8822,9 +8822,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -9054,6 +9052,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7926,9 +7926,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -8158,6 +8156,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)
@@ -8374,9 +8374,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -8606,6 +8604,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)
@@ -8822,9 +8822,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -9054,6 +9052,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7926,9 +7926,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -8158,6 +8156,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)
@@ -8374,9 +8374,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -8606,6 +8604,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)
@@ -8822,9 +8822,7 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
-        name: backplane-acs-admins-cluster-aggregate
-        labels:
-          managed.openshift.io/aggregate-to-acs-admins: cluster
+        name: backplane-acs-admins-cluster
       rules:
       - apiGroups:
         - config.openshift.io
@@ -9054,6 +9052,8 @@ objects:
         name: backplane-acs-admins-project
         namespace: openshift-rbac-permissions
       spec:
+        clusterPermissions:
+        - backplane-acs-admins-cluster
         permissions:
         - clusterRoleName: view
           namespacesAllowedRegex: (^redhat-.*|^rhacs$|^rhacs-.*|^openshift$|^openshift-.*|^default$|^kube$|^kube-.*)


### PR DESCRIPTION
* renames backplane-acs-admins-cluster-aggregate to backplane-acs-admins-cluster 
*  renames  backplane-acs-admins-project SubjectPermission to backplane-acs-admins to indicate that SubjectPermission contains both project and cluster scope permissions  
* adds backplane-acs-admins-cluster role to the backplane-acs-admins SubjectPermission

### What type of PR is this?
feature

### What this PR does / why we need it?

to enable backplane-acs-admins-cluster-aggregate role 

### Which Jira/Github issue(s) this PR fixes?

[MTSRE-1684](https://issues.redhat.com//browse/MTSRE-1684)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
