### PR TITLE
OSD-26221: update automated HCP OIDC limited support timing and messaging

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/oidc-deleted-limited-support.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/oidc-deleted-limited-support.yaml
@@ -8,7 +8,7 @@ spec:
     name: oidc-deleted-notification
     summary: Cluster is in Limited Support due to unsupported cloud provider configuration
     notificationMessage: |-
-      Your cluster requires you to take action because Red Hat is not able to access the infrastructure with the provided credentials. Please restore the credentials and permissions provided during install. If you have deleted the associated OpenIDConnectProvider, please recreate it by executing the command: rosa create oidc-provider --mode manual --cluster $CLUSTER
+      Your cluster requires action because Red Hat is either unable to access the infrastructure with the provided credentials or the credentials lack the necessary permissions to perform required actions. Please restore the credentials and permissions configured during the installation. For more details, refer to https://access.redhat.com/solutions/7098558 
     resendWait: 0
     severity: Info
     limitedSupport: true

--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
@@ -20,7 +20,7 @@ spec:
           # that the cluster is not rolling out in our expression (= hypershift_cluster_initial_rolling_out_duration_seconds does not exist)
           # hypershift_cluster_initial_rolling_out_duration_seconds stops being emitted once the cluster is rolled out
           expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace, source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m])) > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
-          for: 10m
+          for: 4m # api-ErrorBudgetBurn is our highest SLA and triggers after 5 minutes of CrashLooping kube-apiserver pods. KAS pods can CrashLoop due to missing OIDC/invalid AWS permissions. To reduce self-resolving alerts, we need the limited support to be in place before the alert triggers.
           labels:
             severity: warning
             send_managed_notification: "true"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24907,12 +24907,11 @@ objects:
           name: oidc-deleted-notification
           summary: Cluster is in Limited Support due to unsupported cloud provider
             configuration
-          notificationMessage: 'Your cluster requires you to take action because Red
-            Hat is not able to access the infrastructure with the provided credentials.
-            Please restore the credentials and permissions provided during install.
-            If you have deleted the associated OpenIDConnectProvider, please recreate
-            it by executing the command: rosa create oidc-provider --mode manual --cluster
-            $CLUSTER'
+          notificationMessage: 'Your cluster requires action because Red Hat is either
+            unable to access the infrastructure with the provided credentials or the
+            credentials lack the necessary permissions to perform required actions.
+            Please restore the credentials and permissions configured during the installation.
+            For more details, refer to https://access.redhat.com/solutions/7098558 '
           resendWait: 0
           severity: Info
           limitedSupport: true
@@ -39895,7 +39894,7 @@ objects:
               source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
               > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
               unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
-            for: 10m
+            for: 4m
             labels:
               severity: warning
               send_managed_notification: 'true'

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24907,12 +24907,11 @@ objects:
           name: oidc-deleted-notification
           summary: Cluster is in Limited Support due to unsupported cloud provider
             configuration
-          notificationMessage: 'Your cluster requires you to take action because Red
-            Hat is not able to access the infrastructure with the provided credentials.
-            Please restore the credentials and permissions provided during install.
-            If you have deleted the associated OpenIDConnectProvider, please recreate
-            it by executing the command: rosa create oidc-provider --mode manual --cluster
-            $CLUSTER'
+          notificationMessage: 'Your cluster requires action because Red Hat is either
+            unable to access the infrastructure with the provided credentials or the
+            credentials lack the necessary permissions to perform required actions.
+            Please restore the credentials and permissions configured during the installation.
+            For more details, refer to https://access.redhat.com/solutions/7098558 '
           resendWait: 0
           severity: Info
           limitedSupport: true
@@ -39895,7 +39894,7 @@ objects:
               source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
               > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
               unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
-            for: 10m
+            for: 4m
             labels:
               severity: warning
               send_managed_notification: 'true'

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24907,12 +24907,11 @@ objects:
           name: oidc-deleted-notification
           summary: Cluster is in Limited Support due to unsupported cloud provider
             configuration
-          notificationMessage: 'Your cluster requires you to take action because Red
-            Hat is not able to access the infrastructure with the provided credentials.
-            Please restore the credentials and permissions provided during install.
-            If you have deleted the associated OpenIDConnectProvider, please recreate
-            it by executing the command: rosa create oidc-provider --mode manual --cluster
-            $CLUSTER'
+          notificationMessage: 'Your cluster requires action because Red Hat is either
+            unable to access the infrastructure with the provided credentials or the
+            credentials lack the necessary permissions to perform required actions.
+            Please restore the credentials and permissions configured during the installation.
+            For more details, refer to https://access.redhat.com/solutions/7098558 '
           resendWait: 0
           severity: Info
           limitedSupport: true
@@ -39895,7 +39894,7 @@ objects:
               source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
               > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
               unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
-            for: 10m
+            for: 4m
             labels:
               severity: warning
               send_managed_notification: 'true'


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Currently, clusters that have etcd encryption enabled but a customer messed up the KMS permissions/deleted the oidc provider lands in limited support after 10 minutes. The first alert already trigger after 5 minutes.

This results in self-resolving alerts and results in SRE ignoring the alert even when it doesn't self resolve, purely by following patterns. 

Furthermore, the messaging in the limited support is no longer accurate. The issue can be due to a deleted OIDC provider in the customer aws account side, but it is more often than not an issue with the KMS permissions. 

This PR:
- updates the time it takes for clusters to land in LS to 4 minutes (below the 5 minutes it takes for the first alerts to trigger)
- updates the messaging to point at possible KMS issues when etcd encryption is enabled

Long term, we will want to point this at a KCS to be more dynamic. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-26221

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
