### PR TITLE
Enable pre-health check feature in managed-upgrade-operator

### DIFF
--- a/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml
@@ -26,6 +26,9 @@ data:
     nodeDrain:
       timeOut: 45
       expectedNodeDrainTime: 8
+    featureGate:
+      enabled:
+      - PreHealthCheck
     healthCheck:
       ignoredCriticals:
       - MetricsClientSendFailingSRE

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23755,19 +23755,20 @@ objects:
           \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
           \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - MetricsClientSendFailingSRE\n\
-          \  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n  # OSD-22494\n \
-          \ - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n  - ClusterMonitoringErrorBudgetBurnSRE\n\
-          \  - ConfigureAlertmanagerOperatorOfflineSRE\n  - console-ErrorBudgetBurn\n\
-          \  - ControlPlaneNodeFileDescriptorLimitSRE\n  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n\
-          \  - ControlPlaneNodeFilesystemSpaceFillingUp\n  - CustomerWorkloadPreventingDrainSRE\n\
-          \  - EbsVolumeBurstBalanceLT20PctSRE\n  - EbsVolumeStuckAttaching10MinSRE\n\
-          \  - EbsVolumeStuckDetaching10MinSRE\n  - etcdHighNumberOfFailedGRPCRequests\n\
-          \  - ExcessiveContainerMemoryCriticalSRE\n  - ExtremelyHighIndividualControlPlaneCPU\n\
-          \  - ExtremelyHighIndividualControlPlaneMemory\n  - HAProxyDown\n  - InsightsOperatorDownSRE\n\
-          \  - KubePersistentVolumeFillingUp\n  - KubePersistentVolumeInodesFillingUp\n\
-          \  - KubePersistentVolumeUsageCriticalCustomer\n  - KubePersistentVolumeUsageCriticalLayeredProduct\n\
-          \  - MCDRebootError\n  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
+          \ 8\nfeatureGate:\n  enabled:\n  - PreHealthCheck\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - MetricsClientSendFailingSRE\n  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n\
+          \  # OSD-22494\n  - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n\
+          \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
+          \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
+          \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
+          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
+          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
+          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
+          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
+          \  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
+          \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
+          \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
           \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
           \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
           \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23755,19 +23755,20 @@ objects:
           \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
           \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - MetricsClientSendFailingSRE\n\
-          \  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n  # OSD-22494\n \
-          \ - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n  - ClusterMonitoringErrorBudgetBurnSRE\n\
-          \  - ConfigureAlertmanagerOperatorOfflineSRE\n  - console-ErrorBudgetBurn\n\
-          \  - ControlPlaneNodeFileDescriptorLimitSRE\n  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n\
-          \  - ControlPlaneNodeFilesystemSpaceFillingUp\n  - CustomerWorkloadPreventingDrainSRE\n\
-          \  - EbsVolumeBurstBalanceLT20PctSRE\n  - EbsVolumeStuckAttaching10MinSRE\n\
-          \  - EbsVolumeStuckDetaching10MinSRE\n  - etcdHighNumberOfFailedGRPCRequests\n\
-          \  - ExcessiveContainerMemoryCriticalSRE\n  - ExtremelyHighIndividualControlPlaneCPU\n\
-          \  - ExtremelyHighIndividualControlPlaneMemory\n  - HAProxyDown\n  - InsightsOperatorDownSRE\n\
-          \  - KubePersistentVolumeFillingUp\n  - KubePersistentVolumeInodesFillingUp\n\
-          \  - KubePersistentVolumeUsageCriticalCustomer\n  - KubePersistentVolumeUsageCriticalLayeredProduct\n\
-          \  - MCDRebootError\n  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
+          \ 8\nfeatureGate:\n  enabled:\n  - PreHealthCheck\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - MetricsClientSendFailingSRE\n  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n\
+          \  # OSD-22494\n  - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n\
+          \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
+          \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
+          \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
+          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
+          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
+          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
+          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
+          \  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
+          \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
+          \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
           \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
           \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
           \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23755,19 +23755,20 @@ objects:
           \    # KubeletDown - https://issues.redhat.com/browse/OCPBUGS-20201\n  \
           \  - KubeletDown\nscale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger:\
           \ 30\n  timeOut: 120\nnodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime:\
-          \ 8\nhealthCheck:\n  ignoredCriticals:\n  - MetricsClientSendFailingSRE\n\
-          \  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n  # OSD-22494\n \
-          \ - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n  - ClusterMonitoringErrorBudgetBurnSRE\n\
-          \  - ConfigureAlertmanagerOperatorOfflineSRE\n  - console-ErrorBudgetBurn\n\
-          \  - ControlPlaneNodeFileDescriptorLimitSRE\n  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n\
-          \  - ControlPlaneNodeFilesystemSpaceFillingUp\n  - CustomerWorkloadPreventingDrainSRE\n\
-          \  - EbsVolumeBurstBalanceLT20PctSRE\n  - EbsVolumeStuckAttaching10MinSRE\n\
-          \  - EbsVolumeStuckDetaching10MinSRE\n  - etcdHighNumberOfFailedGRPCRequests\n\
-          \  - ExcessiveContainerMemoryCriticalSRE\n  - ExtremelyHighIndividualControlPlaneCPU\n\
-          \  - ExtremelyHighIndividualControlPlaneMemory\n  - HAProxyDown\n  - InsightsOperatorDownSRE\n\
-          \  - KubePersistentVolumeFillingUp\n  - KubePersistentVolumeInodesFillingUp\n\
-          \  - KubePersistentVolumeUsageCriticalCustomer\n  - KubePersistentVolumeUsageCriticalLayeredProduct\n\
-          \  - MCDRebootError\n  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
+          \ 8\nfeatureGate:\n  enabled:\n  - PreHealthCheck\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - MetricsClientSendFailingSRE\n  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n\
+          \  # OSD-22494\n  - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n\
+          \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
+          \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
+          \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
+          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
+          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
+          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
+          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
+          \  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
+          \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
+          \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
           \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
           \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
           \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Enable the prehealth check in the managed-upgrade-operator in staging environment. So we could monitor the stability.
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
