### PR TITLE
Correct API version for CronJob in ocm-agent-operator reinstall

### DIFF
--- a/deploy/osd-26960/01-cronjob.yaml
+++ b/deploy/osd-26960/01-cronjob.yaml
@@ -1,17 +1,17 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: sre-operator-reinstall
   namespace: openshift-ocm-agent-operator
 spec:
-  ttlSecondsAfterFinished: 100
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
   concurrencyPolicy: Replace
   schedule: "*/30 * * * *"
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 100
       template:
         spec:
           serviceAccountName: sre-operator-reinstall-sa

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27218,19 +27218,19 @@ objects:
       - kind: ServiceAccount
         name: sre-operator-reinstall-sa
         namespace: openshift-ocm-agent-operator
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: sre-operator-reinstall
         namespace: openshift-ocm-agent-operator
       spec:
-        ttlSecondsAfterFinished: 100
         failedJobsHistoryLimit: 1
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
         schedule: '*/30 * * * *'
         jobTemplate:
           spec:
+            ttlSecondsAfterFinished: 100
             template:
               spec:
                 serviceAccountName: sre-operator-reinstall-sa

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27218,19 +27218,19 @@ objects:
       - kind: ServiceAccount
         name: sre-operator-reinstall-sa
         namespace: openshift-ocm-agent-operator
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: sre-operator-reinstall
         namespace: openshift-ocm-agent-operator
       spec:
-        ttlSecondsAfterFinished: 100
         failedJobsHistoryLimit: 1
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
         schedule: '*/30 * * * *'
         jobTemplate:
           spec:
+            ttlSecondsAfterFinished: 100
             template:
               spec:
                 serviceAccountName: sre-operator-reinstall-sa

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27218,19 +27218,19 @@ objects:
       - kind: ServiceAccount
         name: sre-operator-reinstall-sa
         namespace: openshift-ocm-agent-operator
-    - apiVersion: batch/v1beta1
+    - apiVersion: batch/v1
       kind: CronJob
       metadata:
         name: sre-operator-reinstall
         namespace: openshift-ocm-agent-operator
       spec:
-        ttlSecondsAfterFinished: 100
         failedJobsHistoryLimit: 1
         successfulJobsHistoryLimit: 3
         concurrencyPolicy: Replace
         schedule: '*/30 * * * *'
         jobTemplate:
           spec:
+            ttlSecondsAfterFinished: 100
             template:
               spec:
                 serviceAccountName: sre-operator-reinstall-sa


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?

The previous CronJob deploy is failing for some clusters because `batch/v1beta1` is not a valid API version anymore. At least CronJob has been in `batch/v1` since OCP 4.11 per [docs](https://docs.openshift.com/container-platform/4.11/rest_api/workloads_apis/cronjob-batch-v1.html#cronjob-batch-v1).

I checked all the way to 4.17 and confirmed the CronJob is listed as `batch/v1`. This also moves the `ttlSecondsAfterFinished` to the `jobTemplate` per the docs.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
