### PR TITLE
WIP: OSD-26538: create a SelectorSyncSet for sdn-to-ovn migration

### DIFF
--- a/deploy/osd-sdn-to-ovn-migration/config.yaml
+++ b/deploy/osd-sdn-to-ovn-migration/config.yaml
@@ -1,0 +1,17 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    # Exclusions
+    - key: api.openshift.com/limited-support
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+    # Inclusions
+    - key: hive.openshift.io/version-major-minor
+      operator: In
+      values: ["4.16"]
+    # Only apply the SyncSet if this label has a value, thus kicking off the migration
+    - key: api.openshift.com/sdn-migration-start
+      operator: Exists

--- a/deploy/osd-sdn-to-ovn-migration/network-operator.patch.yaml
+++ b/deploy/osd-sdn-to-ovn-migration/network-operator.patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: operator.openshift.io/v1
+applyMode: AlwaysApply
+enableResourceTemplates: true
+kind: Network
+name: cluster
+patch: |-
+  {
+    "spec": {
+      "defaultNetwork": {
+        "ovnKubernetesConfig": {
+          "ipv4": {
+            "internalJoinSubnet": {{ fromCDLabel "api.openshift.com/sdn-migration-join-ipv4" }}, 
+            "internalMasqueradeSubnet": {{ fromCDLabel "api.openshift.com/sdn-migration-masquerade-ipv4" }},
+            "internalTransitSwitchSubnet": {{ fromCDLabel "api.openshift.com/sdn-migration-transit-ipv4" }}
+          }
+        }
+      }
+    }
+  }
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -33684,6 +33684,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-sdn-to-ovn-migration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/limited-support
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+      - key: api.openshift.com/sdn-migration-start
+        operator: Exists
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: AlwaysApply
+      enableResourceTemplates: true
+      kind: Network
+      name: cluster
+      patch: "{\n  \"spec\": {\n    \"defaultNetwork\": {\n      \"ovnKubernetesConfig\"\
+        : {\n        \"ipv4\": {\n          \"internalJoinSubnet\": {{ fromCDLabel\
+        \ \"api.openshift.com/sdn-migration-join-ipv4\" }}, \n          \"internalMasqueradeSubnet\"\
+        : {{ fromCDLabel \"api.openshift.com/sdn-migration-masquerade-ipv4\" }},\n\
+        \          \"internalTransitSwitchSubnet\": {{ fromCDLabel \"api.openshift.com/sdn-migration-transit-ipv4\"\
+        \ }}\n        }\n      }\n    }\n  }\n}"
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-serviceaccounts
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -33684,6 +33684,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-sdn-to-ovn-migration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/limited-support
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+      - key: api.openshift.com/sdn-migration-start
+        operator: Exists
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: AlwaysApply
+      enableResourceTemplates: true
+      kind: Network
+      name: cluster
+      patch: "{\n  \"spec\": {\n    \"defaultNetwork\": {\n      \"ovnKubernetesConfig\"\
+        : {\n        \"ipv4\": {\n          \"internalJoinSubnet\": {{ fromCDLabel\
+        \ \"api.openshift.com/sdn-migration-join-ipv4\" }}, \n          \"internalMasqueradeSubnet\"\
+        : {{ fromCDLabel \"api.openshift.com/sdn-migration-masquerade-ipv4\" }},\n\
+        \          \"internalTransitSwitchSubnet\": {{ fromCDLabel \"api.openshift.com/sdn-migration-transit-ipv4\"\
+        \ }}\n        }\n      }\n    }\n  }\n}"
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-serviceaccounts
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -33684,6 +33684,47 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-sdn-to-ovn-migration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/limited-support
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+      - key: api.openshift.com/sdn-migration-start
+        operator: Exists
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: AlwaysApply
+      enableResourceTemplates: true
+      kind: Network
+      name: cluster
+      patch: "{\n  \"spec\": {\n    \"defaultNetwork\": {\n      \"ovnKubernetesConfig\"\
+        : {\n        \"ipv4\": {\n          \"internalJoinSubnet\": {{ fromCDLabel\
+        \ \"api.openshift.com/sdn-migration-join-ipv4\" }}, \n          \"internalMasqueradeSubnet\"\
+        : {{ fromCDLabel \"api.openshift.com/sdn-migration-masquerade-ipv4\" }},\n\
+        \          \"internalTransitSwitchSubnet\": {{ fromCDLabel \"api.openshift.com/sdn-migration-transit-ipv4\"\
+        \ }}\n        }\n      }\n    }\n  }\n}"
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-serviceaccounts
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR is a draft/wip of attempting to use SelectorSyncSets to copy labels from a ClusterDeployment to the Network resource to signal the network operator to kickoff an SDN to OVN migration. See this [doc](https://docs.google.com/document/d/1LfM1bCV271djxOlSTSrRP0QvZmJuw3oXbsFwIW6qqcA/edit?tab=t.0#heading=h.gb08e8likfqs) for more details.

**Open questions and assumptions:**

- Does this look right at first glance?
- We _only_ support this from 4.16 > 4.17, so I selected only those clusters
- We _only_ support this for IPV4 at this time
- Applying these labels, even if they are `""` to the operator will result in a no-op
- The existence of these labels post-migration will result in a no-op

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-26538

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
