### PR TITLE
Excludes openshift-cnv namespace

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -22,7 +22,7 @@ spec:
       expr: |-
         max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~"openshift-.*"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~"openshift-.*"} )
         unless on(namespace)
-          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno)"}
+          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)"}
       for: 15m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35616,7 +35616,8 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno)\"}"
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              }"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35616,7 +35616,8 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno)\"}"
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              }"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35616,7 +35616,8 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno)\"}"
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              }"
             for: 15m
             labels:
               severity: critical


### PR DESCRIPTION
Excludes the openshift-cnv namespace from PDB alerts we get alerted on.
