### PR TITLE
disable UpgradeConfigSyncFailureOver4HrSRE alert for 4.16 temporary

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -54,7 +54,8 @@ spec:
       # Alert if MUO has been unable to successfully sync with its upgrade policy provider for a four-hour window
       # It will also be used for detecting the connection/authentication between cluster and OCM
       # Should be moved to OCM Agent service eventually
-      expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h]) or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
+      # FIXME: When SDE-2153 shipped
+      expr: (absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h]) or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400) and count(cluster_version{type="cluster", version!~"4.16.*"}) > 0
       for: 2m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35173,8 +35173,9 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
-              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
+            expr: (absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
+              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400) and
+              count(cluster_version{type="cluster", version!~"4.16.*"}) > 0
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35173,8 +35173,9 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
-              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
+            expr: (absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
+              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400) and
+              count(cluster_version{type="cluster", version!~"4.16.*"}) > 0
             for: 2m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35173,8 +35173,9 @@ objects:
               description: node drain takes too long and cannot be finished in the
                 given time period during cluster upgrade
           - alert: UpgradeConfigSyncFailureOver4HrSRE
-            expr: absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
-              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400
+            expr: (absent_over_time(upgradeoperator_upgradeconfig_sync_timestamp[4h])
+              or time() - upgradeoperator_upgradeconfig_sync_timestamp > 14400) and
+              count(cluster_version{type="cluster", version!~"4.16.*"}) > 0
             for: 2m
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Workaround to disable the alert temporarily before the MUO fix roll out.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OSD-24234](https://issues.redhat.com/browse/OSD-24234)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
