### PR TITLE
OSD-22575: add permissions to dedicated-reader and dedicated-admin to view console/monitoring tab data

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -898,6 +898,16 @@ spec:
                                 - get
                                 - list
                                 - watch
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resourceNames:
+                                - k8s
+                              resources:
+                                - prometheuses/api
+                              verbs:
+                                - get
+                                - create
+                                - update
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -320,3 +320,19 @@ rules:
   - get
   - list
   - watch
+### BEGIN - Allow viewing observe tab data in console and query the thanos API
+# Permission is needed in the project openshift-monitoring
+# prometheuses/api is an abstract construct and doesn't map to any concrete object
+# `get` is sufficient for the cluster console observe tab
+# `create` and `update` verbs allow interacting with the api directly
+- apiGroups:
+  - monitoring.coreos.com
+  resourceNames:
+  - k8s
+  resources:
+  - prometheuses/api
+  verbs:
+  - get
+  - create
+  - update
+### END - Allow viewing observe tab data in console and query the thanos API

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7268,6 +7268,16 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resourceNames:
+                    - k8s
+                    resources:
+                    - prometheuses/api
+                    verbs:
+                    - get
+                    - create
+                    - update
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -34206,6 +34216,16 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resourceNames:
+        - k8s
+        resources:
+        - prometheuses/api
+        verbs:
+        - get
+        - create
+        - update
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7268,6 +7268,16 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resourceNames:
+                    - k8s
+                    resources:
+                    - prometheuses/api
+                    verbs:
+                    - get
+                    - create
+                    - update
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -34206,6 +34216,16 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resourceNames:
+        - k8s
+        resources:
+        - prometheuses/api
+        verbs:
+        - get
+        - create
+        - update
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7268,6 +7268,16 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resourceNames:
+                    - k8s
+                    resources:
+                    - prometheuses/api
+                    verbs:
+                    - get
+                    - create
+                    - update
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -34206,6 +34216,16 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resourceNames:
+        - k8s
+        resources:
+        - prometheuses/api
+        verbs:
+        - get
+        - create
+        - update
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

With 4.15, `cluster-monitoring-view` [was updated](https://github.com/openshift/cluster-monitoring-operator/blob/master/assets/cluster-monitoring-operator/cluster-role-view.yaml#L15-L24) to work with `kube-rbac-proxy`, but now requires access to `prometheuses/api` in the `openshift-monitoring` namespace. Previously, `oauth-proxy` was used and permissions were gated on `get namespaces`. 

Resources  needed for the console monitoring tab for 4.15+ are now queried through the prometheuses/api subresource in the `openshift-monitoring` namespace

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-22575

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
