### PR TITLE
ROX-24844: ACS Secured Cluster Permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp_exporters/
 generated/
 .DS_Store
 .vscode/
+.idea/

--- a/deploy/backplane/acs/06-acs-rhacs-secured-cluster-role.yml
+++ b/deploy/backplane/acs/06-acs-rhacs-secured-cluster-role.yml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-acs-rhacs-secured-cluster
+  namespace: rhacs-secured-cluster
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    resourceNames:
+      - admission-control-tls
+      - collector-tls
+      - sensor-tls
+    verbs:
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+    resourceNames:
+      - sensor
+      - collector
+      - admission-control
+    verbs:
+      - get
+      - patch

--- a/deploy/backplane/acs/06-acs-rhacs-secured-cluster-rolebinding.yml
+++ b/deploy/backplane/acs/06-acs-rhacs-secured-cluster-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-acs-rhacs-secured-cluster
+  namespace: rhacs-secured-cluster
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-acs-rhacs-secured-cluster

--- a/docs/backplane/requirements/acs/10-acs-managed-service.md
+++ b/docs/backplane/requirements/acs/10-acs-managed-service.md
@@ -177,4 +177,11 @@ Permissions at cluster scope.
 * patch persistentvolumeclaims
 * patch statefulsets
 
-**Note** Please update this document as addional permisions are requested, thank you.
+## backplane-acs-rhacs-secured-cluster: `rhacs-secured-cluster`
+
+- ACS team needs to create/update Secured Cluster init-bundles
+
+* create tls secrets
+* update tls secrets
+
+**Note** Please update this document as additional permissions are requested, thank you.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -8622,6 +8622,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9335,6 +9378,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10048,6 +10134,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -8622,6 +8622,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9335,6 +9378,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10048,6 +10134,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -8622,6 +8622,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -9335,6 +9378,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10048,6 +10134,49 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - admission-control-tls
+        - collector-tls
+        - sensor-tls
+        verbs:
+        - create
+        - update
+        - patch
+      - apiGroups:
+        - apps
+        resources:
+        - deployments
+        - daemonsets
+        resourceNames:
+        - sensor
+        - collector
+        - admission-control
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Grant secrets write permissions to the secured cluster namespace for the ACS team.
Access is required to rotate client certificates using init-bundles.

### Which Jira/Github issue(s) this PR fixes?

Fixes [ROX-24844](https://issues.redhat.com//browse/ROX-24844)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
