### PR TITLE
Add permission to delete kubernetes.io/cluster/* tag from subnets on HCP

### DIFF
--- a/resources/sts/4.16/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.16/hypershift/sts_hcp_installer_permission_policy.json
@@ -323,6 +323,26 @@
             }
         },
         {
+            "Sid": "DeleteTagsK8sSubnet",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeleteTags"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:subnet/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:TagKeys": "false"
+                },
+                "ForAllValues:StringLike": {
+                    "aws:TagKeys": [
+                        "kubernetes.io/cluster/*"
+                    ]
+                }
+            }
+        },
+        {
             "Sid": "ListPoliciesAttachedToRoles",
             "Effect": "Allow",
             "Action": [

--- a/resources/sts/4.17/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.17/hypershift/sts_hcp_installer_permission_policy.json
@@ -323,6 +323,26 @@
             }
         },
         {
+            "Sid": "DeleteTagsK8sSubnet",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeleteTags"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:subnet/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:TagKeys": "false"
+                },
+                "ForAllValues:StringLike": {
+                    "aws:TagKeys": [
+                        "kubernetes.io/cluster/*"
+                    ]
+                }
+            }
+        },
+        {
             "Sid": "ListPoliciesAttachedToRoles",
             "Effect": "Allow",
             "Action": [

--- a/resources/sts/4.18/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/4.18/hypershift/sts_hcp_installer_permission_policy.json
@@ -323,6 +323,26 @@
             }
         },
         {
+            "Sid": "DeleteTagsK8sSubnet",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeleteTags"
+            ],
+            "Resource": [
+                "arn:aws:ec2:*:*:subnet/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:TagKeys": "false"
+                },
+                "ForAllValues:StringLike": {
+                    "aws:TagKeys": [
+                        "kubernetes.io/cluster/*"
+                    ]
+                }
+            }
+        },
+        {
             "Sid": "ListPoliciesAttachedToRoles",
             "Effect": "Allow",
             "Action": [


### PR DESCRIPTION
https://issues.redhat.com/browse/OSD-24447

This adds permission for the installer to remove `kubernets.io/cluster/*` tags on subnets. This is needed as subnets have a default limit of 50 tags, which can be exhausted quickly if the same subnet(s) are used for multiple k8s cluster installations if they are not removed on uninstall. Currently the HCP installer has permissions to add the tags but not to remove them.

Note: The null condition is added due to a quirk of the AWS api. Running `aws ec2 aws ec2 delete-tags --resources $SUBNET_ID --tag Key=foo` will fail given that the conditions on the policy only allow the `kubernetes.io/cluster` tag to be deleted. But if no tags are specified, i.e. `aws ec2 delete-tags --resources $SUBNET_ID`, all tags are deleted from the subnet as there is no body to compare to the tag condition. With the null condition added, this is prevented, and a tag must be specified during deletion. 

An example from AWS where they mention it:
https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html#access_tags_control-tag-keys