### PR TITLE
OSD-22635: remove SRE role ability pod exec and attach

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -206,12 +206,6 @@ spec:
                               verbs:
                                 - create
                             - apiGroups:
-                                - ""
-                              resources:
-                                - pods/exec
-                              verbs:
-                                - create
-                            - apiGroups:
                                 - batch
                               resources:
                                 - jobs
@@ -226,13 +220,6 @@ spec:
                               verbs:
                                 - delete
                                 - deletecollection
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - pods
-                                - pods/attach
-                              verbs:
-                                - create
                             - apiGroups:
                                 - ""
                               resources:

--- a/deploy/backplane/lpsre/rhmi/01-rhmi-lpsre-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/lpsre/rhmi/01-rhmi-lpsre-admins-project.ClusterRole.yaml
@@ -33,14 +33,6 @@ rules:
   verbs:
   - delete
   - deletecollection
-# LP SRE can use oc debug
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/attach
-  verbs:
-  - create
 # LP SRE can get pod logs
 - apiGroups:
   - ""

--- a/deploy/backplane/lpsre/rhoam/01-rhoam-lpsre-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/lpsre/rhoam/01-rhoam-lpsre-admins-project.ClusterRole.yaml
@@ -33,14 +33,6 @@ rules:
   verbs:
   - delete
   - deletecollection
-# LP SRE can use oc debug
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/attach
-  verbs:
-  - create
 # LP SRE can get pod logs
 - apiGroups:
   - ""

--- a/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
@@ -17,13 +17,6 @@ rules:
   - pods/portforward
   verbs:
   - create
-  # SRE can run commands in pods
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
 # SRE can manage jobs and builds
 - apiGroups:
   - batch
@@ -40,14 +33,6 @@ rules:
   verbs:
   - delete
   - deletecollection
-# SRE can use oc debug
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/attach
-  verbs:
-  - create
 # SRE can delete pods
 - apiGroups:
   - ""  

--- a/docs/backplane/requirements/srep/10-managed-ocp.md
+++ b/docs/backplane/requirements/srep/10-managed-ocp.md
@@ -25,10 +25,8 @@ Permissions at cluster scope.
 Permisions at namespace scope.
 * evict pods
 * portforward pods
-* exec pods
 * create and delete jobs
 * delete builds
-* oc debug
 * create security reviews
 * resize and delete PVCs
 * scale applications

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -2870,12 +2870,6 @@ objects:
                     verbs:
                     - create
                   - apiGroups:
-                    - ''
-                    resources:
-                    - pods/exec
-                    verbs:
-                    - create
-                  - apiGroups:
                     - batch
                     resources:
                     - jobs
@@ -2890,13 +2884,6 @@ objects:
                     verbs:
                     - delete
                     - deletecollection
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - pods
-                    - pods/attach
-                    verbs:
-                    - create
                   - apiGroups:
                     - ''
                     resources:
@@ -18355,13 +18342,6 @@ objects:
         - ''
         resources:
         - pods
-        - pods/attach
-        verbs:
-        - create
-      - apiGroups:
-        - ''
-        resources:
-        - pods
         - pods/log
         verbs:
         - get
@@ -18545,13 +18525,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -18762,13 +18735,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -19004,13 +18970,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -20107,12 +20066,6 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - ''
-        resources:
-        - pods/exec
-        verbs:
-        - create
-      - apiGroups:
         - batch
         resources:
         - jobs
@@ -20127,13 +20080,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -2870,12 +2870,6 @@ objects:
                     verbs:
                     - create
                   - apiGroups:
-                    - ''
-                    resources:
-                    - pods/exec
-                    verbs:
-                    - create
-                  - apiGroups:
                     - batch
                     resources:
                     - jobs
@@ -2890,13 +2884,6 @@ objects:
                     verbs:
                     - delete
                     - deletecollection
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - pods
-                    - pods/attach
-                    verbs:
-                    - create
                   - apiGroups:
                     - ''
                     resources:
@@ -18355,13 +18342,6 @@ objects:
         - ''
         resources:
         - pods
-        - pods/attach
-        verbs:
-        - create
-      - apiGroups:
-        - ''
-        resources:
-        - pods
         - pods/log
         verbs:
         - get
@@ -18545,13 +18525,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -18762,13 +18735,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -19004,13 +18970,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -20107,12 +20066,6 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - ''
-        resources:
-        - pods/exec
-        verbs:
-        - create
-      - apiGroups:
         - batch
         resources:
         - jobs
@@ -20127,13 +20080,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -2870,12 +2870,6 @@ objects:
                     verbs:
                     - create
                   - apiGroups:
-                    - ''
-                    resources:
-                    - pods/exec
-                    verbs:
-                    - create
-                  - apiGroups:
                     - batch
                     resources:
                     - jobs
@@ -2890,13 +2884,6 @@ objects:
                     verbs:
                     - delete
                     - deletecollection
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - pods
-                    - pods/attach
-                    verbs:
-                    - create
                   - apiGroups:
                     - ''
                     resources:
@@ -18355,13 +18342,6 @@ objects:
         - ''
         resources:
         - pods
-        - pods/attach
-        verbs:
-        - create
-      - apiGroups:
-        - ''
-        resources:
-        - pods
         - pods/log
         verbs:
         - get
@@ -18545,13 +18525,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -18762,13 +18735,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -19004,13 +18970,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:
@@ -20107,12 +20066,6 @@ objects:
         verbs:
         - create
       - apiGroups:
-        - ''
-        resources:
-        - pods/exec
-        verbs:
-        - create
-      - apiGroups:
         - batch
         resources:
         - jobs
@@ -20127,13 +20080,6 @@ objects:
         verbs:
         - delete
         - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        - pods/attach
-        verbs:
-        - create
       - apiGroups:
         - ''
         resources:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?

Gates `oc exec` and `oc debug` behind `--as backplane-cluster-admin`. Exec and debug can be used to access customer data, e.g. via execing into etcd pods or debugging onto nodes.

### Which Jira/Github issue(s) this PR fixes?

First pass at https://issues.redhat.com/browse/OSD-22635

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
