### PR TITLE
[OCM-12870] define management cluster cronjob to perform olm dance

### DIFF
--- a/deploy/ocm-12870/01-ClusterRole.yaml
+++ b/deploy/ocm-12870/01-ClusterRole.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-adp-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-adp-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  - catalogsources
+  - operatorgroups
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-adp-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-adp-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-adp-operator

--- a/deploy/ocm-12870/02-CronJob.yaml
+++ b/deploy/ocm-12870/02-CronJob.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-adp-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-adp-operator
+
+              # Check for the status OADP v1.3.4 version 
+              # (previous version: ocm-agent-operator.v1.2.x). 
+              # If we it's not succeeded, do OLM dance The resources will be re-created 
+              # with the latest version
+
+              CSV_PHASE=$(oc -n openshift-adp-operator get csv oadp-operator.v1.3.4 -ojsonpath='{.status.phase}{"\n"}') || true
+              # This does nothing if the expected CSV is not found.
+              echo "CSV_PHASE is $CSV_PHASE"
+              if [[ -z ${CSV_PHASE} || ${CSV_PHASE} != "Succeeded" ]]; then
+                # Take backup of the files to be recreated (subscription, catalogsource and operatorgroup)
+                oc -n "$NAMESPACE" get subs redhat-oadp-operator -oyaml > /tmp/01-subs.yaml
+                oc -n "$NAMESPACE" get og openshift-adp-operator -oyaml > /tmp/03-og.yaml
+
+                # Delete bits
+                oc -n "$NAMESPACE" delete clusterserviceversions.operators.coreos.com $(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName==""OADP Operator")")].metadata.name}') || true
+                oc -n "$NAMESPACE" delete installplan.operators.coreos.com -l operators.coreos.com/redhat-oadp-operator.openshift-adp-operator=""
+                oc -n "$NAMESPACE" delete subs redhat-oadp-operator
+                oc -n "$NAMESPACE" delete og openshift-adp-operator
+
+                # Recreate the resources to re-install the operator
+                oc -n "$NAMESPACE" create -f /tmp/01-subs.yaml
+                oc -n "$NAMESPACE" create -f /tmp/03-og.yaml
+              else
+                echo "Skipping OLM dance as OADP already successully installed with latest version or expected version was not found."
+              fi
+
+              # Prevent the job from -rerunning
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              oc -n "$NAMESPACE" delete rolebinding/sre-operator-reinstall-rb role/sre-operator-reinstall-role || true
+              exit 0

--- a/deploy/ocm-12870/README.md
+++ b/deploy/ocm-12870/README.md
@@ -1,0 +1,11 @@
+# OCM-12870
+
+## About
+
+
+This `CronJob` is a fix for https://issues.redhat.com/browse/OCM-12870 rollout
+
+## References:
+* [OCM-12870][]
+
+[OCM-12870]: https://issues.redhat.com/browse/OCM-12870

