### PR TITLE
[OSD-22081] Add new patch to allow dns-default pods to schedule on infra nodes.

### DIFF
--- a/deploy/osd-dns-default/README.md
+++ b/deploy/osd-dns-default/README.md
@@ -1,0 +1,13 @@
+# OSD-22081
+
+This will allow dns-default pods to run on every node of a cluster.
+
+This did lead to problems, when infra nodes were using worker nodes that were
+overloaded to handle the DNS requests.
+
+Instead with this patch, the infra nodes will get their own dns-default pods,
+removing this source of issues.
+
+This patch has to patch-in the default master-toleration as well, as just adding
+the infra toleration will remove the implicit master toleration that is present
+in a default installation.

--- a/deploy/osd-dns-default/config.yaml
+++ b/deploy/osd-dns-default/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/deploy/osd-dns-default/dns-default.Dns.patch.yaml
+++ b/deploy/osd-dns-default/dns-default.Dns.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: operator.openshift.io/v1
+applyMode: Sync
+kind: DNS
+name: default
+patchtype: merge
+patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule", "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect": "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28342,6 +28342,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-dns-default
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: Sync
+      kind: DNS
+      name: default
+      patchtype: merge
+      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
+        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-cluster-monitoring-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28342,6 +28342,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-dns-default
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: Sync
+      kind: DNS
+      name: default
+      patchtype: merge
+      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
+        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-cluster-monitoring-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28342,6 +28342,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-dns-default
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: Sync
+      kind: DNS
+      name: default
+      patchtype: merge
+      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
+        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-cluster-monitoring-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This is to fix OSD-22081 - probes from blackbox-exporter might fail if an infra nodes uses an overloaded workers node's DNS pod.

Simply moving the blackbox-exporter lead to problems for 4.12 clusters.

### What type of PR is this?
Feature

### What this PR does / why we need it?

It will patch the DNS operator to allow running the pods on infra nodes to prevent spurios probe failures for the blackbox exporter, when the infra node uses a worker node's DNS pod but the worker is too overloaded to respond.

### Which Jira/Github issue(s) this PR fixes?

OSD-22081

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR
- [X] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
