### PR TITLE
ROX-26660: backplane permissions for rhobs, grafana and gitops CRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp_exporters/
 generated/
 .DS_Store
 .vscode/
+.idea/

--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -303,6 +303,26 @@ spec:
                                 - list
                                 - watch
                             - apiGroups:
+                                - monitoring.rhobs
+                              resources:
+                                - alertmanagerconfigs
+                                - alertmanagers
+                                - monitoringstacks
+                                - podmonitors
+                                - probes
+                                - prometheusagents
+                                - prometheuses
+                                - prometheusrules
+                                - scrapeconfigs
+                                - servicemonitors
+                                - thanosqueriers
+                                - thanosrulers
+                                - uiplugins
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
                                 - config.openshift.io
                               resources:
                                 - clusteroperators
@@ -736,34 +756,35 @@ spec:
                             namespace: rhacs-observability
                         rules:
                             - apiGroups:
-                                - monitoring.coreos.com
+                                - monitoring.rhobs
                               resources:
                                 - alertmanagerconfigs
                                 - alertmanagers
+                                - monitoringstacks
                                 - podmonitors
                                 - probes
+                                - prometheusagents
                                 - prometheuses
                                 - prometheusrules
+                                - scrapeconfigs
                                 - servicemonitors
+                                - thanosqueriers
                                 - thanosrulers
+                                - uiplugins
                               verbs:
                                 - get
                                 - list
                                 - watch
                             - apiGroups:
-                                - observability.redhat.com
+                                - grafana.integreatly.org
                               resources:
-                                - observabilities
-                              verbs:
-                                - get
-                                - list
-                                - watch
-                            - apiGroups:
-                                - integreatly.org
-                              resources:
-                                - grafanas
-                                - grafanadatasources
+                                - grafanaalertrulegroups
+                                - grafanacontactpoints
                                 - grafanadashboards
+                                - grafanadatasources
+                                - grafanafolders
+                                - grafananotificationpolicies
+                                - grafanas
                               verbs:
                                 - get
                                 - list
@@ -792,6 +813,49 @@ spec:
                             apiGroup: rbac.authorization.k8s.io
                             kind: Role
                             name: backplane-acs-rhacs-observability
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-acs-openshift-gitops
+                            namespace: openshift-gitops
+                        rules:
+                            - apiGroups:
+                                - argoproj.io
+                              resources:
+                                - argocds
+                                - analysisruns
+                                - analysistemplates
+                                - applications
+                                - applicationsets
+                                - appprojects
+                                - clusteranalysistemplates
+                                - experiments
+                                - notificationsconfigurations
+                                - rolloutmanagers
+                                - rollouts
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-acs-openshift-gitops
+                            namespace: openshift-gitops
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-acs-openshift-gitops
                         subjects:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group

--- a/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
@@ -295,6 +295,27 @@ rules:
   - get
   - list
   - watch
+# ACS SRE can view RHOBS observability resources
+- apiGroups:
+  - monitoring.rhobs
+  resources:
+  - alertmanagerconfigs
+  - alertmanagers
+  - monitoringstacks
+  - podmonitors
+  - probes
+  - prometheusagents
+  - prometheuses
+  - prometheusrules
+  - scrapeconfigs
+  - servicemonitors
+  - thanosqueriers
+  - thanosrulers
+  - uiplugins
+  verbs:
+  - get
+  - list
+  - watch
 # ACS SRE can view clusteroperators
 - apiGroups:
   - config.openshift.io

--- a/deploy/backplane/acs/05-acs-rhacs-observability-role.yml
+++ b/deploy/backplane/acs/05-acs-rhacs-observability-role.yml
@@ -6,36 +6,36 @@ metadata:
 rules:
 # ACS SRE can vew monitoring resources
 - apiGroups:
-  - monitoring.coreos.com
+  - monitoring.rhobs
   resources:
   - alertmanagerconfigs
   - alertmanagers
