### PR TITLE
Move CreateTags permission for ENIs to match Instances

### DIFF
--- a/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -160,28 +160,14 @@
       }
     },
     {
-      "Sid": "CreateTagsCAPAControllerNetworkInterface",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateTags"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/red-hat-managed": "true"
-        }
-      }
-    },
-    {
       "Sid": "RunInstancesRequest",
       "Effect": "Allow",
       "Action": [
         "ec2:RunInstances"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:instance/*"
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:network-interface/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -196,7 +182,6 @@
         "ec2:RunInstances"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:subnet/*",
         "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:volume/*"


### PR DESCRIPTION
### What type of PR is this?
Refactor

### What this PR does / why we need it?
This moves the permissions for creating tags on ENIs to match the same restrictions for tagging Instances. Specifically, this change meets the following criteria:
- ENIs must be tagged with red-hat-managed: true 
- ENIs cannot be tagged after creation
- ENIs can only be tagged when created as part of a call to RunInstances (creating an EC2 instance). 