### PR TITLE
Update ClusterOperatorDegradedSRE Alert

### DIFF
--- a/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
   groups:
     - name: sre-cluster-version-operator
       rules:
-        - alert: ClusterOperatorDegradedCriticalSRE
+        - alert: ClusterOperatorDegradedSRE
           annotations:
             summary: Cluster operator has been degraded for 2 days.
             description: The {{ $labels.name }} operator is degraded because {{

--- a/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-cluster-version-operator.PrometheusRule.yaml
@@ -11,33 +11,6 @@ spec:
   groups:
     - name: sre-cluster-version-operator
       rules:
-        - alert: ClusterOperatorDegradedSRE
-          annotations:
-            summary: Cluster operator has been degraded for 1 day.
-            description: The {{ "{{ $labels.name }}" }} operator is degraded because {{ "{{
-              $labels.reason }}" }}, and the components it manages may have
-              reduced quality of service.  Cluster upgrades may not complete.
-              For more information refer to 'oc get -o yaml clusteroperator {{
-              "{{ $labels.name }}" }}'{{ "{{ with $console_url :=
-              \"console_url\" | query }}{{ if ne (len (label \"url\" (first
-              $console_url ) ) ) 0}} or {{ label \"url\" (first $console_url )
-              }}/settings/cluster/{{ end }}{{ end }}" }}.
-          expr: >
-            max by (namespace, name, reason)
-
-            (
-              (
-                cluster_operator_conditions{job="cluster-version-operator", condition="Degraded", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"}
-                or on (namespace, name)
-                group by (namespace, name) (cluster_operator_up{job="cluster-version-operator", name =~ "kube-apiserver|kube-controller-manager|kube-scheduler"})
-              ) == 1
-            )
-          for: 1d
-          labels:
-            link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
-            namespace: openshift-monitoring
-            needs_attention: "true"
-            severity: warning
         - alert: ClusterOperatorDegradedCriticalSRE
           annotations:
             summary: Cluster operator has been degraded for 2 days.
@@ -65,5 +38,4 @@ spec:
           labels:
             link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
             namespace: openshift-monitoring
-            needs_attention: "true"
             severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35864,27 +35864,6 @@ objects:
         groups:
         - name: sre-cluster-version-operator
           rules:
-          - alert: ClusterOperatorDegradedSRE
-            annotations:
-              summary: Cluster operator has been degraded for 1 day.
-              description: The {{ "{{ $labels.name }}" }} operator is degraded because
-                {{ "{{ $labels.reason }}" }}, and the components it manages may have
-                reduced quality of service.  Cluster upgrades may not complete. For
-                more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
-                }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if
-                ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
-                (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
-            expr: "max by (namespace, name, reason)\n(\n  (\n    cluster_operator_conditions{job=\"\
-              cluster-version-operator\", condition=\"Degraded\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
-              }\n    or on (namespace, name)\n    group by (namespace, name) (cluster_operator_up{job=\"\
-              cluster-version-operator\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
-              })\n  ) == 1\n)\n"
-            for: 1d
-            labels:
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
-              namespace: openshift-monitoring
-              needs_attention: 'true'
-              severity: warning
           - alert: ClusterOperatorDegradedCriticalSRE
             annotations:
               summary: Cluster operator has been degraded for 2 days.
@@ -35905,7 +35884,6 @@ objects:
             labels:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
               namespace: openshift-monitoring
-              needs_attention: 'true'
               severity: critical
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35864,7 +35864,7 @@ objects:
         groups:
         - name: sre-cluster-version-operator
           rules:
