### PR TITLE
feat(OSD-24893): add 4.17 wif config

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -1,0 +1,402 @@
+id: v4.17
+kind: WifTemplate
+service_accounts:
+  - access_method: impersonate
+    id: osd-deployer
+    osd_role: deployer
+    roles:
+      - id: osd_deployer
+        kind: Role
+        permissions:
+          - compute.addresses.create
+          - compute.addresses.createInternal
+          - compute.addresses.delete
+          - compute.addresses.deleteInternal
+          - compute.addresses.get
+          - compute.addresses.list
+          - compute.addresses.use
+          - compute.addresses.useInternal
+          - compute.disks.create
+          - compute.disks.delete
+          - compute.disks.get
+          - compute.disks.list
+          - compute.disks.setLabels
+          - compute.firewalls.create
+          - compute.firewalls.delete
+          - compute.firewalls.get
+          - compute.firewalls.list
+          - compute.forwardingRules.create
+          - compute.forwardingRules.delete
+          - compute.forwardingRules.get
+          - compute.forwardingRules.list
+          - compute.forwardingRules.setLabels
+          - compute.globalOperations.get
+          - compute.healthChecks.create
+          - compute.healthChecks.delete
+          - compute.healthChecks.get
+          - compute.healthChecks.list
+          - compute.healthChecks.useReadOnly
+          - compute.httpHealthChecks.create
+          - compute.httpHealthChecks.delete
+          - compute.httpHealthChecks.get
+          - compute.httpHealthChecks.list
+          - compute.httpHealthChecks.useReadOnly
+          - compute.images.list
+          - compute.instanceGroups.create
+          - compute.instanceGroups.delete
+          - compute.instanceGroups.get
+          - compute.instanceGroups.list
+          - compute.instanceGroups.update
+          - compute.instanceGroups.use
+          - compute.instances.create
+          - compute.instances.delete
+          - compute.instances.get
+          - compute.instances.getSerialPortOutput
+          - compute.instances.list
+          - compute.instances.setLabels
+          - compute.instances.setMetadata
+          - compute.instances.setServiceAccount
+          - compute.instances.setTags
+          - compute.instances.stop
+          - compute.instances.use
+          - compute.machineTypes.get
+          - compute.machineTypes.list
+          - compute.networks.create
+          - compute.networks.delete
+          - compute.networks.get
+          - compute.networks.list
+          - compute.networks.updatePolicy
+          - compute.regionBackendServices.create
+          - compute.regionBackendServices.delete
+          - compute.regionBackendServices.get
+          - compute.regionBackendServices.list
+          - compute.regionBackendServices.update
+          - compute.regionBackendServices.use
+          - compute.regionOperations.get
+          - compute.regions.get
+          - compute.regions.list
+          - compute.routers.create
+          - compute.routers.delete
+          - compute.routers.get
+          - compute.routers.list
+          - compute.routers.update
+          - compute.routes.list
+          - compute.serviceAttachments.create
+          - compute.serviceAttachments.delete
+          - compute.serviceAttachments.get
+          - compute.subnetworks.create
+          - compute.subnetworks.delete
+          - compute.subnetworks.get
+          - compute.subnetworks.list
+          - compute.subnetworks.use
+          - compute.subnetworks.useExternalIp
+          - compute.targetPools.addInstance
+          - compute.targetPools.create
+          - compute.targetPools.delete
+          - compute.targetPools.get
+          - compute.targetPools.list
+          - compute.targetPools.removeInstance
+          - compute.targetPools.use
+          - compute.zoneOperations.get
+          - compute.zones.get
+          - compute.zones.list
+          - dns.changes.create
+          - dns.changes.get
+          - dns.managedZones.create
+          - dns.managedZones.delete
+          - dns.managedZones.get
+          - dns.managedZones.list
+          - dns.networks.bindPrivateDNSZone
+          - dns.resourceRecordSets.create
+          - dns.resourceRecordSets.delete
+          - dns.resourceRecordSets.list
+          - iam.roles.get
+          - iam.serviceAccountKeys.create
+          - iam.serviceAccountKeys.delete
+          - iam.serviceAccountKeys.get
+          - iam.serviceAccountKeys.list
+          - iam.serviceAccounts.actAs
+          - iam.serviceAccounts.create
+          - iam.serviceAccounts.delete
+          - iam.serviceAccounts.get
+          - iam.serviceAccounts.list
+          - monitoring.timeSeries.list
+          - resourcemanager.projects.get
+          - resourcemanager.projects.getIamPolicy
+          - resourcemanager.projects.setIamPolicy
+          - serviceusage.quotas.get
+          - serviceusage.services.list
+          - storage.buckets.create
+          - storage.buckets.delete
+          - storage.buckets.get
+          - storage.buckets.getIamPolicy
+          - storage.buckets.list
+          - storage.objects.create
+          - storage.objects.delete
+          - storage.objects.get
+          - storage.objects.list
+  - access_method: impersonate
+    id: osd-support
+    kind: ServiceAccount
+    osd_role: support
+    roles:
+      - id: compute.admin
+        kind: Role
+        predefined: true
+      - id: dns.admin
+        kind: Role
+        predefined: true
+      - id: iam.roleAdmin
+        kind: Role
+        predefined: true
+      - id: iam.securityAdmin
+        kind: Role
+        predefined: true
+      - id: iam.serviceAccountAdmin
+        kind: Role
+        predefined: true
+      - id: iam.serviceAccountKeyAdmin
+        kind: Role
+        predefined: true
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+      - id: storage.admin
+        kind: Role
+        predefined: true
+  - access_method: wif
+    credential_request:
+      secret_ref:
+        name: cloud-credential-operator-gcp-ro-creds
+        namespace: openshift-cloud-credential-operator
+      service_account_names:
+        - cloud-credential-operator
+    id: cloud-credential-operator-gcp-ro-creds
+    kind: ServiceAccount
+    osd_role: cloud-credential-operator-gcp-ro-creds
+    roles:
+      - id: cloud_credential_operator_gcp_ro_creds
+        kind: Role
+        permissions:
+          - iam.roles.get
+          - iam.serviceAccountKeys.list
+          - iam.serviceAccounts.get
+          - resourcemanager.projects.get
+          - resourcemanager.projects.getIamPolicy
+          - serviceusage.services.list
+  - access_method: wif
+    credential_request:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-cloud-network-config-controller
+      service_account_names:
+        - cloud-network-config-controller
+    id: openshift-cloud-network-config-controller-gcp
+    kind: ServiceAccount
+    osd_role: operator-cloud-network-config-controller-gcp
+    roles:
+      - id: openshift_cloud_network_config_controller_gcp
+        kind: Role
+        permissions:
+          - compute.instances.get
+          - compute.instances.updateNetworkInterface
+          - compute.subnetworks.get
+          - compute.subnetworks.use
+          - compute.zoneOperations.get
+  - access_method: wif
+    credential_request:
+      secret_ref:
+        name: gcp-ccm-cloud-credentials
+        namespace: openshift-cloud-controller-manager
+      service_account_names:
+        - cloud-controller-manager
+    id: openshift-gcp-ccm
+    kind: ServiceAccount
+    osd_role: operator-gcp-ccm
+    roles:
+      - id: openshift_gcp_ccm
+        kind: Role
+        permissions:
+          - compute.addresses.create
+          - compute.addresses.delete
+          - compute.addresses.get
+          - compute.addresses.list
+          - compute.firewalls.create
+          - compute.firewalls.delete
+          - compute.firewalls.get
+          - compute.firewalls.update
+          - compute.forwardingRules.create
+          - compute.forwardingRules.delete
+          - compute.forwardingRules.get
+          - compute.healthChecks.create
+          - compute.healthChecks.delete
+          - compute.healthChecks.get
+          - compute.healthChecks.update
+          - compute.httpHealthChecks.create
+          - compute.httpHealthChecks.delete
+          - compute.httpHealthChecks.get
+          - compute.httpHealthChecks.update
+          - compute.instanceGroups.create
+          - compute.instanceGroups.delete
+          - compute.instanceGroups.get
+          - compute.instanceGroups.update
+          - compute.instances.get
+          - compute.instances.use
+          - compute.regionBackendServices.create
+          - compute.regionBackendServices.delete
+          - compute.regionBackendServices.get
+          - compute.regionBackendServices.update
+          - compute.targetPools.addInstance
+          - compute.targetPools.create
+          - compute.targetPools.delete
+          - compute.targetPools.get
+          - compute.targetPools.removeInstance
+          - compute.zones.list
+  - access_method: wif
+    credential_request:
+      secret_ref:
+        name: gcp-pd-cloud-credentials
+        namespace: openshift-cluster-csi-drivers
+      service_account_names:
+        - gcp-pd-csi-driver-operator
+        - gcp-pd-csi-driver-controller-sa
+    id: openshift-gcp-pd-csi-driver-operator
+    kind: ServiceAccount
+    osd_role: operator-gcp-pd-csi-driver-operator
+    roles:
+      - id: compute.storageAdmin
+        kind: Role
+        predefined: true
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+      - id: resourcemanager.tagUser
+        kind: Role
+        predefined: true
+      - id: openshift_gcp_pd_csi_driver_operator
+        kind: Role
+        permissions:
+          - compute.instances.attachDisk
+          - compute.instances.detachDisk
+          - compute.instances.get
+  - access_method: wif
+    credential_request:
+      secret_ref:
+        name: installer-cloud-credentials
+        namespace: openshift-image-registry
+      service_account_names:
+        - cluster-image-registry-operator
+        - registry
+    id: openshift-image-registry-gcs
+    kind: ServiceAccount
+    osd_role: operator-image-registry-gcs
+    roles:
+      - id: openshift_image_registry_gcs
+        kind: Role
+        permissions:
+          - storage.buckets.create
+          - storage.buckets.createTagBinding
+          - storage.buckets.delete
+          - storage.buckets.get
+          - storage.buckets.list
+          - storage.buckets.listEffectiveTags
+          - storage.objects.create
+          - storage.objects.delete
+          - storage.objects.get
+          - storage.objects.list
+          - resourcemanager.tagValueBindings.create
+          - resourcemanager.tagValues.get
+          - resourcemanager.tagValues.list
+  - access_method: wif
+    credential_request:
+      secret_ref:
+        name: cloud-credentials
+        namespace: openshift-ingress-operator
+      service_account_names:
+        - ingress-operator
+    id: openshift-ingress-gcp
+    kind: ServiceAccount
+    osd_role: operator-ingress-gcp
+    roles:
+      - id: openshift_ingress_gcp
+        kind: Role
+        permissions:
+          - dns.changes.create
+          - dns.resourceRecordSets.create
+          - dns.resourceRecordSets.delete
+          - dns.resourceRecordSets.list
+          - dns.resourceRecordSets.update
+  - access_method: wif
+    credential_request:
+      secret_ref:
+        name: gcp-cloud-credentials
+        namespace: openshift-machine-api
+      service_account_names:
+        - machine-api-controllers
+    id: openshift-machine-api-gcp
+    kind: ServiceAccount
+    osd_role: operator-machine-api-gcp
+    roles:
+      - id: openshift_machine_api_gcp
+        kind: Role
+        permissions:
+          - compute.acceleratorTypes.get
+          - compute.acceleratorTypes.list
+          - compute.disks.create
+          - compute.disks.setLabels
+          - compute.globalOperations.get
+          - compute.globalOperations.list
+          - compute.healthChecks.useReadOnly
+          - compute.instanceGroups.create
+          - compute.instanceGroups.delete
+          - compute.instanceGroups.get
+          - compute.instanceGroups.list
+          - compute.instanceGroups.update
+          - compute.instances.create
+          - compute.instances.delete
+          - compute.instances.get
+          - compute.instances.list
+          - compute.instances.setLabels
+          - compute.instances.setMetadata
+          - compute.instances.setServiceAccount
+          - compute.instances.setTags
+          - compute.instances.update
+          - compute.instances.use
+          - compute.machineTypes.get
+          - compute.machineTypes.list
+          - compute.projects.get
+          - compute.regionBackendServices.create
+          - compute.regionBackendServices.get
+          - compute.regionBackendServices.update
+          - compute.regions.get
+          - compute.regions.list
+          - compute.subnetworks.use
+          - compute.subnetworks.useExternalIp
+          - compute.targetPools.addInstance
+          - compute.targetPools.delete
+          - compute.targetPools.get
+          - compute.targetPools.removeInstance
+          - compute.zoneOperations.get
+          - compute.zoneOperations.list
+          - compute.zones.get
+          - compute.zones.list
+          - iam.serviceAccounts.actAs
+          - iam.serviceAccounts.get
+          - iam.serviceAccounts.list
+          - serviceusage.quotas.get
+          - serviceusage.services.get
+          - serviceusage.services.list
+service_apis:
+  - deploymentmanager.googleapis.com
+  - compute.googleapis.com
+  - cloudapis.googleapis.com
+  - cloudresourcemanager.googleapis.com
+  - dns.googleapis.com
+  - networksecurity.googleapis.com
+  - iamcredentials.googleapis.com
+  - iam.googleapis.com
+  - servicemanagement.googleapis.com
+  - serviceusage.googleapis.com
+  - storage-api.googleapis.com
+  - storage-component.googleapis.com
+  - orgpolicy.googleapis.com


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

