### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -14,6 +14,8 @@ spec:
             labels:
                 # Keep this in sync with image
                 managed.openshift.io/version: "v0.1.134-0659320"
+            annotations:
+                openshift.io/required-scc: restricted-v2
         spec:
             containers:
             - name: osd-cluster-ready

--- a/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
+++ b/deploy/osd-rebalance-infra-nodes/10-osd-rebalance-infra-nodes.CronJob.yaml
@@ -13,6 +13,9 @@ spec:
     spec:
       ttlSecondsAfterFinished: 86400
       template:
+        metadata:
+          annotations:
+            openshift.io/required-scc: restricted-v2
         spec:
           affinity:
             nodeAffinity:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29874,6 +29874,8 @@ objects:
             name: osd-cluster-ready
             labels:
               managed.openshift.io/version: v0.1.134-0659320
+            annotations:
+              openshift.io/required-scc: restricted-v2
           spec:
             containers:
             - name: osd-cluster-ready
@@ -33679,6 +33681,9 @@ objects:
           spec:
             ttlSecondsAfterFinished: 86400
             template:
+              metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
               spec:
                 affinity:
                   nodeAffinity:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29874,6 +29874,8 @@ objects:
             name: osd-cluster-ready
             labels:
               managed.openshift.io/version: v0.1.134-0659320
+            annotations:
+              openshift.io/required-scc: restricted-v2
           spec:
             containers:
             - name: osd-cluster-ready
@@ -33679,6 +33681,9 @@ objects:
           spec:
             ttlSecondsAfterFinished: 86400
             template:
+              metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
               spec:
                 affinity:
                   nodeAffinity:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29874,6 +29874,8 @@ objects:
             name: osd-cluster-ready
             labels:
               managed.openshift.io/version: v0.1.134-0659320
+            annotations:
+              openshift.io/required-scc: restricted-v2
           spec:
             containers:
             - name: osd-cluster-ready
@@ -33679,6 +33681,9 @@ objects:
           spec:
             ttlSecondsAfterFinished: 86400
             template:
+              metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
               spec:
                 affinity:
                   nodeAffinity:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This PR pins `restricted-v2` SCC for the `osd-cluster-ready` and `osd-rebalance-infra-nodes` Jobs in the `openshift-monitoring` namespace. Pinning ensures the workload explicitly uses the required SCC and prevents unintended security vulnerabilities.

This is part of the ongoing task to ensure SCC pinning for all workloads in platform namespaces .

### Which Jira/Github issue(s) this PR fixes?

_Fixes [AUTH-482](https://issues.redhat.com/browse/AUTH-482)_ and [sippy test](https://sippy.dptools.openshift.org/sippy-ng/tests/4.19/analysis?test=%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-monitoring%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation&filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-monitoring%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aggregated%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D)

### Special notes for your reviewer:
Please ensure that the `openshift.io/required-scc` annotation is present for the `osd-cluster-ready` and `osd-rebalance-infra-nodes` Jobs in the `openshift-monitoring` namespace after applying this change.

<!---
### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
--->
