### PR TITLE
update 4.17 WIF template

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -419,6 +419,34 @@ service_accounts:
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list
+  - access_method: vm
+    id: osd-worker
+    kind: ServiceAccount
+    osd_role: worker
+    roles:
+      - id: compute.storageAdmin
+        kind: Role
+        predefined: true
+      - id: compute.viewer
+        kind: Role
+        predefined: true
+  - access_method: vm
+    id: osd-control-plane
+    kind: ServiceAccount
+    osd_role: control-plane
+    roles:
+      - id: compute.instanceAdmin
+        kind: Role
+        predefined: true
+      - id: compute.networkAdmin
+        kind: Role
+        predefined: true
+      - id: compute.securityAdmin
+        kind: Role
+        predefined: true
+      - id: compute.storageAdmin
+        kind: Role
+        predefined: true
 service_apis:
   - deploymentmanager.googleapis.com
   - compute.googleapis.com


### PR DESCRIPTION
added definitions for worker and control-plane service accounts

Associated ticket: https://issues.redhat.com/browse/OCM-10202

WifTemplates define the service accounts which the user will create prior to deploying an OSD-GCP cluster using WIF. By adding definitions for worker and control-plane service accounts, we make these service accounts available for OCM to use during cluster deployment. Prior to this, these service accounts were created at deployment time by the Openshift Installer.