### PR TITLE
Reformat wif templates

### DIFF
--- a/resources/wif/4.14/vanilla.yaml
+++ b/resources/wif/4.14/vanilla.yaml
@@ -1,175 +1,140 @@
 id: v4.14
 kind: WifTemplate
 service_accounts:
-  - id: osd-deployer
-    kind: ServiceAccount
+  - access_method: impersonate
+    id: osd-deployer
     osd_role: deployer
-    access_method: impersonate
     roles:
-      - id: osd-deployer
+      - id: osd_deployer
         kind: Role
         permissions:
-          - "compute.addresses.create"
-          - "compute.addresses.createInternal"
-          - "compute.addresses.delete"
-          - "compute.addresses.get"
-          - "compute.addresses.list"
-          - "compute.addresses.use"
-          - "compute.addresses.useInternal"
-          - "compute.firewalls.create"
-          - "compute.firewalls.delete"
-          - "compute.firewalls.get"
-          - "compute.firewalls.list"
-          - "compute.forwardingRules.create"
-          - "compute.forwardingRules.get"
-          - "compute.forwardingRules.list"
-          - "compute.forwardingRules.setLabels"
-          - "compute.networks.create"
-          - "compute.networks.get"
-          - "compute.networks.list"
-          - "compute.networks.updatePolicy"
-          - "compute.routers.create"
-          - "compute.routers.get"
-          - "compute.routers.list"
-          - "compute.routers.update"
-          - "compute.routes.list"
-          - "compute.subnetworks.create"
-          - "compute.subnetworks.get"
-          - "compute.subnetworks.list"
-          - "compute.subnetworks.use"
-          - "compute.subnetworks.useExternalIp"
-          - "compute.regionBackendServices.create"
-          - "compute.regionBackendServices.get"
-          - "compute.regionBackendServices.list"
-          - "compute.regionBackendServices.update"
-          - "compute.regionBackendServices.use"
-          - "compute.targetPools.addInstance"
-          - "compute.targetPools.create"
-          - "compute.targetPools.get"
-          - "compute.targetPools.list"
-          - "compute.targetPools.removeInstance"
-          - "compute.targetPools.use"
-          - "dns.changes.create"
-          - "dns.changes.get"
-          - "dns.managedZones.create"
-          - "dns.managedZones.get"
-          - "dns.managedZones.list"
-          - "dns.networks.bindPrivateDNSZone"
-          - "dns.resourceRecordSets.create"
-          - "dns.resourceRecordSets.list"
-          - "iam.serviceAccountKeys.create"
-          - "iam.serviceAccountKeys.delete"
-          - "iam.serviceAccountKeys.get"
-          - "iam.serviceAccountKeys.list"
-          - "iam.serviceAccounts.actAs"
-          - "iam.serviceAccounts.create"
-          - "iam.serviceAccounts.delete"
-          - "iam.serviceAccounts.get"
-          - "iam.serviceAccounts.list"
-          - "resourcemanager.projects.get"
-          - "resourcemanager.projects.getIamPolicy"
-          - "resourcemanager.projects.setIamPolicy"
-          - "compute.disks.create"
-          - "compute.disks.get"
-          - "compute.disks.list"
-          - "compute.disks.setLabels"
-          - "compute.instanceGroups.create"
-          - "compute.instanceGroups.delete"
-          - "compute.instanceGroups.get"
-          - "compute.instanceGroups.list"
-          - "compute.instanceGroups.update"
-          - "compute.instanceGroups.use"
-          - "compute.instances.create"
-          - "compute.instances.delete"
-          - "compute.instances.get"
-          - "compute.instances.list"
-          - "compute.instances.setLabels"
-          - "compute.instances.setMetadata"
-          - "compute.instances.setServiceAccount"
-          - "compute.instances.setTags"
-          - "compute.instances.use"
-          - "compute.machineTypes.get"
-          - "compute.machineTypes.list"
-          - "storage.buckets.create"
-          - "storage.buckets.delete"
-          - "storage.buckets.get"
-          - "storage.buckets.list"
-          - "storage.objects.create"
-          - "storage.objects.delete"
-          - "storage.objects.get"
-          - "storage.objects.list"
-          - "compute.healthChecks.create"
-          - "compute.healthChecks.get"
-          - "compute.healthChecks.list"
-          - "compute.healthChecks.useReadOnly"
-          - "compute.httpHealthChecks.create"
-          - "compute.httpHealthChecks.get"
-          - "compute.httpHealthChecks.list"
-          - "compute.httpHealthChecks.useReadOnly"
-          - "compute.globalOperations.get"
-          - "compute.regionOperations.get"
-          - "compute.regions.list"
-          - "compute.zoneOperations.get"
-          - "compute.zones.get"
-          - "compute.zones.list"
-          - "monitoring.timeSeries.list"
-          - "serviceusage.quotas.get"
-          - "serviceusage.services.list"
-          - "iam.roles.get"
-          - "compute.images.list"
-          - "compute.instances.getSerialPortOutput"
-          - "compute.addresses.delete"
-          - "compute.addresses.deleteInternal"
-          - "compute.addresses.list"
-          - "compute.firewalls.delete"
-          - "compute.firewalls.list"
-          - "compute.forwardingRules.delete"
-          - "compute.forwardingRules.list"
-          - "compute.networks.delete"
-          - "compute.networks.list"
-          - "compute.networks.updatePolicy"
-          - "compute.routers.delete"
-          - "compute.routers.list"
-          - "compute.routes.list"
-          - "compute.subnetworks.delete"
-          - "compute.subnetworks.list"
-          - "compute.regionBackendServices.delete"
-          - "compute.regionBackendServices.list"
-          - "compute.targetPools.delete"
-          - "compute.targetPools.list"
-          - "dns.changes.create"
-          - "dns.managedZones.delete"
-          - "dns.managedZones.get"
-          - "dns.managedZones.list"
-          - "dns.resourceRecordSets.delete"
-          - "dns.resourceRecordSets.list"
-          - "iam.serviceAccounts.delete"
-          - "iam.serviceAccounts.get"
-          - "iam.serviceAccounts.list"
-          - "resourcemanager.projects.getIamPolicy"
-          - "resourcemanager.projects.setIamPolicy"
-          - "compute.disks.delete"
-          - "compute.disks.list"
-          - "compute.instanceGroups.delete"
-          - "compute.instanceGroups.list"
-          - "compute.instances.delete"
-          - "compute.instances.list"
-          - "compute.instances.stop"
-          - "compute.machineTypes.list"
-          - "storage.buckets.delete"
-          - "storage.buckets.getIamPolicy"
-          - "storage.buckets.list"
-          - "storage.objects.delete"
-          - "storage.objects.list"
-          - "compute.healthChecks.delete"
-          - "compute.healthChecks.list"
-          - "compute.httpHealthChecks.delete"
-          - "compute.httpHealthChecks.list"
-          - "compute.images.list"
-  - id: osd-support
+          - compute.addresses.create
+          - compute.addresses.createInternal
+          - compute.addresses.delete
+          - compute.addresses.deleteInternal
+          - compute.addresses.get
+          - compute.addresses.list
+          - compute.addresses.use
+          - compute.addresses.useInternal
+          - compute.disks.create
+          - compute.disks.delete
+          - compute.disks.get
+          - compute.disks.list
+          - compute.disks.setLabels
+          - compute.firewalls.create
+          - compute.firewalls.delete
+          - compute.firewalls.get
+          - compute.firewalls.list
+          - compute.forwardingRules.create
+          - compute.forwardingRules.delete
+          - compute.forwardingRules.get
+          - compute.forwardingRules.list
+          - compute.forwardingRules.setLabels
+          - compute.globalOperations.get
+          - compute.healthChecks.create
+          - compute.healthChecks.delete
+          - compute.healthChecks.get
+          - compute.healthChecks.list
+          - compute.healthChecks.useReadOnly
+          - compute.httpHealthChecks.create
+          - compute.httpHealthChecks.delete
+          - compute.httpHealthChecks.get
+          - compute.httpHealthChecks.list
+          - compute.httpHealthChecks.useReadOnly
+          - compute.images.list
+          - compute.instanceGroups.create
+          - compute.instanceGroups.delete
+          - compute.instanceGroups.get
+          - compute.instanceGroups.list
+          - compute.instanceGroups.update
+          - compute.instanceGroups.use
+          - compute.instances.create
+          - compute.instances.delete
+          - compute.instances.get
+          - compute.instances.getSerialPortOutput
+          - compute.instances.list
+          - compute.instances.setLabels
+          - compute.instances.setMetadata
+          - compute.instances.setServiceAccount
+          - compute.instances.setTags
+          - compute.instances.stop
+          - compute.instances.use
+          - compute.machineTypes.get
+          - compute.machineTypes.list
+          - compute.networks.create
+          - compute.networks.delete
+          - compute.networks.get
+          - compute.networks.list
+          - compute.networks.updatePolicy
+          - compute.regionBackendServices.create
+          - compute.regionBackendServices.delete
+          - compute.regionBackendServices.get
+          - compute.regionBackendServices.list
+          - compute.regionBackendServices.update
+          - compute.regionBackendServices.use
+          - compute.regionOperations.get
+          - compute.regions.list
+          - compute.routers.create
+          - compute.routers.delete
+          - compute.routers.get
+          - compute.routers.list
+          - compute.routers.update
+          - compute.routes.list
+          - compute.subnetworks.create
+          - compute.subnetworks.delete
+          - compute.subnetworks.get
+          - compute.subnetworks.list
+          - compute.subnetworks.use
+          - compute.subnetworks.useExternalIp
+          - compute.targetPools.addInstance
+          - compute.targetPools.create
+          - compute.targetPools.delete
+          - compute.targetPools.get
+          - compute.targetPools.list
+          - compute.targetPools.removeInstance
+          - compute.targetPools.use
+          - compute.zoneOperations.get
+          - compute.zones.get
+          - compute.zones.list
+          - dns.changes.create
+          - dns.changes.get
+          - dns.managedZones.create
+          - dns.managedZones.delete
+          - dns.managedZones.get
+          - dns.managedZones.list
+          - dns.networks.bindPrivateDNSZone
+          - dns.resourceRecordSets.create
+          - dns.resourceRecordSets.delete
+          - dns.resourceRecordSets.list
+          - iam.roles.get
+          - iam.serviceAccountKeys.create
+          - iam.serviceAccountKeys.delete
+          - iam.serviceAccountKeys.get
+          - iam.serviceAccountKeys.list
+          - iam.serviceAccounts.actAs
+          - iam.serviceAccounts.create
+          - iam.serviceAccounts.delete
+          - iam.serviceAccounts.get
+          - iam.serviceAccounts.list
+          - monitoring.timeSeries.list
+          - resourcemanager.projects.get
+          - resourcemanager.projects.getIamPolicy
+          - resourcemanager.projects.setIamPolicy
+          - serviceusage.quotas.get
+          - serviceusage.services.list
+          - storage.buckets.create
+          - storage.buckets.delete
+          - storage.buckets.get
+          - storage.buckets.getIamPolicy
+          - storage.buckets.list
+          - storage.objects.create
+          - storage.objects.delete
+          - storage.objects.get
+          - storage.objects.list
+  - access_method: impersonate
+    id: osd-support
     kind: ServiceAccount
     osd_role: support
