### PR TITLE
add ACM Policies for ACS backplane

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -1,0 +1,791 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: backplane-acs
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: backplane-acs
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: Namespace
+                        metadata:
+                            name: openshift-backplane-addon-acs-fleet-shard
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: backplane-acs-admins-cluster
+                        rules:
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - projects
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - infrastructures
+                                - oauths
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - project.openshift.io
+                              resources:
+                                - projects
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - namespaces
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - operator.openshift.io
+                              resources:
+                                - ingresscontrollers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ingress.operator.openshift.io
+                              resources:
+                                - dnsrecords
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - networking.k8s.io
+                              resources:
+                                - ingresses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - ingresses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - networks
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - nodes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - events
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/log
+                              verbs:
+                                - get
+                                - watch
+                                - list
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - deployments
+                                - statefulsets
+                                - daemonsets
+                                - replicasets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - replicationcontrollers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - batch
+                              resources:
+                                - jobs
+                                - cronjobs
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - configmaps
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - policy
+                              resources:
+                                - poddisruptionbudgets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - services
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - networking.k8s.io
+                              resources:
+                                - networkpolicies
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - rbac.authorization.k8s.io
+                              resources:
+                                - roles
+                                - rolebindings
+                                - clusterroles
+                                - clusterrolebindings
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apiextensions.k8s.io
+                              resources:
+                                - customresourcedefinitions
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - metrics.k8s.io
+                              resources:
+                                - pods
+                                - nodes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - storage.k8s.io
+                              resources:
+                                - storageclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - persistentvolumes
+                                - persistentvolumeclaims
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - snapshot.storage.k8s.io
+                              resources:
+                                - volumesnapshots
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - template.openshift.io
+                              resources:
+                                - templates
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - external-secrets.io
+                              resources:
+                                - clustersecretstores
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - machineconfiguration.openshift.io
+                              resources:
+                                - machineconfigs
+                                - machineconfigpools
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - alertmanagerconfigs
+                                - alertmanagers
+                                - podmonitors
+                                - probes
+                                - prometheuses
+                                - prometheusrules
+                                - servicemonitors
+                                - thanosrulers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - clusteroperators
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - clusterversions
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - namespaces
+                                - clusterserviceversions
+                                - subscriptions
+                                - catalogsources
+                                - operatorgroups
+                                - operators
+                                - installplans
+                                - olmconfigs
+                                - operatorconditions
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - serviceaccounts
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - resourcequotas
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - quota.openshift.io
+                              resources:
+                                - appliedclusterresourcequotas
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - limitranges
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - autoscaling
+                              resources:
+                                - horizontalpodautoscalers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - helm.openshift.io
+                              resources:
+                                - projecthelmchartrepositories
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - addons.managed.openshift.io
+                              resources:
+                                - addonoperators
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - machine.openshift.io
+                              resources:
+                                - machines
+                                - machinesets
+                                - machinehealthchecks
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - autoscaling.openshift.io
+                              resources:
+                                - machineautoscalers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - autoscaling.k8s.io
+                              resources:
+                                - verticalpodautoscalers
+                                - verticalpodautoscalercheckpoints
+                                - verticalpodautoscalercontrollers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: backplane-acs-admins-project
+                        rules:
+                            - apiGroups:
+                                - platform.stackrox.io
+                                - cloud.stackrox.io
+                              resources:
+                                - centrals
+                                - securedclusters
+                                - fleetshards
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                                - pods/log
+                              verbs:
+                                - get
+                                - watch
+                                - list
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - services
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - deployments
+                                - statefulsets
+                                - daemonsets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - app.k8s.io
+                              resources:
+                                - applications
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - route.openshift.io
+                              resources:
+                                - routes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - k8s.ovn.org
+                              resources:
+                                - egressfirewalls
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - rbac.authorization.k8s.io
+                              resources:
+                                - roles
+                                - rolebindings
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - persistentvolumeclaims
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - external-secrets.io
+                              resources:
+                                - secretstores
+                                - externalsecrets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - serviceaccounts
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - security.openshift.io
+                              resources:
+                                - securitycontextconstraints
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/portforward
+                                - pods/exec
+                              verbs:
+                                - create
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                              verbs:
+                                - delete
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-acs-openshift-ingress
+                            namespace: openshift-ingress
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                                - pods/log
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - deployments
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-acs-openshift-ingress
+                            namespace: openshift-ingress
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-acs-openshift-ingress
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-acs-openshift-monitoring
+                            namespace: openshift-monitoring
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods
+                                - pods/log
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - statefulsets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - services
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - deployments
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - pods/portforward
+                              verbs:
+                                - create
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-acs-openshift-monitoring
+                            namespace: openshift-monitoring
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-acs-openshift-monitoring
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-acs-openshift-console
+                            namespace: openshift-console
+                        rules:
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - deployments
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-acs-openshift-console
+                            namespace: openshift-console
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-acs-openshift-console
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-acs-rhacs-observability
+                            namespace: rhacs-observability
+                        rules:
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resources:
+                                - alertmanagerconfigs
+                                - alertmanagers
+                                - podmonitors
+                                - probes
+                                - prometheuses
+                                - prometheusrules
+                                - servicemonitors
+                                - thanosrulers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - observability.redhat.com
+                              resources:
+                                - observabilities
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - integreatly.org
+                              resources:
+                                - grafanas
+                                - grafanadatasources
+                                - grafanadashboards
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - persistentvolumeclaims
+                              verbs:
+                                - patch
+                            - apiGroups:
+                                - apps
+                              resources:
+                                - statefulsets
+                              verbs:
+                                - patch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-acs-rhacs-observability
+                            namespace: rhacs-observability
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-acs-rhacs-observability
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+    remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-backplane-acs
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: api.openshift.com/addon-acs-fleetshard
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-backplane-acs
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-backplane-acs
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: backplane-acs

