### PR TITLE
feat: add workaround for RHOAIENG-12824

### DIFF
--- a/deploy/rhoai/README.md
+++ b/deploy/rhoai/README.md
@@ -1,0 +1,7 @@
+# Managed Red Hat OpenShift AI
+
+## rhods-prometheus-viewer ClusterRoleBinding
+
+Workaround applied for issues identified with federated metrics for `RHOAI <=2.13` on OCP 4.16 clusters.
+
+See [RHOAIENG-12824](https://issues.redhat.com/browse/RHOAIENG-12824) for background information.

--- a/deploy/rhoai/config.yaml
+++ b/deploy/rhoai/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/addon-managed-odh
+    operator: In
+    values: ["true"]
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.16"]

--- a/deploy/rhoai/rhods-prometheus-viewer.ClusterRoleBinding.yaml
+++ b/deploy/rhoai/rhods-prometheus-viewer.ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhods-prometheus-viewer
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: redhat-ods-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view 

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35547,6 +35547,41 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rhoai
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/addon-managed-odh
+        operator: In
+        values:
+        - 'true'
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: rhods-prometheus-viewer
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus
+        namespace: redhat-ods-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-monitoring-view
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosa-console-branding
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35547,6 +35547,41 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rhoai
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/addon-managed-odh
+        operator: In
+        values:
+        - 'true'
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: rhods-prometheus-viewer
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus
+        namespace: redhat-ods-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-monitoring-view
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosa-console-branding
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35547,6 +35547,41 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rhoai
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/addon-managed-odh
+        operator: In
+        values:
+        - 'true'
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: rhods-prometheus-viewer
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus
+        namespace: redhat-ods-monitoring
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-monitoring-view
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosa-console-branding
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?

This PR applies a workaround for [RHOAIENG-12824](https://issues.redhat.com//browse/RHOAIENG-12824) to 4.16 OSD/ROSA Classic clusters where the RHOAI addon is installed

### Which Jira/Github issue(s) this PR fixes?

[RHOAIENG-12824](https://issues.redhat.com//browse/RHOAIENG-12824)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