-    access_method: impersonate
     roles:
       - id: compute.admin
         kind: Role
@@ -186,10 +151,10 @@ service_accounts:
       - id: iam.serviceAccountAdmin
         kind: Role
         predefined: true
-      - id: iam.ServiceAccountKeyAdmin
+      - id: iam.serviceAccountKeyAdmin
         kind: Role
         predefined: true
-      - id: iam.ServiceAccountUser
+      - id: iam.serviceAccountUser
         kind: Role
         predefined: true
       - id: storage.admin
@@ -197,10 +162,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credential-operator-gcp-ro-creds
-        Namespace: openshift-cloud-credential-operator
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credential-operator-gcp-ro-creds
+        namespace: openshift-cloud-credential-operator
+      service_account_names:
         - cloud-credential-operator
     id: cloud-credential-operator-gcp-ro-creds
     kind: ServiceAccount
@@ -214,10 +179,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credentials
-        Namespace: openshift-cloud-network-config-controller
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-cloud-network-config-controller
+      service_account_names:
         - cloud-network-config-controller
     id: openshift-cloud-network-config-controller-gcp
     kind: ServiceAccount
@@ -228,10 +193,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: capg-manager-bootstrap-credentials
-        Namespace: openshift-cluster-api
-      ServiceAccountNames:
+      secret_ref:
+        name: capg-manager-bootstrap-credentials
+        namespace: openshift-cluster-api
+      service_account_names:
         - cluster-capi-operator
     id: openshift-cluster-api-gcp
     kind: ServiceAccount
