### PR TITLE
OSD-23696- Add monitoring for the custom interceptor

### DIFF
--- a/deploy/sre-prometheus/100-cad-interceptor-crashlooping.yaml
+++ b/deploy/sre-prometheus/100-cad-interceptor-crashlooping.yaml
@@ -13,7 +13,7 @@ spec:
     - alert: CADInterceptorCrashloopingSRE
       expr: |
         sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace="configuration-anomaly-detection",pod=~"cad-interceptor-.*"}) >= 2
-      for: 30m
+      for: 5m
       labels:
         severity: critical
         source: "https://issues.redhat.com/browse/OSD-23696"

--- a/deploy/sre-prometheus/100-cad-interceptor-crashlooping.yaml
+++ b/deploy/sre-prometheus/100-cad-interceptor-crashlooping.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-managed-cad-service-crashlooping
+    role: alert-rules
+  name: sre-managed-cad-service-crashlooping
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-managed-cad-service-crashlooping
+    rules:
+    - alert: CADInterceptorCrashloopingSRE
+      expr: |
+        sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff", namespace="configuration-anomaly-detection",pod=~"cad-interceptor-.*"}) >= 2
+      for: 30m
+      labels:
+        severity: critical
+        source: "https://issues.redhat.com/browse/OSD-23696"
+        link: "https://github.com/openshift/ops-sop/blob/master/v4/alerts/CADInterceptorCrashloopingSRE.md"
+      annotations:
+        message: CAD interceptor deployment pods have been crashlooping for 30 minutes.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36389,6 +36389,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-cad-service-crashlooping
+          role: alert-rules
+        name: sre-managed-cad-service-crashlooping
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-cad-service-crashlooping
+          rules:
+          - alert: CADInterceptorCrashloopingSRE
+            expr: 'sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+              namespace="configuration-anomaly-detection",pod=~"cad-interceptor-.*"})
+              >= 2
+
+              '
+            for: 30m
+            labels:
+              severity: critical
+              source: https://issues.redhat.com/browse/OSD-23696
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CADInterceptorCrashloopingSRE.md
+            annotations:
+              message: CAD interceptor deployment pods have been crashlooping for
+                30 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-cluster-version-operator
           role: alert-rules
         name: sre-cluster-version-operator

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36411,7 +36411,7 @@ objects:
               >= 2
 
               '
-            for: 30m
+            for: 5m
             labels:
               severity: critical
               source: https://issues.redhat.com/browse/OSD-23696

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36389,6 +36389,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-cad-service-crashlooping
+          role: alert-rules
+        name: sre-managed-cad-service-crashlooping
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-cad-service-crashlooping
+          rules:
+          - alert: CADInterceptorCrashloopingSRE
+            expr: 'sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+              namespace="configuration-anomaly-detection",pod=~"cad-interceptor-.*"})
+              >= 2
+
+              '
+            for: 30m
+            labels:
+              severity: critical
+              source: https://issues.redhat.com/browse/OSD-23696
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CADInterceptorCrashloopingSRE.md
+            annotations:
+              message: CAD interceptor deployment pods have been crashlooping for
+                30 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-cluster-version-operator
           role: alert-rules
         name: sre-cluster-version-operator

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36411,7 +36411,7 @@ objects:
               >= 2
 
               '
-            for: 30m
+            for: 5m
             labels:
               severity: critical
               source: https://issues.redhat.com/browse/OSD-23696

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36389,6 +36389,32 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-managed-cad-service-crashlooping
+          role: alert-rules
+        name: sre-managed-cad-service-crashlooping
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-managed-cad-service-crashlooping
+          rules:
+          - alert: CADInterceptorCrashloopingSRE
+            expr: 'sum(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+              namespace="configuration-anomaly-detection",pod=~"cad-interceptor-.*"})
+              >= 2
+
+              '
+            for: 30m
+            labels:
+              severity: critical
+              source: https://issues.redhat.com/browse/OSD-23696
+              link: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CADInterceptorCrashloopingSRE.md
+            annotations:
+              message: CAD interceptor deployment pods have been crashlooping for
+                30 minutes.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-cluster-version-operator
           role: alert-rules
         name: sre-cluster-version-operator

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36411,7 +36411,7 @@ objects:
               >= 2
 
               '
-            for: 30m
+            for: 5m
             labels:
               severity: critical
               source: https://issues.redhat.com/browse/OSD-23696


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This PR creates a CADInterceptorCrashloopingSRE alerts so SRE knows when the interceptor service for CAD is down

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-23696
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
