### PR TITLE
Backporting STS permission s3:PutBucketPolicy

### DIFF
--- a/resources/sts/4.12/sts_installer_permission_policy.json
+++ b/resources/sts/4.12/sts_installer_permission_policy.json
@@ -189,7 +189,8 @@
                 "ec2:DescribeVpcEndpointServices",
                 "ec2:ModifyVpcEndpointServicePermissions",
                 "kms:DescribeKey",
-                "cloudwatch:GetMetricData"
+                "cloudwatch:GetMetricData",
+                "s3:PutBucketPolicy"
             ],
             "Resource": "*"
         },

--- a/resources/sts/4.13/sts_installer_permission_policy.json
+++ b/resources/sts/4.13/sts_installer_permission_policy.json
@@ -191,7 +191,8 @@
                 "ec2:DescribeVpcEndpointServices",
                 "ec2:ModifyVpcEndpointServicePermissions",
                 "kms:DescribeKey",
-                "cloudwatch:GetMetricData"
+                "cloudwatch:GetMetricData",
+                "s3:PutBucketPolicy"
             ],
             "Resource": "*"
         },

--- a/resources/sts/4.14/sts_installer_permission_policy.json
+++ b/resources/sts/4.14/sts_installer_permission_policy.json
@@ -190,7 +190,8 @@
                 "ec2:DescribeVpcEndpointServices",
                 "ec2:ModifyVpcEndpointServicePermissions",
                 "kms:DescribeKey",
-                "cloudwatch:GetMetricData"
+                "cloudwatch:GetMetricData",
+                "s3:PutBucketPolicy"
             ],
             "Resource": "*"
         },

--- a/resources/sts/4.15/sts_installer_permission_policy.json
+++ b/resources/sts/4.15/sts_installer_permission_policy.json
@@ -190,7 +190,8 @@
                 "ec2:DescribeVpcEndpointServices",
                 "ec2:ModifyVpcEndpointServicePermissions",
                 "kms:DescribeKey",
-                "cloudwatch:GetMetricData"
+                "cloudwatch:GetMetricData",
+                "s3:PutBucketPolicy"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature.  

### What this PR does / why we need it?
This will add the STS permission for "s3:PutBucketPolicy".  This is expected to fix an issue running "rosa create oidc-config" in version 4.12 - 4.15.  This already exists int he 4.16 policy.  

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