@@ -248,10 +213,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-ccm-cloud-credentials
-        Namespace: openshift-cloud-controller-manager
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-ccm-cloud-credentials
+        namespace: openshift-cloud-controller-manager
+      service_account_names:
         - cloud-controller-manager
     id: openshift-gcp-ccm
     kind: ServiceAccount
@@ -268,10 +233,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-pd-cloud-credentials
-        Namespace: openshift-cluster-csi-drivers
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-pd-cloud-credentials
+        namespace: openshift-cluster-csi-drivers
+      service_account_names:
         - gcp-pd-csi-driver-operator
         - gcp-pd-csi-driver-controller-sa
     id: openshift-gcp-pd-csi-driver-operator
@@ -289,10 +254,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: installer-cloud-credentials
-        Namespace: openshift-image-registry
-      ServiceAccountNames:
+      secret_ref:
+        name: installer-cloud-credentials
+        namespace: openshift-image-registry
+      service_account_names:
         - cluster-image-registry-operator
         - registry
     id: openshift-image-registry-gcs
@@ -307,10 +272,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credentials
-        Namespace: openshift-ingress-operator
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-ingress-operator
+      service_account_names:
         - ingress-operator
     id: openshift-ingress-gcp
     kind: ServiceAccount
@@ -321,10 +286,10 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-cloud-credentials
-        Namespace: openshift-machine-api
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-cloud-credentials
+        namespace: openshift-machine-api
+      service_account_names:
         - machine-api-controllers
     id: openshift-machine-api-gcp
     kind: ServiceAccount

--- a/resources/wif/4.15/vanilla.yaml
+++ b/resources/wif/4.15/vanilla.yaml
@@ -1,175 +1,140 @@
 id: v4.15
 kind: WifTemplate
 service_accounts:
-  - id: osd-deployer
-    kind: ServiceAccount
+  - access_method: impersonate
+    id: osd-deployer
     osd_role: deployer
-    access_method: impersonate
     roles:
-      - id: osd-deployer
+      - id: osd_deployer
         kind: Role
         permissions:
