### PR TITLE
OSD-26176: remove invalid field from monitoring config

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
@@ -76,13 +76,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    grafana:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config-non-uwm/config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/config.yaml
@@ -3,7 +3,7 @@ selectorSyncSet:
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
-      values: ["4.5"]
+      values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10"]
     - key: ext-managed.openshift.io/uwm-disabled
       operator: In
       values: ["true"]

--- a/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -76,13 +76,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    grafana:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config-non-uwm/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
@@ -38,7 +38,7 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-      retention: 11d
+      retention: 7d
       retentionSize: 90GB
       volumeClaimTemplate:
         metadata:

--- a/deploy/cluster-monitoring-config-non-uwm/pre-4.11/config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/pre-4.11/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.6", "4.7", "4.8", "4.9", "4.10"]
+  - key: ext-managed.openshift.io/uwm-disabled
+    operator: In
+    values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: NotIn
+    values: ["management-cluster"]

--- a/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -76,13 +76,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    grafana:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config/config.yaml
+++ b/deploy/cluster-monitoring-config/config.yaml
@@ -3,7 +3,7 @@ selectorSyncSet:
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
-      values: ["4.5"]
+      values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10"]
     - key: ext-managed.openshift.io/uwm-disabled
       operator: NotIn
       values: ["true"]

--- a/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -76,13 +76,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    grafana:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    enableUserWorkload: false
+    enableUserWorkload: true
     prometheusK8s:
       remoteWrite:
       - url: ${OBSERVATORIUM_URL}
@@ -38,7 +38,7 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-      retention: 11d
+      retention: 7d
       retentionSize: 90GB
       volumeClaimTemplate:
         metadata:

--- a/deploy/cluster-monitoring-config/pre-4.11/config.yaml
+++ b/deploy/cluster-monitoring-config/pre-4.11/config.yaml
@@ -1,0 +1,15 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10"]
+  - key: ext-managed.openshift.io/uwm-disabled
+    operator: NotIn
+    values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: NotIn
+    values: ["management-cluster"]

--- a/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -51,13 +51,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    grafana:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     k8sPrometheusAdapter:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -23082,6 +23082,11 @@ objects:
         operator: NotIn
         values:
         - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -23124,8 +23129,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -23154,6 +23157,11 @@ objects:
         operator: NotIn
         values:
         - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: In
         values:
@@ -23191,8 +23199,6 @@ objects:
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23252,8 +23258,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -23263,6 +23267,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -23320,7 +23326,75 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-non-uwm-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23331,6 +23405,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -23392,7 +23468,80 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23403,6 +23552,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -30426,9 +30577,7 @@ objects:
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
-          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -23082,6 +23082,11 @@ objects:
         operator: NotIn
         values:
         - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -23124,8 +23129,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -23154,6 +23157,11 @@ objects:
         operator: NotIn
         values:
         - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: In
         values:
@@ -23191,8 +23199,6 @@ objects:
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23252,8 +23258,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -23263,6 +23267,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -23320,7 +23326,75 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-non-uwm-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23331,6 +23405,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -23392,7 +23468,80 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23403,6 +23552,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -30426,9 +30577,7 @@ objects:
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
-          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -23082,6 +23082,11 @@ objects:
         operator: NotIn
         values:
         - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -23124,8 +23129,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -23154,6 +23157,11 @@ objects:
         operator: NotIn
         values:
         - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: In
         values:
@@ -23191,8 +23199,6 @@ objects:
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23252,8 +23258,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -23263,6 +23267,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -23320,7 +23326,75 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-non-uwm-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23331,6 +23405,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -23392,7 +23468,80 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-pre-4.11
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.5'
+        - '4.6'
+        - '4.7'
+        - '4.8'
+        - '4.9'
+        - '4.10'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -23403,6 +23552,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -30426,9 +30577,7 @@ objects:
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
-          \ Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/resources/cluster-monitoring-config/config.yaml
+++ b/resources/cluster-monitoring-config/config.yaml
@@ -72,13 +72,6 @@ prometheusOperator:
     - effect: NoSchedule
       key: node-role.kubernetes.io/infra
       operator: Exists
-grafana:
-  nodeSelector:
-    node-role.kubernetes.io/infra: ""
-  tolerations:
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/infra
-      operator: Exists
 k8sPrometheusAdapter:
   nodeSelector:
     node-role.kubernetes.io/infra: ""

--- a/scripts/generate-cmo-config.py
+++ b/scripts/generate-cmo-config.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
 
