### PR TITLE
Remove MGO CRs from dedicated-admins

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -53,6 +53,7 @@ spec:
                                         - cloud-ingress-operator
                                         - rbac-permissions-operator
                                         - splunk-forwarder-operator-og
+                                        - must-gather-operator
                                         - redhat-layered-product-og
                                         - addon-rhmi-og
                                         - addon-rhmi-internal-og
@@ -69,6 +70,7 @@ spec:
                                         - openshift-managed-upgrade-operator
                                         - openshift-velero
                                         - openshift-ocm-agent-operator
+                                        - openshift-must-gather-operator
                                         - openshift-addon-operator
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
@@ -105,6 +107,7 @@ spec:
                                         - openshift-velero
                                         - openshift-managed-upgrade-operator
                                         - openshift-ocm-agent-operator
+                                        - openshift-must-gather-operator
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
                         metadata:

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml
@@ -23,6 +23,7 @@ aggregationRule:
       - cloud-ingress-operator
       - rbac-permissions-operator
       - splunk-forwarder-operator-og
+      - must-gather-operator
       # Layred Product operator groups
       - redhat-layered-product-og
       # RHMI operator groups (legacy)
@@ -45,6 +46,7 @@ aggregationRule:
       - openshift-managed-upgrade-operator
       - openshift-velero
       - openshift-ocm-agent-operator
+      - openshift-must-gather-operator
       # MTSRE AddonOperator namespace
       - openshift-addon-operator
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/03-dedicated-admins-project.ClusterRole.yaml
@@ -29,6 +29,7 @@ aggregationRule:
       - openshift-velero
       - openshift-managed-upgrade-operator
       - openshift-ocm-agent-operator
+      - openshift-must-gather-operator
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -7190,6 +7190,7 @@ objects:
                         - cloud-ingress-operator
                         - rbac-permissions-operator
                         - splunk-forwarder-operator-og
+                        - must-gather-operator
                         - redhat-layered-product-og
                         - addon-rhmi-og
                         - addon-rhmi-internal-og
@@ -7206,6 +7207,7 @@ objects:
                         - openshift-managed-upgrade-operator
                         - openshift-velero
                         - openshift-ocm-agent-operator
+                        - openshift-must-gather-operator
                         - openshift-addon-operator
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -7242,6 +7244,7 @@ objects:
                         - openshift-velero
                         - openshift-managed-upgrade-operator
                         - openshift-ocm-agent-operator
+                        - openshift-must-gather-operator
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
                   metadata:
@@ -34223,6 +34226,7 @@ objects:
             - cloud-ingress-operator
             - rbac-permissions-operator
             - splunk-forwarder-operator-og
+            - must-gather-operator
             - redhat-layered-product-og
             - addon-rhmi-og
             - addon-rhmi-internal-og
@@ -34239,6 +34243,7 @@ objects:
             - openshift-managed-upgrade-operator
             - openshift-velero
             - openshift-ocm-agent-operator
+            - openshift-must-gather-operator
             - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
@@ -34272,6 +34277,7 @@ objects:
             - openshift-velero
             - openshift-managed-upgrade-operator
             - openshift-ocm-agent-operator
+            - openshift-must-gather-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -7190,6 +7190,7 @@ objects:
                         - cloud-ingress-operator
                         - rbac-permissions-operator
                         - splunk-forwarder-operator-og
+                        - must-gather-operator
                         - redhat-layered-product-og
                         - addon-rhmi-og
                         - addon-rhmi-internal-og
@@ -7206,6 +7207,7 @@ objects:
                         - openshift-managed-upgrade-operator
                         - openshift-velero
                         - openshift-ocm-agent-operator
+                        - openshift-must-gather-operator
                         - openshift-addon-operator
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -7242,6 +7244,7 @@ objects:
                         - openshift-velero
                         - openshift-managed-upgrade-operator
                         - openshift-ocm-agent-operator
+                        - openshift-must-gather-operator
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
                   metadata:
@@ -34223,6 +34226,7 @@ objects:
             - cloud-ingress-operator
             - rbac-permissions-operator
             - splunk-forwarder-operator-og
+            - must-gather-operator
             - redhat-layered-product-og
             - addon-rhmi-og
             - addon-rhmi-internal-og
@@ -34239,6 +34243,7 @@ objects:
             - openshift-managed-upgrade-operator
             - openshift-velero
             - openshift-ocm-agent-operator
+            - openshift-must-gather-operator
             - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
@@ -34272,6 +34277,7 @@ objects:
             - openshift-velero
             - openshift-managed-upgrade-operator
             - openshift-ocm-agent-operator
+            - openshift-must-gather-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -7190,6 +7190,7 @@ objects:
                         - cloud-ingress-operator
                         - rbac-permissions-operator
                         - splunk-forwarder-operator-og
+                        - must-gather-operator
                         - redhat-layered-product-og
                         - addon-rhmi-og
                         - addon-rhmi-internal-og
@@ -7206,6 +7207,7 @@ objects:
                         - openshift-managed-upgrade-operator
                         - openshift-velero
                         - openshift-ocm-agent-operator
+                        - openshift-must-gather-operator
                         - openshift-addon-operator
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
@@ -7242,6 +7244,7 @@ objects:
                         - openshift-velero
                         - openshift-managed-upgrade-operator
                         - openshift-ocm-agent-operator
+                        - openshift-must-gather-operator
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
                   metadata:
@@ -34223,6 +34226,7 @@ objects:
             - cloud-ingress-operator
             - rbac-permissions-operator
             - splunk-forwarder-operator-og
+            - must-gather-operator
             - redhat-layered-product-og
             - addon-rhmi-og
             - addon-rhmi-internal-og
@@ -34239,6 +34243,7 @@ objects:
             - openshift-managed-upgrade-operator
             - openshift-velero
             - openshift-ocm-agent-operator
+            - openshift-must-gather-operator
             - openshift-addon-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
@@ -34272,6 +34277,7 @@ objects:
             - openshift-velero
             - openshift-managed-upgrade-operator
             - openshift-ocm-agent-operator
+            - openshift-must-gather-operator
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Removes ability for dedicated-admins to manage MGO resources

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-21667

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
