### PR TITLE
Fix: remove whitespace at end of OIDC limited support message

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/oidc-deleted-limited-support.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/oidc-deleted-limited-support.yaml
@@ -8,7 +8,7 @@ spec:
     name: oidc-deleted-notification
     summary: Cluster is in Limited Support due to unsupported cloud provider configuration
     notificationMessage: |-
-      Your cluster requires action because Red Hat is either unable to access the infrastructure with the provided credentials or the credentials lack the necessary permissions to perform required actions. Please restore the credentials and permissions configured during the installation. For more details, refer to https://access.redhat.com/solutions/7098558 
+      Your cluster requires action because Red Hat is either unable to access the infrastructure with the provided credentials or the credentials lack the necessary permissions to perform required actions. Please restore the credentials and permissions configured during the installation. For more details, refer to https://access.redhat.com/solutions/7098558
     resendWait: 0
     severity: Info
     limitedSupport: true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24907,11 +24907,11 @@ objects:
           name: oidc-deleted-notification
           summary: Cluster is in Limited Support due to unsupported cloud provider
             configuration
-          notificationMessage: 'Your cluster requires action because Red Hat is either
+          notificationMessage: Your cluster requires action because Red Hat is either
             unable to access the infrastructure with the provided credentials or the
             credentials lack the necessary permissions to perform required actions.
             Please restore the credentials and permissions configured during the installation.
-            For more details, refer to https://access.redhat.com/solutions/7098558 '
+            For more details, refer to https://access.redhat.com/solutions/7098558
           resendWait: 0
           severity: Info
           limitedSupport: true

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24907,11 +24907,11 @@ objects:
           name: oidc-deleted-notification
           summary: Cluster is in Limited Support due to unsupported cloud provider
             configuration
-          notificationMessage: 'Your cluster requires action because Red Hat is either
+          notificationMessage: Your cluster requires action because Red Hat is either
             unable to access the infrastructure with the provided credentials or the
             credentials lack the necessary permissions to perform required actions.
             Please restore the credentials and permissions configured during the installation.
-            For more details, refer to https://access.redhat.com/solutions/7098558 '
+            For more details, refer to https://access.redhat.com/solutions/7098558
           resendWait: 0
           severity: Info
           limitedSupport: true

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24907,11 +24907,11 @@ objects:
           name: oidc-deleted-notification
           summary: Cluster is in Limited Support due to unsupported cloud provider
             configuration
-          notificationMessage: 'Your cluster requires action because Red Hat is either
+          notificationMessage: Your cluster requires action because Red Hat is either
             unable to access the infrastructure with the provided credentials or the
             credentials lack the necessary permissions to perform required actions.
             Please restore the credentials and permissions configured during the installation.
-            For more details, refer to https://access.redhat.com/solutions/7098558 '
+            For more details, refer to https://access.redhat.com/solutions/7098558
           resendWait: 0
           severity: Info
           limitedSupport: true


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

ocm agent operator logs: 
```
time="2024-12-06T02:59:19Z" level=info msg="will send limited support for notification" notification=oidc-deleted-notification
time="2024-12-06T02:59:19Z" level=error msg="failed processing alert" error="a firing alert could not be successfully processed limited support reason for fleetnotification 'oidc-deleted-notification' could not be set for cluster 636a9f0e-b627-448c-a7be-97b207833b7f, err: can't post limited support: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '2826fa82-6e25-495c-a6b5-3cb1ec8f0a3f': 'details' must not end with space"
```

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