+import copy
 import oyaml as yaml
 import os
 
 input_file_path = os.path.join("resources", "cluster-monitoring-config", "config.yaml")
 output_file_path_non_uwm = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_non_uwm_4_5 = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "clusters-v4.5", "50-GENERATED-cluster-monitoring-config.yaml")
+output_file_path_non_uwm_pre_411 = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "pre-4.11", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_uwm = os.path.join("deploy", "cluster-monitoring-config", "50-GENERATED-cluster-monitoring-config.yaml")
+output_file_path_uwm_pre_411 = os.path.join("deploy", "cluster-monitoring-config", "pre-4.11", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_fr = os.path.join("deploy", "osd-fedramp-cluster-monitoring-config", "50-GENERATED-cluster-monitoring-config.yaml")
 output_mc_file_path_non_uwm = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "management-clusters", "50-GENERATED-cluster-monitoring-config.yaml")
 output_mc_file_path_uwm = os.path.join("deploy", "cluster-monitoring-config", "management-clusters", "50-GENERATED-cluster-monitoring-config.yaml")
-
 
 def str_presenter(dumper, data):
   if len(data.splitlines()) > 1:  # check for multiline string
@@ -19,31 +21,41 @@ def str_presenter(dumper, data):
 
 yaml.add_representer(str, str_presenter)
 
-def dump_configmap(input_path, configmap_path, enableUserWorkload, disableremoteWrite, retentionTime = "11d"):
+def dump_configmap(input_path, configmap_path, enableUserWorkload,
+                   disableremoteWrite, retentionTime = "11d",
+                   enableGrafana = False):
     with open(input_path,'r') as input_file:
         config = yaml.safe_load(input_file)
         config["enableUserWorkload"] = enableUserWorkload
         config["prometheusK8s"]["retention"] = retentionTime
         if disableremoteWrite:
            del config['prometheusK8s']['remoteWrite']
-        
+
+        if enableGrafana:
+            # Grafana config was removed in 4.11, pre-4.11, put it back
+            config["grafana"] = copy.deepcopy(config["prometheusOperator"])
+
         cmo_config = {
             "apiVersion": "v1",
             "kind": "ConfigMap",
             "metadata": {
                 "name": "cluster-monitoring-config" ,
-                "namespace": "openshift-monitoring" 
+                "namespace": "openshift-monitoring"
             },
             "data": {
                 "config.yaml": yaml.dump(config)
             }
         }
+
+
         with open(configmap_path, 'w') as outfile:
             yaml.dump(cmo_config, outfile)
 
 dump_configmap(input_file_path, output_file_path_uwm, True, False)
+dump_configmap(input_file_path, output_file_path_uwm_pre_411, True, False, "7d", True)
 dump_configmap(input_file_path, output_file_path_non_uwm, False, False)
-dump_configmap(input_file_path, output_file_path_non_uwm_4_5, False, False)
+dump_configmap(input_file_path, output_file_path_non_uwm_4_5, False, False, "11d", True)
+dump_configmap(input_file_path, output_file_path_non_uwm_pre_411, False, False, "7d", True)
 dump_configmap(input_file_path, output_file_path_fr, True, True)
 dump_configmap(input_file_path, output_mc_file_path_uwm, True, False, "7d")
 dump_configmap(input_file_path, output_mc_file_path_non_uwm, False, False, "7d")


### PR DESCRIPTION
### What type of PR is this?

bug

### What this PR does / why we need it?

What it does:

- Removes "grafana" from the existing CMO configs
- Introduces patched CMO configs for 4.5->4.11 for UWM and non-UWM clusters

Why:

The monitoring operator is degraded on 4.18: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/58078/rehearse-58078-periodic-ci-openshift-release-master-nightly-4.18-e2e-rosa-sts-ovn/1848795679447584768

It’s reporting:

```
message: "failed to parse data at key \"config.yaml\": error unmarshaling JSON: while decoding JSON: json: unknown field \"grafana\""
```

This is because of a change in 4.18 that makes the config more strict, warning about unknown fields:
https://github.com/openshift/cluster-monitoring-operator/commit/937d47fdf31eb7bab028e4a85ca0a85288ab087c

“grafana” hasn’t been listed in the options for config.yml in the docs since 4.10, and starting with 4.18 this will degrade the monitoring operator.

I updated resources/cluster-monitoring-config/config.yaml and ran `make`.

### Which Jira/Github issue(s) this PR fixes?

Fixes # [OSD-26176](https://issues.redhat.com//browse/OSD-26176) 

### Special notes for your reviewer:

None