### PR TITLE
Adding machineautoscalers RBAC and requirements CEE RBAC + Requirements

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -71,7 +71,8 @@ spec:
                             - apiGroups:
                                 - autoscaling.openshift.io
                               resources:
-                                - '*'
+                                - clusterautoscalers
+                                - machineautoscalers
                               verbs:
                                 - get
                                 - list

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -68,6 +68,14 @@ spec:
                                 - get
                                 - list
                                 - watch
+                            - apiGroups:
+                                - autoscaling.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
@@ -43,7 +43,8 @@ rules:
 - apiGroups:
   - autoscaling.openshift.io
   resources:
-  - '*'
+  - clusterautoscalers
+  - machineautoscalers
   verbs:
   - get
   - list

--- a/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml
@@ -39,3 +39,13 @@ rules:
   - get
   - list
   - watch
+# CEE can view machineautoscalerconfigs
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+

--- a/docs/backplane/requirements/cee/20-machineautoscaler.md
+++ b/docs/backplane/requirements/cee/20-machineautoscaler.md
@@ -8,7 +8,6 @@ These premissions are the baseline across the managed fleet and apply to all pro
 
 - OSD
 - ROSA Classic
-- ROSA HCP
 
 ## openshift-backplane-cee: `cluster`
 

--- a/docs/backplane/requirements/cee/20-machineautoscaler.md
+++ b/docs/backplane/requirements/cee/20-machineautoscaler.md
@@ -1,0 +1,22 @@
+# CEE on OSD/ROSA
+
+label selectors:
+
+- managed=true (implied)
+
+These premissions are the baseline across the managed fleet and apply to all product flavors:
+
+- OSD
+- ROSA Classic
+- ROSA HCP
+
+## openshift-backplane-cee: `cluster`
+
+These permissions are at cluster scope:
+
+- get machineautoscaler
+- list machineautoscaler
+- watch machineautoscaler
+
+* CEE needs read-only access to the `machineautoscaler` cluster resource. The `machineautoscaler` is a non-sensetive data. Having read-only access will help CEE to investigate customer issues related to the `machineautoscaler` and the `clusterautoscaler`. 
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1621,6 +1621,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10939,6 +10947,14 @@ objects:
         - k8s.ovn.org
         resources:
         - egressips
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - '*'
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1624,7 +1624,8 @@ objects:
                   - apiGroups:
                     - autoscaling.openshift.io
                     resources:
-                    - '*'
+                    - clusterautoscalers
+                    - machineautoscalers
                     verbs:
                     - get
                     - list
@@ -10954,7 +10955,8 @@ objects:
       - apiGroups:
         - autoscaling.openshift.io
         resources:
-        - '*'
+        - clusterautoscalers
+        - machineautoscalers
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1621,6 +1621,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10939,6 +10947,14 @@ objects:
         - k8s.ovn.org
         resources:
         - egressips
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - '*'
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1624,7 +1624,8 @@ objects:
                   - apiGroups:
                     - autoscaling.openshift.io
                     resources:
-                    - '*'
+                    - clusterautoscalers
+                    - machineautoscalers
                     verbs:
                     - get
                     - list
@@ -10954,7 +10955,8 @@ objects:
       - apiGroups:
         - autoscaling.openshift.io
         resources:
-        - '*'
+        - clusterautoscalers
+        - machineautoscalers
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1621,6 +1621,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -10939,6 +10947,14 @@ objects:
         - k8s.ovn.org
         resources:
         - egressips
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - '*'
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1624,7 +1624,8 @@ objects:
                   - apiGroups:
                     - autoscaling.openshift.io
                     resources:
-                    - '*'
+                    - clusterautoscalers
+                    - machineautoscalers
                     verbs:
                     - get
                     - list
@@ -10954,7 +10955,8 @@ objects:
       - apiGroups:
         - autoscaling.openshift.io
         resources:
-        - '*'
+        - clusterautoscalers
+        - machineautoscalers
         verbs:
         - get
         - list


### PR DESCRIPTION
What type of PR is this?
(bug/feature/cleanup/documentation)

'make' doesn't get triggered https://github.com/openshift/managed-cluster-config/pull/2161 and https://github.com/openshift/managed-cluster-config/pull/2162

raising a new PR to see why actions failing to test with a freshly forked repo to see if it makes any diff 

was discussing this issue https://redhat-internal.slack.com/archives/C016S65RNG5/p1720078609433969


What type of PR is this?
Based on the slack thread mentioned in Special notes below was decided to create a PR in order to update RBAC rules in a proper way as CEE should have read access to the non-sensetive objects so that MCS/CEE can get the object from oc directly.

What this PR does / why we need it?
By adding read-only RBAC to machineautoscalers will allow CEE to troubleshoot issue related to autos-calling easier

`oc get machineautoscaler -o yaml -n openshift-machine-api

apiVersion: v1
items: []
kind: List
metadata:
resourceVersion: ""
Error from server (Forbidden): machineautoscalers.autoscaling.openshift.io is forbidden: User "system:serviceaccount:openshift-backplane-cee:8d5ec3a2bb1e28f30a0c48a9eeb707f3" cannot list resource "machineautoscalers" in API group "autoscaling.openshift.io" in the namespace "openshift-machine-api"`

Special notes for your reviewer:
Discussed in the backplane slack thread

https://redhat-internal.slack.com/archives/C016S65RNG5/p1720078609433969