### PR TITLE
OSD-27041: remove 'viewer' from srep service cluster permissions

### DIFF
--- a/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
@@ -6,8 +6,6 @@ metadata:
 spec:
   clusterPermissions:
   - backplane-srep-service-cluster-cluster
-  # permit get at global scope https://issues.redhat.com/browse/OSD-15997
-  - view
   permissions:
   - clusterRoleName: backplane-srep-service-cluster-project
     namespacesAllowedRegex: "(^uhc.*|^ocm.*|^klusterlet.*)"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -22885,7 +22885,6 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
-        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -22885,7 +22885,6 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
-        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -22885,7 +22885,6 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
-        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

Removes SRE-P viewer permissions on service cluster as these had unwanted side effects, see ticket. 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-27041

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