--- a/deploy/backplane/acs/config.yaml
+++ b/deploy/backplane/acs/config.yaml
@@ -5,3 +5,7 @@ selectorSyncSet:
     api.openshift.com/addon-acs-fleetshard-qe: "true"
     api.openshift.com/addon-acs-fleetshard-dev: "true"
   matchLabelsApplyMode: "OR"
+policy:
+    destination: "acm-policies"
+clusterSelectors:
+  'api.openshift.com/addon-acs-fleetshard': 'true'

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -637,6 +637,794 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-acs
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-acs
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-acs-admins-cluster
+                  rules:
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - infrastructures
+                    - oauths
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - ingresscontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ingress.operator.openshift.io
+                    resources:
+                    - dnsrecords
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingresses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - ingresses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - networks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/log
+                    verbs:
+                    - get
+                    - watch
+                    - list
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    - statefulsets
+                    - daemonsets
+                    - replicasets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicationcontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - jobs
+                    - cronjobs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - roles
+                    - rolebindings
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumes
+                    - persistentvolumeclaims
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshots
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - templates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - external-secrets.io
+                    resources:
+                    - clustersecretstores
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigs
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - podmonitors
+                    - probes
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - thanosrulers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - clusteroperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - clusterversions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - namespaces
+                    - clusterserviceversions
+                    - subscriptions
+                    - catalogsources
+                    - operatorgroups
+                    - operators
+                    - installplans
+                    - olmconfigs
+                    - operatorconditions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - serviceaccounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - limitranges
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - helm.openshift.io
+                    resources:
+                    - projecthelmchartrepositories
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - addons.managed.openshift.io
+                    resources:
+                    - addonoperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    - machinesets
+                    - machinehealthchecks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - machineautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.k8s.io
+                    resources:
+                    - verticalpodautoscalers
+                    - verticalpodautoscalercheckpoints
+                    - verticalpodautoscalercontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-acs-admins-project
+                  rules:
+                  - apiGroups:
+                    - platform.stackrox.io
+                    - cloud.stackrox.io
+                    resources:
+                    - centrals
+                    - securedclusters
+                    - fleetshards
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - watch
+                    - list
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    - statefulsets
+                    - daemonsets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - app.k8s.io
+                    resources:
+                    - applications
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - k8s.ovn.org
+                    resources:
+                    - egressfirewalls
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - roles
+                    - rolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - external-secrets.io
+                    resources:
+                    - secretstores
+                    - externalsecrets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - serviceaccounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    - pods/exec
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-ingress
+                    namespace: openshift-ingress
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-ingress
+                    namespace: openshift-ingress
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-ingress
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-monitoring
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - statefulsets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-monitoring
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-monitoring
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-console
+                    namespace: openshift-console
+                  rules:
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-console
+                    namespace: openshift-console
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-console
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-rhacs-observability
+                    namespace: rhacs-observability
+                  rules:
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - podmonitors
+                    - probes
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - thanosrulers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - observability.redhat.com
+                    resources:
+                    - observabilities
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - integreatly.org
+                    resources:
+                    - grafanas
+                    - grafanadatasources
+                    - grafanadashboards
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - statefulsets
+                    verbs:
+                    - patch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-rhacs-observability
+                    namespace: rhacs-observability
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-rhacs-observability
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-acs
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: api.openshift.com/addon-acs-fleetshard
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-acs
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-acs
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-acs
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -637,6 +637,794 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-acs
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-acs
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-acs-admins-cluster
+                  rules:
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - infrastructures
+                    - oauths
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - ingresscontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ingress.operator.openshift.io
+                    resources:
+                    - dnsrecords
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingresses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - ingresses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - networks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/log
+                    verbs:
+                    - get
+                    - watch
+                    - list
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    - statefulsets
+                    - daemonsets
+                    - replicasets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicationcontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - jobs
+                    - cronjobs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - roles
+                    - rolebindings
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumes
+                    - persistentvolumeclaims
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshots
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - templates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - external-secrets.io
+                    resources:
+                    - clustersecretstores
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigs
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - podmonitors
+                    - probes
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - thanosrulers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - clusteroperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - clusterversions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - namespaces
+                    - clusterserviceversions
+                    - subscriptions
+                    - catalogsources
+                    - operatorgroups
+                    - operators
+                    - installplans
+                    - olmconfigs
+                    - operatorconditions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - serviceaccounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - limitranges
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - helm.openshift.io
+                    resources:
+                    - projecthelmchartrepositories
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - addons.managed.openshift.io
+                    resources:
+                    - addonoperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    - machinesets
+                    - machinehealthchecks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - machineautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.k8s.io
+                    resources:
+                    - verticalpodautoscalers
+                    - verticalpodautoscalercheckpoints
+                    - verticalpodautoscalercontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-acs-admins-project
+                  rules:
+                  - apiGroups:
+                    - platform.stackrox.io
+                    - cloud.stackrox.io
+                    resources:
+                    - centrals
+                    - securedclusters
+                    - fleetshards
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - watch
+                    - list
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    - statefulsets
+                    - daemonsets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - app.k8s.io
+                    resources:
+                    - applications
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - k8s.ovn.org
+                    resources:
+                    - egressfirewalls
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - roles
+                    - rolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - external-secrets.io
+                    resources:
+                    - secretstores
+                    - externalsecrets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - serviceaccounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    - pods/exec
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-ingress
+                    namespace: openshift-ingress
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-ingress
+                    namespace: openshift-ingress
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-ingress
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-monitoring
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - statefulsets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-monitoring
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-monitoring
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-console
+                    namespace: openshift-console
+                  rules:
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-console
+                    namespace: openshift-console
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-console
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-rhacs-observability
+                    namespace: rhacs-observability
+                  rules:
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - podmonitors
+                    - probes
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - thanosrulers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - observability.redhat.com
+                    resources:
+                    - observabilities
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - integreatly.org
+                    resources:
+                    - grafanas
+                    - grafanadatasources
+                    - grafanadashboards
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - statefulsets
+                    verbs:
+                    - patch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-rhacs-observability
+                    namespace: rhacs-observability
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-rhacs-observability
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-acs
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: api.openshift.com/addon-acs-fleetshard
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-acs
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-acs
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-acs
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -637,6 +637,794 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: backplane-acs
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: backplane-acs
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    name: openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-acs-admins-cluster
+                  rules:
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - infrastructures
+                    - oauths
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - ingresscontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ingress.operator.openshift.io
+                    resources:
+                    - dnsrecords
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingresses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - ingresses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - networks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - events
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/log
+                    verbs:
+                    - get
+                    - watch
+                    - list
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    - statefulsets
+                    - daemonsets
+                    - replicasets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - replicationcontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - batch
+                    resources:
+                    - jobs
+                    - cronjobs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - configmaps
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - poddisruptionbudgets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - networkpolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - roles
+                    - rolebindings
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumes
+                    - persistentvolumeclaims
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshots
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - templates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - external-secrets.io
+                    resources:
+                    - clustersecretstores
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigs
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - podmonitors
+                    - probes
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - thanosrulers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - clusteroperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - clusterversions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - namespaces
+                    - clusterserviceversions
+                    - subscriptions
+                    - catalogsources
+                    - operatorgroups
+                    - operators
+                    - installplans
+                    - olmconfigs
+                    - operatorconditions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - serviceaccounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - limitranges
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling
+                    resources:
+                    - horizontalpodautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - helm.openshift.io
+                    resources:
+                    - projecthelmchartrepositories
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - addons.managed.openshift.io
+                    resources:
+                    - addonoperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machine.openshift.io
+                    resources:
+                    - machines
+                    - machinesets
+                    - machinehealthchecks
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - machineautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.k8s.io
+                    resources:
+                    - verticalpodautoscalers
+                    - verticalpodautoscalercheckpoints
+                    - verticalpodautoscalercontrollers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: backplane-acs-admins-project
+                  rules:
+                  - apiGroups:
+                    - platform.stackrox.io
+                    - cloud.stackrox.io
+                    resources:
+                    - centrals
+                    - securedclusters
+                    - fleetshards
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - watch
+                    - list
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    - statefulsets
+                    - daemonsets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - app.k8s.io
+                    resources:
+                    - applications
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - k8s.ovn.org
+                    resources:
+                    - egressfirewalls
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - roles
+                    - rolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - external-secrets.io
+                    resources:
+                    - secretstores
+                    - externalsecrets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - serviceaccounts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    - pods/exec
+                    verbs:
+                    - create
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    verbs:
+                    - delete
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-ingress
+                    namespace: openshift-ingress
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-ingress
+                    namespace: openshift-ingress
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-ingress
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-monitoring
+                    namespace: openshift-monitoring
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods
+                    - pods/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - statefulsets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - services
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - pods/portforward
+                    verbs:
+                    - create
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-monitoring
+                    namespace: openshift-monitoring
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-monitoring
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-console
+                    namespace: openshift-console
+                  rules:
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - deployments
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-console
+                    namespace: openshift-console
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-console
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-rhacs-observability
+                    namespace: rhacs-observability
+                  rules:
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - podmonitors
+                    - probes
+                    - prometheuses
+                    - prometheusrules
+                    - servicemonitors
+                    - thanosrulers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - observability.redhat.com
+                    resources:
+                    - observabilities
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - integreatly.org
+                    resources:
+                    - grafanas
+                    - grafanadatasources
+                    - grafanadashboards
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - persistentvolumeclaims
+                    verbs:
+                    - patch
+                  - apiGroups:
+                    - apps
+                    resources:
+                    - statefulsets
+                    verbs:
+                    - patch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-rhacs-observability
+                    namespace: rhacs-observability
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-rhacs-observability
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-backplane-acs
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: api.openshift.com/addon-acs-fleetshard
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-backplane-acs
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-backplane-acs
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: backplane-acs
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: backplane-cee-sp
         namespace: openshift-acm-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -13,6 +13,7 @@ base_directory = "./deploy/"
 # This script doesn't walk the sub-directories.
 directories = [
         'backplane',
+        'backplane/acs',
         'backplane/cee',
         'backplane/cse',
         'backplane/csm',
@@ -64,11 +65,10 @@ for directory in sorted(directories, key=str.casefold):
         if entry.name == config_filename:
             with open(entry.path) as config_file:
                 config = yaml.safe_load(config_file)
-                if config['deploymentMode'] == 'Policy':
-                    if 'clusterSelectors' in config:
-                        cluster_selectors = config['clusterSelectors']
-                    if 'namespaceSelector' in config:
-                        namespace_selectors = config['namespaceSelector']
+                if 'clusterSelectors' in config:
+                    cluster_selectors = config['clusterSelectors']
+                if 'namespaceSelector' in config:
+                    namespace_selectors = config['namespaceSelector']
     #create a dir in /resources to hold the newly generated policy-generator-config.yaml
     #copy over the generator template
     shutil.copy(policy_generator_config, temp_directory)


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
to enable the same access to HCP clusters for ACS via backplane

### Which Jira/Github issue(s) this PR fixes?
- https://issues.redhat.com/browse/MTSRE-1878

### Special notes for your reviewer:
complemented by a labeling of the clusters in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/111028

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