-          - "compute.addresses.create"
-          - "compute.addresses.createInternal"
-          - "compute.addresses.delete"
-          - "compute.addresses.get"
-          - "compute.addresses.list"
-          - "compute.addresses.use"
-          - "compute.addresses.useInternal"
-          - "compute.firewalls.create"
-          - "compute.firewalls.delete"
-          - "compute.firewalls.get"
-          - "compute.firewalls.list"
-          - "compute.forwardingRules.create"
-          - "compute.forwardingRules.get"
-          - "compute.forwardingRules.list"
-          - "compute.forwardingRules.setLabels"
-          - "compute.networks.create"
-          - "compute.networks.get"
-          - "compute.networks.list"
-          - "compute.networks.updatePolicy"
-          - "compute.routers.create"
-          - "compute.routers.get"
-          - "compute.routers.list"
-          - "compute.routers.update"
-          - "compute.routes.list"
-          - "compute.subnetworks.create"
-          - "compute.subnetworks.get"
-          - "compute.subnetworks.list"
-          - "compute.subnetworks.use"
-          - "compute.subnetworks.useExternalIp"
-          - "compute.regionBackendServices.create"
-          - "compute.regionBackendServices.get"
-          - "compute.regionBackendServices.list"
-          - "compute.regionBackendServices.update"
-          - "compute.regionBackendServices.use"
-          - "compute.targetPools.addInstance"
-          - "compute.targetPools.create"
-          - "compute.targetPools.get"
-          - "compute.targetPools.list"
-          - "compute.targetPools.removeInstance"
-          - "compute.targetPools.use"
-          - "dns.changes.create"
-          - "dns.changes.get"
-          - "dns.managedZones.create"
-          - "dns.managedZones.get"
-          - "dns.managedZones.list"
-          - "dns.networks.bindPrivateDNSZone"
-          - "dns.resourceRecordSets.create"
-          - "dns.resourceRecordSets.list"
-          - "iam.serviceAccountKeys.create"
-          - "iam.serviceAccountKeys.delete"
-          - "iam.serviceAccountKeys.get"
-          - "iam.serviceAccountKeys.list"
-          - "iam.serviceAccounts.actAs"
-          - "iam.serviceAccounts.create"
-          - "iam.serviceAccounts.delete"
-          - "iam.serviceAccounts.get"
-          - "iam.serviceAccounts.list"
-          - "resourcemanager.projects.get"
-          - "resourcemanager.projects.getIamPolicy"
-          - "resourcemanager.projects.setIamPolicy"
-          - "compute.disks.create"
-          - "compute.disks.get"
-          - "compute.disks.list"
-          - "compute.disks.setLabels"
-          - "compute.instanceGroups.create"
-          - "compute.instanceGroups.delete"
-          - "compute.instanceGroups.get"
-          - "compute.instanceGroups.list"
-          - "compute.instanceGroups.update"
-          - "compute.instanceGroups.use"
-          - "compute.instances.create"
-          - "compute.instances.delete"
-          - "compute.instances.get"
-          - "compute.instances.list"
-          - "compute.instances.setLabels"
-          - "compute.instances.setMetadata"
-          - "compute.instances.setServiceAccount"
-          - "compute.instances.setTags"
-          - "compute.instances.use"
-          - "compute.machineTypes.get"
-          - "compute.machineTypes.list"
-          - "storage.buckets.create"
-          - "storage.buckets.delete"
-          - "storage.buckets.get"
-          - "storage.buckets.list"
-          - "storage.objects.create"
-          - "storage.objects.delete"
-          - "storage.objects.get"
-          - "storage.objects.list"
-          - "compute.healthChecks.create"
-          - "compute.healthChecks.get"
-          - "compute.healthChecks.list"
-          - "compute.healthChecks.useReadOnly"
-          - "compute.httpHealthChecks.create"
-          - "compute.httpHealthChecks.get"
-          - "compute.httpHealthChecks.list"
-          - "compute.httpHealthChecks.useReadOnly"
-          - "compute.globalOperations.get"
-          - "compute.regionOperations.get"
-          - "compute.regions.list"
-          - "compute.zoneOperations.get"
-          - "compute.zones.get"
-          - "compute.zones.list"
-          - "monitoring.timeSeries.list"
-          - "serviceusage.quotas.get"
-          - "serviceusage.services.list"
-          - "iam.roles.get"
-          - "compute.images.list"
-          - "compute.instances.getSerialPortOutput"
-          - "compute.addresses.delete"
-          - "compute.addresses.deleteInternal"
-          - "compute.addresses.list"
-          - "compute.firewalls.delete"
-          - "compute.firewalls.list"
-          - "compute.forwardingRules.delete"
-          - "compute.forwardingRules.list"
-          - "compute.networks.delete"
-          - "compute.networks.list"
-          - "compute.networks.updatePolicy"
-          - "compute.routers.delete"
-          - "compute.routers.list"
-          - "compute.routes.list"
-          - "compute.subnetworks.delete"
-          - "compute.subnetworks.list"
-          - "compute.regionBackendServices.delete"
-          - "compute.regionBackendServices.list"
-          - "compute.targetPools.delete"
-          - "compute.targetPools.list"
-          - "dns.changes.create"
-          - "dns.managedZones.delete"
-          - "dns.managedZones.get"
-          - "dns.managedZones.list"
-          - "dns.resourceRecordSets.delete"
-          - "dns.resourceRecordSets.list"
-          - "iam.serviceAccounts.delete"
-          - "iam.serviceAccounts.get"
-          - "iam.serviceAccounts.list"
-          - "resourcemanager.projects.getIamPolicy"
-          - "resourcemanager.projects.setIamPolicy"
-          - "compute.disks.delete"
-          - "compute.disks.list"
-          - "compute.instanceGroups.delete"
-          - "compute.instanceGroups.list"
-          - "compute.instances.delete"
-          - "compute.instances.list"
-          - "compute.instances.stop"
-          - "compute.machineTypes.list"
-          - "storage.buckets.delete"
-          - "storage.buckets.getIamPolicy"
-          - "storage.buckets.list"
-          - "storage.objects.delete"
-          - "storage.objects.list"
-          - "compute.healthChecks.delete"
-          - "compute.healthChecks.list"
-          - "compute.httpHealthChecks.delete"
-          - "compute.httpHealthChecks.list"
-          - "compute.images.list"
-  - id: osd-support
+          - compute.addresses.create
+          - compute.addresses.createInternal
+          - compute.addresses.delete
+          - compute.addresses.deleteInternal
+          - compute.addresses.get
+          - compute.addresses.list
+          - compute.addresses.use
+          - compute.addresses.useInternal
+          - compute.disks.create
+          - compute.disks.delete
+          - compute.disks.get
+          - compute.disks.list
+          - compute.disks.setLabels
+          - compute.firewalls.create
+          - compute.firewalls.delete
+          - compute.firewalls.get
+          - compute.firewalls.list
+          - compute.forwardingRules.create
+          - compute.forwardingRules.delete
+          - compute.forwardingRules.get
+          - compute.forwardingRules.list
+          - compute.forwardingRules.setLabels
+          - compute.globalOperations.get
+          - compute.healthChecks.create
+          - compute.healthChecks.delete
+          - compute.healthChecks.get
+          - compute.healthChecks.list
+          - compute.healthChecks.useReadOnly
+          - compute.httpHealthChecks.create
+          - compute.httpHealthChecks.delete
+          - compute.httpHealthChecks.get
+          - compute.httpHealthChecks.list
+          - compute.httpHealthChecks.useReadOnly
+          - compute.images.list
+          - compute.instanceGroups.create
+          - compute.instanceGroups.delete
+          - compute.instanceGroups.get
+          - compute.instanceGroups.list
+          - compute.instanceGroups.update
+          - compute.instanceGroups.use
+          - compute.instances.create
+          - compute.instances.delete
+          - compute.instances.get
+          - compute.instances.getSerialPortOutput
+          - compute.instances.list
+          - compute.instances.setLabels
+          - compute.instances.setMetadata
+          - compute.instances.setServiceAccount
+          - compute.instances.setTags
+          - compute.instances.stop
+          - compute.instances.use
+          - compute.machineTypes.get
+          - compute.machineTypes.list
+          - compute.networks.create
+          - compute.networks.delete
+          - compute.networks.get
+          - compute.networks.list
+          - compute.networks.updatePolicy
+          - compute.regionBackendServices.create
+          - compute.regionBackendServices.delete
+          - compute.regionBackendServices.get
+          - compute.regionBackendServices.list
+          - compute.regionBackendServices.update
+          - compute.regionBackendServices.use
+          - compute.regionOperations.get
+          - compute.regions.list
+          - compute.routers.create
+          - compute.routers.delete
+          - compute.routers.get
+          - compute.routers.list
+          - compute.routers.update
+          - compute.routes.list
+          - compute.subnetworks.create
+          - compute.subnetworks.delete
+          - compute.subnetworks.get
+          - compute.subnetworks.list
+          - compute.subnetworks.use
+          - compute.subnetworks.useExternalIp
+          - compute.targetPools.addInstance
+          - compute.targetPools.create
+          - compute.targetPools.delete
+          - compute.targetPools.get
+          - compute.targetPools.list
+          - compute.targetPools.removeInstance
+          - compute.targetPools.use
+          - compute.zoneOperations.get
+          - compute.zones.get
+          - compute.zones.list
+          - dns.changes.create
+          - dns.changes.get
+          - dns.managedZones.create
+          - dns.managedZones.delete
+          - dns.managedZones.get
+          - dns.managedZones.list
+          - dns.networks.bindPrivateDNSZone
+          - dns.resourceRecordSets.create
+          - dns.resourceRecordSets.delete
+          - dns.resourceRecordSets.list
+          - iam.roles.get
+          - iam.serviceAccountKeys.create
+          - iam.serviceAccountKeys.delete
+          - iam.serviceAccountKeys.get
+          - iam.serviceAccountKeys.list
+          - iam.serviceAccounts.actAs
+          - iam.serviceAccounts.create
+          - iam.serviceAccounts.delete
+          - iam.serviceAccounts.get
+          - iam.serviceAccounts.list
+          - monitoring.timeSeries.list
+          - resourcemanager.projects.get
+          - resourcemanager.projects.getIamPolicy
+          - resourcemanager.projects.setIamPolicy
+          - serviceusage.quotas.get
+          - serviceusage.services.list
+          - storage.buckets.create
+          - storage.buckets.delete
+          - storage.buckets.get
+          - storage.buckets.getIamPolicy
+          - storage.buckets.list
+          - storage.objects.create
+          - storage.objects.delete
+          - storage.objects.get
+          - storage.objects.list
+  - access_method: impersonate
+    id: osd-support
     kind: ServiceAccount
     osd_role: support
-    access_method: impersonate
     roles:
       - id: compute.admin
         kind: Role
@@ -186,10 +151,10 @@ service_accounts:
       - id: iam.serviceAccountAdmin
         kind: Role
         predefined: true
