### PR TITLE
Increase capa annotator cronjob frequency 

### DIFF
--- a/deploy/osd-25821-capa-annotator/10-CronJob.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/description: "Patches 4.17 Manifest works to fixed CAPI version https://issues.redhat.com/browse/OSD-25821"
 spec:
-  schedule: "*/5 * * * *" # Every five minutes
+  schedule: "*/2 * * * *" # Every two minutes
   concurrencyPolicy: Replace
   jobTemplate:
     spec:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25876,7 +25876,7 @@ objects:
           kubernetes.io/description: Patches 4.17 Manifest works to fixed CAPI version
             https://issues.redhat.com/browse/OSD-25821
       spec:
-        schedule: '*/5 * * * *'
+        schedule: '*/2 * * * *'
         concurrencyPolicy: Replace
         jobTemplate:
           spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25876,7 +25876,7 @@ objects:
           kubernetes.io/description: Patches 4.17 Manifest works to fixed CAPI version
             https://issues.redhat.com/browse/OSD-25821
       spec:
-        schedule: '*/5 * * * *'
+        schedule: '*/2 * * * *'
         concurrencyPolicy: Replace
         jobTemplate:
           spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25876,7 +25876,7 @@ objects:
           kubernetes.io/description: Patches 4.17 Manifest works to fixed CAPI version
             https://issues.redhat.com/browse/OSD-25821
       spec:
-        schedule: '*/5 * * * *'
+        schedule: '*/2 * * * *'
         concurrencyPolicy: Replace
         jobTemplate:
           spec:


### PR DESCRIPTION
Increases the capa annotator cronjob frequency to decrease cluster worker node start up times. 