+  - monitoringstacks
   - podmonitors
   - probes
+  - prometheusagents
   - prometheuses
   - prometheusrules
+  - scrapeconfigs
   - servicemonitors
+  - thanosqueriers
   - thanosrulers
-  verbs:
-  - get
-  - list
-  - watch
-# ACS SRE can view observabilities
-- apiGroups:
-  - observability.redhat.com
-  resources:
-  - observabilities
+  - uiplugins
   verbs:
   - get
   - list
   - watch
 # ACS SRE can view grafanas
 - apiGroups:
-  - integreatly.org
+  - grafana.integreatly.org
   resources:
-  - grafanas
-  - grafanadatasources
+  - grafanaalertrulegroups
+  - grafanacontactpoints
   - grafanadashboards
+  - grafanadatasources
+  - grafanafolders
+  - grafananotificationpolicies
+  - grafanas
   verbs:
   - get
   - list

--- a/deploy/backplane/acs/06-acs-openshift-gitops-role.yml
+++ b/deploy/backplane/acs/06-acs-openshift-gitops-role.yml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-acs-openshift-gitops
+  namespace: openshift-gitops
+rules:
+# ACS SRE can view gitops resources
+- apiGroups:
+  - argoproj.io
+  resources:
+  - argocds
+  - analysisruns
+  - analysistemplates
+  - applications
+  - applicationsets
+  - appprojects
+  - clusteranalysistemplates
+  - experiments
+  - notificationsconfigurations
+  - rolloutmanagers
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/acs/06-acs-openshift-gitops-rolebinding.yml
+++ b/deploy/backplane/acs/06-acs-openshift-gitops-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-acs-openshift-gitops
+  namespace: openshift-gitops
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-acs-openshift-gitops

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -934,6 +934,26 @@ objects:
                     - list
                     - watch
                   - apiGroups:
+                    - monitoring.rhobs
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - monitoringstacks
+                    - podmonitors
+                    - probes
+                    - prometheusagents
+                    - prometheuses
+                    - prometheusrules
+                    - scrapeconfigs
+                    - servicemonitors
+                    - thanosqueriers
+                    - thanosrulers
+                    - uiplugins
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
                     - config.openshift.io
                     resources:
                     - clusteroperators
@@ -1367,34 +1387,35 @@ objects:
                     namespace: rhacs-observability
                   rules:
                   - apiGroups:
-                    - monitoring.coreos.com
+                    - monitoring.rhobs
                     resources:
                     - alertmanagerconfigs
                     - alertmanagers
+                    - monitoringstacks
                     - podmonitors
                     - probes
+                    - prometheusagents
                     - prometheuses
                     - prometheusrules
+                    - scrapeconfigs
                     - servicemonitors
+                    - thanosqueriers
                     - thanosrulers
+                    - uiplugins
                     verbs:
                     - get
                     - list
                     - watch
                   - apiGroups:
-                    - observability.redhat.com
+                    - grafana.integreatly.org
                     resources:
-                    - observabilities
-                    verbs:
-                    - get
-                    - list
-                    - watch
-                  - apiGroups:
-                    - integreatly.org
-                    resources:
-                    - grafanas
-                    - grafanadatasources
+                    - grafanaalertrulegroups
+                    - grafanacontactpoints
                     - grafanadashboards
+                    - grafanadatasources
+                    - grafanafolders
+                    - grafananotificationpolicies
+                    - grafanas
                     verbs:
                     - get
                     - list
@@ -1423,6 +1444,49 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-acs-rhacs-observability
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-gitops
+                    namespace: openshift-gitops
+                  rules:
+                  - apiGroups:
+                    - argoproj.io
+                    resources:
+                    - argocds
+                    - analysisruns
+                    - analysistemplates
+                    - applications
+                    - applicationsets
+                    - appprojects
+                    - clusteranalysistemplates
+                    - experiments
+                    - notificationsconfigurations
+                    - rolloutmanagers
+                    - rollouts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-gitops
+                    namespace: openshift-gitops
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-gitops
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -9247,6 +9311,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -9673,34 +9757,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -9730,6 +9815,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10021,6 +10143,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -10447,34 +10589,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -10504,6 +10647,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10795,6 +10975,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -11221,34 +11421,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -11278,6 +11479,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -934,6 +934,26 @@ objects:
                     - list
                     - watch
                   - apiGroups:
