### PR TITLE
[OSD-21742] - Added admin gates for 4.16

### DIFF
--- a/deploy/osd-cluster-acks/ocp/4.16/admin-gates.yaml
+++ b/deploy/osd-cluster-acks/ocp/4.16/admin-gates.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  ack-4.16-flowschemas-removal: "true"
+  ack-4.16-prioritylevelconfigurations-removal: "true"
+kind: ConfigMap
+metadata:
+  name: admin-acks
+  namespace: openshift-config

--- a/deploy/osd-cluster-acks/ocp/4.16/config.yaml
+++ b/deploy/osd-cluster-acks/ocp/4.16/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Upsert
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.15"]
+  - key: api.openshift.com/gate-ocp
+    operator: In
+    values: ["4.16"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26644,6 +26644,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-ocp-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.15'
+      - key: api.openshift.com/gate-ocp
+        operator: In
+        values:
+        - '4.16'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      data:
+        ack-4.16-flowschemas-removal: 'true'
+        ack-4.16-prioritylevelconfigurations-removal: 'true'
+      kind: ConfigMap
+      metadata:
+        name: admin-acks
+        namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-ocp-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26644,6 +26644,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-ocp-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.15'
+      - key: api.openshift.com/gate-ocp
+        operator: In
+        values:
+        - '4.16'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      data:
+        ack-4.16-flowschemas-removal: 'true'
+        ack-4.16-prioritylevelconfigurations-removal: 'true'
+      kind: ConfigMap
+      metadata:
+        name: admin-acks
+        namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-ocp-4.9
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26644,6 +26644,37 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-ocp-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.15'
+      - key: api.openshift.com/gate-ocp
+        operator: In
+        values:
+        - '4.16'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      data:
+        ack-4.16-flowschemas-removal: 'true'
+        ack-4.16-prioritylevelconfigurations-removal: 'true'
+      kind: ConfigMap
+      metadata:
+        name: admin-acks
+        namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-ocp-4.9
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Added admin gates for 4.16

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-21742

### For reviewers:

OCM gate and admin-acks are created based on the new feature gate reported by [QE: feature gate](https://redhat-internal.slack.com/archives/C070BJ1NS1E/p1715922826958479?thread_ts=1714710012.518619&cid=C070BJ1NS1E)

- OCM Gate added for 4.16
```
ocm get /api/clusters_mgmt/v1/version_gates | jq -r '.items[] | select(.version_raw_id_prefix=="4.16")'
{
  "kind": "VersionGate",
  "id": "abc08218-17ef-11ef-9b4e-0a580a820515",
  "href": "/api/clusters_mgmt/v1/version_gates/abc08218-17ef-11ef-9b4e-0a580a820515",
  "version_raw_id_prefix": "4.16",
  "label": "api.openshift.com/gate-ocp",
  "value": "4.16",
  "warning_message": "To prevent an outage on your cluster, review any APIs in use that will be removed, and migrate them to the appropriate new API version. Failure to evaluate and migrate components affected by this update can cause some types of workloads to stop functioning.",
  "description": "OpenShift removes several Kubernetes APIs, including flowschemas (flowcontrol.apiserver.k8s.io/v1beta2) and prioritylevelconfigurations (flowcontrol.apiserver.k8s.io/v1beta2) in OpenShift 4.16.",
  "documentation_url": "https://access.redhat.com/articles/6955985",
  "sts_only": false,
  "creation_timestamp": "2024-05-22T03:59:21.791747Z"
}
```
- KCS regarding the API deprecations and removals: https://access.redhat.com/articles/6955985
- More context: https://redhat-internal.slack.com/archives/C070BJ1NS1E/p1715144639473059?thread_ts=1714710012.518619&cid=C070BJ1NS1E
