### PR TITLE
Allow ROSANodePoolManagementPolicy to reconcile tags on ENIs

### DIFF
--- a/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -42,7 +42,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-ROSA-Worker"
+        "arn:*:iam::*:role/*-ROSA-Worker-Role"
       ],
       "Condition": {
         "StringEquals": {

--- a/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -111,20 +111,22 @@
       }
     },
     {
-      "Sid": "CreateTags",
+      "Sid": "CreateTagsRunInstances",
       "Effect": "Allow",
       "Action": [
         "ec2:CreateTags"
       ],
       "Resource": [
         "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:volume/*"
       ],
       "Condition": {
         "StringEquals": {
-            "ec2:CreateAction": [
-                "RunInstances"
-            ]
+          "ec2:CreateAction": [
+            "RunInstances"
+          ],
+          "aws:RequestTag/red-hat-managed": "true"
         }
       }
     },
@@ -138,24 +140,25 @@
           "arn:aws:ec2:*:*:instance/*"
       ],
       "Condition": {
-          "StringEquals": {
-              "aws:ResourceTag/red-hat-managed": "true"
-          }
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
       }
     },
     {
-      "Sid": "CreateTagsCAPAControllerReconcileVolume",
+      "Sid": "ReconcileTags",
       "Effect": "Allow",
       "Action": [
-          "ec2:CreateTags"
+        "ec2:CreateTags"
       ],
       "Resource": [
-          "arn:aws:ec2:*:*:volume/*"
+        "arn:aws:ec2:*:*:network-interface/*",
+        "arn:aws:ec2:*:*:volume/*"
       ],
       "Condition": {
-          "StringEquals": {
-              "aws:RequestTag/red-hat-managed": "true"
-          }
+        "StringEquals": {
+          "aws:RequestTag/red-hat-managed": "true"
+        }
       }
     },
     {


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

This is for the [egressIP feature](https://docs.openshift.com/rosa/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.html) of the cluster-network-operator. It relies on performing actions against network interface (ENI) objects in AWS. However, its [AWS Managed Policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ROSACloudNetworkConfigOperatorPolicy.html) only allows it to perform actions against ENIs with the `red-hat-managed: true` tag and none of the worker node ENIs of ROSA HCP clusters have this tag

cluster-api-provider-aws is already trying to tag the ENIs after creation https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/0baa03c61701a287678b0ac83b66a8018886e54f/pkg/cloud/services/ec2/instances.go#L294-L303, however the ROSANodePoolManagementPolicy does not have the necessary AWS permissions.

This PR fixies this bug on the ROSANodePoolManagementPolicy Managed Policy:

#### Allow CAPA to reconcile tags on ENIs
* CAPA has been trying to tag ENIs, however this has not been allowed by
  our managed policy and considered non-impactful
* However, recently we realized that this prevents the egressIP feature
  from working and this PR fixes this bug

### Which Jira/Github issue(s) this PR fixes?
[OSD-19650](https://issues.redhat.com//browse/OSD-19650)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
