### PR TITLE
New configuration for FedRAMP

### DIFF
--- a/deploy/osd-fedramp-managed-upgrade-operator-config/customer-clusters/10-managed-upgrade-operator-configmap.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/customer-clusters/10-managed-upgrade-operator-configmap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: managed-upgrade-operator-config
+  namespace: openshift-managed-upgrade-operator
+data:
+  config.yaml: |
+    upgradeType: OSD
+    configManager:
+      source: OCM
+      ocmBaseUrl: ${OCM_BASE_URL}
+      watchInterval: 60
+    maintenance:
+      controlPlaneTime: 130
+      ignoredAlerts:
+        controlPlaneCriticals:
+        - ClusterOperatorDown
+    scale:
+      timeOut: 30
+    upgradeWindow:
+      delayTrigger: 30
+      timeOut: 120
+    nodeDrain:
+      timeOut: 45
+      expectedNodeDrainTime: 8
+    healthCheck:
+      ignoredCriticals:
+      - MetricsClientSendFailingSRE
+      - PruningCronjobErrorSRE
+      - etcdGRPCRequestsSlow
+      # OSD-22494
+      - AlertmanagerFailedReload
+      - CloudIngressOperatorOfflineSRE
+      - ClusterMonitoringErrorBudgetBurnSRE
+      - ConfigureAlertmanagerOperatorOfflineSRE
+      - console-ErrorBudgetBurn
+      - ControlPlaneNodeFileDescriptorLimitSRE
+      - ControlPlaneNodeFilesystemAlmostOutOfFiles
+      - ControlPlaneNodeFilesystemSpaceFillingUp
+      - CustomerWorkloadPreventingDrainSRE
+      - EbsVolumeBurstBalanceLT20PctSRE
+      - EbsVolumeStuckAttaching10MinSRE
+      - EbsVolumeStuckDetaching10MinSRE
+      - etcdHighNumberOfFailedGRPCRequests
+      - ExcessiveContainerMemoryCriticalSRE
+      - ExtremelyHighIndividualControlPlaneCPU
+      - ExtremelyHighIndividualControlPlaneMemory
+      - HAProxyDown
+      - InsightsOperatorDownSRE
+      - KubePersistentVolumeFillingUp
+      - KubePersistentVolumeInodesFillingUp
+      - KubePersistentVolumeUsageCriticalCustomer
+      - KubePersistentVolumeUsageCriticalLayeredProduct
+      - MCDRebootError
+      - MultipleVersionsOfEFSCSIDriverInstalled
+      - NodeClockNotSynchronising
+      - NodeFileDescriptorLimit
+      - NodeFilesystemAlmostOutOfSpace
+      - NodeFilesystemAlmostOutOfFiles
+      - NodeFilesystemSpaceFillingUp
+      - NodeFilesystemFilesFillingUp
+      - NodeRAIDDegraded
+      - NorthboundStale
+      - OCMAgentResponseFailureServiceLogsSRE
+      - PodDisruptionBudgetLimit
+      - PrometheusTargetSyncFailure
+      - RouterAvailabilityLT30PctSRE
+      - RunawaySDNPreventingContainerCreationSRE
+      - SouthboundStale
+      - ThanosRuleQueueIsDroppingAlerts
+      - WorkerNodeFileDescriptorLimitSRE
+      - WorkerNodeFilesystemAlmostOutOfFiles
+      - WorkerNodeFilesystemSpaceFillingUp
+      ignoredNamespaces:
+      - openshift-logging
+      - openshift-redhat-marketplace
+      - openshift-operators
+      - openshift-customer-monitoring
+      - openshift-cnv
+      - openshift-route-monitoring-operator
+      - openshift-user-workload-monitoring
+      - openshift-pipelines
+    extDependencyAvailabilityChecks:
+      http:
+        timeout: 10
+        urls:
+          - ${OCM_BASE_URL}/api/clusters_mgmt/v1      
+    environment:
+      fedramp: false

--- a/deploy/osd-fedramp-managed-upgrade-operator-config/customer-clusters/config.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/customer-clusters/config.yaml
@@ -12,5 +12,5 @@ selectorSyncSet:
     - key: app-interface-managed
       operator: In
       values:
-        - "true"
+        - "false"
   resourceApplyMode: Upsert

