### PR TITLE
Add NetworkMigrationDelayedSRE and NetworkMigrationBlocked alerts

### DIFF
--- a/deploy/sre-prometheus/100-network-live-migration.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-network-live-migration.PrometheusRule.yaml
@@ -31,10 +31,10 @@ spec:
                 )
               )
             )
-            >
-            count(cluster:nodes_roles) * 1800
+            >bool
+            sum(cluster:nodes_roles) * 1800
           )
-          and
+          and on()
           openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"} == 1
       for: 1m
       labels:

--- a/deploy/sre-prometheus/100-network-live-migration.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-network-live-migration.PrometheusRule.yaml
@@ -1,0 +1,52 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-network-live-migration
+    role: alert-rules
+  name: sre-network-live-migration
+  namespace: openshift-monitoring
+spec:
+  groups:
+  - name: sre-network-live-migration
+    rules:
+    # Alert if live migration from SDN to OVN is in-progress for more than 
+    - alert: NetworkMigrationDelayedSRE
+      expr:
+          (
+            (
+              max(
+                max_over_time(
+                  timestamp(
+                    openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"} == 1
+                  )[5d:]
+                )
+              )
+              -
+              min(
+                min_over_time(
+                  timestamp(
+                    openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"} == 1
+                  )[5d:]
+                )
+              )
+            )
+            >
+            count(cluster:nodes_roles) * 1800
+          )
+          and
+          openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"} == 1
+      for: 1m
+      labels:
+        severity: critical
+        namespace: openshift-network-operator
+      annotations:
+        message: Live migration from SDN to OVN is taking much longer than expected to complete.
+    - alert: NetworkMigrationBlocked
+      expr: openshift_network_operator_live_migration_blocked == 1
+      for: 5m
+      labels:
+        severity: warning
+        namespace: openshift-network-operator
+      annotations:
+        message: Network operator cannot start the requested migration from SDN to OVN due to {{ $labels.reason }}.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37245,7 +37245,7 @@ objects:
           - alert: NetworkMigrationDelayedSRE
             expr: ( ( max( max_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
               == 1 )[5d:] ) ) - min( min_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
-              == 1 )[5d:] ) ) ) > count(cluster:nodes_roles) * 1800 ) and openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) ) >bool sum(cluster:nodes_roles) * 1800 ) and on() openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
               == 1
             for: 1m
             labels:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37234,6 +37234,39 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-network-live-migration
+          role: alert-rules
+        name: sre-network-live-migration
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-network-live-migration
+          rules:
+          - alert: NetworkMigrationDelayedSRE
+            expr: ( ( max( max_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) - min( min_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) ) > count(cluster:nodes_roles) * 1800 ) and openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1
+            for: 1m
+            labels:
+              severity: critical
+              namespace: openshift-network-operator
+            annotations:
+              message: Live migration from SDN to OVN is taking much longer than expected
+                to complete.
+          - alert: NetworkMigrationBlocked
+            expr: openshift_network_operator_live_migration_blocked == 1
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-network-operator
+            annotations:
+              message: Network operator cannot start the requested migration from
+                SDN to OVN due to {{ $labels.reason }}.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-filedescriptor-limit
           role: alert-rules
         name: sre-node-filedescriptor-limit

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37245,7 +37245,7 @@ objects:
           - alert: NetworkMigrationDelayedSRE
             expr: ( ( max( max_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
               == 1 )[5d:] ) ) - min( min_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
-              == 1 )[5d:] ) ) ) > count(cluster:nodes_roles) * 1800 ) and openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) ) >bool sum(cluster:nodes_roles) * 1800 ) and on() openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
               == 1
             for: 1m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37234,6 +37234,39 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-network-live-migration
+          role: alert-rules
+        name: sre-network-live-migration
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-network-live-migration
+          rules:
+          - alert: NetworkMigrationDelayedSRE
+            expr: ( ( max( max_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) - min( min_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) ) > count(cluster:nodes_roles) * 1800 ) and openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1
+            for: 1m
+            labels:
+              severity: critical
+              namespace: openshift-network-operator
+            annotations:
+              message: Live migration from SDN to OVN is taking much longer than expected
+                to complete.
+          - alert: NetworkMigrationBlocked
+            expr: openshift_network_operator_live_migration_blocked == 1
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-network-operator
+            annotations:
+              message: Network operator cannot start the requested migration from
+                SDN to OVN due to {{ $labels.reason }}.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-filedescriptor-limit
           role: alert-rules
         name: sre-node-filedescriptor-limit

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37245,7 +37245,7 @@ objects:
           - alert: NetworkMigrationDelayedSRE
             expr: ( ( max( max_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
               == 1 )[5d:] ) ) - min( min_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
-              == 1 )[5d:] ) ) ) > count(cluster:nodes_roles) * 1800 ) and openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) ) >bool sum(cluster:nodes_roles) * 1800 ) and on() openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
               == 1
             for: 1m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37234,6 +37234,39 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-network-live-migration
+          role: alert-rules
+        name: sre-network-live-migration
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-network-live-migration
+          rules:
+          - alert: NetworkMigrationDelayedSRE
+            expr: ( ( max( max_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) - min( min_over_time( timestamp( openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1 )[5d:] ) ) ) > count(cluster:nodes_roles) * 1800 ) and openshift_network_operator_live_migration_condition{type="NetworkTypeMigrationInProgress"}
+              == 1
+            for: 1m
+            labels:
+              severity: critical
+              namespace: openshift-network-operator
+            annotations:
+              message: Live migration from SDN to OVN is taking much longer than expected
+                to complete.
+          - alert: NetworkMigrationBlocked
+            expr: openshift_network_operator_live_migration_blocked == 1
+            for: 5m
+            labels:
+              severity: warning
+              namespace: openshift-network-operator
+            annotations:
+              message: Network operator cannot start the requested migration from
+                SDN to OVN due to {{ $labels.reason }}.
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-node-filedescriptor-limit
           role: alert-rules
         name: sre-node-filedescriptor-limit


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?
This PR implements [OSD-25335](https://issues.redhat.com/browse/OSD-25335), which calls for new alerts covering the SDN to OVN migration. 

### Which Jira/Github issue(s) this PR fixes?
[OSD-25335](https://issues.redhat.com/browse/OSD-25335)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
