### PR TITLE
Fleet-wide custom-domains-operator

### DIFF
--- a/deploy/osd-24397/00-roles.yaml
+++ b/deploy/osd-24397/00-roles.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-cdo-reinstall-sa
+  namespace: openshift-custom-domains-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-cdo-reinstall-role
+  namespace: openshift-custom-domains-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-cdo-reinstall-rolebinding
+  namespace: openshift-custom-domains-operator
+roleRef:
+  kind: Role
+  name: sre-cdo-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-custom-domains-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-cdo-reinstall-sa
+  namespace: openshift-custom-domains-operator

--- a/deploy/osd-24397/01-job.yaml
+++ b/deploy/osd-24397/01-job.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sre-cdo-reinstall
+  namespace: openshift-custom-domains-operator
+spec:
+  template:
+    spec:
+      serviceAccountName: sre-cdo-reinstall-sa
+      restartPolicy: Never
+      containers:
+      - name: operator-reinstaller
+        image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+        imagePullPolicy: Always
+        command:
+        - sh
+        - -c
+        - |
+          #!/bin/bash
+          set -euxo pipefail
+          NAMESPACE=openshift-custom-domains-operator
+
+          # Check for the presence of CDO v0.1.247-394c11f (current latest). If it exists, do nothing. If any other version is found clean up OLM resources
+          if ! oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com custom-domains-operator.v0.1.245-c1065b7; then
+            oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com $(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName=="custom-domains-operator")].metadata.name}') || true
+            oc -n "$NAMESPACE" delete installplan.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=""
+            oc -n "$NAMESPACE" delete subscriptions.operators.coreos.com custom-domains-operator
+          fi
+          exit 0

--- a/deploy/osd-24397/config.yaml
+++ b/deploy/osd-24397/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11","4.12","4.13","4.14","4.15","4.16"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25377,6 +25377,98 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-24397
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-cdo-reinstall-sa
+        namespace: openshift-custom-domains-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-cdo-reinstall-role
+        namespace: openshift-custom-domains-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-cdo-reinstall-rolebinding
+        namespace: openshift-custom-domains-operator
+      roleRef:
+        kind: Role
+        name: sre-cdo-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-custom-domains-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-cdo-reinstall-sa
+        namespace: openshift-custom-domains-operator
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-cdo-reinstall
+        namespace: openshift-custom-domains-operator
+      spec:
+        template:
+          spec:
+            serviceAccountName: sre-cdo-reinstall-sa
+            restartPolicy: Never
+            containers:
+            - name: operator-reinstaller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
+                \n# Check for the presence of CDO v0.1.247-394c11f (current latest).\
+                \ If it exists, do nothing. If any other version is found clean up\
+                \ OLM resources\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                \ custom-domains-operator.v0.1.245-c1065b7; then\n  oc -n \"$NAMESPACE\"\
+                \ delete clusterserviceversions.operators.coreos.com $(oc -n \"$NAMESPACE\"\
+                \ get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName==\"\
+                custom-domains-operator\")].metadata.name}') || true\n  oc -n \"$NAMESPACE\"\
+                \ delete installplan.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
+                \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                \ custom-domains-operator\nfi\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25377,6 +25377,98 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-24397
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-cdo-reinstall-sa
+        namespace: openshift-custom-domains-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-cdo-reinstall-role
+        namespace: openshift-custom-domains-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-cdo-reinstall-rolebinding
+        namespace: openshift-custom-domains-operator
+      roleRef:
+        kind: Role
+        name: sre-cdo-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-custom-domains-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-cdo-reinstall-sa
+        namespace: openshift-custom-domains-operator
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-cdo-reinstall
+        namespace: openshift-custom-domains-operator
+      spec:
+        template:
+          spec:
+            serviceAccountName: sre-cdo-reinstall-sa
+            restartPolicy: Never
+            containers:
+            - name: operator-reinstaller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
+                \n# Check for the presence of CDO v0.1.247-394c11f (current latest).\
+                \ If it exists, do nothing. If any other version is found clean up\
+                \ OLM resources\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                \ custom-domains-operator.v0.1.245-c1065b7; then\n  oc -n \"$NAMESPACE\"\
+                \ delete clusterserviceversions.operators.coreos.com $(oc -n \"$NAMESPACE\"\
+                \ get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName==\"\
+                custom-domains-operator\")].metadata.name}') || true\n  oc -n \"$NAMESPACE\"\
+                \ delete installplan.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
+                \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                \ custom-domains-operator\nfi\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25377,6 +25377,98 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-24397
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-cdo-reinstall-sa
+        namespace: openshift-custom-domains-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-cdo-reinstall-role
+        namespace: openshift-custom-domains-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-cdo-reinstall-rolebinding
+        namespace: openshift-custom-domains-operator
+      roleRef:
+        kind: Role
+        name: sre-cdo-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-custom-domains-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-cdo-reinstall-sa
+        namespace: openshift-custom-domains-operator
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-cdo-reinstall
+        namespace: openshift-custom-domains-operator
+      spec:
+        template:
+          spec:
+            serviceAccountName: sre-cdo-reinstall-sa
+            restartPolicy: Never
+            containers:
+            - name: operator-reinstaller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-custom-domains-operator\n\
+                \n# Check for the presence of CDO v0.1.247-394c11f (current latest).\
+                \ If it exists, do nothing. If any other version is found clean up\
+                \ OLM resources\nif ! oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                \ custom-domains-operator.v0.1.245-c1065b7; then\n  oc -n \"$NAMESPACE\"\
+                \ delete clusterserviceversions.operators.coreos.com $(oc -n \"$NAMESPACE\"\
+                \ get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName==\"\
+                custom-domains-operator\")].metadata.name}') || true\n  oc -n \"$NAMESPACE\"\
+                \ delete installplan.operators.coreos.com -l operators.coreos.com/custom-domains-operator.openshift-custom-domains-operator=\"\
+                \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                \ custom-domains-operator\nfi\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What this PR does / why we need it?
Ensures deployment of CDO across the fleet is the latest version. Currently, ~55% of CDO deployments are on a version 10 months old. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-24397

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
