### PR TITLE
OCPBUGS-25341 - Add job to refresh packageserver csv across fleet 

### DIFF
--- a/deploy/ocpbugs-25341/01-serviceaccount.yaml
+++ b/deploy/ocpbugs-25341/01-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "sre-replace-packageserver-csv"
+  namespace: "openshift-operator-lifecycle-manager"

--- a/deploy/ocpbugs-25341/02-role.yaml
+++ b/deploy/ocpbugs-25341/02-role.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "sre-replace-packageserver-csv"
+  namespace: "openshift-operator-lifecycle-manager"
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - "clusterserviceversions"
+  verbs:
+  - list
+  - get
+  - watch
+  - delete

--- a/deploy/ocpbugs-25341/03-rolebinding.yaml
+++ b/deploy/ocpbugs-25341/03-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "sre-replace-packageserver-csv"
+  namespace: "openshift-operator-lifecycle-manager"
+roleRef:
+  kind: Role
+  name: "sre-replace-packageserver-csv"
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: "sre-replace-packageserver-csv"
+  namespace: "openshift-operator-lifecycle-manager"

--- a/deploy/ocpbugs-25341/04-job.yaml
+++ b/deploy/ocpbugs-25341/04-job.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "sre-replace-packageserver-csv"
+  namespace: "openshift-operator-lifecycle-manager"
+spec:
+  ttlSecondsAfterFinish: 100
+  template:
+    spec:
+      serviceAccountName: "sre-replace-packageserver-csv"
+      restartPolicy: Never
+      containers:
+      - name: delete-csv
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: Always
+        command:
+        - sh
+        - -c
+        - |
+          #!/bin/sh
+          set -euxo pipefail
+          oc -n openshift-operator-lifecycle-manager delete csv packageserver

--- a/deploy/ocpbugs-25341/config.yaml
+++ b/deploy/ocpbugs-25341/config.yaml
@@ -1,0 +1,8 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23996,6 +23996,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-25341
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - watch
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      roleRef:
+        kind: Role
+        name: sre-replace-packageserver-csv
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        ttlSecondsAfterFinish: 100
+        template:
+          spec:
+            serviceAccountName: sre-replace-packageserver-csv
+            restartPolicy: Never
+            containers:
+            - name: delete-csv
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - '#!/bin/sh
+
+                set -euxo pipefail
+
+                oc -n openshift-operator-lifecycle-manager delete csv packageserver
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-773
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23996,6 +23996,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-25341
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - watch
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      roleRef:
+        kind: Role
+        name: sre-replace-packageserver-csv
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        ttlSecondsAfterFinish: 100
+        template:
+          spec:
+            serviceAccountName: sre-replace-packageserver-csv
+            restartPolicy: Never
+            containers:
+            - name: delete-csv
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - '#!/bin/sh
+
+                set -euxo pipefail
+
+                oc -n openshift-operator-lifecycle-manager delete csv packageserver
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-773
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23996,6 +23996,83 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocpbugs-25341
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - watch
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      roleRef:
+        kind: Role
+        name: sre-replace-packageserver-csv
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-replace-packageserver-csv
+        namespace: openshift-operator-lifecycle-manager
+      spec:
+        ttlSecondsAfterFinish: 100
+        template:
+          spec:
+            serviceAccountName: sre-replace-packageserver-csv
+            restartPolicy: Never
+            containers:
+            - name: delete-csv
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - '#!/bin/sh
+
+                set -euxo pipefail
+
+                oc -n openshift-operator-lifecycle-manager delete csv packageserver
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocpbugs-773
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Deletes the `packageserver` clusterserviceversion object in the `openshift-operator-lifecycle-manager` namespace on every cluster in the fleet as a workaround to excessive alerting caused by OCPBUGS-25341

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ OCPBUGS-25341

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
