### PR TITLE
Update 10-managed-upgrade-operator-configmap.yaml

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -66,6 +66,7 @@ data:
       - NorthboundStale
       - OCMAgentResponseFailureServiceLogsSRE
       - PodDisruptionBudgetLimit
+      - PodDisruptionBudgetLimitSRE
       - PrometheusTargetSyncFailure
       - RouterAvailabilityLT30PctSRE
       - RunawaySDNPreventingContainerCreationSRE

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22555,9 +22555,9 @@ objects:
           \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
           \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
           \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\
-          \  - PodDisruptionBudgetLimit\n  - PrometheusTargetSyncFailure\n  - RouterAvailabilityLT30PctSRE\n\
-          \  - RunawaySDNPreventingContainerCreationSRE\n  - SouthboundStale\n  -\
-          \ ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
+          \  - PodDisruptionBudgetLimit\n  - PodDisruptionBudgetLimitSRE\n  - PrometheusTargetSyncFailure\n\
+          \  - RouterAvailabilityLT30PctSRE\n  - RunawaySDNPreventingContainerCreationSRE\n\
+          \  - SouthboundStale\n  - ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
           \  - WorkerNodeFilesystemAlmostOutOfFiles\n  - WorkerNodeFilesystemSpaceFillingUp\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22555,9 +22555,9 @@ objects:
           \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
           \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
           \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\
-          \  - PodDisruptionBudgetLimit\n  - PrometheusTargetSyncFailure\n  - RouterAvailabilityLT30PctSRE\n\
-          \  - RunawaySDNPreventingContainerCreationSRE\n  - SouthboundStale\n  -\
-          \ ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
+          \  - PodDisruptionBudgetLimit\n  - PodDisruptionBudgetLimitSRE\n  - PrometheusTargetSyncFailure\n\
+          \  - RouterAvailabilityLT30PctSRE\n  - RunawaySDNPreventingContainerCreationSRE\n\
+          \  - SouthboundStale\n  - ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
           \  - WorkerNodeFilesystemAlmostOutOfFiles\n  - WorkerNodeFilesystemSpaceFillingUp\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22555,9 +22555,9 @@ objects:
           \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
           \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
           \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\
-          \  - PodDisruptionBudgetLimit\n  - PrometheusTargetSyncFailure\n  - RouterAvailabilityLT30PctSRE\n\
-          \  - RunawaySDNPreventingContainerCreationSRE\n  - SouthboundStale\n  -\
-          \ ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
+          \  - PodDisruptionBudgetLimit\n  - PodDisruptionBudgetLimitSRE\n  - PrometheusTargetSyncFailure\n\
+          \  - RouterAvailabilityLT30PctSRE\n  - RunawaySDNPreventingContainerCreationSRE\n\
+          \  - SouthboundStale\n  - ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
           \  - WorkerNodeFilesystemAlmostOutOfFiles\n  - WorkerNodeFilesystemSpaceFillingUp\n\
           \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
           \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\


### PR DESCRIPTION
Adds the new SRE-flavor of the PDBLimit alert to be ignored as part of the upgrade process, since we were already ignoring the original alert.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
