### PR TITLE
[OSD-25526] Add cronjob to olm-dance openshift-ocm-agent-operator.

### DIFF
--- a/deploy/osd-25526-oao-olm-dance/00-roles.yaml
+++ b/deploy/osd-25526-oao-olm-dance/00-roles.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-ocm-agent-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-ocm-agent-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  - catalogsources
+  - operatorgroups
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "ocmagent.managed.openshift.io"
+  resources:
+  - managednotifications
+  - managedfleetnotifications
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-ocm-agent-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-ocm-agent-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-ocm-agent-operator

--- a/deploy/osd-25526-oao-olm-dance/01-cronjob.yaml
+++ b/deploy/osd-25526-oao-olm-dance/01-cronjob.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-ocm-agent-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-ocm-agent-operator
+
+              # Check for the status OAO v0.1.278 version (previous version:
+              # ocm-agent-operator.v0.1.276-g09f3778). If we it's not succeeded,
+              # do OLM dance The resources will be re-created with the latest
+              # version
+              CSV_PHASE=$(oc -n openshift-ocm-agent-operator get csv ocm-agent-operator.v0.1.278-g71cfd0b -ojsonpath='{.status.phase}{"\n"}') || true
+              #CSV_STATUS=$(oc -n openshift-ocm-agent-operator get csv -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator= -oname;echo $?)
+              # This does nothing if the expected CSV is not found.
+              if [[ -n ${CSV_PHASE} && ${CSV_PHASE} != "Succeeded" ]]; then
+                # Take backup of the files to be recreated (subscription, catalogsource and operatorgroup)
+                oc -n "$NAMESPACE" get subs ocm-agent-operator -oyaml > /tmp/01-ocm-agent-operator-subs.yaml
+                oc -n "$NAMESPACE" get catsrc ocm-agent-operator-registry -oyaml > /tmp/02-ocm-agent-operator-registry.yaml
+                oc -n "$NAMESPACE" get og ocm-agent-operator-og -oyaml > /tmp/03-ocm-agent-operator-og.yaml
+
+                oc -n "$NAMESPACE" delete managednotification --all
+                oc -n "$NAMESPACE" delete managedfleetnotifications --all
+                oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com $(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName=="ocm-agent-operator")].metadata.name}') || true
+                oc -n "$NAMESPACE" delete installplan.operators.coreos.com -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator=""
+                oc -n "$NAMESPACE" delete subs ocm-agent-operator
+                oc -n "$NAMESPACE" delete catsrc ocm-agent-operator-registry
+                oc -n "$NAMESPACE" delete og ocm-agent-operator-og
+
+                # Recreate the resources to re-install the operator
+                oc -n "$NAMESPACE" create -f /tmp/01-ocm-agent-operator-subs.yaml
+                oc -n "$NAMESPACE" create -f /tmp/02-ocm-agent-operator-registry.yaml
+                oc -n "$NAMESPACE" create -f /tmp/03-ocm-agent-operator-og.yaml
+              else
+                echo "Skipping OLM dance as OAO already successully installed with latest version or expected version was not found."
+              fi
+
+              # Prevent the job from -rerunning
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              oc -n "$NAMESPACE" delete rolebinding/sre-operator-reinstall-rb role/sre-operator-reinstall-role || true
+              exit 0

