### PR TITLE
SDCICD-1292: set MGO NS resourceApplyMode=Upsert

### DIFF
--- a/deploy/osd-must-gather-operator/config.yaml
+++ b/deploy/osd-must-gather-operator/config.yaml
@@ -1,5 +1,5 @@
 deploymentMode: "SelectorSyncSet" 
 selectorSyncSet: 
-  resourceApplyMode: "Sync"
+  resourceApplyMode: "Upsert"
 policy:
   destination: "acm-policies"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29969,7 +29969,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: Namespace

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29969,7 +29969,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: Namespace

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29969,7 +29969,7 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
+    resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
### What type of PR is this?

/cleanup

### What this PR does / why we need it?

This namespace should not be defined in MCC as it conflicts with the namespace defined in the operator repository. Set the resourceApplyMode to Upsert to allow deleting the SSS in a future PR, and avoiding deletion of the namespace itself (the other SSS will take care of that).

The namespace is also defined here:

https://github.com/openshift/must-gather-operator/blob/36981769f414e8c138484e4c8f370cba63aafa1c/hack/olm-registry/olm-artifacts-template.yaml#L33

https://redhat-internal.slack.com/archives/CFJD1NZFT/p1716216917180149?thread_ts=1715864690.782999&cid=CFJD1NZFT

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/SDCICD-1292

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
