### PR TITLE
updates Raf's role, replaces Tony with Brian as FL

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,13 +9,12 @@ aliases:
     - Tafhim
     - Tof1973
   srep-functional-leads:
-    - rafael-azevedo
     - mjlshen
-    - iamkirkbater
-    - tonytheleg
+    - theautoroboto
     - sam-nguyen7
     - bmeng
     - ravitri
+    - clcollins    
   srep-team-leads:
     - cblecker
     - jharrington22
@@ -26,6 +25,8 @@ aliases:
     - dustman9000
     - wanghaoran1988
     - bng0y
+    - rafael-azevedo   
+    - iamkirkbater     
   sre-alert-sme:
     - ravitri
     - jeremyeder


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?
* updates @rafael-azevedo role to TL
* removes @tonytheleg and replaces with @theautoroboto as FL for FedRAMP

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
