### PR TITLE
[OSD-22081] Put dns-default pods on infras

### DIFF
--- a/deploy/osd-dns-default/README.md
+++ b/deploy/osd-dns-default/README.md
@@ -1,0 +1,13 @@
+# OSD-22081
+
+This will allow dns-default pods to run on every node of a cluster.
+
+This did lead to problems, when infra nodes were using worker nodes that were
+overloaded to handle the DNS requests.
+
+Instead with this patch, the infra nodes will get their own dns-default pods,
+removing this source of issues.
+
+This patch has to patch-in the default master-toleration as well, as just adding
+the infra toleration will remove the implicit master toleration that is present
+in a default installation.

--- a/deploy/osd-dns-default/config.yaml
+++ b/deploy/osd-dns-default/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/deploy/osd-dns-default/config.yaml
+++ b/deploy/osd-dns-default/config.yaml
@@ -1,8 +1,3 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: "Sync"
-  matchExpressions:
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values:
-      - "true"

--- a/deploy/osd-dns-default/dns-default.Dns.patch.yaml
+++ b/deploy/osd-dns-default/dns-default.Dns.patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.openshift.io/v1
+applyMode: Sync
+kind: DNS
+name: default
+patchType: merge
+patch: >-
+  {"spec":
+    {"nodePlacement":
+      {"tolerations":
+        [
+          {"effect": "NoSchedule", "key": "node-role.kubernetes.io", "value": "infra", "operator": "Equal"},
+          {"effect": "NoSchedule", "key": "node-role.kubernetes.io/infra", "operator": "Exists"},
+          {"effect": "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}
+        ]
+      }
+    }
+  }

--- a/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
+++ b/deploy/osd-rebalance-infra-nodes/07-osd-rebalance-infra-nodes.ConfigMap.yaml
@@ -136,9 +136,6 @@ data:
         done
     }
 
-    echo "INFO: Rebalancing openshift-dns/dns-default Daemonset..."
-    kubeDaemonsetMisscheduled "openshift-dns" "dns.operator.openshift.io/daemonset-dns=default"
-
     echo "INFO: Rebalancing prometheus pods..."
     rebalancePods prometheus openshift-monitoring app prometheus-data
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28384,6 +28384,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-dns-default
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: Sync
+      kind: DNS
+      name: default
+      patchtype: merge
+      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
+        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-cluster-monitoring-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28389,21 +28389,19 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: operator.openshift.io/v1
       applyMode: Sync
       kind: DNS
       name: default
-      patchtype: merge
-      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
-        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
-        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+      patchType: merge
+      patch: "{\"spec\":\n  {\"nodePlacement\":\n    {\"tolerations\":\n      [\n\
+        \        {\"effect\": \"NoSchedule\", \"key\": \"node-role.kubernetes.io\"\
+        , \"value\": \"infra\", \"operator\": \"Equal\"},\n        {\"effect\": \"\
+        NoSchedule\", \"key\": \"node-role.kubernetes.io/infra\", \"operator\": \"\
+        Exists\"},\n        {\"effect\": \"NoSchedule\", \"key\": \"node-role.kubernetes.io/master\"\
+        , \"operator\": \"Exists\"}\n      ]\n    }\n  }\n}"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -30888,18 +30886,16 @@ objects:
           \ --ignore-not-found=true \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<<\
           \ \"$misscheduled_pods\"\n      else\n        echo \"INFO: no misscheduled\
           \ pods in $ns namespaces\"\n      fi\n    done\n}\n\necho \"INFO: Rebalancing\
-          \ openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled \"\
-          openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\n\
-          echo \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
-          \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
-          \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
-          \ app prometheus-user-workload-db\n\necho \"INFO: Rebalancing alertmanager\
-          \ pods...\"\nrebalancePods alertmanager openshift-monitoring app alertmanager-data\n\
-          \necho \"INFO: Rebalancing splunk-heavy-forwarder pods...\"\nrebalancePods\
-          \ splunk-heavy-forwarder openshift-security name\n\nif $REBALANCE_PODS;\
-          \ then\n    echo \"INFO: Restarting prometheus operator...\"\n    OPERATOR_POD=$(\
-          \ oc get pod -n openshift-monitoring -l app.kubernetes.io/name=prometheus-operator\
-          \ -o jsonpath='{.items[*].metadata.name}' )\n    oc delete pod -n openshift-monitoring\
+          \ prometheus pods...\"\nrebalancePods prometheus openshift-monitoring app\
+          \ prometheus-data\n\necho \"INFO: Rebalancing UWM prometheus pods...\"\n\
+          rebalancePods prometheus openshift-user-workload-monitoring app prometheus-user-workload-db\n\
+          \necho \"INFO: Rebalancing alertmanager pods...\"\nrebalancePods alertmanager\
+          \ openshift-monitoring app alertmanager-data\n\necho \"INFO: Rebalancing\
+          \ splunk-heavy-forwarder pods...\"\nrebalancePods splunk-heavy-forwarder\
+          \ openshift-security name\n\nif $REBALANCE_PODS; then\n    echo \"INFO:\
+          \ Restarting prometheus operator...\"\n    OPERATOR_POD=$( oc get pod -n\
+          \ openshift-monitoring -l app.kubernetes.io/name=prometheus-operator -o\
+          \ jsonpath='{.items[*].metadata.name}' )\n    oc delete pod -n openshift-monitoring\
           \ $OPERATOR_POD --wait=true\n    sleep 10\nfi\n\necho \"INFO: Check pending\
           \ prometheus pods...\"\ncheckPendingPods prometheus openshift-monitoring\
           \ app\n\necho \"INFO: Check pending UWM prometheus pods...\"\ncheckPendingPods\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28384,6 +28384,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-dns-default
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: Sync
+      kind: DNS
+      name: default
+      patchtype: merge
+      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
+        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-cluster-monitoring-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28389,21 +28389,19 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: operator.openshift.io/v1
       applyMode: Sync
       kind: DNS
       name: default
