### PR TITLE
Permissions required for GCP Inquiries API

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -8,6 +8,7 @@ service_accounts:
       - id: osd_deployer_v4.17
         kind: Role
         permissions:
+          - compute.acceleratorTypes.list
           - compute.addresses.create
           - compute.addresses.createInternal
           - compute.addresses.delete
@@ -84,6 +85,8 @@ service_accounts:
           - compute.networks.list
           - compute.networks.updatePolicy
           - compute.networks.use
+          - cloudkms.cryptoKeys.list
+          - cloudkms.keyRings.list
           - compute.regionBackendServices.create
           - compute.regionBackendServices.delete
           - compute.regionBackendServices.get


### PR DESCRIPTION
The osd-deployer service account needs these additional permissions to support various GCP Inquiries API that retrieve VPC , KMS Keyrings , Keys   invoked by UI component to display them in the console during deployment workflow.

Ref: https://issues.redhat.com/browse/OCM-10780