### PR TITLE
Sync OWNERS_ALIASES with boilerplate

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,7 @@
+# ================================ DO NOT EDIT ================================
+# This file is managed in https://github.com/openshift/boilerplate
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
-
+# =============================================================================
 aliases:
   srep-functional-team-aurora:
     - abyrne55

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,51 +1,93 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#OWNERS_ALIASES
 
 aliases:
-  srep-region-leads:
-    - MitaliBhalla
-    - tnierman
-    - bergmannf
+  srep-functional-team-aurora:
+    - abyrne55
     - dakotalongRH
-    - Tafhim
-    - Tof1973
-    - devppratik
-  srep-functional-leads:
+    - joshbranham
+    - luis-falcon
+    - reedcort
+  srep-functional-team-fedramp:
+    - tonytheleg
     - theautoroboto
-    - sam-nguyen7
-    - bmeng
+    - rhdedgar
+    - katherinelc321
+    - robotmaxtron
+    - rojasreinold
+    - hbhushan3
+    - fsferraz-rh
+  srep-functional-team-hulk:
+    - a7vicky
+    - rendhalver
     - ravitri
+    - shitaljante
+    - devppratik
+    - Tafhim
+    - tkong-redhat
+    - TheUndeadKing
+    - vaidehi411
+    - chamalabey
+  srep-functional-team-orange:
+    - bergmannf
+    - bng0y
+    - typeid
+    - Makdaam
+    - mrWinston
+    - Nikokolas3270
+    - ninabauer
+    - RaphaelBut
+  srep-functional-team-rocket:
+    - aliceh
+    - anispate
     - clcollins
+    - Mhodesty
+    - nephomaniac
+    - tnierman
+  srep-functional-team-security:
+    - jaybeeunix
+    - sam-nguyen7
+    - wshearn
+    - dem4gus
+    - npecka
+    - pshickeydev
+    - casey-williams-rh
+  srep-functional-team-thor:
+    - bmeng
+    - MitaliBhalla
+    - hectorakemp
+    - feichashao
+    - samanthajayasinghe
+    - xiaoyu74
+    - Dee-6777
+    - Tessg22
+  srep-infra-cicd:
+    - mmazur
+    - mrsantamaria
+    - ritmun
+    - jbpratt
+    - yiqinzhang
+  srep-functional-leads:
+    - abyrne55
+    - clcollins
+    - Nikokolas3270
+    - theautoroboto
+    - bmeng
+    - sam-nguyen7
+    - ravitri
+    - mmazur
   srep-team-leads:
-    - cblecker
-    - jharrington22
+    - rafael-azevedo
+    - iamkirkbater
     - rogbas
-    - jewzaam
     - fahlmant
     - dustman9000
     - wanghaoran1988
     - bng0y
-    - rafael-azevedo
-    - iamkirkbater
-  sre-alert-sme:
-    - ravitri
-    - jeremyeder
-    - wanghaoran1988
-    - boranx
-    - rogbas
-  sre-mst-observatorium:
-    - jeremyeder
-    - jharrington22
-  srep-architects:
-    - jewzaam
-    - jharrington22
-    - cblecker
-  sd-architects:
-    - jewzaam
-    - jharrington22
-    - cblecker
-    - jmelis
-    - pbergene
   sre-group-leads:
     - apahim
     - maorfr
     - rogbas
+  srep-architects:
+    - jewzaam
+    - jharrington22
+    - cblecker

--- a/docs/backplane/OWNERS
+++ b/docs/backplane/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- sd-architects
+- srep-architects
 options:
   no_parent_owners: true


### PR DESCRIPTION
This cleanup PR syncs OWNERS_ALIASES with that of openshift/boilerplate, specifically [this file](https://github.com/openshift/boilerplate/blob/master/boilerplate/openshift/golang-osd-operator/OWNERS_ALIASES). The boilerplate version was ordered differently than this repo's, so the diff looks a lot more dramatic than it actually is (feel free to use [yamldiff](https://www.yamldiff.com/) to verify). The new version also renames the `sd-architects` group to `srep-architects`, so this PR also patches the only file in this repo that used that group alias.