### PR TITLE
OSD-26770: Update PassWorkerRole SID for Hypershift CAPA policies

### DIFF
--- a/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.12/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -41,7 +41,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-ROSA-Worker"
+        "arn:*:iam::*:role/*-ROSA-Worker-Role"
       ],
       "Condition": {
         "StringEquals": {

--- a/resources/sts/4.13/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.13/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -41,7 +41,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-ROSA-Worker"
+        "arn:*:iam::*:role/*-ROSA-Worker-Role"
       ],
       "Condition": {
         "StringEquals": {

--- a/resources/sts/4.14/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.14/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -42,7 +42,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-ROSA-Worker"
+        "arn:*:iam::*:role/*-ROSA-Worker-Role"
       ],
       "Condition": {
         "StringEquals": {

--- a/resources/sts/4.15/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.15/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -42,7 +42,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-ROSA-Worker"
+        "arn:*:iam::*:role/*-ROSA-Worker-Role"
       ],
       "Condition": {
         "StringEquals": {

--- a/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.16/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -42,7 +42,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-ROSA-Worker"
+        "arn:*:iam::*:role/*-ROSA-Worker-Role"
       ],
       "Condition": {
         "StringEquals": {

--- a/resources/sts/4.17/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.17/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -42,7 +42,7 @@
       ],
       "Effect": "Allow",
       "Resource": [
-        "arn:*:iam::*:role/*-ROSA-Worker"
+        "arn:*:iam::*:role/*-ROSA-Worker-Role"
       ],
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
The AWS managed policies for Hypershift have a diff from what is actually live in AWS, specifically around the `PassWorkerRole` resource selection. This reflects the value as defined in AWS for our policy, which will prevent an accidental bugs when presenting updated policies in the future.

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-26770

### Special notes for your reviewer:

This is the stanza defined in AWS:
```
        {
            "Sid": "PassWorkerRole",
            "Effect": "Allow",
            "Action": [
                "iam:PassRole"
            ],
            "Resource": [
                "arn:*:iam::*:role/*-ROSA-Worker-Role"
            ],
            "Condition": {
                "StringEquals": {
                    "iam:PassedToService": [
                        "ec2.amazonaws.com"
                    ]
                }
            }
```
<img width="682" alt="Screenshot 2024-11-21 at 9 13 49 AM" src="https://github.com/user-attachments/assets/65672975-407a-4b69-8ff3-d671ab176714">

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