--- a/deploy/osd-fedramp-managed-upgrade-operator-config/hive-prod01/config.yaml
+++ b/deploy/osd-fedramp-managed-upgrade-operator-config/hive-prod01/config.yaml
@@ -8,5 +8,9 @@ selectorSyncSet:
     - key: hive-prod01
       operator: In
       values:
-      - "true"            
+      - "true"
+    - key: app-interface-managed
+      operator: In
+      values:
+        - "true"
   resourceApplyMode: Upsert

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30586,6 +30586,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: app-interface-managed
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -30632,6 +30636,70 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-customer-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: hive-prod01
+        operator: NotIn
+        values:
+        - 'true'
+      - key: app-interface-managed
+        operator: In
+        values:
+        - 'false'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - MetricsClientSendFailingSRE\n  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n\
+          \  # OSD-22494\n  - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n\
+          \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
+          \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
+          \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
+          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
+          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
+          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
+          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
+          \  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
+          \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
+          \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
+          \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
+          \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
+          \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\
+          \  - PodDisruptionBudgetLimit\n  - PrometheusTargetSyncFailure\n  - RouterAvailabilityLT30PctSRE\n\
+          \  - RunawaySDNPreventingContainerCreationSRE\n  - SouthboundStale\n  -\
+          \ ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
+          \  - WorkerNodeFilesystemAlmostOutOfFiles\n  - WorkerNodeFilesystemSpaceFillingUp\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
+          \      \nenvironment:\n  fedramp: false\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-managed-upgrade-operator-config-hive-prod01
   spec:
     clusterDeploymentSelector:
@@ -30643,6 +30711,10 @@ objects:
         values:
         - 'true'
       - key: hive-prod01
+        operator: In
+        values:
+        - 'true'
+      - key: app-interface-managed
         operator: In
         values:
         - 'true'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30586,6 +30586,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: app-interface-managed
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -30632,6 +30636,70 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-customer-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: hive-prod01
+        operator: NotIn
+        values:
+        - 'true'
+      - key: app-interface-managed
+        operator: In
+        values:
+        - 'false'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - MetricsClientSendFailingSRE\n  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n\
+          \  # OSD-22494\n  - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n\
+          \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
+          \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
+          \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
+          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
+          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
+          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
+          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
+          \  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
+          \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
+          \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
+          \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
+          \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
+          \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\
+          \  - PodDisruptionBudgetLimit\n  - PrometheusTargetSyncFailure\n  - RouterAvailabilityLT30PctSRE\n\
+          \  - RunawaySDNPreventingContainerCreationSRE\n  - SouthboundStale\n  -\
+          \ ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
+          \  - WorkerNodeFilesystemAlmostOutOfFiles\n  - WorkerNodeFilesystemSpaceFillingUp\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
+          \      \nenvironment:\n  fedramp: false\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-managed-upgrade-operator-config-hive-prod01
   spec:
     clusterDeploymentSelector:
@@ -30643,6 +30711,10 @@ objects:
         values:
         - 'true'
       - key: hive-prod01
+        operator: In
+        values:
+        - 'true'
+      - key: app-interface-managed
         operator: In
         values:
         - 'true'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30586,6 +30586,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: app-interface-managed
+        operator: In
+        values:
+        - 'true'
     resourceApplyMode: Upsert
     resources:
     - apiVersion: v1
