### PR TITLE
adding permission to 4.17 wif template

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -144,6 +144,7 @@ service_accounts:
           - iam.serviceAccounts.list
           - iam.serviceAccounts.signBlob
           - monitoring.timeSeries.list
+          - orgpolicy.policy.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
           - resourcemanager.projects.setIamPolicy


### PR DESCRIPTION
The osd-deployer service account needs the ability to get organization policies in order to run preflights.

[OCM-10387](https://issues.redhat.com//browse/OCM-10387)