### PR TITLE
Adds CloudCredentials annotation for 4.15 GCP Upgrades

### DIFF
--- a/deploy/osd-cluster-acks/gcp/4.15/config.yaml
+++ b/deploy/osd-cluster-acks/gcp/4.15/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.14"]
+  - key: hive.openshift.io/cluster-platform
+    operator: In
+    values: ["gcp"]

--- a/deploy/osd-cluster-acks/gcp/4.15/osd-gcp-ack_CloudCredential.yaml
+++ b/deploy/osd-cluster-acks/gcp/4.15/osd-gcp-ack_CloudCredential.yaml
@@ -1,0 +1,6 @@
+apiVersion: operator.openshift.io/v1
+kind: CloudCredential
+name: cluster
+applyMode: AlwaysApply
+patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27816,6 +27816,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-gcp-4.15
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.14'
+      - key: hive.openshift.io/cluster-platform
+        operator: In
+        values:
+        - gcp
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: CloudCredential
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-ocp-4.12
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27816,6 +27816,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-gcp-4.15
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.14'
+      - key: hive.openshift.io/cluster-platform
+        operator: In
+        values:
+        - gcp
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: CloudCredential
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-ocp-4.12
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27816,6 +27816,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-acks-gcp-4.15
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.14'
+      - key: hive.openshift.io/cluster-platform
+        operator: In
+        values:
+        - gcp
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      kind: CloudCredential
+      name: cluster
+      applyMode: AlwaysApply
+      patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.15"}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-acks-ocp-4.12
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
https://issues.redhat.com/browse/OHSS-35990 

### What this PR does / why we need it?
GCP cluster upgrade from 4.14 to 4.15 is currently failing due to cloudcredential needing more permission.

- Existing GCP clusters have rolled out the new permission in https://issues.redhat.com/browse/OSD-20579
- New GCP clusters have rolled out the new permission in https://github.com/openshift/gcp-project-operator/pull/214 


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
