### PR TITLE
OSD-20289: remove console-ErrorBudgetBurn for MCs

### DIFF
--- a/deploy/osd-route-monitor-operator/management-cluster/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
+++ b/deploy/osd-route-monitor-operator/management-cluster/100-openshift-route-monitor-operator.api.ClusterUrlMonitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.openshift.io/v1alpha1
+kind: ClusterUrlMonitor
+metadata:
+  name: api
+  namespace: openshift-route-monitor-operator
+spec:
+  prefix: https://api.
+  port: "6443"
+  suffix: /livez
+  slo:
+    targetAvailabilityPercent: "99.0"

--- a/deploy/osd-route-monitor-operator/management-cluster/README.md
+++ b/deploy/osd-route-monitor-operator/management-cluster/README.md
@@ -1,0 +1,9 @@
+This subfolder is a workaround for https://issues.redhat.com/browse/OSD-20289 / https://issues.redhat.com/browse/OCPBUGS-30260. Once https://issues.redhat.com/browse/OSD-20289 is resolved, we should remove this folder and remove the following in the `config.yaml` under the parent `osd-route-monitor-operator` folder:
+```
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: NotIn
+    values: 
+      - "management-cluster"
+```
+
+With this subfolder, we're essentially disabling the console-ErrorBudgetBurn alerts for all management clusters as they are constantly paging due to https://issues.redhat.com/browse/OCPBUGS-30260. 

--- a/deploy/osd-route-monitor-operator/management-cluster/config.yaml
+++ b/deploy/osd-route-monitor-operator/management-cluster/config.yaml
@@ -6,6 +6,6 @@ selectorSyncSet:
     values:
       - "true"
   - key: ext-hypershift.openshift.io/cluster-type
-    operator: NotIn
+    operator: In
     values: 
       - "management-cluster"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30954,6 +30954,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.openshift.io/v1alpha1
@@ -30979,6 +30983,40 @@ objects:
           suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-route-monitor-operator-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: ClusterUrlMonitor
+      metadata:
+        name: api
+        namespace: openshift-route-monitor-operator
+      spec:
+        prefix: https://api.
+        port: '6443'
+        suffix: /livez
+        slo:
+          targetAvailabilityPercent: '99.0'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30954,6 +30954,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.openshift.io/v1alpha1
@@ -30979,6 +30983,40 @@ objects:
           suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-route-monitor-operator-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: ClusterUrlMonitor
+      metadata:
+        name: api
+        namespace: openshift-route-monitor-operator
+      spec:
+        prefix: https://api.
+        port: '6443'
+        suffix: /livez
+        slo:
+          targetAvailabilityPercent: '99.0'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30954,6 +30954,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: monitoring.openshift.io/v1alpha1
@@ -30979,6 +30983,40 @@ objects:
           suffix: /health
         slo:
           targetAvailabilityPercent: '99.5'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-route-monitor-operator-management-cluster
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: monitoring.openshift.io/v1alpha1
+      kind: ClusterUrlMonitor
+      metadata:
+        name: api
+        namespace: openshift-route-monitor-operator
+      spec:
+        prefix: https://api.
+        port: '6443'
+        suffix: /livez
+        slo:
+          targetAvailabilityPercent: '99.0'
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

Console-ErrorBudgetBurn is miss-firing on MCs due to https://issues.redhat.com/browse/OCPBUGS-30260. This PR disables the alert for MCs, we will turn it back on after the bug is fixed (it's an acceptance criteria of [OSD-20289](https://issues.redhat.com//browse/OSD-20289). 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-20289

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