-      patchtype: merge
-      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
-        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
-        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+      patchType: merge
+      patch: "{\"spec\":\n  {\"nodePlacement\":\n    {\"tolerations\":\n      [\n\
+        \        {\"effect\": \"NoSchedule\", \"key\": \"node-role.kubernetes.io\"\
+        , \"value\": \"infra\", \"operator\": \"Equal\"},\n        {\"effect\": \"\
+        NoSchedule\", \"key\": \"node-role.kubernetes.io/infra\", \"operator\": \"\
+        Exists\"},\n        {\"effect\": \"NoSchedule\", \"key\": \"node-role.kubernetes.io/master\"\
+        , \"operator\": \"Exists\"}\n      ]\n    }\n  }\n}"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -30888,18 +30886,16 @@ objects:
           \ --ignore-not-found=true \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<<\
           \ \"$misscheduled_pods\"\n      else\n        echo \"INFO: no misscheduled\
           \ pods in $ns namespaces\"\n      fi\n    done\n}\n\necho \"INFO: Rebalancing\
-          \ openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled \"\
-          openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\n\
-          echo \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
-          \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
-          \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
-          \ app prometheus-user-workload-db\n\necho \"INFO: Rebalancing alertmanager\
-          \ pods...\"\nrebalancePods alertmanager openshift-monitoring app alertmanager-data\n\
-          \necho \"INFO: Rebalancing splunk-heavy-forwarder pods...\"\nrebalancePods\
-          \ splunk-heavy-forwarder openshift-security name\n\nif $REBALANCE_PODS;\
-          \ then\n    echo \"INFO: Restarting prometheus operator...\"\n    OPERATOR_POD=$(\
-          \ oc get pod -n openshift-monitoring -l app.kubernetes.io/name=prometheus-operator\
-          \ -o jsonpath='{.items[*].metadata.name}' )\n    oc delete pod -n openshift-monitoring\
+          \ prometheus pods...\"\nrebalancePods prometheus openshift-monitoring app\
+          \ prometheus-data\n\necho \"INFO: Rebalancing UWM prometheus pods...\"\n\
+          rebalancePods prometheus openshift-user-workload-monitoring app prometheus-user-workload-db\n\
+          \necho \"INFO: Rebalancing alertmanager pods...\"\nrebalancePods alertmanager\
+          \ openshift-monitoring app alertmanager-data\n\necho \"INFO: Rebalancing\
+          \ splunk-heavy-forwarder pods...\"\nrebalancePods splunk-heavy-forwarder\
+          \ openshift-security name\n\nif $REBALANCE_PODS; then\n    echo \"INFO:\
+          \ Restarting prometheus operator...\"\n    OPERATOR_POD=$( oc get pod -n\
+          \ openshift-monitoring -l app.kubernetes.io/name=prometheus-operator -o\
+          \ jsonpath='{.items[*].metadata.name}' )\n    oc delete pod -n openshift-monitoring\
           \ $OPERATOR_POD --wait=true\n    sleep 10\nfi\n\necho \"INFO: Check pending\
           \ prometheus pods...\"\ncheckPendingPods prometheus openshift-monitoring\
           \ app\n\necho \"INFO: Check pending UWM prometheus pods...\"\ncheckPendingPods\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28384,6 +28384,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-dns-default
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: Sync
+      kind: DNS
+      name: default
+      patchtype: merge
+      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
+        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
+        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-cluster-monitoring-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28389,21 +28389,19 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     patches:
     - apiVersion: operator.openshift.io/v1
       applyMode: Sync
       kind: DNS
       name: default