--- a/deploy/osd-25526-oao-olm-dance/config.yaml
+++ b/deploy/osd-25526-oao-olm-dance/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16", "4.17"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/osd-25526-oao-olm-dance/readme.md
+++ b/deploy/osd-25526-oao-olm-dance/readme.md
@@ -1,0 +1,3 @@
+# README
+
+This cronjob is a fix for https://issues.redhat.com/browse/OSD-25526 and ITN-193

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25874,6 +25874,168 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-25526-oao-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-ocm-agent-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - managednotifications
+        - managedfleetnotifications
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-ocm-agent-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-ocm-agent-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
+                    \n# Check for the status OAO v0.1.278 version (previous version:\n\
+                    # ocm-agent-operator.v0.1.276-g09f3778). If we it's not succeeded,\n\
+                    # do OLM dance The resources will be re-created with the latest\n\
+                    # version\nCSV_PHASE=$(oc -n openshift-ocm-agent-operator get\
+                    \ csv ocm-agent-operator.v0.1.278-g71cfd0b -ojsonpath='{.status.phase}{\"\
+                    \\n\"}') || true\n#CSV_STATUS=$(oc -n openshift-ocm-agent-operator\
+                    \ get csv -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator=\
+                    \ -oname;echo $?)\n# This does nothing if the expected CSV is\
+                    \ not found.\nif [[ -n ${CSV_PHASE} && ${CSV_PHASE} != \"Succeeded\"\
+                    \ ]]; then\n  # Take backup of the files to be recreated (subscription,\
+                    \ catalogsource and operatorgroup)\n  oc -n \"$NAMESPACE\" get\
+                    \ subs ocm-agent-operator -oyaml > /tmp/01-ocm-agent-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get catsrc ocm-agent-operator-registry\
+                    \ -oyaml > /tmp/02-ocm-agent-operator-registry.yaml\n  oc -n \"\
+                    $NAMESPACE\" get og ocm-agent-operator-og -oyaml > /tmp/03-ocm-agent-operator-og.yaml\n\
+                    \n  oc -n \"$NAMESPACE\" delete managednotification --all\n  oc\
+                    \ -n \"$NAMESPACE\" delete managedfleetnotifications --all\n \
+                    \ oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"ocm-agent-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subs ocm-agent-operator\n  oc\
+                    \ -n \"$NAMESPACE\" delete catsrc ocm-agent-operator-registry\n\
+                    \  oc -n \"$NAMESPACE\" delete og ocm-agent-operator-og\n\n  #\
+                    \ Recreate the resources to re-install the operator\n  oc -n \"\
+                    $NAMESPACE\" create -f /tmp/01-ocm-agent-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/02-ocm-agent-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/03-ocm-agent-operator-og.yaml\n\
+                    else\n  echo \"Skipping OLM dance as OAO already successully installed\
+                    \ with latest version or expected version was not found.\"\nfi\n\
+                    \n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete serviceaccount sre-operator-reinstall-sa || true\noc\
+                    \ -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25874,6 +25874,168 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-25526-oao-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-ocm-agent-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - managednotifications
+        - managedfleetnotifications
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-ocm-agent-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-ocm-agent-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
+                    \n# Check for the status OAO v0.1.278 version (previous version:\n\
+                    # ocm-agent-operator.v0.1.276-g09f3778). If we it's not succeeded,\n\
+                    # do OLM dance The resources will be re-created with the latest\n\
+                    # version\nCSV_PHASE=$(oc -n openshift-ocm-agent-operator get\
+                    \ csv ocm-agent-operator.v0.1.278-g71cfd0b -ojsonpath='{.status.phase}{\"\
+                    \\n\"}') || true\n#CSV_STATUS=$(oc -n openshift-ocm-agent-operator\
+                    \ get csv -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator=\
+                    \ -oname;echo $?)\n# This does nothing if the expected CSV is\
+                    \ not found.\nif [[ -n ${CSV_PHASE} && ${CSV_PHASE} != \"Succeeded\"\
+                    \ ]]; then\n  # Take backup of the files to be recreated (subscription,\
+                    \ catalogsource and operatorgroup)\n  oc -n \"$NAMESPACE\" get\
+                    \ subs ocm-agent-operator -oyaml > /tmp/01-ocm-agent-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get catsrc ocm-agent-operator-registry\
+                    \ -oyaml > /tmp/02-ocm-agent-operator-registry.yaml\n  oc -n \"\
+                    $NAMESPACE\" get og ocm-agent-operator-og -oyaml > /tmp/03-ocm-agent-operator-og.yaml\n\
+                    \n  oc -n \"$NAMESPACE\" delete managednotification --all\n  oc\
+                    \ -n \"$NAMESPACE\" delete managedfleetnotifications --all\n \
+                    \ oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"ocm-agent-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subs ocm-agent-operator\n  oc\
+                    \ -n \"$NAMESPACE\" delete catsrc ocm-agent-operator-registry\n\
+                    \  oc -n \"$NAMESPACE\" delete og ocm-agent-operator-og\n\n  #\
+                    \ Recreate the resources to re-install the operator\n  oc -n \"\
+                    $NAMESPACE\" create -f /tmp/01-ocm-agent-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/02-ocm-agent-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/03-ocm-agent-operator-og.yaml\n\
+                    else\n  echo \"Skipping OLM dance as OAO already successully installed\
+                    \ with latest version or expected version was not found.\"\nfi\n\
+                    \n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete serviceaccount sre-operator-reinstall-sa || true\noc\
+                    \ -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25874,6 +25874,168 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-25526-oao-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-ocm-agent-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - managednotifications
+        - managedfleetnotifications
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-ocm-agent-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-ocm-agent-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
+                    \n# Check for the status OAO v0.1.278 version (previous version:\n\
+                    # ocm-agent-operator.v0.1.276-g09f3778). If we it's not succeeded,\n\
+                    # do OLM dance The resources will be re-created with the latest\n\
+                    # version\nCSV_PHASE=$(oc -n openshift-ocm-agent-operator get\
+                    \ csv ocm-agent-operator.v0.1.278-g71cfd0b -ojsonpath='{.status.phase}{\"\
+                    \\n\"}') || true\n#CSV_STATUS=$(oc -n openshift-ocm-agent-operator\
+                    \ get csv -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator=\
+                    \ -oname;echo $?)\n# This does nothing if the expected CSV is\
+                    \ not found.\nif [[ -n ${CSV_PHASE} && ${CSV_PHASE} != \"Succeeded\"\
+                    \ ]]; then\n  # Take backup of the files to be recreated (subscription,\
+                    \ catalogsource and operatorgroup)\n  oc -n \"$NAMESPACE\" get\
+                    \ subs ocm-agent-operator -oyaml > /tmp/01-ocm-agent-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get catsrc ocm-agent-operator-registry\
+                    \ -oyaml > /tmp/02-ocm-agent-operator-registry.yaml\n  oc -n \"\
+                    $NAMESPACE\" get og ocm-agent-operator-og -oyaml > /tmp/03-ocm-agent-operator-og.yaml\n\
+                    \n  oc -n \"$NAMESPACE\" delete managednotification --all\n  oc\
+                    \ -n \"$NAMESPACE\" delete managedfleetnotifications --all\n \
+                    \ oc -n \"$NAMESPACE\" delete clusterserviceversions.operators.coreos.com\
+                    \ $(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -ojsonpath='{.items[?(@.spec.displayName==\"ocm-agent-operator\"\
+                    )].metadata.name}') || true\n  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/ocm-agent-operator.openshift-ocm-agent-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subs ocm-agent-operator\n  oc\
+                    \ -n \"$NAMESPACE\" delete catsrc ocm-agent-operator-registry\n\
+                    \  oc -n \"$NAMESPACE\" delete og ocm-agent-operator-og\n\n  #\
+                    \ Recreate the resources to re-install the operator\n  oc -n \"\
+                    $NAMESPACE\" create -f /tmp/01-ocm-agent-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/02-ocm-agent-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/03-ocm-agent-operator-og.yaml\n\
+                    else\n  echo \"Skipping OLM dance as OAO already successully installed\
+                    \ with latest version or expected version was not found.\"\nfi\n\
+                    \n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete serviceaccount sre-operator-reinstall-sa || true\noc\
+                    \ -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?

OLM dances the openshift-ocm-agent-operator installation.

### Which Jira/Github issue(s) this PR fixes?

Fixes #[OSD-25526](https://issues.redhat.com//browse/OSD-25526)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
