### PR TITLE
[OSD-14859] Add promtool checks to MCC

### DIFF
--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -73,6 +73,8 @@ spec:
           labels:
             namespace: openshift-logging
             severity: info
+            window: short
+            mark: low
         - alert: ElasticsearchNodeDiskWatermarkReachedSRE
           annotations:
             message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.
@@ -90,6 +92,8 @@ spec:
           labels:
             namespace: openshift-logging
             severity: warning
+            window: short
+            mark: high
         - alert: ElasticsearchNodeDiskWatermarkReachedSRE
           annotations:
             message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
@@ -107,6 +111,8 @@ spec:
           labels:
             namespace: openshift-logging
             severity: warning
+            window: short
+            mark: flood
         - alert: ElasticsearchJVMHeapUseHighSRE
           annotations:
             message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.
@@ -184,6 +190,8 @@ spec:
           labels:
             namespace: openshift-logging
             severity: warning
+            window: long
+            mark: low
         - alert: ElasticsearchNodeDiskWatermarkReachedSRE
           annotations:
             message: Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.
@@ -201,6 +209,8 @@ spec:
           labels:
             namespace: openshift-logging
             severity: warning
+            window: long
+            mark: high
         - alert: ElasticsearchNodeDiskWatermarkReachedSRE
           annotations:
             message: Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark.
@@ -218,3 +228,5 @@ spec:
           labels:
             namespace: openshift-logging
             severity: warning
+            window: long
+            mark: flood

--- a/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
@@ -83,6 +83,7 @@ spec:
         namespace: dynatrace
         severity: critical
         daemonset: hcp-workload-oneagent
+        state: degraded
       annotations:
         summary: "HCP workload oneagent daemonset missing"
         description: "HCP workload oneagent daemonset in the 'dynatrace' namespace is missing for 60 minutes."
@@ -95,6 +96,7 @@ spec:
         namespace: dynatrace
         severity: critical
         daemonset: hcp-workload-oneagent
+        state: missing
       annotations:
         summary: "HCP workload oneagent pods degraded"
         description: "At least one HCP workload oneagent pod in the 'dynatrace' namespace is not available for 60 minutes."
@@ -107,6 +109,7 @@ spec:
         namespace: dynatrace
         severity: critical
         daemonset: request-serving-oneagent
+        state: missing
       annotations:
         summary: "Request serving oneagent daemonset missing."
         description: "Request serving oneagent daemonset in the 'dynatrace' namespace is missing for 60 minutes."
@@ -119,6 +122,7 @@ spec:
         namespace: dynatrace
         severity: critical
         daemonset: request-serving-oneagent
+        state: degraded
       annotations:
         summary: "Request serving oneagent pods degraded"
         description: "At least one request serving oneagent pod in the 'dynatrace' namespace is not available for 60 minutes."
@@ -131,6 +135,7 @@ spec:
         namespace: dynatrace
         severity: critical
         statefulset: activegate
+        state: missing
       annotations:
         summary: "Dynatrace Activegate statefulset missing"
         description: "Activegate statefulset in the 'dynatrace' namespace is missing for 60 minutes."
@@ -143,6 +148,7 @@ spec:
         namespace: dynatrace
         severity: critical
         statefulset: activegate
+        state: degraded
       annotations:
         summary: "Dynatrace Activegate pods degraded"
         description: "At least one activegate pod in the 'dynatrace' namespace is not available for 60 minutes."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36489,6 +36489,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: info
+              window: short
+              mark: low
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some
@@ -36504,6 +36506,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: short
+              mark: high
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -36519,6 +36523,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: short
+              mark: flood
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -36607,6 +36613,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: low
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk High Watermark is predicted to be reached within the next
@@ -36622,6 +36630,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: high
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark is predicted to be reached within
@@ -36637,6 +36647,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: flood
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37051,6 +37063,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: hcp-workload-oneagent
+              state: degraded
             annotations:
               summary: HCP workload oneagent daemonset missing
               description: HCP workload oneagent daemonset in the 'dynatrace' namespace
@@ -37065,6 +37078,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: hcp-workload-oneagent
+              state: missing
             annotations:
               summary: HCP workload oneagent pods degraded
               description: At least one HCP workload oneagent pod in the 'dynatrace'
@@ -37078,6 +37092,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: request-serving-oneagent
+              state: missing
             annotations:
               summary: Request serving oneagent daemonset missing.
               description: Request serving oneagent daemonset in the 'dynatrace' namespace
@@ -37092,6 +37107,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: request-serving-oneagent
+              state: degraded
             annotations:
               summary: Request serving oneagent pods degraded
               description: At least one request serving oneagent pod in the 'dynatrace'
@@ -37104,6 +37120,7 @@ objects:
               namespace: dynatrace
               severity: critical
               statefulset: activegate
+              state: missing
             annotations:
               summary: Dynatrace Activegate statefulset missing
               description: Activegate statefulset in the 'dynatrace' namespace is
@@ -37118,6 +37135,7 @@ objects:
               namespace: dynatrace
               severity: critical
               statefulset: activegate
+              state: degraded
             annotations:
               summary: Dynatrace Activegate pods degraded
               description: At least one activegate pod in the 'dynatrace' namespace

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36489,6 +36489,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: info
+              window: short
+              mark: low
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some
@@ -36504,6 +36506,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: short
+              mark: high
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -36519,6 +36523,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: short
+              mark: flood
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -36607,6 +36613,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: low
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk High Watermark is predicted to be reached within the next
@@ -36622,6 +36630,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: high
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark is predicted to be reached within
@@ -36637,6 +36647,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: flood
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37051,6 +37063,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: hcp-workload-oneagent
+              state: degraded
             annotations:
               summary: HCP workload oneagent daemonset missing
               description: HCP workload oneagent daemonset in the 'dynatrace' namespace