-      - id: iam.ServiceAccountKeyAdmin
+      - id: iam.serviceAccountKeyAdmin
         kind: Role
         predefined: true
-      - id: iam.ServiceAccountUser
+      - id: iam.serviceAccountUser
         kind: Role
         predefined: true
       - id: storage.admin
@@ -197,55 +162,55 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credential-operator-gcp-ro-creds
-        Namespace: openshift-cloud-credential-operator
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credential-operator-gcp-ro-creds
+        namespace: openshift-cloud-credential-operator
+      service_account_names:
         - cloud-credential-operator
     id: cloud-credential-operator-gcp-ro-creds
     kind: ServiceAccount
     osd_role: cloud-credential-operator-gcp-ro-creds
     roles:
-      - id: cloud-credential-operator-gcp-ro-creds
+      - id: cloud_credential_operator_gcp_ro_creds
         kind: Role
         permissions:
           - iam.roles.get
-          - iam.serviceAccounts.get
           - iam.serviceAccountKeys.list
+          - iam.serviceAccounts.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
           - serviceusage.services.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credentials
-        Namespace: openshift-cloud-network-config-controller
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-cloud-network-config-controller
+      service_account_names:
         - cloud-network-config-controller
     id: openshift-cloud-network-config-controller-gcp
     kind: ServiceAccount
     osd_role: operator-cloud-network-config-controller-gcp
     roles:
-      - id: openshift-cloud-network-config-controller-gcp
+      - id: openshift_cloud_network_config_controller_gcp
         kind: Role
         permissions:
-          - compute.instances.updateNetworkInterface
-          - compute.subnetworks.use
-          - compute.subnetworks.get
-          - compute.zoneOperations.get
           - compute.instances.get
+          - compute.instances.updateNetworkInterface
+          - compute.subnetworks.get
+          - compute.subnetworks.use
+          - compute.zoneOperations.get
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: capg-manager-bootstrap-credentials
-        Namespace: openshift-cluster-api
-      ServiceAccountNames:
+      secret_ref:
+        name: capg-manager-bootstrap-credentials
+        namespace: openshift-cluster-api
+      service_account_names:
         - cluster-capi-operator
     id: openshift-cluster-api-gcp
     kind: ServiceAccount
     osd_role: operator-cluster-api-gcp
     roles:
-      - id: openshift-cluster-api-gcp
+      - id: openshift_cluster_api_gcp
         kind: Role
         permissions:
           - compute.addresses.create
@@ -299,16 +264,16 @@ service_accounts:
           - iam.serviceAccounts.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-ccm-cloud-credentials
-        Namespace: openshift-cloud-controller-manager
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-ccm-cloud-credentials
+        namespace: openshift-cloud-controller-manager
+      service_account_names:
         - cloud-controller-manager
     id: openshift-gcp-ccm
     kind: ServiceAccount
     osd_role: operator-gcp-ccm
     roles:
-      - id: openshift-gcp-ccm
+      - id: openshift_gcp_ccm
         kind: Role
         permissions:
           - compute.addresses.create
@@ -348,10 +313,10 @@ service_accounts:
           - compute.zones.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-pd-cloud-credentials
-        Namespace: openshift-cluster-csi-drivers
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-pd-cloud-credentials
+        namespace: openshift-cluster-csi-drivers
+      service_account_names:
         - gcp-pd-csi-driver-operator
         - gcp-pd-csi-driver-controller-sa
     id: openshift-gcp-pd-csi-driver-operator
@@ -364,32 +329,32 @@ service_accounts:
       - id: iam.serviceAccountUser
         kind: Role
         predefined: true
-      - id: openshift-gcp-pd-csi-driver-operator
+      - id: openshift_gcp_pd_csi_driver_operator
         kind: Role
         permissions:
-          - compute.instances.get
           - compute.instances.attachDisk
           - compute.instances.detachDisk
+          - compute.instances.get
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: installer-cloud-credentials
-        Namespace: openshift-image-registry
-      ServiceAccountNames:
+      secret_ref:
+        name: installer-cloud-credentials
+        namespace: openshift-image-registry
+      service_account_names:
         - cluster-image-registry-operator
         - registry
     id: openshift-image-registry-gcs
     kind: ServiceAccount
     osd_role: operator-image-registry-gcs
     roles:
-      - id: openshift-image-registry-gcs
+      - id: openshift_image_registry_gcs
         kind: Role
         permissions:
           - storage.buckets.create
+          - storage.buckets.createTagBinding
           - storage.buckets.delete
           - storage.buckets.get
           - storage.buckets.list
-          - storage.buckets.createTagBinding
           - storage.buckets.listEffectiveTags
           - storage.objects.create
           - storage.objects.delete
@@ -397,40 +362,37 @@ service_accounts:
           - storage.objects.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credentials
-        Namespace: openshift-ingress-operator
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-ingress-operator
+      service_account_names:
         - ingress-operator
     id: openshift-ingress-gcp
     kind: ServiceAccount
     osd_role: operator-ingress-gcp
     roles:
-      - id: openshift-ingress-gcp
+      - id: openshift_ingress_gcp
         kind: Role
         permissions:
           - dns.changes.create
           - dns.resourceRecordSets.create
-          - dns.resourceRecordSets.update
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
+          - dns.resourceRecordSets.update
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-cloud-credentials
-        Namespace: openshift-machine-api
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-cloud-credentials
+        namespace: openshift-machine-api
+      service_account_names:
         - machine-api-controllers
     id: openshift-machine-api-gcp
     kind: ServiceAccount
     osd_role: operator-machine-api-gcp
     roles:
-      - id: openshift-machine-api-gcp
+      - id: openshift_machine_api_gcp
         kind: Role
         permissions:
-          - iam.serviceAccounts.actAs
-          - iam.serviceAccounts.get
-          - iam.serviceAccounts.list
           - compute.acceleratorTypes.get
           - compute.acceleratorTypes.list
           - compute.disks.create
@@ -447,17 +409,17 @@ service_accounts:
           - compute.instances.delete
           - compute.instances.get
           - compute.instances.list
-          - compute.instances.use
           - compute.instances.setLabels
           - compute.instances.setMetadata
-          - compute.instances.setTags
           - compute.instances.setServiceAccount
+          - compute.instances.setTags
           - compute.instances.update
+          - compute.instances.use
           - compute.machineTypes.get
           - compute.machineTypes.list
           - compute.projects.get
-          - compute.regionBackendServices.get
           - compute.regionBackendServices.create
