### PR TITLE
OSD-21162 add MachineHealthCheckUnterminatedShortCircuitSRE

### DIFF
--- a/deploy/sre-prometheus/100-machine-health-check-unterminated-short-circuit.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-machine-health-check-unterminated-short-circuit.PrometheusRule.yaml
@@ -16,6 +16,7 @@ spec:
       for: 30m
       labels:
         severity: critical
+        namespace: '{{ $labels.namespace }}'
       annotations:
         description: |
           The number of unhealthy machines has exceeded the `maxUnhealthy` limit for the check, you should check

--- a/deploy/sre-prometheus/100-machine-health-check-unterminated-short-circuit.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-machine-health-check-unterminated-short-circuit.PrometheusRule.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-machine-health-check-unterminated-short-circuit-alert
+    role: alert-rules
+  name: sre-machine-health-check-unterminated-short-circuit-alert
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-machine-health-check-unterminated-short-circuit-alert
+    rules:
+    - alert: MachineHealthCheckUnterminatedShortCircuitSRE
+      expr: |
+        mapi_machinehealthcheck_short_circuit == 1
+      for: 30m
+      labels:
+        severity: critical
+      annotations:
+        description: |
+          The number of unhealthy machines has exceeded the `maxUnhealthy` limit for the check, you should check
+          the status of machines in the cluster.
+        summary: machine health check {{ $labels.name }} has been disabled by short
+          circuit for more than 30 minutes
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34436,6 +34436,35 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-machine-health-check-unterminated-short-circuit-alert
+          role: alert-rules
+        name: sre-machine-health-check-unterminated-short-circuit-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-machine-health-check-unterminated-short-circuit-alert
+          rules:
+          - alert: MachineHealthCheckUnterminatedShortCircuitSRE
+            expr: 'mapi_machinehealthcheck_short_circuit == 1
+
+              '
+            for: 30m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              description: 'The number of unhealthy machines has exceeded the `maxUnhealthy`
+                limit for the check, you should check
+
+                the status of machines in the cluster.
+
+                '
+              summary: machine health check {{ $labels.name }} has been disabled by
+                short circuit for more than 30 minutes
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-node-metadata-operator-alerts
           role: alert-rules
         name: sre-managed-node-metadata-operator-alerts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34436,6 +34436,35 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-machine-health-check-unterminated-short-circuit-alert
+          role: alert-rules
+        name: sre-machine-health-check-unterminated-short-circuit-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-machine-health-check-unterminated-short-circuit-alert
+          rules:
+          - alert: MachineHealthCheckUnterminatedShortCircuitSRE
+            expr: 'mapi_machinehealthcheck_short_circuit == 1
+
+              '
+            for: 30m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              description: 'The number of unhealthy machines has exceeded the `maxUnhealthy`
+                limit for the check, you should check
+
+                the status of machines in the cluster.
+
+                '
+              summary: machine health check {{ $labels.name }} has been disabled by
+                short circuit for more than 30 minutes
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-node-metadata-operator-alerts
           role: alert-rules
         name: sre-managed-node-metadata-operator-alerts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34436,6 +34436,35 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-machine-health-check-unterminated-short-circuit-alert
+          role: alert-rules
+        name: sre-machine-health-check-unterminated-short-circuit-alert
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-machine-health-check-unterminated-short-circuit-alert
+          rules:
+          - alert: MachineHealthCheckUnterminatedShortCircuitSRE
+            expr: 'mapi_machinehealthcheck_short_circuit == 1
+
+              '
+            for: 30m
+            labels:
+              severity: critical
+              namespace: '{{ $labels.namespace }}'
+            annotations:
+              description: 'The number of unhealthy machines has exceeded the `maxUnhealthy`
+                limit for the check, you should check
+
+                the status of machines in the cluster.
+
+                '
+              summary: machine health check {{ $labels.name }} has been disabled by
+                short circuit for more than 30 minutes
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-managed-node-metadata-operator-alerts
           role: alert-rules
         name: sre-managed-node-metadata-operator-alerts


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

[OSD-21162](https://issues.redhat.com//browse/OSD-21162) 

Add MachineHealthCheckUnterminatedShortCircuitSRE as a critical alert.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
