### PR TITLE
ROX-25275: Add permissions to read ACS addon objects for ACS team

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -474,7 +474,6 @@ spec:
                                 - watch
                             - apiGroups:
                                 - package-operator.run
-                                - addons.managed.openshift.io
                               resources:
                                 - clusterpackages
                                 - clusterobjectdeployments
@@ -484,6 +483,13 @@ spec:
                                 - objectdeployments
                                 - objectsets
                                 - objecttemplates
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - addons.managed.openshift.io
+                              resources:
                                 - addons
                                 - addoninstance
                                 - addonoperators

--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -473,6 +473,25 @@ spec:
                                 - list
                                 - watch
                             - apiGroups:
+                                - package-operator.run
+                                - addons.managed.openshift.io
+                              resources:
+                                - clusterpackages
+                                - clusterobjectdeployments
+                                - clusterobjectsets
+                                - clusterobjecttemplates
+                                - packages
+                                - objectdeployments
+                                - objectsets
+                                - objecttemplates
+                                - addons
+                                - addoninstance
+                                - addonoperators
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
                                 - app.k8s.io
                               resources:
                                 - applications

--- a/deploy/backplane/acs/01-acs-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-project.ClusterRole.yaml
@@ -45,10 +45,9 @@ rules:
   - get
   - list
   - watch
-# ACS Team can view ACS Addon CRs
+# ACS Team can view ACS Addon CRs in package-operator.run API group
 - apiGroups:
   - package-operator.run
-  - addons.managed.openshift.io
   resources:
   - clusterpackages
   - clusterobjectdeployments
@@ -58,6 +57,14 @@ rules:
   - objectdeployments
   - objectsets
   - objecttemplates
+  verbs:
+  - get
+  - list
+  - watch
+# ACS Team can view ACS Addon CRs in addons.managed.openshift.io API group
+- apiGroups:
+  - addons.managed.openshift.io
+  resources:
   - addons
   - addoninstance
   - addonoperators

--- a/deploy/backplane/acs/01-acs-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-project.ClusterRole.yaml
@@ -45,6 +45,26 @@ rules:
   - get
   - list
   - watch
+# ACS Team can view ACS Addon CRs
+- apiGroups:
+  - package-operator.run
+  - addons.managed.openshift.io
+  resources:
+  - clusterpackages
+  - clusterobjectdeployments
+  - clusterobjectsets
+  - clusterobjecttemplates
+  - packages
+  - objectdeployments
+  - objectsets
+  - objecttemplates
+  - addons
+  - addoninstance
+  - addonoperators
+  verbs:
+  - get
+  - list
+  - watch
 # ACS SRE can view applications
 - apiGroups:
   - app.k8s.io

--- a/docs/backplane/requirements/acs/10-acs-managed-service.md
+++ b/docs/backplane/requirements/acs/10-acs-managed-service.md
@@ -112,7 +112,7 @@ Permissions at cluster scope.
 * view verticalpodautoscalercontrollers
 
 ## backplane-acs-admins-project: `(^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*|^acscs-dataplane-cd$)`
-- ACS team needs read/list/watch access to core `redhat` and `rhacs` objects within their namespaces.
+- ACS team needs read/list/watch access to core `redhat` and `rhacs` objects within their namespaces. This includes Custom Resource objects for ACS Addon.
 - Permisions at namespace scope.
 
 * view centrals
@@ -135,6 +135,17 @@ Permissions at cluster scope.
 * create pods/portforward
 * create pods/exec
 * delete pods
+* view clusterpackages
+* view clusterobjectdeployments
+* view clusterobjectsets
+* view clusterobjecttemplates
+* view packages
+* view objectdeployments
+* view objectsets
+* view objecttemplates
+* view addons
+* view addoninstance
+* view addonoperators
 
 ## backplane-acs-openshift-ingress: `openshift-ingress`
 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1105,7 +1105,6 @@ objects:
                     - watch
                   - apiGroups:
                     - package-operator.run
-                    - addons.managed.openshift.io
                     resources:
                     - clusterpackages
                     - clusterobjectdeployments
@@ -1115,6 +1114,13 @@ objects:
                     - objectdeployments
                     - objectsets
                     - objecttemplates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - addons.managed.openshift.io
+                    resources:
                     - addons
                     - addoninstance
                     - addonoperators
@@ -9114,7 +9120,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -9124,6 +9129,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators
@@ -9869,7 +9881,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -9879,6 +9890,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators
@@ -10624,7 +10642,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -10634,6 +10651,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1104,6 +1104,25 @@ objects:
                     - list
                     - watch
                   - apiGroups:
+                    - package-operator.run
+                    - addons.managed.openshift.io
+                    resources:
+                    - clusterpackages
+                    - clusterobjectdeployments
+                    - clusterobjectsets
+                    - clusterobjecttemplates
+                    - packages
+                    - objectdeployments
+                    - objectsets
+                    - objecttemplates
+                    - addons
+                    - addoninstance
+                    - addonoperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
                     - app.k8s.io
                     resources:
                     - applications
