### PR TITLE
OSD-26328: deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules: Dedup probe_success

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules.PrometheusRule.yaml
@@ -10,9 +10,19 @@ spec:
   groups:
     - name: sre-slo.rules
       rules:
-        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"}, "sre", "true", "", "")
+        - expr: |
+            sre:telemetry:managed_labels
+            * on (sre) group_left(probe_url)
+            bottomk by (sre) (1,
+              label_replace(probe_success{probe_url=~"^https://api.+"}, "sre", "true", "", "")
+            )
           record: sre:slo:probe_success_api
-        - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"}, "sre", "true", "", "")
+        - expr: |
+            sre:telemetry:managed_labels
+            * on (sre) group_left(probe_url)
+            bottomk by (sre) (1,
+              label_replace(probe_success{probe_url=~"^https://console.+"}, "sre", "true", "", "")
+            )
           record: sre:slo:probe_success_console
         - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total), "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version) sre:telemetry:managed_labels
           record: sre:slo:imageregistry_http_requests_total

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -38164,11 +38164,13 @@ objects:
         groups:
         - name: sre-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"},
-              "sre", "true", "", "")
+          - expr: "sre:telemetry:managed_labels\n* on (sre) group_left(probe_url)\n\
+              bottomk by (sre) (1,\n  label_replace(probe_success{probe_url=~\"^https://api.+\"\
+              }, \"sre\", \"true\", \"\", \"\")\n)\n"
             record: sre:slo:probe_success_api
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"},
-              "sre", "true", "", "")
+          - expr: "sre:telemetry:managed_labels\n* on (sre) group_left(probe_url)\n\
+              bottomk by (sre) (1,\n  label_replace(probe_success{probe_url=~\"^https://console.+\"\
+              }, \"sre\", \"true\", \"\", \"\")\n)\n"
             record: sre:slo:probe_success_console
           - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),
               "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -38164,11 +38164,13 @@ objects:
         groups:
         - name: sre-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"},
-              "sre", "true", "", "")
+          - expr: "sre:telemetry:managed_labels\n* on (sre) group_left(probe_url)\n\
+              bottomk by (sre) (1,\n  label_replace(probe_success{probe_url=~\"^https://api.+\"\
+              }, \"sre\", \"true\", \"\", \"\")\n)\n"
             record: sre:slo:probe_success_api
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"},
-              "sre", "true", "", "")
+          - expr: "sre:telemetry:managed_labels\n* on (sre) group_left(probe_url)\n\
+              bottomk by (sre) (1,\n  label_replace(probe_success{probe_url=~\"^https://console.+\"\
+              }, \"sre\", \"true\", \"\", \"\")\n)\n"
             record: sre:slo:probe_success_console
           - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),
               "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -38164,11 +38164,13 @@ objects:
         groups:
         - name: sre-slo.rules
           rules:
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://api.+"},
-              "sre", "true", "", "")
+          - expr: "sre:telemetry:managed_labels\n* on (sre) group_left(probe_url)\n\
+              bottomk by (sre) (1,\n  label_replace(probe_success{probe_url=~\"^https://api.+\"\
+              }, \"sre\", \"true\", \"\", \"\")\n)\n"
             record: sre:slo:probe_success_api
-          - expr: sre:telemetry:managed_labels * on (sre) group_left(probe_url) label_replace(probe_success{probe_url=~"^https://console.+"},
-              "sre", "true", "", "")
+          - expr: "sre:telemetry:managed_labels\n* on (sre) group_left(probe_url)\n\
+              bottomk by (sre) (1,\n  label_replace(probe_success{probe_url=~\"^https://console.+\"\
+              }, \"sre\", \"true\", \"\", \"\")\n)\n"
             record: sre:slo:probe_success_console
           - expr: label_replace(sum by (code, method) (imageregistry_http_requests_total),
               "sre", "true", "", "") * on (sre) group_left(_id,provider,region,version)


### PR DESCRIPTION
### What type of PR is this?

Cleanup

### What this PR does / why we need it?

[`probe_success` docs][1] are very brief:

> Displays whether or not the probe was a success

But [the implementation][2] sets 1 on success and leaves [the default 0][3] on failure.  This commit adds a [`bottomk`][4] to [avoid][5] (I'm adding some newlines for alignment):

```
./pods/prometheus-k8s-1/prometheus/prometheus/logs/current.log:2024-11-01T15:14:10.557622502Z
ts=2024-11-01T15:14:10.557Z caller=group.go:527 level=warn name=sre:slo:probe_success_api ...
msg="Evaluating rule failed" rule="record: sre:slo:probe_success_api\nexpr: ...
err="found duplicate series for the match group {sre=\"true\"} on the right hand-side of the operation: [
  {__name__=\"probe_success\", ..., instance=\"10.128.2.10:9115\", ..., pod=\"blackbox-exporter-54cd64f588-mzk6t\", ...},
  {__name__=\"probe_success\", ..., instance=\"10.129.2.30:9115\", ..., pod=\"blackbox-exporter-54cd64f588-bh86b\", ...}
];many-to-many matching not allowed: matching labels must be unique on one side"
```

With the new `bottomk`'s aggregation, the recording rule will only have a single matching time-series on the right side, and rule evaluation will be successful.  By using `bottomk` (instead of [`topk` or other aggregator][4]), we prefer the most pessimistic blackbox exporter, so in the unlikely case where one exporter Pod is sad and another is happy, or multiple `probe_url=~"^https://api.+"` match and one is sad while another is happy, the overall `sre:slo:probe_success_*` will be a sad 0, and eventually (if an SLO trips or alert fires) call in an SRE to investigate.

[1]: https://github.com/prometheus/blackbox_exporter/blob/22ccef7034096768671017fa55cc62a331b30565/prober/handler.go#L79
[2]: https://github.com/prometheus/blackbox_exporter/blob/22ccef7034096768671017fa55cc62a331b30565/prober/handler.go#L131-L136
[3]: https://github.com/prometheus/client_golang/blob/0c73c1c55449ff11f0ac21805e87d52c37427c29/prometheus/gauge.go#L78-L108
[4]: https://prometheus.io/docs/prometheus/latest/querying/operators/#aggregation-operators
[5]: https://issues.redhat.com/browse/OSD-26328

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-26328](https://issues.redhat.com//browse/OSD-26328)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