-          - alert: ClusterOperatorDegradedCriticalSRE
+          - alert: ClusterOperatorDegradedSRE
             annotations:
               summary: Cluster operator has been degraded for 2 days.
               description: The {{ $labels.name }} operator is degraded because {{

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35864,27 +35864,6 @@ objects:
         groups:
         - name: sre-cluster-version-operator
           rules:
-          - alert: ClusterOperatorDegradedSRE
-            annotations:
-              summary: Cluster operator has been degraded for 1 day.
-              description: The {{ "{{ $labels.name }}" }} operator is degraded because
-                {{ "{{ $labels.reason }}" }}, and the components it manages may have
-                reduced quality of service.  Cluster upgrades may not complete. For
-                more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
-                }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if
-                ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
-                (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
-            expr: "max by (namespace, name, reason)\n(\n  (\n    cluster_operator_conditions{job=\"\
-              cluster-version-operator\", condition=\"Degraded\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
-              }\n    or on (namespace, name)\n    group by (namespace, name) (cluster_operator_up{job=\"\
-              cluster-version-operator\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
-              })\n  ) == 1\n)\n"
-            for: 1d
-            labels:
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
-              namespace: openshift-monitoring
-              needs_attention: 'true'
-              severity: warning
           - alert: ClusterOperatorDegradedCriticalSRE
             annotations:
               summary: Cluster operator has been degraded for 2 days.
@@ -35905,7 +35884,6 @@ objects:
             labels:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
               namespace: openshift-monitoring
-              needs_attention: 'true'
               severity: critical
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35864,7 +35864,7 @@ objects:
         groups:
         - name: sre-cluster-version-operator
           rules:
-          - alert: ClusterOperatorDegradedCriticalSRE
+          - alert: ClusterOperatorDegradedSRE
             annotations:
               summary: Cluster operator has been degraded for 2 days.
               description: The {{ $labels.name }} operator is degraded because {{

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35864,27 +35864,6 @@ objects:
         groups:
         - name: sre-cluster-version-operator
           rules:
-          - alert: ClusterOperatorDegradedSRE
-            annotations:
-              summary: Cluster operator has been degraded for 1 day.
-              description: The {{ "{{ $labels.name }}" }} operator is degraded because
-                {{ "{{ $labels.reason }}" }}, and the components it manages may have
-                reduced quality of service.  Cluster upgrades may not complete. For
-                more information refer to 'oc get -o yaml clusteroperator {{ "{{ $labels.name
-                }}" }}'{{ "{{ with $console_url := \"console_url\" | query }}{{ if
-                ne (len (label \"url\" (first $console_url ) ) ) 0}} or {{ label \"url\"
-                (first $console_url ) }}/settings/cluster/{{ end }}{{ end }}" }}.
-            expr: "max by (namespace, name, reason)\n(\n  (\n    cluster_operator_conditions{job=\"\
-              cluster-version-operator\", condition=\"Degraded\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
-              }\n    or on (namespace, name)\n    group by (namespace, name) (cluster_operator_up{job=\"\
-              cluster-version-operator\", name =~ \"kube-apiserver|kube-controller-manager|kube-scheduler\"\
-              })\n  ) == 1\n)\n"
-            for: 1d
-            labels:
-              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
-              namespace: openshift-monitoring
-              needs_attention: 'true'
-              severity: warning
           - alert: ClusterOperatorDegradedCriticalSRE
             annotations:
               summary: Cluster operator has been degraded for 2 days.
@@ -35905,7 +35884,6 @@ objects:
             labels:
               link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/ClusterOperatorDegraded.md
               namespace: openshift-monitoring
-              needs_attention: 'true'
               severity: critical
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35864,7 +35864,7 @@ objects:
         groups:
         - name: sre-cluster-version-operator
           rules:
-          - alert: ClusterOperatorDegradedCriticalSRE
+          - alert: ClusterOperatorDegradedSRE
             annotations:
               summary: Cluster operator has been degraded for 2 days.
               description: The {{ $labels.name }} operator is degraded because {{


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
With the addition of the ClusterOperatorDegradedCriticalSRE alert there is no longer a need to have two ClusterOperatorDegraded alerts.
 
### Which Jira/Github issue(s) this PR fixes?
relates to https://issues.redhat.com/browse/OSD-19661
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
