### PR TITLE
[OHSS-32768] Add a job to remove the added dns tolerations.

### DIFF
--- a/deploy/osd-22018-remove-dns-tolerations/01-serviceaccount.yaml
+++ b/deploy/osd-22018-remove-dns-tolerations/01-serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "sre-remove-dns-tolerations"
+  namespace: "openshift-sre-pruning"

--- a/deploy/osd-22018-remove-dns-tolerations/02-role.yaml
+++ b/deploy/osd-22018-remove-dns-tolerations/02-role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "sre-remove-dns-tolerations"
+rules:
+- apiGroups:
+  - "operator.openshift.io"
+  resources:
+  - "dnses"
+  verbs:
+  - get
+  - patch

--- a/deploy/osd-22018-remove-dns-tolerations/03-rolebinding.yaml
+++ b/deploy/osd-22018-remove-dns-tolerations/03-rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "sre-remove-dns-tolerations"
+roleRef:
+  kind: ClusterRole
+  name: "sre-remove-dns-tolerations"
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: "sre-remove-dns-tolerations"
+  namespace: "openshift-sre-pruning"

--- a/deploy/osd-22018-remove-dns-tolerations/04-job.yaml
+++ b/deploy/osd-22018-remove-dns-tolerations/04-job.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "sre-remove-dns-tolerations"
+  namespace: "openshift-sre-pruning"
+spec:
+  ttlSecondsAfterFinish: 100
+  template:
+    spec:
+      serviceAccountName: "sre-remove-dns-tolerations"
+      restartPolicy: Never
+      containers:
+      - name: delete-tolerations
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: Always
+        command:
+        - sh
+        - -c
+        - |
+          #!/bin/sh
+          set -euxo pipefail
+          oc patch dnses.operator.openshift.io default --type merge -p '{"spec": {"nodePlacement": {"tolerations": []}}}'

--- a/deploy/osd-22018-remove-dns-tolerations/config.yaml
+++ b/deploy/osd-22018-remove-dns-tolerations/config.yaml
@@ -1,0 +1,6 @@
+
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions: []

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24519,6 +24519,76 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-22018-remove-dns-tolerations
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions: []
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: sre-remove-dns-tolerations
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - dnses
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-remove-dns-tolerations
+      roleRef:
+        kind: ClusterRole
+        name: sre-remove-dns-tolerations
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+      spec:
+        ttlSecondsAfterFinish: 100
+        template:
+          spec:
+            serviceAccountName: sre-remove-dns-tolerations
+            restartPolicy: Never
+            containers:
+            - name: delete-tolerations
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - '#!/bin/sh
+
+                set -euxo pipefail
+
+                oc patch dnses.operator.openshift.io default --type merge -p ''{"spec":
+                {"nodePlacement": {"tolerations": []}}}''
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24519,6 +24519,76 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-22018-remove-dns-tolerations
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions: []
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: sre-remove-dns-tolerations
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - dnses
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-remove-dns-tolerations
+      roleRef:
+        kind: ClusterRole
+        name: sre-remove-dns-tolerations
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+      spec:
+        ttlSecondsAfterFinish: 100
+        template:
+          spec:
+            serviceAccountName: sre-remove-dns-tolerations
+            restartPolicy: Never
+            containers:
+            - name: delete-tolerations
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - '#!/bin/sh
+
+                set -euxo pipefail
+
+                oc patch dnses.operator.openshift.io default --type merge -p ''{"spec":
+                {"nodePlacement": {"tolerations": []}}}''
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24519,6 +24519,76 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-22018-remove-dns-tolerations
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions: []
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: sre-remove-dns-tolerations
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - dnses
+        verbs:
+        - get
+        - patch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: sre-remove-dns-tolerations
+      roleRef:
+        kind: ClusterRole
+        name: sre-remove-dns-tolerations
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-remove-dns-tolerations
+        namespace: openshift-sre-pruning
+      spec:
+        ttlSecondsAfterFinish: 100
+        template:
+          spec:
+            serviceAccountName: sre-remove-dns-tolerations
+            restartPolicy: Never
+            containers:
+            - name: delete-tolerations
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - '#!/bin/sh
+
+                set -euxo pipefail
+
+                oc patch dnses.operator.openshift.io default --type merge -p ''{"spec":
+                {"nodePlacement": {"tolerations": []}}}''
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This should remove the pods from infra nodes, instead of splitting the fleet into clusters with tolerations and those without.
This would be the case, because [OSD-22081](https://issues.redhat.com//browse/OSD-22081) added tolerations for dns-default pods for infra nodes, but the removal of the patch did not remove those tolerations, so this will remediate this.

### What type of PR is this?
Bug

### What this PR does / why we need it?

Remove tolerations that were added to run dns-default pods on infra nodes.

### Which Jira/Github issue(s) this PR fixes?

[OHSS-35778](https://issues.redhat.com//browse/OHSS-35778)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