This PR adds GCP WIF template for 4.17.

1. Credential request diffs:
    ```
    ./dist/osdctl_linux_amd64_v1/osdctl iampermissions diff -c gcp -b 4.16.0 -t 4.17.0-rc.0
    Downloading Credential Requests for 4.16.0
    Downloading Credential Requests for 4.17.0-rc.0
    Only in /tmp/osdctl-crs-3601789188: 0000_30_cluster-api_00_credentials-request.yaml
    Only in /tmp/osdctl-crs-1398950497: 0000_30_cluster-api_01_credentials-request.yaml
    diff /tmp/osdctl-crs-3601789188/0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml /tmp/osdctl-crs-1398950497/0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml
    29a30,32
    >     - resourcemanager.tagValueBindings.create
    >     - resourcemanager.tagValues.get
    >     - resourcemanager.tagValues.list
    diff /tmp/osdctl-crs-3601789188/0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml /tmp/osdctl-crs-1398950497/0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml
    21a22
    >     - roles/resourcemanager.tagUser
    ```

2. 4.17 hive permissions 

    Additionally to these new permissions, hive needs the permissions documented in https://issues.redhat.com/browse/OSD-24893 for GCP PSC, this manifests in the following 3 additions:
    ```
    compute.serviceAttachments.create
    compute.serviceAttachments.delete
    compute.serviceAttachments.get
    ```

**Total diffs to 4.16:**
```
diff resources/wif/4.16/vanilla.yaml resources/wif/4.17/vanilla.yaml 
1c1
< id: v4.16
---
> id: v4.17
83a84,86
>           - compute.serviceAttachments.create
>           - compute.serviceAttachments.delete
>           - compute.serviceAttachments.get
269a273,275
>       - id: resourcemanager.tagUser
>         kind: Role
>         predefined: true
300a307,309
>           - resourcemanager.tagValueBindings.create
>           - resourcemanager.tagValues.get
>           - resourcemanager.tagValues.list
```

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-24893

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
