### PR TITLE
OSD-20975: Not deploying MVO on GCP WIF clusters

### DIFF
--- a/deploy/velero-configuration/config.yaml
+++ b/deploy/velero-configuration/config.yaml
@@ -4,6 +4,9 @@ selectorSyncSet:
   - key: api.openshift.com/sts
     operator: NotIn
     values: ["true"]
+  - key: api.openshift.com/wif
+    operator: NotIn
+    values: ["true"]
   - key: api.openshift.com/fedramp
     operator: NotIn
     values:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39114,6 +39114,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/wif
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39114,6 +39114,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/wif
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39114,6 +39114,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/wif
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Lets make sure MVO (Managed Velero Operator) is not deployed on OSD clusters running on GCP with WIF (Workload Identity Federation) enabled.
WIF is the GCP equivalent of AWS STS; both are implementing OAuth 2.0. Our policy in that managed clusters should only deploy base operators (i.e. operators that come with OCP) when OAuth 2.0 is in use; indeed we want to keep to a minimal the actions eventually performed by the cluster on the customer cloud provider account when this authentication scheme is in use.
This excludes MVO which is:
- Not a "base" operator, that is to say not an operator bundled with OCP
- Accessing the customer cloud provider

### Which Jira/Github issue(s) this PR fixes?
Implements [OSD-20975](https://issues.redhat.com//browse/OSD-20975)

### Special notes for your reviewer:
The new label has been added in OCM with this MR:
https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/8410

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
