### PR TITLE
OSD-22337 remove the namespaces which are no longer supported by SRE

### DIFF
--- a/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
+++ b/deploy/osd-managed-resources/managed-namespaces.ConfigMap.yaml
@@ -30,7 +30,6 @@ data:
       - name: openshift-deployment-validation-operator
       - name: openshift-managed-node-metadata-operator      
       - name: openshift-file-integrity
-      - name: openshift-logging
       - name: openshift-managed-upgrade-operator
       - name: openshift-must-gather-operator
       - name: openshift-observability-operator

--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -22,7 +22,7 @@ spec:
       expr: |-
         max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~"openshift-.*"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~"openshift-.*"} )
         unless on(namespace)
-          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)"}
+          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|storage)"}
       for: 15m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31370,12 +31370,11 @@ objects:
           \  - name: openshift-container-security\n  - name: openshift-custom-domains-operator\n\
           \  - name: openshift-customer-monitoring\n  - name: openshift-deployment-validation-operator\n\
           \  - name: openshift-managed-node-metadata-operator      \n  - name: openshift-file-integrity\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
-          \  - name: openshift-must-gather-operator\n  - name: openshift-observability-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-scanning\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
+          \  - name: openshift-observability-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-scanning\n  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-suricata\n  - name:\
           \ openshift-validation-webhook\n  - name: openshift-velero\n  - name: openshift-monitoring\n\
           \  - name: openshift\n  - name: openshift-cluster-version\n  - name: goalert\n\
@@ -37095,7 +37094,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|storage)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31370,12 +31370,11 @@ objects:
           \  - name: openshift-container-security\n  - name: openshift-custom-domains-operator\n\
           \  - name: openshift-customer-monitoring\n  - name: openshift-deployment-validation-operator\n\
           \  - name: openshift-managed-node-metadata-operator      \n  - name: openshift-file-integrity\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
-          \  - name: openshift-must-gather-operator\n  - name: openshift-observability-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-scanning\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
+          \  - name: openshift-observability-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-scanning\n  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-suricata\n  - name:\
           \ openshift-validation-webhook\n  - name: openshift-velero\n  - name: openshift-monitoring\n\
           \  - name: openshift\n  - name: openshift-cluster-version\n  - name: goalert\n\
@@ -37095,7 +37094,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|storage)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31370,12 +31370,11 @@ objects:
           \  - name: openshift-container-security\n  - name: openshift-custom-domains-operator\n\
           \  - name: openshift-customer-monitoring\n  - name: openshift-deployment-validation-operator\n\
           \  - name: openshift-managed-node-metadata-operator      \n  - name: openshift-file-integrity\n\
-          \  - name: openshift-logging\n  - name: openshift-managed-upgrade-operator\n\
-          \  - name: openshift-must-gather-operator\n  - name: openshift-observability-operator\n\
-          \  - name: openshift-ocm-agent-operator\n  - name: openshift-operators-redhat\n\
-          \  - name: openshift-osd-metrics\n  - name: openshift-rbac-permissions\n\
-          \  - name: openshift-route-monitor-operator\n  - name: openshift-scanning\n\
-          \  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
+          \  - name: openshift-managed-upgrade-operator\n  - name: openshift-must-gather-operator\n\
+          \  - name: openshift-observability-operator\n  - name: openshift-ocm-agent-operator\n\
+          \  - name: openshift-operators-redhat\n  - name: openshift-osd-metrics\n\
+          \  - name: openshift-rbac-permissions\n  - name: openshift-route-monitor-operator\n\
+          \  - name: openshift-scanning\n  - name: openshift-security\n  - name: openshift-splunk-forwarder-operator\n\
           \  - name: openshift-sre-pruning\n  - name: openshift-suricata\n  - name:\
           \ openshift-validation-webhook\n  - name: openshift-velero\n  - name: openshift-monitoring\n\
           \  - name: openshift\n  - name: openshift-cluster-version\n  - name: goalert\n\
@@ -37095,7 +37094,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|storage)\"\
               }"
             for: 15m
             labels:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Removing openshift-logging namespace from managed-namespace as this namespace is no longer supported by SRE.
Removing openshift-storage namespace in PDBErrorBudgetBurn alert as this namespace is no longer supported by SRE
### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-22337](https://issues.redhat.com/browse/OSD-22337)
Some customer defined alert will not be sent to RH pagerduty
### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster

