### PR TITLE
Adding condition for PSC in non-fr-sts-wif-privatelink

### DIFF
--- a/deploy/osd-rebalance-infra-nodes/non-fr-sts-wif-privatelink/config.yaml
+++ b/deploy/osd-rebalance-infra-nodes/non-fr-sts-wif-privatelink/config.yaml
@@ -10,6 +10,9 @@ selectorSyncSet:
   - key: api.openshift.com/private-link
     operator: NotIn
     values: ["true"]
+  - key: api.openshift.com/private-service-connect
+    operator: NotIn
+    values: ["true"]
   - key: api.openshift.com/fedramp
     operator: NotIn
     values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33292,6 +33292,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/private-service-connect
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33292,6 +33292,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/private-service-connect
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33292,6 +33292,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/private-service-connect
+        operator: NotIn
+        values:
+        - 'true'
       - key: api.openshift.com/fedramp
         operator: NotIn
         values:


### PR DESCRIPTION
This role shouldn't be applied in any Private cluster scenario including Google PSC.

### What type of PR is this?
_bug_

### What this PR does / why we need it?
Adds a condition to exclude an Cloud Ingress Operator RoleBinding from Private clusters (where it fails due to missing Cloud Ingress.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
