### PR TITLE
OSD-25935: Update the 4.17 capa annotator image to 4.17.4

### DIFF
--- a/deploy/osd-25821-capa-annotator/10-CronJob.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob.yaml
@@ -44,8 +44,8 @@ spec:
             args:
             - -c
             - |
-              # CAPI IMAGE 
-              IMAGE="quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6a9fe6f7fedaae423b0ebe78b2a8ae53ad477fd25d8039951dfbf671223eba06"
+              # CAPI IMAGE - 4.17.4
+              IMAGE="quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4"
               # Get all manifestwork objects and extract their names
               managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=4.17 -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
               # Loop through each manifestwork object

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26617,7 +26617,7 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "# CAPI IMAGE \nIMAGE=\"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6a9fe6f7fedaae423b0ebe78b2a8ae53ad477fd25d8039951dfbf671223eba06\"\
+                  - "# CAPI IMAGE - 4.17.4\nIMAGE=\"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4\"\
                     \n# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
                     \ get managedclusters -l openshiftVersion-major-minor=4.17 -o\
                     \ jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26617,7 +26617,7 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "# CAPI IMAGE \nIMAGE=\"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6a9fe6f7fedaae423b0ebe78b2a8ae53ad477fd25d8039951dfbf671223eba06\"\
+                  - "# CAPI IMAGE - 4.17.4\nIMAGE=\"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4\"\
                     \n# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
                     \ get managedclusters -l openshiftVersion-major-minor=4.17 -o\
                     \ jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26617,7 +26617,7 @@ objects:
                   - /bin/bash
                   args:
                   - -c
-                  - "# CAPI IMAGE \nIMAGE=\"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6a9fe6f7fedaae423b0ebe78b2a8ae53ad477fd25d8039951dfbf671223eba06\"\
+                  - "# CAPI IMAGE - 4.17.4\nIMAGE=\"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4\"\
                     \n# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
                     \ get managedclusters -l openshiftVersion-major-minor=4.17 -o\
                     \ jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Feature

### What this PR does / why we need it?
This updates the image used by the `capa-annotator` for 4.17 to use the latest stable z stream, 4.17.4, which includes our
patches to support tagging ENIs in AWS with or without IAM permissions to do so. 

### Which Jira/Github issue(s) this PR fixes?
See epic https://issues.redhat.com/browse/SDE-4496
_Fixes #_

### Special notes for your reviewer:
Image tag sourced from https://openshift-release-artifacts.apps.ci.l2s4.p1.openshiftapps.com/4.17.4/release.txt

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
