### PR TITLE
ITN-281: olm dance ocm-agent-operator

### DIFF
--- a/deploy/osd-26960/00-roles.yaml
+++ b/deploy/osd-26960/00-roles.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-ocm-agent-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-ocm-agent-operator
+rules:
+  - apiGroups:
+      - "operators.coreos.com"
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - installplans
+      - catalogsources
+      - operatorgroups
+    verbs:
+      - list
+      - get
+      - delete
+      - create
+  - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - list
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-ocm-agent-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-ocm-agent-operator
+subjects:
+  - kind: ServiceAccount
+    name: sre-operator-reinstall-sa
+    namespace: openshift-ocm-agent-operator

--- a/deploy/osd-26960/01-cronjob.yaml
+++ b/deploy/osd-26960/01-cronjob.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-ocm-agent-operator
+spec:
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 100
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+            - name: operator-reinstaller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  #!/bin/bash
+                  set -euxo pipefail
+                  NAMESPACE=openshift-ocm-agent-operator
+                  OPERATOR=ocm-agent-operator
+    
+                  CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -o name | grep "$OPERATOR") || true
+                  if [[ ! -z "$CSV_FOUND" ]]; then
+                    # The OLM dance
+                    # delete all CSVs
+                    oc get csv -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n $NAMESPACE
+                    # delete all installplans
+                    oc get installplans -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete installplan -n $NAMESPACE
+                    # get subscription
+                    oc get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json
+                    # delete subscription
+                    oc delete subscriptions -n $NAMESPACE $OPERATOR
+                    # create subscription using the following json
+                    oc create -f /tmp/sub.json
+                    fi
+                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+                  exit 0

--- a/deploy/osd-26960/config.yaml
+++ b/deploy/osd-26960/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: hive.openshift.io/version-major-minor
+      operator: In
+      values: ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16", "4.17"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27133,6 +27133,142 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-26960
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-ocm-agent-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-ocm-agent-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-ocm-agent-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 100
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
+                    OPERATOR=ocm-agent-operator\n\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com -o name | grep\
+                    \ \"$OPERATOR\") || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n\
+                    \  # The OLM dance\n  # delete all CSVs\n  oc get csv -n $NAMESPACE\
+                    \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n\
+                    \ $NAMESPACE\n  # delete all installplans\n  oc get installplans\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete installplan -n $NAMESPACE\n  # get subscription\n  oc\
+                    \ get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status)\
+                    \ | del(.metadata.creationTimestamp) | del(.metadata.generation)\
+                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json\n\
+                    \  # delete subscription\n  oc delete subscriptions -n $NAMESPACE\
+                    \ $OPERATOR\n  # create subscription using the following json\n\
+                    \  oc create -f /tmp/sub.json\n  fi\n  oc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\n  oc -n \"$NAMESPACE\"\
+                    \ delete role sre-operator-reinstall-role || true\n  oc -n \"\
+                    $NAMESPACE\" delete rolebinding sre-operator-reinstall-rb || true\n\
+                    \  oc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27133,6 +27133,142 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-26960
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-ocm-agent-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-ocm-agent-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-ocm-agent-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 100
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
+                    OPERATOR=ocm-agent-operator\n\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com -o name | grep\
+                    \ \"$OPERATOR\") || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n\
+                    \  # The OLM dance\n  # delete all CSVs\n  oc get csv -n $NAMESPACE\
+                    \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n\
+                    \ $NAMESPACE\n  # delete all installplans\n  oc get installplans\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete installplan -n $NAMESPACE\n  # get subscription\n  oc\
+                    \ get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status)\
+                    \ | del(.metadata.creationTimestamp) | del(.metadata.generation)\
+                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json\n\
+                    \  # delete subscription\n  oc delete subscriptions -n $NAMESPACE\
+                    \ $OPERATOR\n  # create subscription using the following json\n\
+                    \  oc create -f /tmp/sub.json\n  fi\n  oc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\n  oc -n \"$NAMESPACE\"\
+                    \ delete role sre-operator-reinstall-role || true\n  oc -n \"\
+                    $NAMESPACE\" delete rolebinding sre-operator-reinstall-rb || true\n\
+                    \  oc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27133,6 +27133,142 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-26960
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-ocm-agent-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-ocm-agent-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-ocm-agent-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-ocm-agent-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-ocm-agent-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 100
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
+                    OPERATOR=ocm-agent-operator\n\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
+                    \ get clusterserviceversions.operators.coreos.com -o name | grep\
+                    \ \"$OPERATOR\") || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n\
+                    \  # The OLM dance\n  # delete all CSVs\n  oc get csv -n $NAMESPACE\
+                    \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n\
+                    \ $NAMESPACE\n  # delete all installplans\n  oc get installplans\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete installplan -n $NAMESPACE\n  # get subscription\n  oc\
+                    \ get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status)\
+                    \ | del(.metadata.creationTimestamp) | del(.metadata.generation)\
+                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json\n\
+                    \  # delete subscription\n  oc delete subscriptions -n $NAMESPACE\
+                    \ $OPERATOR\n  # create subscription using the following json\n\
+                    \  oc create -f /tmp/sub.json\n  fi\n  oc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\n  oc -n \"$NAMESPACE\"\
+                    \ delete role sre-operator-reinstall-role || true\n  oc -n \"\
+                    $NAMESPACE\" delete rolebinding sre-operator-reinstall-rb || true\n\
+                    \  oc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-aquasec-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This reverts commit d7bb9e81afaac92450b7adb5c36b3ee9e9a4e47c.

### What type of PR is this?
cleanup

### What this PR does / why we need it?

ITN-281: olm dance oao one more time as the last dance did not fix the issue fleet wide. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