--- a/deploy/ocm-12870/config.yaml
+++ b/deploy/ocm-12870/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type 
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24871,6 +24871,144 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocm-12870
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-adp-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-adp-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-adp-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-adp-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-adp-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-adp-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-adp-operator\n\
+                    \n# Check for the status OADP v1.3.4 version \n# (previous version:\
+                    \ ocm-agent-operator.v1.2.x). \n# If we it's not succeeded, do\
+                    \ OLM dance The resources will be re-created \n# with the latest\
+                    \ version\n\nCSV_PHASE=$(oc -n openshift-adp-operator get csv\
+                    \ oadp-operator.v1.3.4 -ojsonpath='{.status.phase}{\"\\n\"}')\
+                    \ || true\n# This does nothing if the expected CSV is not found.\n\
+                    echo \"CSV_PHASE is $CSV_PHASE\"\nif [[ -z ${CSV_PHASE} || ${CSV_PHASE}\
+                    \ != \"Succeeded\" ]]; then\n  # Take backup of the files to be\
+                    \ recreated (subscription, catalogsource and operatorgroup)\n\
+                    \  oc -n \"$NAMESPACE\" get subs redhat-oadp-operator -oyaml >\
+                    \ /tmp/01-subs.yaml\n  oc -n \"$NAMESPACE\" get og openshift-adp-operator\
+                    \ -oyaml > /tmp/03-og.yaml\n\n  # Delete bits\n  oc -n \"$NAMESPACE\"\
+                    \ delete clusterserviceversions.operators.coreos.com $(oc -n \"\
+                    $NAMESPACE\" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName==\"\
+                    \"OADP Operator\")\")].metadata.name}') || true\n  oc -n \"$NAMESPACE\"\
+                    \ delete installplan.operators.coreos.com -l operators.coreos.com/redhat-oadp-operator.openshift-adp-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subs redhat-oadp-operator\n\
+                    \  oc -n \"$NAMESPACE\" delete og openshift-adp-operator\n\n \
+                    \ # Recreate the resources to re-install the operator\n  oc -n\
+                    \ \"$NAMESPACE\" create -f /tmp/01-subs.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ create -f /tmp/03-og.yaml\nelse\n  echo \"Skipping OLM dance\
+                    \ as OADP already successully installed with latest version or\
+                    \ expected version was not found.\"\nfi\n\n# Prevent the job from\
+                    \ -rerunning\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24871,6 +24871,144 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocm-12870
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-adp-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-adp-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-adp-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-adp-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-adp-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-adp-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-adp-operator\n\
+                    \n# Check for the status OADP v1.3.4 version \n# (previous version:\
+                    \ ocm-agent-operator.v1.2.x). \n# If we it's not succeeded, do\
+                    \ OLM dance The resources will be re-created \n# with the latest\
+                    \ version\n\nCSV_PHASE=$(oc -n openshift-adp-operator get csv\
+                    \ oadp-operator.v1.3.4 -ojsonpath='{.status.phase}{\"\\n\"}')\
+                    \ || true\n# This does nothing if the expected CSV is not found.\n\
+                    echo \"CSV_PHASE is $CSV_PHASE\"\nif [[ -z ${CSV_PHASE} || ${CSV_PHASE}\
+                    \ != \"Succeeded\" ]]; then\n  # Take backup of the files to be\
+                    \ recreated (subscription, catalogsource and operatorgroup)\n\
+                    \  oc -n \"$NAMESPACE\" get subs redhat-oadp-operator -oyaml >\
+                    \ /tmp/01-subs.yaml\n  oc -n \"$NAMESPACE\" get og openshift-adp-operator\
+                    \ -oyaml > /tmp/03-og.yaml\n\n  # Delete bits\n  oc -n \"$NAMESPACE\"\
+                    \ delete clusterserviceversions.operators.coreos.com $(oc -n \"\
+                    $NAMESPACE\" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName==\"\
+                    \"OADP Operator\")\")].metadata.name}') || true\n  oc -n \"$NAMESPACE\"\
+                    \ delete installplan.operators.coreos.com -l operators.coreos.com/redhat-oadp-operator.openshift-adp-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subs redhat-oadp-operator\n\
+                    \  oc -n \"$NAMESPACE\" delete og openshift-adp-operator\n\n \
+                    \ # Recreate the resources to re-install the operator\n  oc -n\
+                    \ \"$NAMESPACE\" create -f /tmp/01-subs.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ create -f /tmp/03-og.yaml\nelse\n  echo \"Skipping OLM dance\
+                    \ as OADP already successully installed with latest version or\
+                    \ expected version was not found.\"\nfi\n\n# Prevent the job from\
+                    \ -rerunning\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24871,6 +24871,144 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: ocm-12870
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-adp-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-adp-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-adp-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-adp-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-adp-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-adp-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-adp-operator\n\
+                    \n# Check for the status OADP v1.3.4 version \n# (previous version:\
+                    \ ocm-agent-operator.v1.2.x). \n# If we it's not succeeded, do\
+                    \ OLM dance The resources will be re-created \n# with the latest\
+                    \ version\n\nCSV_PHASE=$(oc -n openshift-adp-operator get csv\
+                    \ oadp-operator.v1.3.4 -ojsonpath='{.status.phase}{\"\\n\"}')\
+                    \ || true\n# This does nothing if the expected CSV is not found.\n\
+                    echo \"CSV_PHASE is $CSV_PHASE\"\nif [[ -z ${CSV_PHASE} || ${CSV_PHASE}\
+                    \ != \"Succeeded\" ]]; then\n  # Take backup of the files to be\
+                    \ recreated (subscription, catalogsource and operatorgroup)\n\
+                    \  oc -n \"$NAMESPACE\" get subs redhat-oadp-operator -oyaml >\
+                    \ /tmp/01-subs.yaml\n  oc -n \"$NAMESPACE\" get og openshift-adp-operator\
+                    \ -oyaml > /tmp/03-og.yaml\n\n  # Delete bits\n  oc -n \"$NAMESPACE\"\
+                    \ delete clusterserviceversions.operators.coreos.com $(oc -n \"\
+                    $NAMESPACE\" get clusterserviceversions.operators.coreos.com -ojsonpath='{.items[?(@.spec.displayName==\"\
+                    \"OADP Operator\")\")].metadata.name}') || true\n  oc -n \"$NAMESPACE\"\
+                    \ delete installplan.operators.coreos.com -l operators.coreos.com/redhat-oadp-operator.openshift-adp-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subs redhat-oadp-operator\n\
+                    \  oc -n \"$NAMESPACE\" delete og openshift-adp-operator\n\n \
+                    \ # Recreate the resources to re-install the operator\n  oc -n\
+                    \ \"$NAMESPACE\" create -f /tmp/01-subs.yaml\n  oc -n \"$NAMESPACE\"\
+                    \ create -f /tmp/03-og.yaml\nelse\n  echo \"Skipping OLM dance\
+                    \ as OADP already successully installed with latest version or\
+                    \ expected version was not found.\"\nfi\n\n# Prevent the job from\
+                    \ -rerunning\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?

When fleet manager enables the upgrade of OADP 1.2 -> OADP 1.3, OLM may get stuck.
introduce a new cronjob to do OLM dance.

### Which Jira/Github issue(s) this PR fixes?

_[OCM-12870](https://issues.redhat.com//browse/OCM-12870)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
