### PR TITLE
OSD-25935: Add capa annotator config for 4.15

### DIFF
--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-15.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-15.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: capa-annotator-4-15
+  namespace: openshift-capa-annotator
+  annotations:
+    kubernetes.io/description: "Patches 4.15 Manifest works to fixed CAPI version https://issues.redhat.com/browse/OSD-25821"
+spec:
+  schedule: "*/5 * * * *" # Every five minutes
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: capa-annotator
+          namespace: openshift-capa-annotator
+          annotations:
+            kubernetes.io/description: "Patches 4.15 Manifest works to fixed CAPI version https://issues.redhat.com/browse/OSD-25821"
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                  weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          containers:
+            - name: capa-annotator
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              imagePullPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+              env:
+                - name: IMAGE
+                  # 4.15.39
+                  value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
+                - name: MAJOR_MINOR_VER
+                  value: "4.15"
+              command:
+                - /bin/bash
+              args:
+                - -c
+                - |
+                  # Get all manifestwork objects and extract their names
+                  managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+                  # Loop through each manifestwork object
+                  for clusterID in ${managedclusters[@]};do 
+                    # Extract namespace and name
+                    namespace=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
+                    kinds=$(oc get manifestwork -n $namespace $clusterID -o json | jq -r '.spec.workload.manifests[].kind')
+                    num=0 
+                    for kind in $kinds;do 
+                      if [[ $kind == "HostedCluster" ]]; then
+                          echo $clusterID
+                          #~1 escapes / in bash
+                          json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
+                          echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
+                          oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload"
+                          echo "-------------------------------------------------------------------------"
+                          break
+                      fi
+                    (( num++))
+                    done
+                  done
+          serviceAccountName: capa-annotator
+          automountServiceAccountToken: true
+          restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26677,6 +26677,78 @@ objects:
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
+        name: capa-annotator-4-15
+        namespace: openshift-capa-annotator
+        annotations:
+          kubernetes.io/description: Patches 4.15 Manifest works to fixed CAPI version
+            https://issues.redhat.com/browse/OSD-25821
+      spec:
+        schedule: '*/5 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              metadata:
+                name: capa-annotator
+                namespace: openshift-capa-annotator
+                annotations:
+                  kubernetes.io/description: Patches 4.15 Manifest works to fixed
+                    CAPI version https://issues.redhat.com/browse/OSD-25821
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: capa-annotator
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  env:
+                  - name: IMAGE
+                    value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
+                  - name: MAJOR_MINOR_VER
+                    value: '4.15'
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
+                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
+                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
+                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
+                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
+                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
+                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
+                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
+                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
+                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
+                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
+                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
+                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
+                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                serviceAccountName: capa-annotator
+                automountServiceAccountToken: true
+                restartPolicy: Never
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
         name: capa-annotator-4-16
         namespace: openshift-capa-annotator
         annotations:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26677,6 +26677,78 @@ objects:
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
+        name: capa-annotator-4-15
+        namespace: openshift-capa-annotator
+        annotations:
+          kubernetes.io/description: Patches 4.15 Manifest works to fixed CAPI version
+            https://issues.redhat.com/browse/OSD-25821
+      spec:
+        schedule: '*/5 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              metadata:
+                name: capa-annotator
+                namespace: openshift-capa-annotator
+                annotations:
+                  kubernetes.io/description: Patches 4.15 Manifest works to fixed
+                    CAPI version https://issues.redhat.com/browse/OSD-25821
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: capa-annotator
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  env:
+                  - name: IMAGE
+                    value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
+                  - name: MAJOR_MINOR_VER
+                    value: '4.15'
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
+                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
+                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
+                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
+                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
+                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
+                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
+                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
+                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
+                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
+                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
+                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
+                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
+                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                serviceAccountName: capa-annotator
+                automountServiceAccountToken: true
+                restartPolicy: Never
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
         name: capa-annotator-4-16
         namespace: openshift-capa-annotator
         annotations:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26677,6 +26677,78 @@ objects:
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
+        name: capa-annotator-4-15
+        namespace: openshift-capa-annotator
+        annotations:
+          kubernetes.io/description: Patches 4.15 Manifest works to fixed CAPI version
+            https://issues.redhat.com/browse/OSD-25821
+      spec:
+        schedule: '*/5 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              metadata:
+                name: capa-annotator
+                namespace: openshift-capa-annotator
+                annotations:
+                  kubernetes.io/description: Patches 4.15 Manifest works to fixed
+                    CAPI version https://issues.redhat.com/browse/OSD-25821
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: capa-annotator
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  env:
+                  - name: IMAGE
+                    value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
+                  - name: MAJOR_MINOR_VER
+                    value: '4.15'
+                  command:
+                  - /bin/bash
+                  args:
+                  - -c
+                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
+                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
+                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
+                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
+                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
+                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
+                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
+                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
+                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
+                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
+                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
+                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
+                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
+                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                serviceAccountName: capa-annotator
+                automountServiceAccountToken: true
+                restartPolicy: Never
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
         name: capa-annotator-4-16
         namespace: openshift-capa-annotator
         annotations:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This adds a new CronJob to the capa annotator configuration to patch 4.15 clusters with the  CAPA image for 4.15.39. This image
supports launching instances with ENI tags if IAM allows, gracefully falling back to no tags if IAM does not allow it.

### Which Jira/Github issue(s) this PR fixes?
Fixes https://issues.redhat.com/browse/OSD-25935

### Special notes for your reviewer:
I opted to parameterize the CronJob as it exists instead of creating a more complex bash script that targets N versions.

Additionally, I scanned the commits from 4.15.0 to 4.15.39 and no changes to the `aws-cluster-api-controllers` image beside our ENI tagging change, so has little to no risk to 4.15 clusters prior to 4.15.39.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