+          - compute.regionBackendServices.get
           - compute.regionBackendServices.update
           - compute.regions.get
           - compute.regions.list
@@ -471,6 +433,9 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
+          - iam.serviceAccounts.actAs
+          - iam.serviceAccounts.get
+          - iam.serviceAccounts.list
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list

--- a/resources/wif/4.16/vanilla.yaml
+++ b/resources/wif/4.16/vanilla.yaml
@@ -1,175 +1,140 @@
 id: v4.16
 kind: WifTemplate
 service_accounts:
-  - id: osd-deployer
-    kind: ServiceAccount
+  - access_method: impersonate
+    id: osd-deployer
     osd_role: deployer
-    access_method: impersonate
     roles:
-      - id: osd-deployer
+      - id: osd_deployer
         kind: Role
         permissions:
-          - "compute.addresses.create"
-          - "compute.addresses.createInternal"
-          - "compute.addresses.delete"
-          - "compute.addresses.get"
-          - "compute.addresses.list"
-          - "compute.addresses.use"
-          - "compute.addresses.useInternal"
-          - "compute.firewalls.create"
-          - "compute.firewalls.delete"
-          - "compute.firewalls.get"
-          - "compute.firewalls.list"
-          - "compute.forwardingRules.create"
-          - "compute.forwardingRules.get"
-          - "compute.forwardingRules.list"
-          - "compute.forwardingRules.setLabels"
-          - "compute.networks.create"
-          - "compute.networks.get"
-          - "compute.networks.list"
-          - "compute.networks.updatePolicy"
-          - "compute.routers.create"
-          - "compute.routers.get"
-          - "compute.routers.list"
-          - "compute.routers.update"
-          - "compute.routes.list"
-          - "compute.subnetworks.create"
-          - "compute.subnetworks.get"
-          - "compute.subnetworks.list"
-          - "compute.subnetworks.use"
-          - "compute.subnetworks.useExternalIp"
-          - "compute.regionBackendServices.create"
-          - "compute.regionBackendServices.get"
-          - "compute.regionBackendServices.list"
-          - "compute.regionBackendServices.update"
-          - "compute.regionBackendServices.use"
-          - "compute.targetPools.addInstance"
-          - "compute.targetPools.create"
-          - "compute.targetPools.get"
-          - "compute.targetPools.list"
-          - "compute.targetPools.removeInstance"
-          - "compute.targetPools.use"
-          - "dns.changes.create"
-          - "dns.changes.get"
-          - "dns.managedZones.create"
-          - "dns.managedZones.get"
-          - "dns.managedZones.list"
-          - "dns.networks.bindPrivateDNSZone"
-          - "dns.resourceRecordSets.create"
-          - "dns.resourceRecordSets.list"
-          - "iam.serviceAccountKeys.create"
-          - "iam.serviceAccountKeys.delete"
-          - "iam.serviceAccountKeys.get"
-          - "iam.serviceAccountKeys.list"
-          - "iam.serviceAccounts.actAs"
-          - "iam.serviceAccounts.create"
-          - "iam.serviceAccounts.delete"
-          - "iam.serviceAccounts.get"
-          - "iam.serviceAccounts.list"
-          - "resourcemanager.projects.get"
-          - "resourcemanager.projects.getIamPolicy"
-          - "resourcemanager.projects.setIamPolicy"
-          - "compute.disks.create"
-          - "compute.disks.get"
-          - "compute.disks.list"
-          - "compute.disks.setLabels"
-          - "compute.instanceGroups.create"
-          - "compute.instanceGroups.delete"
-          - "compute.instanceGroups.get"
-          - "compute.instanceGroups.list"
-          - "compute.instanceGroups.update"
-          - "compute.instanceGroups.use"
-          - "compute.instances.create"
-          - "compute.instances.delete"
-          - "compute.instances.get"
-          - "compute.instances.list"
-          - "compute.instances.setLabels"
-          - "compute.instances.setMetadata"
-          - "compute.instances.setServiceAccount"
-          - "compute.instances.setTags"
-          - "compute.instances.use"
-          - "compute.machineTypes.get"
-          - "compute.machineTypes.list"
-          - "storage.buckets.create"
-          - "storage.buckets.delete"
-          - "storage.buckets.get"
-          - "storage.buckets.list"
-          - "storage.objects.create"
-          - "storage.objects.delete"
-          - "storage.objects.get"
-          - "storage.objects.list"
-          - "compute.healthChecks.create"
-          - "compute.healthChecks.get"
-          - "compute.healthChecks.list"
-          - "compute.healthChecks.useReadOnly"
-          - "compute.httpHealthChecks.create"
-          - "compute.httpHealthChecks.get"
-          - "compute.httpHealthChecks.list"
-          - "compute.httpHealthChecks.useReadOnly"
-          - "compute.globalOperations.get"
-          - "compute.regionOperations.get"
-          - "compute.regions.list"
-          - "compute.zoneOperations.get"
-          - "compute.zones.get"
-          - "compute.zones.list"
-          - "monitoring.timeSeries.list"
-          - "serviceusage.quotas.get"
-          - "serviceusage.services.list"
-          - "iam.roles.get"
-          - "compute.images.list"
-          - "compute.instances.getSerialPortOutput"
-          - "compute.addresses.delete"
-          - "compute.addresses.deleteInternal"
-          - "compute.addresses.list"
-          - "compute.firewalls.delete"
-          - "compute.firewalls.list"
-          - "compute.forwardingRules.delete"
-          - "compute.forwardingRules.list"
-          - "compute.networks.delete"
-          - "compute.networks.list"
-          - "compute.networks.updatePolicy"
-          - "compute.routers.delete"
-          - "compute.routers.list"
-          - "compute.routes.list"
-          - "compute.subnetworks.delete"
-          - "compute.subnetworks.list"
-          - "compute.regionBackendServices.delete"
-          - "compute.regionBackendServices.list"
-          - "compute.targetPools.delete"
-          - "compute.targetPools.list"
-          - "dns.changes.create"
-          - "dns.managedZones.delete"
-          - "dns.managedZones.get"
-          - "dns.managedZones.list"
-          - "dns.resourceRecordSets.delete"
-          - "dns.resourceRecordSets.list"
-          - "iam.serviceAccounts.delete"
-          - "iam.serviceAccounts.get"
-          - "iam.serviceAccounts.list"
-          - "resourcemanager.projects.getIamPolicy"
-          - "resourcemanager.projects.setIamPolicy"
-          - "compute.disks.delete"
-          - "compute.disks.list"
-          - "compute.instanceGroups.delete"
-          - "compute.instanceGroups.list"
-          - "compute.instances.delete"
-          - "compute.instances.list"
-          - "compute.instances.stop"
-          - "compute.machineTypes.list"
-          - "storage.buckets.delete"
-          - "storage.buckets.getIamPolicy"
-          - "storage.buckets.list"
-          - "storage.objects.delete"
-          - "storage.objects.list"
-          - "compute.healthChecks.delete"
-          - "compute.healthChecks.list"
-          - "compute.httpHealthChecks.delete"
-          - "compute.httpHealthChecks.list"
-          - "compute.images.list"
-  - id: osd-support
+          - compute.addresses.create
+          - compute.addresses.createInternal
+          - compute.addresses.delete
+          - compute.addresses.deleteInternal
+          - compute.addresses.get
+          - compute.addresses.list
+          - compute.addresses.use
+          - compute.addresses.useInternal
+          - compute.disks.create
+          - compute.disks.delete
+          - compute.disks.get
+          - compute.disks.list
+          - compute.disks.setLabels
+          - compute.firewalls.create
+          - compute.firewalls.delete
+          - compute.firewalls.get
+          - compute.firewalls.list
+          - compute.forwardingRules.create
+          - compute.forwardingRules.delete
+          - compute.forwardingRules.get
+          - compute.forwardingRules.list
+          - compute.forwardingRules.setLabels
+          - compute.globalOperations.get
+          - compute.healthChecks.create
+          - compute.healthChecks.delete
+          - compute.healthChecks.get
+          - compute.healthChecks.list
+          - compute.healthChecks.useReadOnly
+          - compute.httpHealthChecks.create
+          - compute.httpHealthChecks.delete
+          - compute.httpHealthChecks.get
+          - compute.httpHealthChecks.list
+          - compute.httpHealthChecks.useReadOnly
+          - compute.images.list
+          - compute.instanceGroups.create
+          - compute.instanceGroups.delete
+          - compute.instanceGroups.get
+          - compute.instanceGroups.list
+          - compute.instanceGroups.update
+          - compute.instanceGroups.use
+          - compute.instances.create
+          - compute.instances.delete
+          - compute.instances.get
+          - compute.instances.getSerialPortOutput
+          - compute.instances.list
+          - compute.instances.setLabels
+          - compute.instances.setMetadata
+          - compute.instances.setServiceAccount
+          - compute.instances.setTags
+          - compute.instances.stop
+          - compute.instances.use
+          - compute.machineTypes.get
+          - compute.machineTypes.list
+          - compute.networks.create
+          - compute.networks.delete
+          - compute.networks.get
+          - compute.networks.list
+          - compute.networks.updatePolicy
+          - compute.regionBackendServices.create
+          - compute.regionBackendServices.delete
+          - compute.regionBackendServices.get
+          - compute.regionBackendServices.list
+          - compute.regionBackendServices.update
+          - compute.regionBackendServices.use
+          - compute.regionOperations.get
+          - compute.regions.list
+          - compute.routers.create
+          - compute.routers.delete
+          - compute.routers.get
+          - compute.routers.list
+          - compute.routers.update
+          - compute.routes.list
+          - compute.subnetworks.create
+          - compute.subnetworks.delete
+          - compute.subnetworks.get
+          - compute.subnetworks.list
+          - compute.subnetworks.use
+          - compute.subnetworks.useExternalIp
+          - compute.targetPools.addInstance
+          - compute.targetPools.create
+          - compute.targetPools.delete
+          - compute.targetPools.get
+          - compute.targetPools.list
+          - compute.targetPools.removeInstance
+          - compute.targetPools.use
+          - compute.zoneOperations.get
+          - compute.zones.get
+          - compute.zones.list
+          - dns.changes.create
+          - dns.changes.get
+          - dns.managedZones.create
+          - dns.managedZones.delete
+          - dns.managedZones.get
+          - dns.managedZones.list
+          - dns.networks.bindPrivateDNSZone
+          - dns.resourceRecordSets.create
+          - dns.resourceRecordSets.delete
+          - dns.resourceRecordSets.list
+          - iam.roles.get
+          - iam.serviceAccountKeys.create
+          - iam.serviceAccountKeys.delete
+          - iam.serviceAccountKeys.get
+          - iam.serviceAccountKeys.list
+          - iam.serviceAccounts.actAs
+          - iam.serviceAccounts.create
+          - iam.serviceAccounts.delete
+          - iam.serviceAccounts.get
+          - iam.serviceAccounts.list
+          - monitoring.timeSeries.list
+          - resourcemanager.projects.get
+          - resourcemanager.projects.getIamPolicy
+          - resourcemanager.projects.setIamPolicy
+          - serviceusage.quotas.get
+          - serviceusage.services.list
+          - storage.buckets.create
+          - storage.buckets.delete
+          - storage.buckets.get
+          - storage.buckets.getIamPolicy
+          - storage.buckets.list
+          - storage.objects.create
+          - storage.objects.delete
+          - storage.objects.get
+          - storage.objects.list
+  - access_method: impersonate
+    id: osd-support
     kind: ServiceAccount
     osd_role: support
