### PR TITLE
[OSD-22043] Update sre-operators recording rule

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
@@ -14,17 +14,11 @@ spec:
             # csv_succeeded has a value of 1 or 0
             # subscription_sync_total is an integer with value >0
             # joining them with the operator ^ returns a value of 1 or 0
-            label_replace(sre:telemetry:managed_labels, "cluster_version", "$0", "version", ".*")
+              label_replace(sre:telemetry:managed_labels, "cluster_version", "$0", "version", ".*")
             * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, installed, namespace, name, version, channel, package) (
-                  label_replace(
-                    csv_succeeded,
-                    "installed",
-                    "$0",
-                    "name",
-                    ".*"
-                  )
-                ^ on (installed) group_left (name, channel, package)
+              sum by (exported_namespace, name, version, channel, package) (
+                  label_replace(csv_succeeded, "name", "$1", "name", "([^.]+).*")
+                ^ on (name) group_left (channel, package)
                   subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
           record:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36336,9 +36336,9 @@ objects:
           rules:
           - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
               "version", ".*") * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, installed, namespace, name, version, channel,
-              package) ( label_replace( csv_succeeded, "installed", "$0", "name",
-              ".*" ) ^ on (installed) group_left (name, channel, package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
+              sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
+              "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
+              package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
             record: sre:operators:succeeded
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36336,9 +36336,9 @@ objects:
           rules:
           - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
               "version", ".*") * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, installed, namespace, name, version, channel,
-              package) ( label_replace( csv_succeeded, "installed", "$0", "name",
-              ".*" ) ^ on (installed) group_left (name, channel, package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
+              sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
+              "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
+              package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
             record: sre:operators:succeeded
     - apiVersion: monitoring.coreos.com/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36336,9 +36336,9 @@ objects:
           rules:
           - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
               "version", ".*") * on () group_right (_id, cluster_version, provider)
-              sum by (exported_namespace, installed, namespace, name, version, channel,
-              package) ( label_replace( csv_succeeded, "installed", "$0", "name",
-              ".*" ) ^ on (installed) group_left (name, channel, package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
+              sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
+              "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
+              package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
             record: sre:operators:succeeded
     - apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
Updating the sre-operators recording rule to join the csv_succeeded and subscription_sync_total on "operator-name" instead of "operator-name"+"operator version" since csv and subscription can refer to different versions for the same operator.

Ticket: https://issues.redhat.com/browse/OSD-22043