### PR TITLE
exclude the openshift-observability-operator from PDB alerts

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -22,7 +22,7 @@ spec:
       expr: |-
         max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~"openshift-.*"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~"openshift-.*"} )
         unless on(namespace)
-          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)"}
+          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)"}
       for: 15m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37229,7 +37229,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37229,7 +37229,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37229,7 +37229,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)\"\
               }"
             for: 15m
             labels:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

Cleanup

### What this PR does / why we need it?

Removes PDB Disruption Alerting from the openshift-observabilty-operator namespace since this isn't an SRE managed workload.

### Which Jira/Github issue(s) this PR fixes?

_Fixes OSD-25879_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