@@ -30632,6 +30636,70 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-fedramp-managed-upgrade-operator-config-customer-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: In
+        values:
+        - 'true'
+      - key: hive-prod01
+        operator: NotIn
+        values:
+        - 'true'
+      - key: app-interface-managed
+        operator: In
+        values:
+        - 'false'
+    resourceApplyMode: Upsert
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: managed-upgrade-operator-config
+        namespace: openshift-managed-upgrade-operator
+      data:
+        config.yaml: "upgradeType: OSD\nconfigManager:\n  source: OCM\n  ocmBaseUrl:\
+          \ ${OCM_BASE_URL}\n  watchInterval: 60\nmaintenance:\n  controlPlaneTime:\
+          \ 130\n  ignoredAlerts:\n    controlPlaneCriticals:\n    - ClusterOperatorDown\n\
+          scale:\n  timeOut: 30\nupgradeWindow:\n  delayTrigger: 30\n  timeOut: 120\n\
+          nodeDrain:\n  timeOut: 45\n  expectedNodeDrainTime: 8\nhealthCheck:\n  ignoredCriticals:\n\
+          \  - MetricsClientSendFailingSRE\n  - PruningCronjobErrorSRE\n  - etcdGRPCRequestsSlow\n\
+          \  # OSD-22494\n  - AlertmanagerFailedReload\n  - CloudIngressOperatorOfflineSRE\n\
+          \  - ClusterMonitoringErrorBudgetBurnSRE\n  - ConfigureAlertmanagerOperatorOfflineSRE\n\
+          \  - console-ErrorBudgetBurn\n  - ControlPlaneNodeFileDescriptorLimitSRE\n\
+          \  - ControlPlaneNodeFilesystemAlmostOutOfFiles\n  - ControlPlaneNodeFilesystemSpaceFillingUp\n\
+          \  - CustomerWorkloadPreventingDrainSRE\n  - EbsVolumeBurstBalanceLT20PctSRE\n\
+          \  - EbsVolumeStuckAttaching10MinSRE\n  - EbsVolumeStuckDetaching10MinSRE\n\
+          \  - etcdHighNumberOfFailedGRPCRequests\n  - ExcessiveContainerMemoryCriticalSRE\n\
+          \  - ExtremelyHighIndividualControlPlaneCPU\n  - ExtremelyHighIndividualControlPlaneMemory\n\
+          \  - HAProxyDown\n  - InsightsOperatorDownSRE\n  - KubePersistentVolumeFillingUp\n\
+          \  - KubePersistentVolumeInodesFillingUp\n  - KubePersistentVolumeUsageCriticalCustomer\n\
+          \  - KubePersistentVolumeUsageCriticalLayeredProduct\n  - MCDRebootError\n\
+          \  - MultipleVersionsOfEFSCSIDriverInstalled\n  - NodeClockNotSynchronising\n\
+          \  - NodeFileDescriptorLimit\n  - NodeFilesystemAlmostOutOfSpace\n  - NodeFilesystemAlmostOutOfFiles\n\
+          \  - NodeFilesystemSpaceFillingUp\n  - NodeFilesystemFilesFillingUp\n  -\
+          \ NodeRAIDDegraded\n  - NorthboundStale\n  - OCMAgentResponseFailureServiceLogsSRE\n\
+          \  - PodDisruptionBudgetLimit\n  - PrometheusTargetSyncFailure\n  - RouterAvailabilityLT30PctSRE\n\
+          \  - RunawaySDNPreventingContainerCreationSRE\n  - SouthboundStale\n  -\
+          \ ThanosRuleQueueIsDroppingAlerts\n  - WorkerNodeFileDescriptorLimitSRE\n\
+          \  - WorkerNodeFilesystemAlmostOutOfFiles\n  - WorkerNodeFilesystemSpaceFillingUp\n\
+          \  ignoredNamespaces:\n  - openshift-logging\n  - openshift-redhat-marketplace\n\
+          \  - openshift-operators\n  - openshift-customer-monitoring\n  - openshift-cnv\n\
+          \  - openshift-route-monitoring-operator\n  - openshift-user-workload-monitoring\n\
+          \  - openshift-pipelines\nextDependencyAvailabilityChecks:\n  http:\n  \
+          \  timeout: 10\n    urls:\n      - ${OCM_BASE_URL}/api/clusters_mgmt/v1\
+          \      \nenvironment:\n  fedramp: false\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-fedramp-managed-upgrade-operator-config-hive-prod01
   spec:
     clusterDeploymentSelector:
@@ -30643,6 +30711,10 @@ objects:
         values:
         - 'true'
       - key: hive-prod01
+        operator: In
+        values:
+        - 'true'
+      - key: app-interface-managed
         operator: In
         values:
         - 'true'


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_  
bug

### What this PR does / why we need it?  
We have a new label in FedRAMP to distinguish our long-lived app-interface cluster from customer and test clusters.  Sine we are only applying FIO to clusters on-boarded to app-interface, customer upgrades would fail.  By setting `fedramp: false` on the customer config, MUO will not attempt to re-init FIO during upgrades.   I will also make a PR for MUO to update the log message.

### Which Jira/Github issue(s) this PR fixes?
[OSD-22534](https://issues.redhat.com/browse/OSD-22534) 

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
