### PR TITLE
Filter only namespace openshift-monitoring for AlertmanagerSilencesActiveSRE Alert

### DIFF
--- a/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-alertmanager-silence-active.PrometheusRule.yaml
@@ -18,7 +18,7 @@ spec:
       # Also ignores alerting on silences if the cluster readiness job is 
       # less than 1 hour 15 mins (4500s) old, in order to not alert when
       # clusters are being spun up and initial alerts are silenced
-      expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"}) > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace) (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"} < 4500))
+      expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active", namespace="openshift-monitoring"}) > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace) (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"} < 4500))
       for: 15m
       labels:
         severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36074,9 +36074,9 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"})
-              > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace)
-              (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
+            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active",
+              namespace="openshift-monitoring"}) > 0 unless (count(cluster_version{type="updating"})
+              > 0 or sum by(namespace) (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
               < 4500))
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36074,9 +36074,9 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"})
-              > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace)
-              (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
+            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active",
+              namespace="openshift-monitoring"}) > 0 unless (count(cluster_version{type="updating"})
+              > 0 or sum by(namespace) (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
               < 4500))
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36074,9 +36074,9 @@ objects:
         - name: sre-alertmanager-silences-active
           rules:
           - alert: AlertmanagerSilencesActiveSRE
-            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active"})
-              > 0 unless (count(cluster_version{type="updating"}) > 0 or sum by(namespace)
-              (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
+            expr: avg without (instance,pod,endpoint,job,service,state,container)(alertmanager_silences{state="active",
+              namespace="openshift-monitoring"}) > 0 unless (count(cluster_version{type="updating"})
+              > 0 or sum by(namespace) (time() - kube_pod_created{namespace="openshift-monitoring",pod=~"osd-cluster-ready.*"}
               < 4500))
             for: 15m
             labels:


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Filter namespace `openshift-monitoring` for triggering AlertmanagerSilencesActiveSRE Alert

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_[OHSS-36867](https://issues.redhat.com/browse/OHSS-36867)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
