### PR TITLE
[OSD-24939] This commit adds back the STS roles needed by AVO in the …

### DIFF
--- a/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
+++ b/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
@@ -17,10 +17,21 @@
         "ec2:CreateVpcEndpoint",
         "ec2:DeleteVpcEndpoints",
         "ec2:DescribeVpcEndpoints",
+        "ec2:DescribeVpcs",
         "ec2:ModifyVpcEndpoint",
+        "ec2:DescribeVpcEndpointServices",
         "route53:ChangeResourceRecordSets",
         "route53:ListHostedZonesByName",
         "route53:ListResourceRecordSets"
+        "route53:ChangeResourceRecordSets",
+        "route53:ListHostedZonesByName",
+        "route53:ListHostedZonesByVPC",
+        "route53:ListResourceRecordSets",
+        "route53:ListTagsForResource",
+        "route53:GetHostedZone",
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:ChangeTagsForResource"
       ],
       "Resource": "*"
     }

--- a/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
+++ b/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
@@ -22,7 +22,7 @@
         "ec2:DescribeVpcEndpointServices",
         "route53:ChangeResourceRecordSets",
         "route53:ListHostedZonesByName",
-        "route53:ListResourceRecordSets"
+        "route53:ListResourceRecordSets",
         "route53:ChangeResourceRecordSets",
         "route53:ListHostedZonesByName",
         "route53:ListHostedZonesByVPC",

--- a/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
+++ b/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
@@ -21,7 +21,6 @@
         "ec2:ModifyVpcEndpoint",
         "ec2:DescribeVpcEndpointServices",
         "route53:ChangeResourceRecordSets",
-        "route53:ChangeResourceRecordSets",
         "route53:ListHostedZonesByName",
         "route53:ListHostedZonesByVPC",
         "route53:ListResourceRecordSets",

--- a/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
+++ b/resources/sts/4.13/openshift_aws_vpce_operator_avo_aws_creds_policy.json
@@ -21,8 +21,6 @@
         "ec2:ModifyVpcEndpoint",
         "ec2:DescribeVpcEndpointServices",
         "route53:ChangeResourceRecordSets",
-        "route53:ListHostedZonesByName",
-        "route53:ListResourceRecordSets",
         "route53:ChangeResourceRecordSets",
         "route53:ListHostedZonesByName",
         "route53:ListHostedZonesByVPC",
@@ -34,6 +32,25 @@
         "route53:ChangeTagsForResource"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "Route53ManageRecords",
+      "Effect": "Allow",
+      "Action": [
+          "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": "*",
+      "Condition": {
+          "ForAllValues:StringLike": {
+              "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+                  "*.openshiftapps.com",
+                  "*.devshift.org",
+                  "*.hypershift.local",
+                  "*.openshiftusgov.com",
+                  "*.devshiftusgov.com"
+              ]
+          }
+      }
     }
   ]
 }

--- a/resources/sts/4.14/openshift_aws_vpce_operator_avo_aws_creds_policy.json
+++ b/resources/sts/4.14/openshift_aws_vpce_operator_avo_aws_creds_policy.json
@@ -17,10 +17,18 @@
         "ec2:CreateVpcEndpoint",
         "ec2:DeleteVpcEndpoints",
         "ec2:DescribeVpcEndpoints",
+        "ec2:DescribeVpcs",
         "ec2:ModifyVpcEndpoint",
+        "ec2:DescribeVpcEndpointServices",
         "route53:ChangeResourceRecordSets",
         "route53:ListHostedZonesByName",
-        "route53:ListResourceRecordSets"
+        "route53:ListResourceRecordSets",
+        "route53:ListHostedZonesByVPC",
+        "route53:ListTagsForResource",
+        "route53:GetHostedZone",
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:ChangeTagsForResource"
       ],
       "Resource": "*"
     }

--- a/resources/sts/4.14/openshift_aws_vpce_operator_avo_aws_creds_policy.json
+++ b/resources/sts/4.14/openshift_aws_vpce_operator_avo_aws_creds_policy.json
@@ -31,6 +31,25 @@
         "route53:ChangeTagsForResource"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "Route53ManageRecords",
+      "Effect": "Allow",
+      "Action": [
+          "route53:ChangeResourceRecordSets"
+      ],
+      "Resource": "*",
+      "Condition": {
+          "ForAllValues:StringLike": {
+              "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
+                  "*.openshiftapps.com",
+                  "*.devshift.org",
+                  "*.hypershift.local",
+                  "*.openshiftusgov.com",
+                  "*.devshiftusgov.com"
+              ]
+          }
+      }
     }
   ]
 }


### PR DESCRIPTION
…FedRamp environment.

### What type of PR is this?

This PR adds roles needed for AVO in the FedRamp environment.

### What this PR does / why we need it?

We will be unable to monitor 4.13 and 4.14 clusters fully in the FedRamp environment without this change.

### Which Jira/Github issue(s) this PR fixes?

[OSD-24939](https://issues.redhat.com//browse/OSD-24939)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
