### PR TITLE
OHSS-36254: ACS Add packagemanifests cluster permission

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -426,6 +426,12 @@ spec:
                                 - get
                                 - list
                                 - watch
+                            - apiGroups:
+                                - package.opeartors.coreos.com
+                              resources:
+                                - packagemanifests
+                              verbs:
+                                - list
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -427,7 +427,7 @@ spec:
                                 - list
                                 - watch
                             - apiGroups:
-                                - package.opeartors.coreos.com
+                                - packages.operators.coreos.com/v1
                               resources:
                                 - packagemanifests
                               verbs:

--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -427,7 +427,7 @@ spec:
                                 - list
                                 - watch
                             - apiGroups:
-                                - packages.operators.coreos.com/v1
+                                - packages.operators.coreos.com
                               resources:
                                 - packagemanifests
                               verbs:

--- a/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
@@ -433,3 +433,10 @@ rules:
   - get
   - list
   - watch
+# ACS SRE can view information about Addon package
+- apiGroups:
+  - 'package.opeartors.coreos.com'
+  resources:
+  - packagemanifests
+  verbs:
+  - list

--- a/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
@@ -435,7 +435,7 @@ rules:
   - watch
 # ACS SRE can view information about Addon package
 - apiGroups:
-  - 'package.opeartors.coreos.com'
+  - 'packages.operators.coreos.com/v1'
   resources:
   - packagemanifests
   verbs:

--- a/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
@@ -435,7 +435,7 @@ rules:
   - watch
 # ACS SRE can view information about Addon package
 - apiGroups:
-  - 'packages.operators.coreos.com/v1'
+  - packages.operators.coreos.com
   resources:
   - packagemanifests
   verbs:

--- a/docs/backplane/requirements/acs/10-acs-managed-service.md
+++ b/docs/backplane/requirements/acs/10-acs-managed-service.md
@@ -110,6 +110,7 @@ Permissions at cluster scope.
 * view verticalpodautoscalers
 * view verticalpodautoscalercheckpoints
 * view verticalpodautoscalercontrollers
+* view packagemanifests
 
 ## backplane-acs-admins-project: `(^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*|^acscs-dataplane-cd$)`
 - ACS team needs read/list/watch access to core `redhat` and `rhacs` objects within their namespaces. This includes Custom Resource objects for ACS Addon.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1086,7 +1086,7 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - package.opeartors.coreos.com
+                    - packages.operators.coreos.com/v1
                     resources:
                     - packagemanifests
                     verbs:
@@ -9122,7 +9122,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:
@@ -9889,7 +9889,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:
@@ -10656,7 +10656,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1085,6 +1085,12 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - package.opeartors.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -9115,6 +9121,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9876,6 +9888,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10637,6 +10655,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1086,7 +1086,7 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - packages.operators.coreos.com/v1
+                    - packages.operators.coreos.com
                     resources:
                     - packagemanifests
                     verbs:
@@ -9122,7 +9122,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:
@@ -9889,7 +9889,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:
@@ -10656,7 +10656,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1086,7 +1086,7 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - package.opeartors.coreos.com
+                    - packages.operators.coreos.com/v1
                     resources:
                     - packagemanifests
                     verbs:
@@ -9122,7 +9122,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:
@@ -9889,7 +9889,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:
@@ -10656,7 +10656,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1085,6 +1085,12 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - package.opeartors.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -9115,6 +9121,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9876,6 +9888,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10637,6 +10655,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1086,7 +1086,7 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - packages.operators.coreos.com/v1
+                    - packages.operators.coreos.com
                     resources:
                     - packagemanifests
                     verbs:
@@ -9122,7 +9122,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:
@@ -9889,7 +9889,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:
@@ -10656,7 +10656,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1086,7 +1086,7 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - package.opeartors.coreos.com
+                    - packages.operators.coreos.com/v1
                     resources:
                     - packagemanifests
                     verbs:
@@ -9122,7 +9122,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:
@@ -9889,7 +9889,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:
@@ -10656,7 +10656,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - package.opeartors.coreos.com
+        - packages.operators.coreos.com/v1
         resources:
         - packagemanifests
         verbs:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1085,6 +1085,12 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - package.opeartors.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - list
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -9115,6 +9121,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -9876,6 +9888,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -10637,6 +10655,12 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - package.opeartors.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - list
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1086,7 +1086,7 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - packages.operators.coreos.com/v1
+                    - packages.operators.coreos.com
                     resources:
                     - packagemanifests
                     verbs:
@@ -9122,7 +9122,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:
@@ -9889,7 +9889,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:
@@ -10656,7 +10656,7 @@ objects:
         - list
         - watch
       - apiGroups:
-        - packages.operators.coreos.com/v1
+        - packages.operators.coreos.com
         resources:
         - packagemanifests
         verbs:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Additional access 

### What this PR does / why we need it?
ACS team cannot view Addon related CRs even though all necessary CRs permissiones introduced in #2171. This PR should be the missing part similar to `packagemanifests` permission in https://github.com/openshift/managed-cluster-config/blob/77073ee01c08a78968c0fe3bd26b77cb99c090ff/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml#L168-L173 

### Which Jira/Github issue(s) this PR fixes?

[OHSS-36254](https://issues.redhat.com/browse/OHSS-36254)

### Special notes for your reviewer:

### Pre-checks (if applicable):
~- [ ] Tested latest changes against a cluster~
- [x] Included documentation changes with PR
~- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:~

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
