### PR TITLE
wif: adding permission to deployer

### DIFF
--- a/resources/wif/4.14/vanilla.yaml
+++ b/resources/wif/4.14/vanilla.yaml
@@ -73,6 +73,7 @@ service_accounts:
           - compute.regionBackendServices.update
           - compute.regionBackendServices.use
           - compute.regionOperations.get
+          - compute.regions.get
           - compute.regions.list
           - compute.routers.create
           - compute.routers.delete

--- a/resources/wif/4.15/vanilla.yaml
+++ b/resources/wif/4.15/vanilla.yaml
@@ -73,6 +73,7 @@ service_accounts:
           - compute.regionBackendServices.update
           - compute.regionBackendServices.use
           - compute.regionOperations.get
+          - compute.regions.get
           - compute.regions.list
           - compute.routers.create
           - compute.routers.delete

--- a/resources/wif/4.16/vanilla.yaml
+++ b/resources/wif/4.16/vanilla.yaml
@@ -73,6 +73,7 @@ service_accounts:
           - compute.regionBackendServices.update
           - compute.regionBackendServices.use
           - compute.regionOperations.get
+          - compute.regions.get
           - compute.regions.list
           - compute.routers.create
           - compute.routers.delete


### PR DESCRIPTION
During the backend implementation of availability zone derivation, it was discovered that an additional permission must be added to the deployer in order to derive availability zones: `compute.regions.get`

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OCM-10189

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