@@ -37065,6 +37078,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: hcp-workload-oneagent
+              state: missing
             annotations:
               summary: HCP workload oneagent pods degraded
               description: At least one HCP workload oneagent pod in the 'dynatrace'
@@ -37078,6 +37092,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: request-serving-oneagent
+              state: missing
             annotations:
               summary: Request serving oneagent daemonset missing.
               description: Request serving oneagent daemonset in the 'dynatrace' namespace
@@ -37092,6 +37107,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: request-serving-oneagent
+              state: degraded
             annotations:
               summary: Request serving oneagent pods degraded
               description: At least one request serving oneagent pod in the 'dynatrace'
@@ -37104,6 +37120,7 @@ objects:
               namespace: dynatrace
               severity: critical
               statefulset: activegate
+              state: missing
             annotations:
               summary: Dynatrace Activegate statefulset missing
               description: Activegate statefulset in the 'dynatrace' namespace is
@@ -37118,6 +37135,7 @@ objects:
               namespace: dynatrace
               severity: critical
               statefulset: activegate
+              state: degraded
             annotations:
               summary: Dynatrace Activegate pods degraded
               description: At least one activegate pod in the 'dynatrace' namespace

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36489,6 +36489,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: info
+              window: short
+              mark: low
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some
@@ -36504,6 +36506,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: short
+              mark: high
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
@@ -36519,6 +36523,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: short
+              mark: flood
           - alert: ElasticsearchJVMHeapUseHighSRE
             annotations:
               message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
@@ -36607,6 +36613,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: low
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk High Watermark is predicted to be reached within the next
@@ -36622,6 +36630,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: high
           - alert: ElasticsearchNodeDiskWatermarkReachedSRE
             annotations:
               message: Disk Flood Stage Watermark is predicted to be reached within
@@ -36637,6 +36647,8 @@ objects:
             labels:
               namespace: openshift-logging
               severity: warning
+              window: long
+              mark: flood
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:
@@ -37051,6 +37063,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: hcp-workload-oneagent
+              state: degraded
             annotations:
               summary: HCP workload oneagent daemonset missing
               description: HCP workload oneagent daemonset in the 'dynatrace' namespace
@@ -37065,6 +37078,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: hcp-workload-oneagent
+              state: missing
             annotations:
               summary: HCP workload oneagent pods degraded
               description: At least one HCP workload oneagent pod in the 'dynatrace'
@@ -37078,6 +37092,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: request-serving-oneagent
+              state: missing
             annotations:
               summary: Request serving oneagent daemonset missing.
               description: Request serving oneagent daemonset in the 'dynatrace' namespace
@@ -37092,6 +37107,7 @@ objects:
               namespace: dynatrace
               severity: critical
               daemonset: request-serving-oneagent
+              state: degraded
             annotations:
               summary: Request serving oneagent pods degraded
               description: At least one request serving oneagent pod in the 'dynatrace'
@@ -37104,6 +37120,7 @@ objects:
               namespace: dynatrace
               severity: critical
               statefulset: activegate
+              state: missing
             annotations:
               summary: Dynatrace Activegate statefulset missing
               description: Activegate statefulset in the 'dynatrace' namespace is
@@ -37118,6 +37135,7 @@ objects:
               namespace: dynatrace
               severity: critical
               statefulset: activegate
+              state: degraded
             annotations:
               summary: Dynatrace Activegate pods degraded
               description: At least one activegate pod in the 'dynatrace' namespace

--- a/hack/app_sre_pr_check.sh
+++ b/hack/app_sre_pr_check.sh
@@ -21,7 +21,7 @@ do
     fi
 
     JSON_RULESFILE="$(cat "$F" | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))' | jq -r '.spec')"
-    if ! echo "$JSON_RULESFILE" | $CONTAINER_ENGINE run -i --rm --entrypoint promtool $PROMTOOL_IMAGE check rules --lint="none"; then
+    if ! echo "$JSON_RULESFILE" | $CONTAINER_ENGINE run -i --rm --entrypoint promtool $PROMTOOL_IMAGE check rules --lint="all" --lint-fatal; then
       echo "Invalid rules file: '$F'" 
       exit 1
     fi


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
- Lint prometheusrules using promtool in before a PR gets merged

### Which Jira/Github issue(s) this PR fixes?

_Fixes [OSD-14859](https://issues.redhat.com//browse/OSD-14859)_

### Special notes for your reviewer:
- the two prometheus rules files that were changed were previously failing the linting due to duplicate rule definitions.
- This PR adds some labels to those rules so that they become unique again and pass linting by promtool

------

**outdated comments**
- Currently, there are two rule files that are failing validation:
  - ./deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
    ```
    lint error 3 duplicate rule(s) found.
    Metric: DynatraceDynakubeComponenetsDegradedSRE
    Label(s):
      daemonset: hcp-workload-oneagent
      namespace: dynatrace
      severity: critical
    Metric: DynatraceDynakubeComponenetsDegradedSRE
    Label(s):
      daemonset: request-serving-oneagent
      namespace: dynatrace
      severity: critical
    Metric: DynatraceDynakubeComponenetsDegradedSRE
    Label(s):
      namespace: dynatrace
      severity: critical
      statefulset: activegate
    Might cause inconsistency while recording expressions
    ```
  - ./deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
    ```
    lint error 1 duplicate rule(s) found.
    Metric: ElasticsearchNodeDiskWatermarkReachedSRE
    Label(s):
      namespace: openshift-logging
      severity: warning
    Might cause inconsistency while recording expressions
    ```
- before merging, we got to clarify what to do with those.
- But on the plus side, it also shows that the PR is working as intended :)
