### PR TITLE
Reduce ingress labeller schedule to every 5 minutes

### DIFF
--- a/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
+++ b/deploy/osd-legacy-ingress-feature-labeller/10-osd-legacy-ingress-feature-labeller.CronJob.yaml
@@ -7,7 +7,7 @@ spec:
   failedJobsHistoryLimit: 3
   successfulJobsHistoryLimit: 3
   concurrencyPolicy: Replace
-  schedule: "0 * * * *"
+  schedule: "*/5 * * * *"
   jobTemplate:
     spec:
       template:
@@ -15,11 +15,11 @@ spec:
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-              - preference:
-                  matchExpressions:
-                  - key: node-role.kubernetes.io/infra
-                    operator: Exists
-                weight: 1
+                - preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                  weight: 1
           tolerations:
             - effect: NoSchedule
               key: node-role.kubernetes.io/infra
@@ -27,39 +27,39 @@ spec:
           serviceAccountName: osd-legacy-ingress-feature-labeller
           restartPolicy: Never
           containers:
-          - name: osd-legacy-ingress-feature-labeller
-            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
-            imagePullPolicy: Always
-            args:
-            - /usr/bin/python
-            - -c
-            - |
-              import os
-              import json
+            - name: osd-legacy-ingress-feature-labeller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              args:
+                - /usr/bin/python
+                - -c
+                - |
+                  import os
+                  import json
 
-              out = os.popen('oc get clusterdeployment -A -ojson').read()
-              cd_json_items = json.loads(out)["items"]
+                  out = os.popen('oc get clusterdeployment -A -ojson').read()
+                  cd_json_items = json.loads(out)["items"]
 
-              for item in cd_json_items:
-                  labels = item["metadata"]["labels"]
-                  namespace = item["metadata"]["namespace"]
-                  name = item["metadata"]["name"]
-                  print(f'Cluster {name} in namespace {namespace}')
-                  if not labels.get("hive.openshift.io/version-major-minor"):
-                      print("No hive version label on cluster, exiting")
-                      continue
+                  for item in cd_json_items:
+                      labels = item["metadata"]["labels"]
+                      namespace = item["metadata"]["namespace"]
+                      name = item["metadata"]["name"]
+                      print(f'Cluster {name} in namespace {namespace}')
+                      if not labels.get("hive.openshift.io/version-major-minor"):
+                          print("No hive version label on cluster, exiting")
+                          continue
 
-                  if labels.get("hive.openshift.io/version-major-minor") and int(labels["hive.openshift.io/version-major-minor"].split(".")[1]) < 14:
-                      print("Version less than v4.14, exiting")
-                      continue
+                      if labels.get("hive.openshift.io/version-major-minor") and int(labels["hive.openshift.io/version-major-minor"].split(".")[1]) < 14:
+                          print("Version less than v4.14, exiting")
+                          continue
 
-                  if labels.get("ext-managed.openshift.io/legacy-ingress-support"):
-                      print("ext-managed.openshift.io/legacy-ingress-support label already exists, moving to next cluster")
-                      continue
-                  else:
-                      print("ext-managed.openshift.io/legacy-ingress-support label does not exist and cluster is v4.14 or greater. Labelling as legacy-ingress: false.")
-                      cmd = f'oc label clusterdeployment -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support="false"'
-                      print(f"Running {cmd}")
+                      if labels.get("ext-managed.openshift.io/legacy-ingress-support"):
+                          print("ext-managed.openshift.io/legacy-ingress-support label already exists, moving to next cluster")
+                          continue
+                      else:
+                          print("ext-managed.openshift.io/legacy-ingress-support label does not exist and cluster is v4.14 or greater. Labelling as legacy-ingress: false.")
+                          cmd = f'oc label clusterdeployment -n {namespace} {name} ext-managed.openshift.io/legacy-ingress-support="false"'
+                          print(f"Running {cmd}")
 
-                      out = os.popen(cmd)
-                      print(out.read())
+                          out = os.popen(cmd)
+                          print(out.read())

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30579,7 +30579,7 @@ objects:
         failedJobsHistoryLimit: 3
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
-        schedule: 0 * * * *
+        schedule: '*/5 * * * *'
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30579,7 +30579,7 @@ objects:
         failedJobsHistoryLimit: 3
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
-        schedule: 0 * * * *
+        schedule: '*/5 * * * *'
         jobTemplate:
           spec:
             template:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30579,7 +30579,7 @@ objects:
         failedJobsHistoryLimit: 3
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
-        schedule: 0 * * * *
+        schedule: '*/5 * * * *'
         jobTemplate:
           spec:
             template:


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
- Right now the 'Managed Ingress' feature labeller runs every hour. For the feature to function more effectively for customers, we have decided to bring this interval down to 5 minutes. This is so that there is no 'lag time' between a cluster being upgraded and a customer being able to use the new features in `rosa edit ingress`. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-25776
https://redhat-internal.slack.com/archives/CCX9DB894/p1727358496734429?thread_ts=1727202789.794229&cid=CCX9DB894

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
