### PR TITLE
[OSD-19661]  add sre-cluster-version-operator PrometheusRule

### DIFF
--- a/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -8,24 +9,61 @@ metadata:
   namespace: openshift-monitoring
 spec:
   groups:
-  - name: sre-cluster-version-operator
-    rules:
-    - alert: ClusterOperatorDegradedSRE
-      annotations:
-        summary: Cluster operator has been degraded for 1 day.
-        description: The {{ "{{ $labels.name }}" }} operator is degraded because {{ "{{ $labels.reason }}" }}, and the components it manages may have reduced quality of service.  Cluster upgrades may not complete. For more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
-      expr: |
-        max by (namespace, name, reason)
-        (
-          (
-            cluster_operator_conditions{job="cluster-version-operator", condition="Degraded", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"}
-            or on (namespace, name)
-            group by (namespace, name) (cluster_operator_up{job="cluster-version-operator", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"})
-          ) == 1
-        )
-      for: 1d
-      labels:
-        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md"
-        namespace: openshift-monitoring
-        needs_attention: "true"
-        severity: warning
+    - name: sre-cluster-version-operator
+      rules:
+        - alert: ClusterOperatorDegradedSRE
+          annotations:
+            summary: Cluster operator has been degraded for 1 day.
+            description: The {{ "{{ $labels.name }}" }} operator is degraded because {{ "{{
+              $labels.reason }}" }}, and the components it manages may have
+              reduced quality of service.  Cluster upgrades may not complete.
+              For more information refer to 'oc get -o yaml clusteroperator {{
+              "{{ $labels.name }}" }}'{{ "{{ with $console_url :=
+              \"console_url\" | query }}{{ if ne (len (label \"url\" (first
+              $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url )
+              }}/settings/cluster/{{ end }}{{ end }}" }}.
+          expr: >
+            max by (namespace, name, reason)
+
+            (
+              (
+                cluster_operator_conditions{job="cluster-version-operator", condition="Degraded", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"}
+                or on (namespace, name)
+                group by (namespace, name) (cluster_operator_up{job="cluster-version-operator", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"})
+              ) == 1
+            )
+          for: 1d
+          labels:
+            link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+            namespace: openshift-monitoring
+            needs_attention: "true"
+            severity: warning
+        - alert: ClusterOperatorDegradedCriticalSRE
+          annotations:
+            summary: Cluster operator has been degraded for 2 days.
+            description: The {{ $labels.name }} operator is degraded because {{
+              $labels.reason }}, and the components it manages may have reduced
+              quality of service. Cluster upgrades may not complete. For more
+              information refer to 'oc get -o yaml clusteroperator {{
+              $labels.name }}' {{ with $console_url := "console_url" | query }}
+              {{ if ne (len (label "url" (first $console_url))) 0 }} or {{ label
+              "url" (first $console_url) }}/settings/cluster/{{ end }} {{ end
+              }}.
+          expr: >
+            max by (namespace, name, reason)
+
+            (
+             (
+               cluster_operator_conditions{job="cluster-version-operator", name!="version", condition="Degraded"}
+               or on (namespace, name)
+               cluster_operator_conditions{job="cluster-version-operator", name="version", condition="Failing"}
+               or on (namespace, name)
+               group by (namespace, name) (cluster_operator_up{job="cluster-version-operator"})
+             ) == 1
+            )
+          for: 2d
+          labels:
+            link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+            namespace: openshift-monitoring
+            needs_attention: "true"
+            severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35822,6 +35822,28 @@ objects:
               namespace: openshift-monitoring
               needs_attention: 'true'
               severity: warning
+          - alert: ClusterOperatorDegradedCriticalSRE
+            annotations:
+              summary: Cluster operator has been degraded for 2 days.
+              description: The {{ $labels.name }} operator is degraded because {{
+                $labels.reason }}, and the components it manages may have reduced
+                quality of service. Cluster upgrades may not complete. For more information
+                refer to 'oc get -o yaml clusteroperator {{ $labels.name }}' {{ with
+                $console_url := "console_url" | query }} {{ if ne (len (label "url"
+                (first $console_url))) 0 }} or {{ label "url" (first $console_url)
+                }}/settings/cluster/{{ end }} {{ end }}.
+            expr: "max by (namespace, name, reason)\n(\n (\n   cluster_operator_conditions{job=\"\
+              cluster-version-operator\", name!=\"version\", condition=\"Degraded\"\
+              }\n   or on (namespace, name)\n   cluster_operator_conditions{job=\"\
+              cluster-version-operator\", name=\"version\", condition=\"Failing\"\
+              }\n   or on (namespace, name)\n   group by (namespace, name) (cluster_operator_up{job=\"\
+              cluster-version-operator\"})\n ) == 1\n)\n"
+            for: 2d
+            labels:
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+              namespace: openshift-monitoring
+              needs_attention: 'true'
+              severity: critical
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35822,6 +35822,28 @@ objects:
               namespace: openshift-monitoring
               needs_attention: 'true'
               severity: warning
+          - alert: ClusterOperatorDegradedCriticalSRE
+            annotations:
+              summary: Cluster operator has been degraded for 2 days.
+              description: The {{ $labels.name }} operator is degraded because {{
+                $labels.reason }}, and the components it manages may have reduced
+                quality of service. Cluster upgrades may not complete. For more information
+                refer to 'oc get -o yaml clusteroperator {{ $labels.name }}' {{ with
+                $console_url := "console_url" | query }} {{ if ne (len (label "url"
+                (first $console_url))) 0 }} or {{ label "url" (first $console_url)
+                }}/settings/cluster/{{ end }} {{ end }}.
+            expr: "max by (namespace, name, reason)\n(\n (\n   cluster_operator_conditions{job=\"\
+              cluster-version-operator\", name!=\"version\", condition=\"Degraded\"\
+              }\n   or on (namespace, name)\n   cluster_operator_conditions{job=\"\
+              cluster-version-operator\", name=\"version\", condition=\"Failing\"\
+              }\n   or on (namespace, name)\n   group by (namespace, name) (cluster_operator_up{job=\"\
+              cluster-version-operator\"})\n ) == 1\n)\n"
+            for: 2d
+            labels:
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+              namespace: openshift-monitoring
+              needs_attention: 'true'
+              severity: critical
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35822,6 +35822,28 @@ objects:
               namespace: openshift-monitoring
               needs_attention: 'true'
               severity: warning
+          - alert: ClusterOperatorDegradedCriticalSRE
+            annotations:
+              summary: Cluster operator has been degraded for 2 days.
+              description: The {{ $labels.name }} operator is degraded because {{
+                $labels.reason }}, and the components it manages may have reduced
+                quality of service. Cluster upgrades may not complete. For more information
+                refer to 'oc get -o yaml clusteroperator {{ $labels.name }}' {{ with
+                $console_url := "console_url" | query }} {{ if ne (len (label "url"
+                (first $console_url))) 0 }} or {{ label "url" (first $console_url)
+                }}/settings/cluster/{{ end }} {{ end }}.
+            expr: "max by (namespace, name, reason)\n(\n (\n   cluster_operator_conditions{job=\"\
+              cluster-version-operator\", name!=\"version\", condition=\"Degraded\"\
+              }\n   or on (namespace, name)\n   cluster_operator_conditions{job=\"\
+              cluster-version-operator\", name=\"version\", condition=\"Failing\"\
+              }\n   or on (namespace, name)\n   group by (namespace, name) (cluster_operator_up{job=\"\
+              cluster-version-operator\"})\n ) == 1\n)\n"
+            for: 2d
+            labels:
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
+              namespace: openshift-monitoring
+              needs_attention: 'true'
+              severity: critical
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
It will create new ClusterOperatorDegradedCriticalSRE alert for operators in a degraded state for 2 days 
 use case that the degraded operator is blocking the cluster upgrade in https://issues.redhat.com/browse/OHSS-28157

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-19661

### Special notes for your reviewer:

### Pre-checks (if applicable):

