### PR TITLE
Add list TcpProxies to Wif permissions

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -102,6 +102,7 @@ service_accounts:
           - compute.regionOperations.get
           - compute.regions.get
           - compute.regions.list
+          - compute.regionTargetTcpProxies.list
           - compute.routers.create
           - compute.routers.delete
           - compute.routers.get


### PR DESCRIPTION
This permissions was logged as missing in Uninstall logs

ime="2024-10-25T18:56:04Z" level=debug msg="Target TCP Proxies: failed to list target tcp proxies: googleapi: Error 403: Required 'compute.regionTargetTcpProxies.list' permission for 'projects/sda-ccs-1', forbidden"