### PR TITLE
Rename support role id in 4.17 wif template

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -434,7 +434,7 @@ service_apis:
 support:
   principal: sd-sre-platform-gcp-access@redhat.com
   roles:
-    - id: sre-managed-support
+    - id: sre_managed_support
       kind: Role
       permissions:
         - compute.addresses.get


### PR DESCRIPTION
GCP roles cannot use dashes in their id.

### What type of PR is this?
Bug

### What this PR does / why we need it?
Role id does not follow GCP naming requirements

### Which Jira/Github issue(s) this PR fixes?

Relates to https://issues.redhat.com/browse/OCM-10387

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
