### PR TITLE
Enable CPMS fleet wide for existing clusters

### DIFF
--- a/deploy/osd-20594-enable-cpms/config.yaml
+++ b/deploy/osd-20594-enable-cpms/config.yaml
@@ -7,10 +7,6 @@ selectorSyncSet:
   - key: api.openshift.com/fedramp
     operator: NotIn
     values: ["true"]
-  - key: hive.openshift.io/cluster-region
-    operator: In
-    values:
-      - "eu-west-2"
   - key: hive.openshift.io/version-major-minor
     operator: In
     values: ["4.12", "4.13", "4.14", "4.15"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23578,10 +23578,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: hive.openshift.io/cluster-region
-        operator: In
-        values:
-        - eu-west-2
       - key: hive.openshift.io/version-major-minor
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23578,10 +23578,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: hive.openshift.io/cluster-region
-        operator: In
-        values:
-        - eu-west-2
       - key: hive.openshift.io/version-major-minor
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23578,10 +23578,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: hive.openshift.io/cluster-region
-        operator: In
-        values:
-        - eu-west-2
       - key: hive.openshift.io/version-major-minor
         operator: In
         values:


### PR DESCRIPTION
### What this PR does / why we need it?
Removes region selector from cpms activation cronjob for existing clusters.

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-20594

_Fixes #_
https://issues.redhat.com/browse/OSD-20594

### Special notes for your reviewer:
Canary roll out was successful.