### PR TITLE
Remove the gate-sts key from selectorsyncset

### DIFF
--- a/deploy/osd-cluster-acks/sts/4.16/config.yaml
+++ b/deploy/osd-cluster-acks/sts/4.16/config.yaml
@@ -4,9 +4,6 @@ selectorSyncSet:
   - key: hive.openshift.io/version-major-minor
     operator: In
     values: ["4.15"]
-  - key: api.openshift.com/gate-sts
-    operator: In
-    values: ["4.16"]
   - key: api.openshift.com/sts
     operator: In
     values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26932,10 +26932,6 @@ objects:
         operator: In
         values:
         - '4.15'
-      - key: api.openshift.com/gate-sts
-        operator: In
-        values:
-        - '4.16'
       - key: api.openshift.com/sts
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26932,10 +26932,6 @@ objects:
         operator: In
         values:
         - '4.15'
-      - key: api.openshift.com/gate-sts
-        operator: In
-        values:
-        - '4.16'
       - key: api.openshift.com/sts
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26932,10 +26932,6 @@ objects:
         operator: In
         values:
         - '4.15'
-      - key: api.openshift.com/gate-sts
-        operator: In
-        values:
-        - '4.16'
       - key: api.openshift.com/sts
         operator: In
         values:


### PR DESCRIPTION
### What type of PR is this?
_(feature/cleanup)_

### What this PR does / why we need it?
To enable selectorsyncset applying the annotation to all the 4.15 sts clusters regardless the sts-gate

More context: https://redhat-internal.slack.com/archives/C070BJ1NS1E/p1718156320819869?thread_ts=1718024423.392559&cid=C070BJ1NS1E
