### PR TITLE
OSD-20013-Setting obscure tag to remove suricata to move to app-interface

### DIFF
--- a/deploy/osd-suricata/config.yaml
+++ b/deploy/osd-suricata/config.yaml
@@ -1,7 +1,7 @@
 deploymentMode: SelectorSyncSet
 selectorSyncSet:
   matchExpressions:
-    - key: api.openshift.com/fedramp
+    - key: api.openshift.com/fedramp-invalid-tag
       operator: In
       values:
         - "true"


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_  
cleanup

### What this PR does / why we need it?  
We will be moving suricata to app-interface to only target app-interface managed clusters

### Which Jira/Github issue(s) this PR fixes?
[OSD-20013](https://issues.redhat.com//browse/OSD-20013)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ X ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
