### PR TITLE
adding machineautoscalers RBAC and requirements

### DIFF
--- a/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
@@ -39,3 +39,13 @@ rules:
   - get
   - list
   - watch
+# CEE can view machineautoscalerconfigs
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/docs/backplane/requirements/cee/20-machineautoscaler.md
+++ b/docs/backplane/requirements/cee/20-machineautoscaler.md
@@ -1,0 +1,22 @@
+# CEE on OSD/ROSA
+
+label selectors:
+
+- managed=true (implied)
+
+These premissions are the baseline across the managed fleet and apply to all product flavors:
+
+- OSD
+- ROSA Classic
+- ROSA HCP
+
+## openshift-backplane-cee: `cluster`
+
+These permissions are at cluster scope:
+
+- get machineautoscaler
+- list machineautoscaler
+- watch machineautoscaler
+
+* CEE needs read-only access to the `machineautoscaler` cluster resource. The `machineautoscaler` is a non-sensetive data. Having read-only access will help CEE to investigate customer issues related to the `machineautoscaler` and the `clusterautoscaler`. 
+


### PR DESCRIPTION
### What type of PR is this?

Based on the slack thread mentioned in `Special notes` below was decided to create a  PR in order to update RBAC rules in a proper way as CEE should have read access to the non-sensetive objects so that MCS/CEE can get the object from `oc` directly.

### What this PR does / why we need it?
By adding read-only RBAC to `machineautoscalers` will allow CEE to troubleshoot issue related to autos-calling easier


`oc get machineautoscaler -o yaml -n openshift-machine-api

apiVersion: v1
items: []
kind: List
metadata:
  resourceVersion: ""
Error from server (Forbidden): machineautoscalers.autoscaling.openshift.io is forbidden: User "system:serviceaccount:openshift-backplane-cee:8d5ec3a2bb1e28f30a0c48a9eeb707f3" cannot list resource "machineautoscalers" in API group "autoscaling.openshift.io" in the namespace "openshift-machine-api"`


### Special notes for your reviewer:

Discussed in the backplane slack thread 

https://redhat-internal.slack.com/archives/C016S65RNG5/p1720078609433969

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