+                    - monitoring.rhobs
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - monitoringstacks
+                    - podmonitors
+                    - probes
+                    - prometheusagents
+                    - prometheuses
+                    - prometheusrules
+                    - scrapeconfigs
+                    - servicemonitors
+                    - thanosqueriers
+                    - thanosrulers
+                    - uiplugins
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
                     - config.openshift.io
                     resources:
                     - clusteroperators
@@ -1367,34 +1387,35 @@ objects:
                     namespace: rhacs-observability
                   rules:
                   - apiGroups:
-                    - monitoring.coreos.com
+                    - monitoring.rhobs
                     resources:
                     - alertmanagerconfigs
                     - alertmanagers
+                    - monitoringstacks
                     - podmonitors
                     - probes
+                    - prometheusagents
                     - prometheuses
                     - prometheusrules
+                    - scrapeconfigs
                     - servicemonitors
+                    - thanosqueriers
                     - thanosrulers
+                    - uiplugins
                     verbs:
                     - get
                     - list
                     - watch
                   - apiGroups:
-                    - observability.redhat.com
+                    - grafana.integreatly.org
                     resources:
-                    - observabilities
-                    verbs:
-                    - get
-                    - list
-                    - watch
-                  - apiGroups:
-                    - integreatly.org
-                    resources:
-                    - grafanas
-                    - grafanadatasources
+                    - grafanaalertrulegroups
+                    - grafanacontactpoints
                     - grafanadashboards
+                    - grafanadatasources
+                    - grafanafolders
+                    - grafananotificationpolicies
+                    - grafanas
                     verbs:
                     - get
                     - list
@@ -1423,6 +1444,49 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-acs-rhacs-observability
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-gitops
+                    namespace: openshift-gitops
+                  rules:
+                  - apiGroups:
+                    - argoproj.io
+                    resources:
+                    - argocds
+                    - analysisruns
+                    - analysistemplates
+                    - applications
+                    - applicationsets
+                    - appprojects
+                    - clusteranalysistemplates
+                    - experiments
+                    - notificationsconfigurations
+                    - rolloutmanagers
+                    - rollouts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-gitops
+                    namespace: openshift-gitops
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-gitops
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -9247,6 +9311,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -9673,34 +9757,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -9730,6 +9815,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10021,6 +10143,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -10447,34 +10589,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -10504,6 +10647,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10795,6 +10975,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -11221,34 +11421,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -11278,6 +11479,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -934,6 +934,26 @@ objects:
                     - list
                     - watch
                   - apiGroups:
+                    - monitoring.rhobs
+                    resources:
+                    - alertmanagerconfigs
+                    - alertmanagers
+                    - monitoringstacks
+                    - podmonitors
+                    - probes
+                    - prometheusagents
+                    - prometheuses
+                    - prometheusrules
+                    - scrapeconfigs
+                    - servicemonitors
+                    - thanosqueriers
+                    - thanosrulers
+                    - uiplugins
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
                     - config.openshift.io
                     resources:
                     - clusteroperators
@@ -1367,34 +1387,35 @@ objects:
                     namespace: rhacs-observability
                   rules:
                   - apiGroups:
-                    - monitoring.coreos.com
+                    - monitoring.rhobs
                     resources:
                     - alertmanagerconfigs
                     - alertmanagers
+                    - monitoringstacks
                     - podmonitors
                     - probes
+                    - prometheusagents
                     - prometheuses
                     - prometheusrules
+                    - scrapeconfigs
                     - servicemonitors
