### PR TITLE
OSD-21899-update to chrony to reduce makestep from 100 to 10 seconds

### DIFF
--- a/deploy/osd-fedramp-machineconfig/00-fedramp-chrony-master.yaml
+++ b/deploy/osd-fedramp-machineconfig/00-fedramp-chrony-master.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: gzip
-            source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+            source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
           mode: 420
           overwrite: true
           path: /etc/chrony.conf

--- a/deploy/osd-fedramp-machineconfig/00-fedramp-chrony-worker.yaml
+++ b/deploy/osd-fedramp-machineconfig/00-fedramp-chrony-worker.yaml
@@ -13,7 +13,7 @@ spec:
       files:
         - contents:
             compression: gzip
-            source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+            source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
           mode: 420
           overwrite: true
           path: /etc/chrony.conf

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28420,7 +28420,7 @@ objects:
             files:
             - contents:
                 compression: gzip
-                source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+                source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
               mode: 420
               overwrite: true
               path: /etc/chrony.conf
@@ -28438,7 +28438,7 @@ objects:
             files:
             - contents:
                 compression: gzip
-                source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+                source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
               mode: 420
               overwrite: true
               path: /etc/chrony.conf

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28420,7 +28420,7 @@ objects:
             files:
             - contents:
                 compression: gzip
-                source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+                source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
               mode: 420
               overwrite: true
               path: /etc/chrony.conf
@@ -28438,7 +28438,7 @@ objects:
             files:
             - contents:
                 compression: gzip
-                source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+                source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
               mode: 420
               overwrite: true
               path: /etc/chrony.conf

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28420,7 +28420,7 @@ objects:
             files:
             - contents:
                 compression: gzip
-                source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+                source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
               mode: 420
               overwrite: true
               path: /etc/chrony.conf
@@ -28438,7 +28438,7 @@ objects:
             files:
             - contents:
                 compression: gzip
-                source: data:;base64,H4sIAAAAAAAC/5zLTQ6CMBBA4X1PMSeYUlCU45QyxYn9y7QSub2J4t64e8nLV0k2EjD9hCOaM/ZXKEKeBHh+SG0QOZUcApwg2uen1BcNPZpxwOmC5g81/qQWYd88BwK9WdGBZ+1uktOu30dJc3VPTkV7p9qogOk6GFTI68JymLweRr0CAAD//4w+gVLvAAAA
+                source: data:;base64,H4sIAAAAAAAC/5zLXa7CIBBA4XdWMSsYLu0V7XIoHepE/jJgY3dvovXd+HaSk6+RbCRghgktmhMOF6hCgQR4vkvrkDjXEiP8Q3KPd6kPGgc0dsTpjOYHZb9Si3DogSOB3pzoyLP2Vyl516+jpPu2Z6+Su1HrVMH8wahiWReWg5T1IOoZAAD//zWIYUfuAAAA
               mode: 420
               overwrite: true
               path: /etc/chrony.conf


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
bug. 

### What this PR does / why we need it?
[OSD-21899](https://issues.redhat.com/browse/OSD-21899)
The previous change produced promising results in non-prod, but when moving to prod it did not produce the expected results.  This will reduce the makestep in chrony.conf from 100 seconds to 10 seconds.  This setting is more in line with the alert.  The NodeClock alert is configured to alert if the clock is off by > 16 seconds for > 10 minutes.  Setting this to 10 is below this threshold.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:
CR: https://osd-jira.redhat-osd.local:8443/browse/RHOSDCM-1744

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [] Included documentation changes with PR
- [X] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
