### PR TITLE
OSD-20986: Update 4.17 WIF permissions for PSC SSH

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -450,6 +450,7 @@ support:
         - compute.disks.get
         - compute.disks.list
         - compute.disks.setLabels
+        - compute.firewalls.create
         - compute.firewalls.get
         - compute.firewalls.list
         - compute.forwardingRules.get


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

This PR adds the `compute.firewalls.create` permission needed for SSH access. We need to create a firewall rule with port 22 when following our PSC ssh to nod SOP.

### Which Jira/Github issue(s) this PR fixes?

[OSD-20986](https://issues.redhat.com/browse/OSD-20986)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