+                    - thanosqueriers
                     - thanosrulers
+                    - uiplugins
                     verbs:
                     - get
                     - list
                     - watch
                   - apiGroups:
-                    - observability.redhat.com
+                    - grafana.integreatly.org
                     resources:
-                    - observabilities
-                    verbs:
-                    - get
-                    - list
-                    - watch
-                  - apiGroups:
-                    - integreatly.org
-                    resources:
-                    - grafanas
-                    - grafanadatasources
+                    - grafanaalertrulegroups
+                    - grafanacontactpoints
                     - grafanadashboards
+                    - grafanadatasources
+                    - grafanafolders
+                    - grafananotificationpolicies
+                    - grafanas
                     verbs:
                     - get
                     - list
@@ -1423,6 +1444,49 @@ objects:
                     apiGroup: rbac.authorization.k8s.io
                     kind: Role
                     name: backplane-acs-rhacs-observability
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-openshift-gitops
+                    namespace: openshift-gitops
+                  rules:
+                  - apiGroups:
+                    - argoproj.io
+                    resources:
+                    - argocds
+                    - analysisruns
+                    - analysistemplates
+                    - applications
+                    - applicationsets
+                    - appprojects
+                    - clusteranalysistemplates
+                    - experiments
+                    - notificationsconfigurations
+                    - rolloutmanagers
+                    - rollouts
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-openshift-gitops
+                    namespace: openshift-gitops
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-openshift-gitops
                   subjects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
@@ -9247,6 +9311,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -9673,34 +9757,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -9730,6 +9815,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10021,6 +10143,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -10447,34 +10589,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -10504,6 +10647,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -10795,6 +10975,26 @@ objects:
         - list
         - watch
       - apiGroups:
+        - monitoring.rhobs
+        resources:
+        - alertmanagerconfigs
+        - alertmanagers
+        - monitoringstacks
+        - podmonitors
+        - probes
+        - prometheusagents
+        - prometheuses
+        - prometheusrules
+        - scrapeconfigs
+        - servicemonitors
+        - thanosqueriers
+        - thanosrulers
+        - uiplugins
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
         - config.openshift.io
         resources:
         - clusteroperators
@@ -11221,34 +11421,35 @@ objects:
         namespace: rhacs-observability
       rules:
       - apiGroups:
-        - monitoring.coreos.com
+        - monitoring.rhobs
         resources:
         - alertmanagerconfigs
         - alertmanagers
+        - monitoringstacks
         - podmonitors
         - probes
+        - prometheusagents
         - prometheuses
         - prometheusrules
+        - scrapeconfigs
         - servicemonitors
+        - thanosqueriers
         - thanosrulers
+        - uiplugins
         verbs:
         - get
         - list
         - watch
       - apiGroups:
-        - observability.redhat.com
+        - grafana.integreatly.org
         resources:
-        - observabilities
-        verbs:
-        - get
-        - list
-        - watch
-      - apiGroups:
-        - integreatly.org
-        resources:
-        - grafanas
-        - grafanadatasources
+        - grafanaalertrulegroups
+        - grafanacontactpoints
         - grafanadashboards
+        - grafanadatasources
+        - grafanafolders
+        - grafananotificationpolicies
+        - grafanas
         verbs:
         - get
         - list
@@ -11278,6 +11479,43 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-rhacs-observability
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      rules:
+      - apiGroups:
+        - argoproj.io
+        resources:
+        - argocds
+        - analysisruns
+        - analysistemplates
+        - applications
+        - applicationsets
+        - appprojects
+        - clusteranalysistemplates
+        - experiments
+        - notificationsconfigurations
+        - rolloutmanagers
+        - rollouts
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-openshift-gitops
+        namespace: openshift-gitops
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-openshift-gitops
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Add backplane permissions for rhobs, grafana and gitops CRs

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[ROX-26660](https://issues.redhat.com//browse/ROX-26660)_ 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
