### PR TITLE
ensure 4.17 policy is at parity with current changes

### DIFF
--- a/resources/sts/4.17/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.17/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -160,28 +160,14 @@
       }
     },
     {
-      "Sid": "CreateTagsCAPAControllerNetworkInterface",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateTags"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/red-hat-managed": "true"
-        }
-      }
-    },
-    {
       "Sid": "RunInstancesRequest",
       "Effect": "Allow",
       "Action": [
         "ec2:RunInstances"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:instance/*"
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:network-interface/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -196,7 +182,6 @@
         "ec2:RunInstances"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:subnet/*",
         "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:volume/*"


### PR DESCRIPTION
This PR has been tested and merged into the 4.16 folders. This is just ensuring that the 4.17 have parity with the latest changes. 