### PR TITLE
removes the PDB namespace label so the namespace passes through, shou…

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -26,6 +26,5 @@ spec:
       for: 15m
       labels:
         severity: critical
-        namespace: openshift-monitoring
       annotations:
         message: The pod disruption budget is below the minimum disruptions allowed level and is not satisfied. The number of current healthy pods is less than the desired healthy pods.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36006,7 +36006,6 @@ objects:
             for: 15m
             labels:
               severity: critical
-              namespace: openshift-monitoring
             annotations:
               message: The pod disruption budget is below the minimum disruptions
                 allowed level and is not satisfied. The number of current healthy

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36006,7 +36006,6 @@ objects:
             for: 15m
             labels:
               severity: critical
-              namespace: openshift-monitoring
             annotations:
               message: The pod disruption budget is below the minimum disruptions
                 allowed level and is not satisfied. The number of current healthy

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36006,7 +36006,6 @@ objects:
             for: 15m
             labels:
               severity: critical
-              namespace: openshift-monitoring
             annotations:
               message: The pod disruption budget is below the minimum disruptions
                 allowed level and is not satisfied. The number of current healthy


### PR DESCRIPTION
…ld prevent most non-managed namespaces

### What type of PR is this?
Bug

### What this PR does / why we need it?
Removes the openshift-monitoring namespace label in the alert, which should then pass through the namespace from the alert itself, so we will respect all other monitoring labels already applied to monitored namespaces.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-6598_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
