### PR TITLE
OSD-21899-Updating chrony config for worker nodes

### DIFF
--- a/deploy/osd-fedramp-machineconfig/00-fedramp-chrony-worker.yaml
+++ b/deploy/osd-fedramp-machineconfig/00-fedramp-chrony-worker.yaml
@@ -11,7 +11,8 @@ spec:
     storage:
       files:
         - contents:
-            source: data:,server%20129.6.15.28%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.97.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.96.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Adriftfile%20%2Fvar%2Flib%2Fchrony%2Fdrift%0Artcsync%0Alogdir%20%2Fvar%2Flog%2Fchrony
+            compression: gzip
+            source: data:;base64,H4sIAAAAAAAC/5zL3U7DMAzF8fs8hZ8gWVoo7HEyzylW8yXbm9jbI0oRXCLujs5fPyW5k0Cczn7x8dlPrzCEMgnw5SZqULmNXgo8QU3vX8t9o3nycZn9+cXHf6jlT+oqnC1zIQj3JKHwJeCb9PYIe3FiqI+GrqaN1GhAPJ1gdqWvV5bD9PUwnzeYJNy4rVAp6U2oUjPdy+8D1JKxGqP+CDEEoYyl46ZgVAf2OtxHAAAA//8q3ru0RQEAAA==
           mode: 420
           overwrite: true
           path: /etc/chrony.conf

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28396,7 +28396,8 @@ objects:
           storage:
             files:
             - contents:
-                source: data:,server%20129.6.15.28%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.97.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.96.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Adriftfile%20%2Fvar%2Flib%2Fchrony%2Fdrift%0Artcsync%0Alogdir%20%2Fvar%2Flog%2Fchrony
+                compression: gzip
+                source: data:;base64,H4sIAAAAAAAC/5zL3U7DMAzF8fs8hZ8gWVoo7HEyzylW8yXbm9jbI0oRXCLujs5fPyW5k0Cczn7x8dlPrzCEMgnw5SZqULmNXgo8QU3vX8t9o3nycZn9+cXHf6jlT+oqnC1zIQj3JKHwJeCb9PYIe3FiqI+GrqaN1GhAPJ1gdqWvV5bD9PUwnzeYJNy4rVAp6U2oUjPdy+8D1JKxGqP+CDEEoYyl46ZgVAf2OtxHAAAA//8q3ru0RQEAAA==
               mode: 420
               overwrite: true
               path: /etc/chrony.conf

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28396,7 +28396,8 @@ objects:
           storage:
             files:
             - contents:
-                source: data:,server%20129.6.15.28%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.97.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.96.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Adriftfile%20%2Fvar%2Flib%2Fchrony%2Fdrift%0Artcsync%0Alogdir%20%2Fvar%2Flog%2Fchrony
+                compression: gzip
+                source: data:;base64,H4sIAAAAAAAC/5zL3U7DMAzF8fs8hZ8gWVoo7HEyzylW8yXbm9jbI0oRXCLujs5fPyW5k0Cczn7x8dlPrzCEMgnw5SZqULmNXgo8QU3vX8t9o3nycZn9+cXHf6jlT+oqnC1zIQj3JKHwJeCb9PYIe3FiqI+GrqaN1GhAPJ1gdqWvV5bD9PUwnzeYJNy4rVAp6U2oUjPdy+8D1JKxGqP+CDEEoYyl46ZgVAf2OtxHAAAA//8q3ru0RQEAAA==
               mode: 420
               overwrite: true
               path: /etc/chrony.conf

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28396,7 +28396,8 @@ objects:
           storage:
             files:
             - contents:
-                source: data:,server%20129.6.15.28%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.97.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Aserver%20132.163.96.1%20prefer%20iburst%20minpoll%204%20maxpoll%204%0Adriftfile%20%2Fvar%2Flib%2Fchrony%2Fdrift%0Artcsync%0Alogdir%20%2Fvar%2Flog%2Fchrony
+                compression: gzip
+                source: data:;base64,H4sIAAAAAAAC/5zL3U7DMAzF8fs8hZ8gWVoo7HEyzylW8yXbm9jbI0oRXCLujs5fPyW5k0Cczn7x8dlPrzCEMgnw5SZqULmNXgo8QU3vX8t9o3nycZn9+cXHf6jlT+oqnC1zIQj3JKHwJeCb9PYIe3FiqI+GrqaN1GhAPJ1gdqWvV5bD9PUwnzeYJNy4rVAp6U2oUjPdy+8D1JKxGqP+CDEEoYyl46ZgVAf2OtxHAAAA//8q3ru0RQEAAA==
               mode: 420
               overwrite: true
               path: /etc/chrony.conf


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Updating worker node chrony.conf.  

### What this PR does / why we need it?
This is to test a clock sync issue.  This has proven to be a potential fix by applying to Master nodes.  This will do the same for worker nodes.

### Which Jira/Github issue(s) this PR fixes?
[OSD-21899](https://issues.redhat.com/browse/OSD-21899)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
