### PR TITLE
egressIP RBAC for CEE access

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -60,6 +60,14 @@ spec:
                                 - get
                                 - list
                                 - watch
+                            - apiGroups:
+                                - k8s.ovn.org
+                              resources:
+                                - egressips
+                              verbs:
+                                - get
+                                - list
+                                - watch
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
@@ -30,3 +30,12 @@ rules:
   - get
   - list
   - watch
+# CEE can view egressIP 
+- apiGroups:
+  - 'k8s.ovn.org'
+  resources:
+  - egressips
+  verbs:
+  - get
+  - list
+  - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -823,6 +823,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - k8s.ovn.org
+                    resources:
+                    - egressips
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10073,6 +10081,14 @@ objects:
         - apiserver.openshift.io
         resources:
         - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - k8s.ovn.org
+        resources:
+        - egressips
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -823,6 +823,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - k8s.ovn.org
+                    resources:
+                    - egressips
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10073,6 +10081,14 @@ objects:
         - apiserver.openshift.io
         resources:
         - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - k8s.ovn.org
+        resources:
+        - egressips
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -823,6 +823,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - k8s.ovn.org
+                    resources:
+                    - egressips
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10073,6 +10081,14 @@ objects:
         - apiserver.openshift.io
         resources:
         - apirequestcounts
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - k8s.ovn.org
+        resources:
+        - egressips
         verbs:
         - get
         - list


### PR DESCRIPTION
What type of PR is this?

Based on this [PR](https://github.com/openshift/managed-scripts/pull/180) was decided to create a separate PR in order to update RBAC rules in a proper way as CEE should have read access to the non-sensetive objects so that MCS/CEE can get the object from oc directly.

This will allow CEE to retrieve egressIP object, it's config file and node allocation.

What this PR does / why we need it?
CEE doesn't have access to view egressIP object using backplane

`oc get egressip

Error from server (Forbidden): egressips.k8s.ovn.org is forbidden: User "system:serviceaccount:openshift-backplane-cee:8d5ec3a2bb1e28f30a0c48a9eeb707f3" cannot list resource "egressips" in API group "k8s.ovn.org" at the cluster scope`

Having this ability will make a troubleshooting process quicker and easier.