@@ -9094,6 +9113,25 @@ objects:
         - list
         - watch
       - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - app.k8s.io
         resources:
         - applications
@@ -9830,6 +9868,25 @@ objects:
         - list
         - watch
       - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - app.k8s.io
         resources:
         - applications
@@ -10561,6 +10618,25 @@ objects:
         - deployments
         - statefulsets
         - daemonsets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1105,7 +1105,6 @@ objects:
                     - watch
                   - apiGroups:
                     - package-operator.run
-                    - addons.managed.openshift.io
                     resources:
                     - clusterpackages
                     - clusterobjectdeployments
@@ -1115,6 +1114,13 @@ objects:
                     - objectdeployments
                     - objectsets
                     - objecttemplates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - addons.managed.openshift.io
+                    resources:
                     - addons
                     - addoninstance
                     - addonoperators
@@ -9114,7 +9120,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -9124,6 +9129,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators
@@ -9869,7 +9881,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -9879,6 +9890,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators
@@ -10624,7 +10642,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -10634,6 +10651,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1104,6 +1104,25 @@ objects:
                     - list
                     - watch
                   - apiGroups:
+                    - package-operator.run
+                    - addons.managed.openshift.io
+                    resources:
+                    - clusterpackages
+                    - clusterobjectdeployments
+                    - clusterobjectsets
+                    - clusterobjecttemplates
+                    - packages
+                    - objectdeployments
+                    - objectsets
+                    - objecttemplates
+                    - addons
+                    - addoninstance
+                    - addonoperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
                     - app.k8s.io
                     resources:
                     - applications
@@ -9094,6 +9113,25 @@ objects:
         - list
         - watch
       - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - app.k8s.io
         resources:
         - applications
@@ -9830,6 +9868,25 @@ objects:
         - list
         - watch
       - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - app.k8s.io
         resources:
         - applications
@@ -10561,6 +10618,25 @@ objects:
         - deployments
         - statefulsets
         - daemonsets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1105,7 +1105,6 @@ objects:
                     - watch
                   - apiGroups:
                     - package-operator.run
-                    - addons.managed.openshift.io
                     resources:
                     - clusterpackages
                     - clusterobjectdeployments
@@ -1115,6 +1114,13 @@ objects:
                     - objectdeployments
                     - objectsets
                     - objecttemplates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - addons.managed.openshift.io
+                    resources:
                     - addons
                     - addoninstance
                     - addonoperators
@@ -9114,7 +9120,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -9124,6 +9129,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators
@@ -9869,7 +9881,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -9879,6 +9890,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators
@@ -10624,7 +10642,6 @@ objects:
         - watch
       - apiGroups:
         - package-operator.run
-        - addons.managed.openshift.io
         resources:
         - clusterpackages
         - clusterobjectdeployments
@@ -10634,6 +10651,13 @@ objects:
         - objectdeployments
         - objectsets
         - objecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - addons.managed.openshift.io
+        resources:
         - addons
         - addoninstance
         - addonoperators

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1104,6 +1104,25 @@ objects:
                     - list
                     - watch
                   - apiGroups:
+                    - package-operator.run
+                    - addons.managed.openshift.io
+                    resources:
+                    - clusterpackages
+                    - clusterobjectdeployments
+                    - clusterobjectsets
+                    - clusterobjecttemplates
+                    - packages
+                    - objectdeployments
+                    - objectsets
+                    - objecttemplates
+                    - addons
+                    - addoninstance
+                    - addonoperators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
                     - app.k8s.io
                     resources:
                     - applications
@@ -9094,6 +9113,25 @@ objects:
         - list
         - watch
       - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - app.k8s.io
         resources:
         - applications
@@ -9830,6 +9868,25 @@ objects:
         - list
         - watch
       - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - app.k8s.io
         resources:
         - applications
@@ -10561,6 +10618,25 @@ objects:
         - deployments
         - statefulsets
         - daemonsets
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - package-operator.run
+        - addons.managed.openshift.io
+        resources:
+        - clusterpackages
+        - clusterobjectdeployments
+        - clusterobjectsets
+        - clusterobjecttemplates
+        - packages
+        - objectdeployments
+        - objectsets
+        - objecttemplates
+        - addons
+        - addoninstance
+        - addonoperators
         verbs:
         - get
         - list


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
ACS team should be able to list and view ACS Addon related resources

### Which Jira/Github issue(s) this PR fixes?

[ROX-25275](https://issues.redhat.com/browse/ROX-25275)

### Special notes for your reviewer:

### Pre-checks (if applicable):
~- [ ] Tested latest changes against a cluster~
- [ ] Included documentation changes with PR
~- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:~

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