-      patchtype: merge
-      patch: '{"spec": {"nodePlacement": {"tolerations": [{"effect": "NoSchedule",
-        "key": "node-role.kubernetes.io/infra", "operator": "Exists"}, {"effect":
-        "NoSchedule", "key": "node-role.kubernetes.io/master", "operator": "Exists"}]}}}'
+      patchType: merge
+      patch: "{\"spec\":\n  {\"nodePlacement\":\n    {\"tolerations\":\n      [\n\
+        \        {\"effect\": \"NoSchedule\", \"key\": \"node-role.kubernetes.io\"\
+        , \"value\": \"infra\", \"operator\": \"Equal\"},\n        {\"effect\": \"\
+        NoSchedule\", \"key\": \"node-role.kubernetes.io/infra\", \"operator\": \"\
+        Exists\"},\n        {\"effect\": \"NoSchedule\", \"key\": \"node-role.kubernetes.io/master\"\
+        , \"operator\": \"Exists\"}\n      ]\n    }\n  }\n}"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -30888,18 +30886,16 @@ objects:
           \ --ignore-not-found=true \" $2}'`;echo \"INFO: $cmd\"; eval $cmd;done <<<\
           \ \"$misscheduled_pods\"\n      else\n        echo \"INFO: no misscheduled\
           \ pods in $ns namespaces\"\n      fi\n    done\n}\n\necho \"INFO: Rebalancing\
-          \ openshift-dns/dns-default Daemonset...\"\nkubeDaemonsetMisscheduled \"\
-          openshift-dns\" \"dns.operator.openshift.io/daemonset-dns=default\"\n\n\
-          echo \"INFO: Rebalancing prometheus pods...\"\nrebalancePods prometheus\
-          \ openshift-monitoring app prometheus-data\n\necho \"INFO: Rebalancing UWM\
-          \ prometheus pods...\"\nrebalancePods prometheus openshift-user-workload-monitoring\
-          \ app prometheus-user-workload-db\n\necho \"INFO: Rebalancing alertmanager\
-          \ pods...\"\nrebalancePods alertmanager openshift-monitoring app alertmanager-data\n\
-          \necho \"INFO: Rebalancing splunk-heavy-forwarder pods...\"\nrebalancePods\
-          \ splunk-heavy-forwarder openshift-security name\n\nif $REBALANCE_PODS;\
-          \ then\n    echo \"INFO: Restarting prometheus operator...\"\n    OPERATOR_POD=$(\
-          \ oc get pod -n openshift-monitoring -l app.kubernetes.io/name=prometheus-operator\
-          \ -o jsonpath='{.items[*].metadata.name}' )\n    oc delete pod -n openshift-monitoring\
+          \ prometheus pods...\"\nrebalancePods prometheus openshift-monitoring app\
+          \ prometheus-data\n\necho \"INFO: Rebalancing UWM prometheus pods...\"\n\
+          rebalancePods prometheus openshift-user-workload-monitoring app prometheus-user-workload-db\n\
+          \necho \"INFO: Rebalancing alertmanager pods...\"\nrebalancePods alertmanager\
+          \ openshift-monitoring app alertmanager-data\n\necho \"INFO: Rebalancing\
+          \ splunk-heavy-forwarder pods...\"\nrebalancePods splunk-heavy-forwarder\
+          \ openshift-security name\n\nif $REBALANCE_PODS; then\n    echo \"INFO:\
+          \ Restarting prometheus operator...\"\n    OPERATOR_POD=$( oc get pod -n\
+          \ openshift-monitoring -l app.kubernetes.io/name=prometheus-operator -o\
+          \ jsonpath='{.items[*].metadata.name}' )\n    oc delete pod -n openshift-monitoring\
           \ $OPERATOR_POD --wait=true\n    sleep 10\nfi\n\necho \"INFO: Check pending\
           \ prometheus pods...\"\ncheckPendingPods prometheus openshift-monitoring\
           \ app\n\necho \"INFO: Check pending UWM prometheus pods...\"\ncheckPendingPods\


### PR DESCRIPTION
### What type of PR is this?
Feature: reintroduce the patch for [OSD-22081](https://issues.redhat.com//browse/OSD-22081) - this allows dns-default pods to run on infras and updates the cronjob to rebalance infra nodes to not remove them.

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-22081](https://issues.redhat.com//browse/OSD-22081)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
