### PR TITLE
osd-logging[-unsupported]: applyBehavior: CreateOnly

### DIFF
--- a/deploy/osd-logging/config.yaml
+++ b/deploy/osd-logging/config.yaml
@@ -3,6 +3,12 @@ selectorSyncSet:
   # if this config no longer applies, don't delete the resources
   resourceApplyMode: "Upsert"
 
+  # Ignore the kubectl.kubernetes.io/last-applied-configuration
+  # annotation when patching resources. The result is that map additions
+  # made externally (e.g. by the customer) will be ignored rather than
+  # reverted.
+  applyBehavior: CreateOnly
+
   matchExpressions:
   # Enable in-cluster logging alerts for those clusters that already have logging installed
   # https://issues.redhat.com/browse/OSD-7564

--- a/deploy/osd-logging/unsupported/config.yaml
+++ b/deploy/osd-logging/unsupported/config.yaml
@@ -2,6 +2,13 @@ deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   # if we ever remove this, do not remove the resources
   resourceApplyMode: "Upsert"
+
+  # Ignore the kubectl.kubernetes.io/last-applied-configuration
+  # annotation when patching resources. The result is that map additions
+  # made externally (e.g. by the customer) will be ignored rather than
+  # reverted.
+  applyBehavior: CreateOnly
+
   matchExpressions:
   # Disable in-cluster logging alerts for those clusters that do not already have logging installed
   # We removed the version check because that would conflict with this check here for clusters that

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30682,6 +30682,7 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: Namespace
@@ -30927,6 +30928,7 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: Namespace

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30682,6 +30682,7 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: Namespace
@@ -30927,6 +30928,7 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: Namespace

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30682,6 +30682,7 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: Namespace
@@ -30927,6 +30928,7 @@ objects:
         values:
         - 'true'
     resourceApplyMode: Upsert
+    applyBehavior: CreateOnly
     resources:
     - apiVersion: v1
       kind: Namespace


### PR DESCRIPTION
### What this PR does / why we need it?

The `osd-logging` and `osd-logging-unsupported` SelectorSyncSets include the `openshift-logging` namespace. Customers wishing to add labels to it -- e.g. to enable logging -- do not want such changes reverted whenever hive reapplies the syncset. The default `spec.applyBehavior`, `Apply`, causes hive to use `kubectl apply` to compute the patch to apply to the target object; and `kubectl apply` uses the
`kubectl.kubernetes.io/last-applied-configuration` annotation to decide whether to remove or ignore map entries such as labels. If the customer used `kubectl apply` to add their label, the result would be hive removing it.

Switch these two SelectorSyncSets to use `spec.applyBehavior: CreateOnly` instead. This causes hive to *not* use `kubectl apply` to compute the patch, and thus the
`kubectl.kubernetes.io/last-applied-configuration` annotation is ignored, and thus hive will only assert map values (such as labels) that are present in the syncset resources, and not remove others.



### What type of PR is this?
_bug_


### Which Jira/Github issue(s) this PR fixes?

_Fixes [HIVE-2577](https://issues.redhat.com//browse/HIVE-2577)_

### Special notes for your reviewer:
NOTE: This setting applies to the whole of a SelectorSyncSet. This means that the other resources in these two are also affected: additions made by customers will not be reverted. If this turns out to be a problem, the resources may need to be split into separate [Selector]SyncSets with different `applyBehavior`s as appropriate.


### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
