### PR TITLE
ITN 2024 00255

### DIFF
--- a/deploy/ITN-2024-00255_CAMO-UnsafeFailForward/10-openshift-cluster-monitoring-operatorgroup.patch.yaml
+++ b/deploy/ITN-2024-00255_CAMO-UnsafeFailForward/10-openshift-cluster-monitoring-operatorgroup.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+name: openshift-cluster-monitoring
+namespace: openshift-monitoring
+applyMode: AlwaysApply
+patch: '{"spec":{"upgradeStrategy":"TechPreviewUnsafeFailForward"}}'
+patchType: merge

--- a/deploy/ITN-2024-00255_CAMO-UnsafeFailForward/config.yaml
+++ b/deploy/ITN-2024-00255_CAMO-UnsafeFailForward/config.yaml
@@ -1,0 +1,3 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"


### PR DESCRIPTION
- **add region leads as OWNERS for alerts**
- **formatting conditions less permissive as requested**
- **Only deploy MC alerts to STS MCs**
- **Do not reschedule infra pods if there are already the number of infra node pods running on infra nodes (#1949)**
- **extended HCP policies that CU can opt-in**
- **Modify promrule so it doesn't deploy to int/stg hive**
- **on push: make**
- **[OSD-19800](https://issues.redhat.com//browse/OSD-19800): replace ClusterOperatorDown(insights)**
- **Add references & logType field to managed notification**
- **add sre-cluster-version-operator PrometheusRule**
- **make results**
- **removed resource conditioniioning per request**
- **bump up cgao heartbeat alert to 90m**
- **on push: make**
- **Remove management of openshift-logging operatorgroup**
- **Fix typo in variable name in rebalance script**
- **on push: make**
- **Use internal OCM endpoint proxy for MUO**
- **[OSD-19769] Add ClusterMonitoringErrorBudgetBurnSRE alert**
- **Update LPRSE permissions for ACS**
- **Add 4.15 version gates**
- **on push: make**
- **ocm-agent: Fix wrong alert label**
- **add container policy for FR image signatures**
- **FR image signatures int 4.11&12 only**
- **ran make**
- **Split inodes < 3% alert for workers and controlplanes.**
- **Update OWNERS_ALIASES**
- **signature validation to FR int 4.11&12 masters**
- **ran make**
- **update scanning and suricata images for CVE patching**
- **updates MUO config for FR for all environments**
- **Add openshift-compliance-monkey to managed namespaces**
- **[OSD-19897](https://issues.redhat.com//browse/OSD-19897) - New FedRAMP namespaces (#1973)**
- **[OSD-19703](https://issues.redhat.com//browse/OSD-19703) - Add inital alerts for OADP on MCs (#1979)**
- **[OCM-5315](https://issues.redhat.com//browse/OCM-5315) & [ACM-9127](https://issues.redhat.com//browse/ACM-9127) Policy will be non-compliant until the default IngressController resource appears (#1964)**
- **signature verification for FR stg 4.11&12**
- **ran make**
- **Copy 4.14 STS policies to 4.15**
- **add alert for ocm-agent pull secret invalid**
- **signature verification for FR prod 4.11&12**
- **ran make**
- **reverts fr prod01 back to LOCAL muo config**
- **updates label for container sig validation to properly target stage clusters**
- **Grant SRE read permissions on the autoscaling.openshift.io API group**
- **Migrate OADP prometheusrules to openshift-monitoring (#1986)**
- **Move ClusterMonitoringErrorBudgetBurnSRE to warning**
- **[OSD-19769] Lower ClusterMonitoringErrorBudgetBurnSRE SLO**
- **[OCM-2303](https://issues.redhat.com//browse/OCM-2303) | [HCP] Disable ingress certificate in ACM policy if configmap parameter is true**
- **remove unneeded kms:DescribeKey permission from 4.14+ (#1965)**
- **bump cgao inactive heartbeat alert to 120m**
- **on push: make**
- **initial small addition**
- **working cronjob for automatic node restarting for seccomp issue**
- **Add generated files**
- **Revert "Use internal OCM endpoint proxy for MUO on non-management clusters"**
- **Fix bug with kms:DescribeKey and break out describe actions**
- **[OSD-20478] Import csv_succeeded into observatorium**
- **[OSD-19863](https://issues.redhat.com//browse/OSD-19863): Lower retention for management cluster CMO prometheus data**
- **Move retention parameter to script**
- **[OSD-20527](https://issues.redhat.com//browse/OSD-20527): Adding appropriate attributes to notifications in terms of priority, severity and references**
- **[OSD-18515](https://issues.redhat.com//browse/OSD-18515): Handling the KubePersistentVolumeFillingUp alerts on 'openshift-user-workload-monitoring' namespace with the ocm-agent operator**
- **ran make**
- **osd-suricata: add proper pod-security labels**
- **hack: make generated output**
- **deploy,hack: not covered by make**
- **change cmo to remoteWrite directly using oauth2**
- **[OSD-20478] Add recording rule to track sre operators state**
- **Add ALLOW_CORDON_WORKER_NODE_ENTITY_IDS as a feature flag for MCVW**
- **Fix references to be an array**
- **on push: make**
- **[OSD-19863](https://issues.redhat.com//browse/OSD-19863) add oidc deleted managedfleetnotification**
- **Update managedfleetnotifications README**
- **[OSD-19769] Re-enable ClusterMonitoringErrorBudgetBurnSRE alert**
- **Add template paramenter OBSERVATORIUM_URL**
- **Remove token-refresher resources**
- **Add Benson to team leads**
- **fix gpg error for marketplace operators (#2009)**
- **[OSD-20478] Filter only for SRE Operators in the sre operators recording rule**
- **[OSD-20479] Add addon-operator to sre operators recording rule**
- **deprecate direct deployment method**
- **specify direct deployment instructions**
- **Update README.md**
- **stage fedramp fix gpg error for marketplace operators**
- **prod fedramp fix gpg error for marketplace operators**
- **Add new warning alert to track average infra CPU utilization the past hour**
- **Change sre-infra-resizing-alerts to critical (#2016)**
- **Remove log linking workaround in 4.15**
- **on push: make**
- **ensure CPMS is disabled on 4.15 for now**
- **Grant LPSRE dynatrace read permissions**
- **on push: make**
- **backplane owners allow parent owners**
- **[OSD-20486] Adding an automated SL when KubeNodeUnschedulableSRE alerting and changing the alert severity to Warning (#2024)**
- **schedule monitoring-plugin pods onto infra nodes**
- **Revert "Add ALLOW_CORDON_WORKER_NODE_ENTITY_IDS as a feature flag for MCVW"**
- **scripts/generate_template.py: set enableResourceParameters in sss**
- **[SDCICD-1229](https://issues.redhat.com//browse/SDCICD-1229): add cluster metadata cm**
- **hold fire for the node condition alerts to avoid flipping notification sending**
- **on push: make**
- **[SDCICD-1229](https://issues.redhat.com//browse/SDCICD-1229): fup: s/enableResourceParameters/enableResourceTemplates/g**
- **[XCMSTRAT-305](https://issues.redhat.com//browse/XCMSTRAT-305) | feat: add list role / list attached role policies perm to hcp managed installer policy**
- **make target for checklinks**
- **Added conditions**
- **Skip Makefile from broken links check**
- **Adds merge patchtype**
- **on push: make**
- **update monitoring config in correct place**
- **on push: make**
- **make**
- **Revert "ensure CPMS is disabled on 4.15 for now"**
- **Reapply "ensure CPMS is disabled on 4.15 for now"**
- **Add route-monitor-operator to sre:operators:succeeded recording rule**
- **Templatize NodeCondition notifications**
- **new suricata image excluding flooding rules**
- **ran make**
- **[OSD-21066] Add cronjob to OLM Dance configure-alertmanager-operator**
- **[OSD-21066] Fix olm dance cronjob**
- **Allow HCP Installer policy to tag subnets with the tag format that k8s expects**
- **[OSD-21066] Fix olm dance cronjob**
- **[OSD-21066] Fix olm dance cronjob**
- **Add Alerting rule: OCMAgentServiceLogsSentExceedingLimit**
- **[OSD-20569](https://issues.redhat.com//browse/OSD-20569) - Alerts for oneagent and activegate pods**
- **Updates OCMAgentServiceLogsSentExceedingLimit Alerting Rule**
- **updates images for suricata/scanning in FedRAMP to patch CVE's**
- **[OSD-21066] Remove CAMO olm dance cronjob**
- **[OCM-6862](https://issues.redhat.com//browse/OCM-6862) | feat: add tag condition on when retrieving policies attached to roles**
- **Correcting docs URLs from 13 March 2024 docs 404 report Corrected two docs URLs and two engineering references to git repos. There is another broken link (https://docs.openshift.com/rosa/rosa_cluster_admin/rosa-cordoning-nodes) that cannot be permanently corrected until https://issues.redhat.com/browse/OSDOCS-9494 is complete; best alternative link for now is https://docs.openshift.com/container-platform/4.15/nodes/nodes/nodes-nodes-working.html#nodes-nodes-working-marking_nodes-nodes-working so using that until [OSDOCS-9494](https://issues.redhat.com//browse/OSDOCS-9494) is corrected**
- **Export preceding  version and stream in upgradeoperator_upgrade_result metric**
- **on push: make**
- **Adding selectorSyncSet with secret to configure OBO Alertmanager**
- **Adding READEME.md for the hypershift-obo-alertmanager-config**
- **Add metric cpms_enabled to cmo's remoteWrite filter**
- **Add metric cpms_enabled to cmo's remoteWrite filter**
- **feat: Add oidc-missing and sre-kubelet-debugging-handlers-enabled alerts**
- **Added new instance types r7i.48xlarge and r7i.metal-48xl to longer time out list**
- **on push: make**
- **adding conditioning for instance profile get**
- **Adding new ACS team RBAC to MMC.**
- **feat(OSD-20591,[OSD-20593](https://issues.redhat.com//browse/OSD-20593)): remove cpms disabelement cronjobs**
- **fixing label matching for acs addon.**
- **begin scan migration, rm from FR stg/int**
- **ran make**
- **Remove RHOSAK and RHOC**
- **fixing namespace for service account mapping.**
- **[SDCICD-1254](https://issues.redhat.com//browse/SDCICD-1254): remove osd-cluster-metadata**
- **removed newline and "for" clause**
- **modified changes**
- **Remove r7i.metal-48xl from the metal machine healthcheck based on QE test failure**
- **on push: make**
- **Update the OBO prometheus rules**
- **Separates ClusterMonitoring and UWM Error Budget Alerts**
- **ITN-56: Fix [OSD-21066](https://issues.redhat.com//browse/OSD-21066) cronjob**
- **added /health so console would curl lightweight health endpoint**
- **Revert "ITN-56: Fix [OSD-21066](https://issues.redhat.com//browse/OSD-21066) cronjob"**
- **[OSD-21045](https://issues.redhat.com//browse/OSD-21045) : Adding in 4.16 STS policies**
- **Fixing identation**
- **Copy the extended support policy forward to 4.15 and 4.16 hypershift sts definitions**
- **Add patch for default ingress router replicas to 3, based on the Org ID of the clusterdeployment**
- **on push: make**
- **use full name for kind subscriptions.operators.coreos.com to avoid confusion**
- **make generate-hive-templates**
- **fix role**
- **make generate-hive-templates**
- **add addon-acs-fleetshard-qa perm which is used for ACS staging env clusters**
- **on push: make**
- **Fix syntax error preventing rollout**
- **softens the language about node troubleshooting**
- **on push: make**
- **adding ACS Service Access requirement documentation.**
- **removing pvc deleting.**
- ** updating service document to reflect current pr.**
- **removing TBH tag**
- ** updating ACS Access Requirement doc removing finalizers.**
- **Add ec2:DescribeDhcpOptions to CAPA controller for HCP**
- **[monitoring] Send all UWM alerts to the CU**
- **update regex to work for 4.15 too**
- **Additional aggregate cluster role and access for ACS:CS. (#2075)**
- **([OSD-21220](https://issues.redhat.com//browse/OSD-21220))**
- **([OSD-21219](https://issues.redhat.com//browse/OSD-21219)) Rename core permission policy files to reflect that they are boundaries**
- **([OSD-21221](https://issues.redhat.com//browse/OSD-21221)) Rename PrivateLink installer policy to reflect boundaries**
- **Don't include redundant infos in SL message**
- **[ROX-23697](https://issues.redhat.com//browse/ROX-23697): Add additional ACS-CS roles (#2088)**
- **Fix addon-acs-fleetshard typo for qe**
- **on push: make**
- **Refactors the upstream PDBLimit alert**
- **on push: make**
- **on push: make**
- **Consolidate image registry config patches (#2091)**
- **[ROX-23697](https://issues.redhat.com//browse/ROX-23697): add ACS-CS backplane console permissions**
- **[ROX-23697](https://issues.redhat.com//browse/ROX-23697): run make**
- **[ROX-23697](https://issues.redhat.com//browse/ROX-23697): run make**
- **transferring malware scanning out of mcc**
- **Enable cpms with canary rollout in eu-west-3**
- **use eu-west-2 instead to have some more clusters**
- **Activate cpms only in versions >= 4.12**
- **fix ocpbugs-15043 cronjob failing to detect seccomp issues**
- **[OSD-22494](https://issues.redhat.com//browse/OSD-22494): Update list for Critical Alerts in MUO IgnoreCritical List**
- **Enable CPMS fleet wide for existing clusters**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): Add ACSCS backplane ingress read**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): Add ACSCS backplane ingress read**
- **Remove cpms activation patch**
- **add backplane-acs-admins-cluster cluster scoped role to the backplane-acs-admins subjectpermission**
- **OSD-15299**
- **Remove HaProxyDownSRE from ignored alerts**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): ACSCS additional permissions**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): ACSCS additional permissions**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): ACSCS additional permissions**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): ACSCS additional permissions**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): ACSCS additional permissions**
- **Add MachineHealthCheckUnterminatedShortCircuit alert for SRE in critical level in MCC**
- **rebased with PR suggestions**
- **rebased with PR suggestions**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): ACSCS additional permissions**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): PR Comments**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): PR Comments**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): PR Comments**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): PR Comments**
- **Update docs/backplane/requirements/acs/10-acs-managed-service-nonprod.md**
- **Update OSD Cluster Ready version**
- **on push: make**
- **Update 10-managed-upgrade-operator-configmap.yaml**
- **on push: make**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): Fix acscs machine api permissions**
- **[ROX-23744](https://issues.redhat.com//browse/ROX-23744): Fix acscs permissions**
- **[OSD-20289](https://issues.redhat.com//browse/OSD-20289): remove console-ErrorBudgetBurn for MCs**
- **Refactors alert definition.**
- **on push: make**
- **Mcs requirements (#2121)**
- **updating to test NTP issues**
- **ran make**
- **first draft promtool rule validation in pr check**
- **disable duplicate rule linting**
- **moving a test config to worker nodes to test**
- **ran make**
- **Added admin gates for 4.16**
- **offboard supreeth**
- **[SDCICD-1292](https://issues.redhat.com//browse/SDCICD-1292): set MGO NS resourceApplyMode=Upsert**
- **[OSD-22575](https://issues.redhat.com//browse/OSD-22575): add permissions to dedicated-reader and dedicated-admin to view console/monitoring tab data**
- **add labels to resovle name conflicts in promrules**
- **[OSD-22043] Update sre-operators recording rule**
- **updating chrony.conf for FedRAMP**
- **setting to makestep 100 3 rather than 300**
- **ran make**
- **update to chrony to reduce makestep from 100 to 10 seconds**
- **removes fedramp clusters from commercial specific sss**
- **Add 4.16 sts gates**
- **Add 4.16 version gates**
- **Add new patch to allow dns-default pods to schedule on infra nodes.**
- **[OSD-23863](https://issues.redhat.com//browse/OSD-23863): disable KubeletDebuggingHandlersEnabledSRE alert on int/staging**
- **Revert "[OSD-23863](https://issues.redhat.com//browse/OSD-23863): disable KubeletDebuggingHandlersEnabledSRE alert on int/staging"**
- **MUO ignores KubeletDebuggingHandlersEnabledSRE on MCs for upgrades**
- **Excludes openshift-cnv namespace (#2139)**
- **OCPBUGS-25341 - Add cronjob to delete packageserver csv every hour**
- **Fix patchType field capitalization.**
- **Revert "Fix patchType field capitalization."**
- **Revert "Add new patch to allow dns-default pods to schedule on infra nodes."**
- **Add new patch to allow dns-default pods to schedule on infra nodes.**
- **Update osd-rebelance-infra-nodes.**
- **Add new patch to allow dns-default pods to schedule on infra nodes.**
- **on push: make**
- **Add new 4.16 permissions for CAPI in the installer**
- **Remove the gate-sts key from selectorsyncset**
- **[ROX-24728](https://issues.redhat.com//browse/ROX-24728): additional ACS permissions**
- **run make**
- **[OSD-22635](https://issues.redhat.com//browse/OSD-22635): remove SRE role ability pod exec and attach**
- **Add comment about individual maintainers**
- **Add missing 4.16 upgrade ack: https://access.redhat.com/articles/7031404 (#2150)**
- **Adding permissions in backplane for CEE to support ACS:CS**
- **[ROX-24901](https://issues.redhat.com//browse/ROX-24901): Allow ACS SRE to delete pods**
- **Adding docs update for CEE permissions and fixing broken link in requirements**
- **Update docs/backplane/requirements/cee/40-backplane-cee.md**
- **[OSD-22254] initial permissions for gcp wif (#2148)**
- **disable UpgradeConfigSyncFailureOver4HrSRE alert for 4.16 temporary**
- **add ACM consider ACM cluster and namespace selectors not only for deploymentMode Policy to support dual deployments to both Classic and HCP with ACM selectorsPolicies for ACS backplane**
- **Revert running dns pods on infra nodes.**
- **add ACM Policies for ACS backplane**
- **Revert "Update osd-rebelance-infra-nodes."**
- **Make**
- **Remove osd-must-gather-operator SSS containing MGO namespace**
- **Give more helpful error msg on a PR check edge case**
- **on push: make**
- **Add a job to remove the added tolerations.**
- **Create remediation for CDO CSV out of date**
- **on push: make**
- **[OSD-24397](https://issues.redhat.com//browse/OSD-24397) Fix typo to OLM version check in previous commit**
- **CEE RBAC + Requirements**
- **on push: make**
- **Correct bundle version**
- **on push: make**
- **[backplane/lpsre] add missing matchLabel for addon-acs-fleetshard-qe**
- **run make**
- **Add permissions to read ACS addon objects for ACS team**
- **Specify API groups**
- **Update suricata sha**
- **Remove remediation for CDO CSV out of date (#2167)**
- **Adds 4.15 sts gates for GCP**
- **Restor MGO's NS, but for fedramp only**
- **on push: make**
- **[OSD-19661]  Escalate CO degraded warning to critical**
- **Exclude MGO from dedicated-admins role aggregation**
- **on push: make**
- **Reformat wif templates**
- **Revert the patch which temporarily disable the UpgradeConfigSyncFailureOver4HrSRE alert on 4.16.x cluster**
- **update the template**
- **Update ClusterOperatorDegradedSRE Alert (#2181)**
- **Enable pre-health check feature in managed-upgrade-operator**
- **[OSD-19661](https://issues.redhat.com//browse/OSD-19661) Fix newline with yaml**
- **[OSD-19661](https://issues.redhat.com//browse/OSD-19661) Fix prometheus rule for UpgradeConfigSyncFailureOver4HrSRE**
- **removing openshift-cluster-api-gcp from WIF templates**
- **wif: adding permission to deployer**
- **[OSD-20975](https://issues.redhat.com//browse/OSD-20975): Not deploying MVO on GCP WIF clusters**
- **[OSD-24939] This commit adds back the STS roles needed by AVO in the FedRamp environment.**
- **[OSD-24939] Fixing a missing comma.**
- **[OSD-24939] Fixing what I missed in the PR.**
- **[OSD-24939] Fixed duplicate role.**
- **Update deploy/backplane/cee/01-cee-cluster-readers-cluster.ClusterRole.yml**
- **Update docs/backplane/requirements/cee/20-machineautoscaler.md**
- **on push: make**
- **[OSD-23975](https://issues.redhat.com//browse/OSD-23975) Add new record rule for MUO prehealth check result**
- **Move mgo config file to old path**
- **Bring back generation of acm policies for MGO ns**
- **on push: make**
- **[OSD-24939] After discussing these changes further within the FedRamp team, we decided to increase the scope of [OSD-24939](https://issues.redhat.com//browse/OSD-24939) to cover 4.15 and 4.16 as well.**
- **[OSD-24693](https://issues.redhat.com//browse/OSD-24693) enable notifciation feature in Managed upgrade operator**
- **Updating the RLs and FLs list for MCC**
- **[OHSS-36254](https://issues.redhat.com//browse/OHSS-36254): ACS Add packagemanifests cluster permission (#2192)**
- **Allow SREP to get/list/watch scheduling.hypershift.openshift.io resources**
- **feat([OSD-24893](https://issues.redhat.com//browse/OSD-24893)): add 4.17 wif config**
- **GCP WIFTemplate 4.17: add missing installer permissions**
- **OCM development changes to 4.17 wif template**
- **update 4.17 WIF template**
- **wif template: reducing permissions of 4.17 osd-deployer**
- **wif template: defining support group**
- **wif template renaming group_email field**
- **Move ACS addon cluster scoped objects perms**
- **[OSD-24978](https://issues.redhat.com//browse/OSD-24978): Not deploying CIO on GCP WIF clusters + uniformizing WIF handling with STS**
- **[OSD-24978](https://issues.redhat.com//browse/OSD-24978): Renaming some files following the support of GCP WIF**
- **Add permission to tag ENI's with red-hat-managed: true**
- **Move only cluster scpoed objects to cluster config**
- **replace severity:error with warnings, major, and info, depending on the notification.**
- **add retry count for backplane clean up job**
- **ran make file.**
- **Changed some notifications according to recommendations from Kirk**
- **Add 4.17 version gates**
- **Corrected typos**
- **on push: make**
- **updates Raf's role, replaces Tony with Brian as FL**
- **adding permission to 4.17 wif template**
- **filter namespace openshift-user-workload-monitoring out for AlertmanagerSilencesActiveSRE Alert**
- **Update SA name to fix failed job runs**
- **Adding in 4.17 STS policies**
- **Run make to fix failed PR build**
- **gcp_inquiries_permissions**
- **feat: add workaround for RHOAIENG-12824**
- **Add cronjob to olm-dance openshift-ocm-agent-operator.**
- **updated prom queries**
- **Revert "Add cronjob to olm-dance openshift-ocm-agent-operator."**
- **Remove no longer needed one-off job.**
- **Run make.**
- **Update permissions for sre-managed-support role**
- **ran make command**
- **updated message for KubeNodeUnschedulableSRE alert**
- **updated message**
- **Rename support role id in 4.17 wif template**
- **Update permissions for sre-managed-support role**
- **Updated sts-gate template**
- **on push: make**
- **Copies the CEE role to mcs-tier-two for backplane**
- **on push: make**
- **Update permissions for sre-managed-support role**
- **Reduce ingress labeller schedule to every 5m**
- **Adds required docs for MCS Tier Two Support**
- **s/CEE/MCS Tier Two Support Users**
- **Fix filename**
- **Updates docs for cee/mcs-tier-two as requested from review**
- **on push: make**
- **comments**
- **add back view permission**
- **on push: make**
- **addl permissions for kms**
- **pin capa to fixed version in 4.17**
- **pin capa to fixed version in 4.17**
- **fixed foldername**
- **Delete deploy/OSD-25821-capa-annotator directory**
- **on push: make**
- **fixed file format**
- **on push: make**
- **fixed cronjob frequency**
- **on push: make**
- **PR updates**
- **on push: make**
- **added break and fixed logging format for readability**
- **on push: make**
- **exclude the openshift-observability-operator from PDB alerts**
- **on push: make**
- **Updated Prom query after review**
- **Add cronjob to olm-dance openshift-ocm-agent-operator**
- **updated the oao csv version**
- **Removing CR removal steps and updating JIRA ref**
- **Adding make changes**
- **https://issues.redhat.com/browse/OSD-25331**
- **removed changes for CustomerWorkloadPreventingDrainSRE**
- **Fixing checks for specific OAO version**
- **on push: make**
- **Moving role binding for FedRAMP**
- **ran make**
- **🫡 Remove mjlshen from approvers**
- **wif_psc_permissions**
- **Add ppanda to region leads**
- **Remove Suricata from MCC in favor of app-interface**
- **ran make**
- **remove IDS Tester**
- **Update 4.17 WIF permissions for PSC SSH**
- **Reverting OAO olm dance work for OSD-25349**
- **New configuration for FedRAMP**
- **ran make**
- **[OSD-26176](https://issues.redhat.com//browse/OSD-26176): cmo config grafana is removed on 4.11+**
- **[OSD-26181](https://issues.redhat.com//browse/OSD-26181): Remove cluster from limited support if all reasons are overriden**
- **Add make-generated files**
- **updated node role**
- **reframing alert message/summary statement**
- **Remove unnecessary wif configs and rename SA ids and Role ids in 4.17 config**
- **Remove NautiluX**
- **[OSD-26173](https://issues.redhat.com//browse/OSD-26173): remove CIO SA and apischeme deployment from PSC clusters**
- **on push: make**
- **Add list TcpProxies to wif permissions**
- **updating alert fire timing**
- **updates generate policy config to add backplane mcs tier 2**
- **change label match for fedRAMP**
- **Add forwardingrules.use to deployer role**
- **Update fedramp config to 4.14**
- **deploy/sre-prometheus/centralized-observability/100-sre-slo-recording-rules: Dedup probe_success**
- **Adding condition for PSC in non-fr-sts-wif-privatelink**
- **on push: make**
- **[OCM-10657] Adding permissions needed for preflight checks to the osd-deployer role**
- **Update the 4.17 capa annotator image to 4.17.4**
- **fixing the rmo issue**
- **Updated the RMO version with v0.1.700-g504ef15**
- **Modify RMO olm dance to target the whole fleet, fix some bugs**
- **Removing RMO OLM dance**
- **Add capa annotator configuration for 4.16 HCP clusters**
- **"TechPreviewUnsafeFailForward" upgradeStrategy for openshift-cluster-monitoring operatorGroup**
