### PR TITLE
Allow SREP to get/list/watch scheduling.hypershift.openshift.io resources

### DIFF
--- a/deploy/backplane/srep/hypershift/management-cluster/10-srep-management-cluster-cluster.ClusteRole.yml
+++ b/deploy/backplane/srep/hypershift/management-cluster/10-srep-management-cluster-cluster.ClusteRole.yml
@@ -39,6 +39,7 @@ rules:
 # SRE can view HCP resources at cluster scope
 - apiGroups:
   - hypershift.openshift.io
+  - scheduling.hypershift.openshift.io
   resources:
   - '*'
   verbs:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -21813,6 +21813,7 @@ objects:
         - watch
       - apiGroups:
         - hypershift.openshift.io
+        - scheduling.hypershift.openshift.io
         resources:
         - '*'
         verbs:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -21813,6 +21813,7 @@ objects:
         - watch
       - apiGroups:
         - hypershift.openshift.io
+        - scheduling.hypershift.openshift.io
         resources:
         - '*'
         verbs:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -21813,6 +21813,7 @@ objects:
         - watch
       - apiGroups:
         - hypershift.openshift.io
+        - scheduling.hypershift.openshift.io
         resources:
         - '*'
         verbs:


### PR DESCRIPTION
### What this PR does / why we need it?
Allow SREP to get/list/watch scheduling.hypershift.openshift.io cluster-scoped resources, namely `clustersizingconfigurations.scheduling.hypershift.openshift.io`

### Which Jira/Github issue(s) this PR fixes?
[OSD-25135](https://issues.redhat.com//browse/OSD-25135)