-    access_method: impersonate
     roles:
       - id: compute.admin
         kind: Role
@@ -186,10 +151,10 @@ service_accounts:
       - id: iam.serviceAccountAdmin
         kind: Role
         predefined: true
-      - id: iam.ServiceAccountKeyAdmin
+      - id: iam.serviceAccountKeyAdmin
         kind: Role
         predefined: true
-      - id: iam.ServiceAccountUser
+      - id: iam.serviceAccountUser
         kind: Role
         predefined: true
       - id: storage.admin
@@ -197,55 +162,55 @@ service_accounts:
         predefined: true
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credential-operator-gcp-ro-creds
-        Namespace: openshift-cloud-credential-operator
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credential-operator-gcp-ro-creds
+        namespace: openshift-cloud-credential-operator
+      service_account_names:
         - cloud-credential-operator
     id: cloud-credential-operator-gcp-ro-creds
     kind: ServiceAccount
     osd_role: cloud-credential-operator-gcp-ro-creds
     roles:
-      - id: cloud-credential-operator-gcp-ro-creds
+      - id: cloud_credential_operator_gcp_ro_creds
         kind: Role
         permissions:
           - iam.roles.get
-          - iam.serviceAccounts.get
           - iam.serviceAccountKeys.list
+          - iam.serviceAccounts.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
           - serviceusage.services.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credentials
