### PR TITLE
Updated permissions for WIF permissions

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -302,6 +302,9 @@ service_accounts:
           - storage.objects.delete
           - storage.objects.get
           - storage.objects.list
+          - resourcemanager.tagValueBindings.create
+          - resourcemanager.tagValues.get
+          - resourcemanager.tagValues.list
   - access_method: wif
     credential_request:
       secret_ref:


### PR DESCRIPTION
Part of [OSD-24681](https://issues.redhat.com/browse/OSD-24681) ticket:

Updated permissions for WIF permissions as well by comparing using below cmd:
1. osdctl iampermissions diff -c gcp -b 4.16.0 -t 4.17.0-rc.1