### PR TITLE
removes fedramp clusters from commercial specific sss

### DIFF
--- a/deploy/cloud-ingress-operator-configuration/routerreplicas-osd-8028/config.yaml
+++ b/deploy/cloud-ingress-operator-configuration/routerreplicas-osd-8028/config.yaml
@@ -4,3 +4,6 @@ selectorSyncSet:
     - key: api.openshift.com/id
       operator: In
       values: "${{ROUTER_REPLICA_CLUSTER_IDS}}"
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]           

--- a/deploy/crio-loglinking/config.yaml
+++ b/deploy/crio-loglinking/config.yaml
@@ -11,3 +11,6 @@ selectorSyncSet:
     - key: api.openshift.com/legal-entity-id
       operator: In
       values: "${{LOG_LINKING_ENTITY_IDS}}"
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]      

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21383,6 +21383,10 @@ objects:
       - key: api.openshift.com/id
         operator: In
         values: ${{ROUTER_REPLICA_CLUSTER_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: v1
@@ -22024,6 +22028,10 @@ objects:
       - key: api.openshift.com/legal-entity-id
         operator: In
         values: ${{LOG_LINKING_ENTITY_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21383,6 +21383,10 @@ objects:
       - key: api.openshift.com/id
         operator: In
         values: ${{ROUTER_REPLICA_CLUSTER_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: v1
@@ -22024,6 +22028,10 @@ objects:
       - key: api.openshift.com/legal-entity-id
         operator: In
         values: ${{LOG_LINKING_ENTITY_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21383,6 +21383,10 @@ objects:
       - key: api.openshift.com/id
         operator: In
         values: ${{ROUTER_REPLICA_CLUSTER_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: v1
@@ -22024,6 +22028,10 @@ objects:
       - key: api.openshift.com/legal-entity-id
         operator: In
         values: ${{LOG_LINKING_ENTITY_IDS}}
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?

FedRAMP does not have the cloud ingress operator, nor does it support Adobe in FedRAMP as a customer. Since we do not have FedRAMP specific values to deploy with for these SSS, removing them from our clusters as it causes sync errors and noise.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ FedRAMP in-boundary ticket

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