-        Namespace: openshift-cloud-network-config-controller
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-cloud-network-config-controller
+      service_account_names:
         - cloud-network-config-controller
     id: openshift-cloud-network-config-controller-gcp
     kind: ServiceAccount
     osd_role: operator-cloud-network-config-controller-gcp
     roles:
-      - id: openshift-cloud-network-config-controller-gcp
+      - id: openshift_cloud_network_config_controller_gcp
         kind: Role
         permissions:
-          - compute.instances.updateNetworkInterface
-          - compute.subnetworks.use
-          - compute.subnetworks.get
-          - compute.zoneOperations.get
           - compute.instances.get
+          - compute.instances.updateNetworkInterface
+          - compute.subnetworks.get
+          - compute.subnetworks.use
+          - compute.zoneOperations.get
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: capg-manager-bootstrap-credentials
-        Namespace: openshift-cluster-api
-      ServiceAccountNames:
+      secret_ref:
+        name: capg-manager-bootstrap-credentials
+        namespace: openshift-cluster-api
+      service_account_names:
         - cluster-capi-operator
     id: openshift-cluster-api-gcp
     kind: ServiceAccount
     osd_role: operator-cluster-api-gcp
     roles:
-      - id: openshift-cluster-api-gcp
+      - id: openshift_cluster_api_gcp
         kind: Role
         permissions:
           - compute.addresses.create
@@ -299,16 +264,16 @@ service_accounts:
           - iam.serviceAccounts.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-ccm-cloud-credentials
-        Namespace: openshift-cloud-controller-manager
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-ccm-cloud-credentials
+        namespace: openshift-cloud-controller-manager
+      service_account_names:
         - cloud-controller-manager
     id: openshift-gcp-ccm
     kind: ServiceAccount
     osd_role: operator-gcp-ccm
     roles:
-      - id: openshift-gcp-ccm
+      - id: openshift_gcp_ccm
         kind: Role
         permissions:
           - compute.addresses.create
@@ -348,10 +313,10 @@ service_accounts:
           - compute.zones.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-pd-cloud-credentials
-        Namespace: openshift-cluster-csi-drivers
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-pd-cloud-credentials
+        namespace: openshift-cluster-csi-drivers
+      service_account_names:
         - gcp-pd-csi-driver-operator
         - gcp-pd-csi-driver-controller-sa
     id: openshift-gcp-pd-csi-driver-operator
@@ -364,32 +329,32 @@ service_accounts:
       - id: iam.serviceAccountUser
         kind: Role
         predefined: true
-      - id: openshift-gcp-pd-csi-driver-operator
+      - id: openshift_gcp_pd_csi_driver_operator
         kind: Role
         permissions:
-          - compute.instances.get
           - compute.instances.attachDisk
           - compute.instances.detachDisk
+          - compute.instances.get
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: installer-cloud-credentials
-        Namespace: openshift-image-registry
-      ServiceAccountNames:
+      secret_ref:
+        name: installer-cloud-credentials
+        namespace: openshift-image-registry
+      service_account_names:
         - cluster-image-registry-operator
         - registry
     id: openshift-image-registry-gcs
     kind: ServiceAccount
     osd_role: operator-image-registry-gcs
     roles:
-      - id: openshift-image-registry-gcs
+      - id: openshift_image_registry_gcs
         kind: Role
         permissions:
           - storage.buckets.create
+          - storage.buckets.createTagBinding
           - storage.buckets.delete
           - storage.buckets.get
           - storage.buckets.list
-          - storage.buckets.createTagBinding
           - storage.buckets.listEffectiveTags
           - storage.objects.create
           - storage.objects.delete
@@ -397,40 +362,37 @@ service_accounts:
           - storage.objects.list
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: cloud-credentials
-        Namespace: openshift-ingress-operator
-      ServiceAccountNames:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-ingress-operator
+      service_account_names:
         - ingress-operator
     id: openshift-ingress-gcp
     kind: ServiceAccount
     osd_role: operator-ingress-gcp
     roles:
-      - id: openshift-ingress-gcp
+      - id: openshift_ingress_gcp
         kind: Role
         permissions:
           - dns.changes.create
           - dns.resourceRecordSets.create
-          - dns.resourceRecordSets.update
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
+          - dns.resourceRecordSets.update
   - access_method: wif
     credential_request:
-      SecretRef:
-        Name: gcp-cloud-credentials
-        Namespace: openshift-machine-api
-      ServiceAccountNames:
+      secret_ref:
+        name: gcp-cloud-credentials
+        namespace: openshift-machine-api
+      service_account_names:
         - machine-api-controllers
     id: openshift-machine-api-gcp
     kind: ServiceAccount
     osd_role: operator-machine-api-gcp
     roles:
-      - id: openshift-machine-api-gcp
+      - id: openshift_machine_api_gcp
         kind: Role
         permissions:
-          - iam.serviceAccounts.actAs
-          - iam.serviceAccounts.get
-          - iam.serviceAccounts.list
           - compute.acceleratorTypes.get
           - compute.acceleratorTypes.list
           - compute.disks.create
@@ -447,17 +409,17 @@ service_accounts:
           - compute.instances.delete
           - compute.instances.get
           - compute.instances.list
-          - compute.instances.use
           - compute.instances.setLabels
           - compute.instances.setMetadata
-          - compute.instances.setTags
           - compute.instances.setServiceAccount
+          - compute.instances.setTags
           - compute.instances.update
+          - compute.instances.use
           - compute.machineTypes.get
           - compute.machineTypes.list
           - compute.projects.get
-          - compute.regionBackendServices.get
           - compute.regionBackendServices.create
+          - compute.regionBackendServices.get
           - compute.regionBackendServices.update
           - compute.regions.get
           - compute.regions.list
@@ -471,6 +433,9 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
+          - iam.serviceAccounts.actAs
+          - iam.serviceAccounts.get
+          - iam.serviceAccounts.list
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list


### PR DESCRIPTION
### What type of PR is this?
Cleanup

### What this PR does / why we need it?
It cleans up the gcp wif templates for hygiene and correctness with the following changes:

1. Replace "-"s in role ids with "_"
2. Remove quotes from permissions for consistency
3. Sort permission lists alphabetically and remove duplicates
4. Fix typo in "iam.ServiceAccountKeyAdmin" and "iam.ServiceAccountUser"
5. Convert all keys to snake_case

### Which Jira/Github issue(s) this PR fixes?

Is needed for https://issues.redhat.com/browse/OCM-9646

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
