### PR TITLE
"TechPreviewUnsafeFailForward" upgradeStrategy for openshift-cluster-monitoring operatorGroup

### DIFF
--- a/deploy/itn-2024-00255_camo-unsafefailforward/10-openshift-cluster-monitoring-operatorgroup.patch.yaml
+++ b/deploy/itn-2024-00255_camo-unsafefailforward/10-openshift-cluster-monitoring-operatorgroup.patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+name: openshift-cluster-monitoring
+namespace: openshift-monitoring
+applyMode: AlwaysApply
+patch: '{"spec":{"upgradeStrategy":"TechPreviewUnsafeFailForward"}}'
+patchType: merge

--- a/deploy/itn-2024-00255_camo-unsafefailforward/config.yaml
+++ b/deploy/itn-2024-00255_camo-unsafefailforward/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16", "4.17"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24363,6 +24363,38 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: itn-2024-00255_camo-unsafefailforward
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      name: openshift-cluster-monitoring
+      namespace: openshift-monitoring
+      applyMode: AlwaysApply
+      patch: '{"spec":{"upgradeStrategy":"TechPreviewUnsafeFailForward"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24363,6 +24363,38 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: itn-2024-00255_camo-unsafefailforward
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      name: openshift-cluster-monitoring
+      namespace: openshift-monitoring
+      applyMode: AlwaysApply
+      patch: '{"spec":{"upgradeStrategy":"TechPreviewUnsafeFailForward"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24363,6 +24363,38 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: itn-2024-00255_camo-unsafefailforward
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      name: openshift-cluster-monitoring
+      namespace: openshift-monitoring
+      applyMode: AlwaysApply
+      patch: '{"spec":{"upgradeStrategy":"TechPreviewUnsafeFailForward"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: kubelet-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Enables the "TechPreviewUnsafeFailForward" upgradeStrategy for the
openshift-cluster-monitoring operator group, to allow OLM to bypass
failed CSV versions, skipping the OLM dance.

REF: ITN-2024-00255

Signed-off-by: Chris Collins <collins.christopher@gmail.com>
