### PR TITLE
Fix oao olm dance cronjob to ignore cases where resources are missing

### DIFF
--- a/deploy/osd-26960/01-cronjob.yaml
+++ b/deploy/osd-26960/01-cronjob.yaml
@@ -8,7 +8,7 @@ spec:
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
   concurrencyPolicy: Replace
-  schedule: "*/23 * * * *"
+  schedule: "*/30 * * * *"
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 100

--- a/deploy/osd-26960/01-cronjob.yaml
+++ b/deploy/osd-26960/01-cronjob.yaml
@@ -8,7 +8,7 @@ spec:
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 3
   concurrencyPolicy: Replace
-  schedule: "*/30 * * * *"
+  schedule: "*/23 * * * *"
   jobTemplate:
     spec:
       ttlSecondsAfterFinished: 100
@@ -28,23 +28,43 @@ spec:
                   set -euxo pipefail
                   NAMESPACE=openshift-ocm-agent-operator
                   OPERATOR=ocm-agent-operator
+
+                  # Path for temporary subscription JSON backup
+                  SUB_JSON_PATH="/tmp/sub.json"
     
-                  CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -o name | grep "$OPERATOR") || true
-                  if [[ ! -z "$CSV_FOUND" ]]; then
-                    # The OLM dance
-                    # delete all CSVs
-                    oc get csv -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n $NAMESPACE
-                    # delete all installplans
-                    oc get installplans -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete installplan -n $NAMESPACE
-                    # get subscription
-                    oc get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json
-                    # delete subscription
-                    oc delete subscriptions -n $NAMESPACE $OPERATOR
-                    # create subscription using the following json
-                    oc create -f /tmp/sub.json
-                    fi
-                    oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
-                    oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
-                    oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
-                    oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
-                  exit 0
+                  # The OLM dance
+
+                  # Delete CSVs if they exist
+                  CSV_LIST=$(oc get csv -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
+                  if [[ -n "$CSV_LIST" ]]; then
+                    echo "Deleting CSVs for operator $OPERATOR in namespace $NAMESPACE..."
+                    echo "$CSV_LIST" | xargs -r -I {} oc delete csv -n "$NAMESPACE" {}
+                  else
+                    echo "No CSVs found for operator $OPERATOR in namespace $NAMESPACE."
+                  fi
+
+                  # Delete InstallPlans if they exist
+                  INSTALLPLAN_LIST=$(oc get installplans -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
+                  if [[ -n "$INSTALLPLAN_LIST" ]]; then
+                    echo "Deleting InstallPlans for operator $OPERATOR in namespace $NAMESPACE..."
+                    echo "$INSTALLPLAN_LIST" | xargs -r -I {} oc delete installplan -n "$NAMESPACE" {}
+                  else
+                    echo "No InstallPlans found for operator $OPERATOR in namespace $NAMESPACE."
+                  fi
+
+                  # Delete and re-create fresh subscription if it exists
+                  if oc get subscription -n "$NAMESPACE" "$OPERATOR" -o json > "$SUB_JSON_PATH" 2>/dev/null; then
+                    echo "Subscription found for operator $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH..."
+                    jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' "$SUB_JSON_PATH" > "${SUB_JSON_PATH}.tmp" && mv "${SUB_JSON_PATH}.tmp" "$SUB_JSON_PATH"
+                    echo "Deleting subscription for operator $OPERATOR in namespace $NAMESPACE..."
+                    oc delete subscriptions -n "$NAMESPACE" "$OPERATOR" || echo "Failed to delete subscription for operator $OPERATOR."
+                    echo "Re-creating subscription for operator $OPERATOR in namespace $NAMESPACE..."
+                    oc create -f "$SUB_JSON_PATH"
+                  else
+                    echo "No subscription found for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation."
+                  fi
+
+                  oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+                  oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+                  oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+                  oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27243,25 +27243,41 @@ objects:
                   - sh
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
-                    OPERATOR=ocm-agent-operator\n\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com -o name | grep\
-                    \ \"$OPERATOR\") || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n\
-                    \  # The OLM dance\n  # delete all CSVs\n  oc get csv -n $NAMESPACE\
-                    \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n\
-                    \ $NAMESPACE\n  # delete all installplans\n  oc get installplans\
-                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
-                    \ delete installplan -n $NAMESPACE\n  # get subscription\n  oc\
-                    \ get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status)\
-                    \ | del(.metadata.creationTimestamp) | del(.metadata.generation)\
-                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json\n\
-                    \  # delete subscription\n  oc delete subscriptions -n $NAMESPACE\
-                    \ $OPERATOR\n  # create subscription using the following json\n\
-                    \  oc create -f /tmp/sub.json\n  fi\n  oc -n \"$NAMESPACE\" delete\
-                    \ cronjob sre-operator-reinstall || true\n  oc -n \"$NAMESPACE\"\
-                    \ delete role sre-operator-reinstall-role || true\n  oc -n \"\
-                    $NAMESPACE\" delete rolebinding sre-operator-reinstall-rb || true\n\
-                    \  oc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\nexit 0\n"
+                    OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
+                    \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
+                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get csv -n \"$NAMESPACE\"\
+                    \ | grep \"$OPERATOR\" || true | awk '{print $1}')\nif [[ -n \"\
+                    $CSV_LIST\" ]]; then\n  echo \"Deleting CSVs for operator $OPERATOR\
+                    \ in namespace $NAMESPACE...\"\n  echo \"$CSV_LIST\" | xargs -r\
+                    \ -I {} oc delete csv -n \"$NAMESPACE\" {}\nelse\n  echo \"No\
+                    \ CSVs found for operator $OPERATOR in namespace $NAMESPACE.\"\
+                    \nfi\n\n# Delete InstallPlans if they exist\nINSTALLPLAN_LIST=$(oc\
+                    \ get installplans -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true\
+                    \ | awk '{print $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
+                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
+                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
+                    \ {} oc delete installplan -n \"$NAMESPACE\" {}\nelse\n  echo\
+                    \ \"No InstallPlans found for operator $OPERATOR in namespace\
+                    \ $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh subscription\
+                    \ if it exists\nif oc get subscription -n \"$NAMESPACE\" \"$OPERATOR\"\
+                    \ -o json > \"$SUB_JSON_PATH\" 2>/dev/null; then\n  echo \"Subscription\
+                    \ found for operator $OPERATOR in namespace $NAMESPACE. Backing\
+                    \ it up to $SUB_JSON_PATH...\"\n  jq 'del(.status) | del(.metadata.creationTimestamp)\
+                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
+                    \ | del(.metadata.uid)' \"$SUB_JSON_PATH\" > \"${SUB_JSON_PATH}.tmp\"\
+                    \ && mv \"${SUB_JSON_PATH}.tmp\" \"$SUB_JSON_PATH\"\n  echo \"\
+                    Deleting subscription for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  oc delete subscriptions -n \"$NAMESPACE\" \"$OPERATOR\" ||\
+                    \ echo \"Failed to delete subscription for operator $OPERATOR.\"\
+                    \n  echo \"Re-creating subscription for operator $OPERATOR in\
+                    \ namespace $NAMESPACE...\"\n  oc create -f \"$SUB_JSON_PATH\"\
+                    \nelse\n  echo \"No subscription found for operator $OPERATOR\
+                    \ in namespace $NAMESPACE. Skipping re-creation.\"\nfi\n\noc -n\
+                    \ \"$NAMESPACE\" delete cronjob sre-operator-reinstall || true\n\
+                    oc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role ||\
+                    \ true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27243,25 +27243,41 @@ objects:
                   - sh
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
-                    OPERATOR=ocm-agent-operator\n\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com -o name | grep\
-                    \ \"$OPERATOR\") || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n\
-                    \  # The OLM dance\n  # delete all CSVs\n  oc get csv -n $NAMESPACE\
-                    \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n\
-                    \ $NAMESPACE\n  # delete all installplans\n  oc get installplans\
-                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
-                    \ delete installplan -n $NAMESPACE\n  # get subscription\n  oc\
-                    \ get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status)\
-                    \ | del(.metadata.creationTimestamp) | del(.metadata.generation)\
-                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json\n\
-                    \  # delete subscription\n  oc delete subscriptions -n $NAMESPACE\
-                    \ $OPERATOR\n  # create subscription using the following json\n\
-                    \  oc create -f /tmp/sub.json\n  fi\n  oc -n \"$NAMESPACE\" delete\
-                    \ cronjob sre-operator-reinstall || true\n  oc -n \"$NAMESPACE\"\
-                    \ delete role sre-operator-reinstall-role || true\n  oc -n \"\
-                    $NAMESPACE\" delete rolebinding sre-operator-reinstall-rb || true\n\
-                    \  oc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\nexit 0\n"
+                    OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
+                    \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
+                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get csv -n \"$NAMESPACE\"\
+                    \ | grep \"$OPERATOR\" || true | awk '{print $1}')\nif [[ -n \"\
+                    $CSV_LIST\" ]]; then\n  echo \"Deleting CSVs for operator $OPERATOR\
+                    \ in namespace $NAMESPACE...\"\n  echo \"$CSV_LIST\" | xargs -r\
+                    \ -I {} oc delete csv -n \"$NAMESPACE\" {}\nelse\n  echo \"No\
+                    \ CSVs found for operator $OPERATOR in namespace $NAMESPACE.\"\
+                    \nfi\n\n# Delete InstallPlans if they exist\nINSTALLPLAN_LIST=$(oc\
+                    \ get installplans -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true\
+                    \ | awk '{print $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
+                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
+                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
+                    \ {} oc delete installplan -n \"$NAMESPACE\" {}\nelse\n  echo\
+                    \ \"No InstallPlans found for operator $OPERATOR in namespace\
+                    \ $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh subscription\
+                    \ if it exists\nif oc get subscription -n \"$NAMESPACE\" \"$OPERATOR\"\
+                    \ -o json > \"$SUB_JSON_PATH\" 2>/dev/null; then\n  echo \"Subscription\
+                    \ found for operator $OPERATOR in namespace $NAMESPACE. Backing\
+                    \ it up to $SUB_JSON_PATH...\"\n  jq 'del(.status) | del(.metadata.creationTimestamp)\
+                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
+                    \ | del(.metadata.uid)' \"$SUB_JSON_PATH\" > \"${SUB_JSON_PATH}.tmp\"\
+                    \ && mv \"${SUB_JSON_PATH}.tmp\" \"$SUB_JSON_PATH\"\n  echo \"\
+                    Deleting subscription for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  oc delete subscriptions -n \"$NAMESPACE\" \"$OPERATOR\" ||\
+                    \ echo \"Failed to delete subscription for operator $OPERATOR.\"\
+                    \n  echo \"Re-creating subscription for operator $OPERATOR in\
+                    \ namespace $NAMESPACE...\"\n  oc create -f \"$SUB_JSON_PATH\"\
+                    \nelse\n  echo \"No subscription found for operator $OPERATOR\
+                    \ in namespace $NAMESPACE. Skipping re-creation.\"\nfi\n\noc -n\
+                    \ \"$NAMESPACE\" delete cronjob sre-operator-reinstall || true\n\
+                    oc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role ||\
+                    \ true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27243,25 +27243,41 @@ objects:
                   - sh
                   - -c
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
-                    OPERATOR=ocm-agent-operator\n\nCSV_FOUND=$(oc -n \"$NAMESPACE\"\
-                    \ get clusterserviceversions.operators.coreos.com -o name | grep\
-                    \ \"$OPERATOR\") || true\nif [[ ! -z \"$CSV_FOUND\" ]]; then\n\
-                    \  # The OLM dance\n  # delete all CSVs\n  oc get csv -n $NAMESPACE\
-                    \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete csv -n\
-                    \ $NAMESPACE\n  # delete all installplans\n  oc get installplans\
-                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
-                    \ delete installplan -n $NAMESPACE\n  # get subscription\n  oc\
-                    \ get subscription -n $NAMESPACE $OPERATOR -o json | jq 'del(.status)\
-                    \ | del(.metadata.creationTimestamp) | del(.metadata.generation)\
-                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json\n\
-                    \  # delete subscription\n  oc delete subscriptions -n $NAMESPACE\
-                    \ $OPERATOR\n  # create subscription using the following json\n\
-                    \  oc create -f /tmp/sub.json\n  fi\n  oc -n \"$NAMESPACE\" delete\
-                    \ cronjob sre-operator-reinstall || true\n  oc -n \"$NAMESPACE\"\
-                    \ delete role sre-operator-reinstall-role || true\n  oc -n \"\
-                    $NAMESPACE\" delete rolebinding sre-operator-reinstall-rb || true\n\
-                    \  oc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\nexit 0\n"
+                    OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
+                    \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
+                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get csv -n \"$NAMESPACE\"\
+                    \ | grep \"$OPERATOR\" || true | awk '{print $1}')\nif [[ -n \"\
+                    $CSV_LIST\" ]]; then\n  echo \"Deleting CSVs for operator $OPERATOR\
+                    \ in namespace $NAMESPACE...\"\n  echo \"$CSV_LIST\" | xargs -r\
+                    \ -I {} oc delete csv -n \"$NAMESPACE\" {}\nelse\n  echo \"No\
+                    \ CSVs found for operator $OPERATOR in namespace $NAMESPACE.\"\
+                    \nfi\n\n# Delete InstallPlans if they exist\nINSTALLPLAN_LIST=$(oc\
+                    \ get installplans -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true\
+                    \ | awk '{print $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
+                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
+                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
+                    \ {} oc delete installplan -n \"$NAMESPACE\" {}\nelse\n  echo\
+                    \ \"No InstallPlans found for operator $OPERATOR in namespace\
+                    \ $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh subscription\
+                    \ if it exists\nif oc get subscription -n \"$NAMESPACE\" \"$OPERATOR\"\
+                    \ -o json > \"$SUB_JSON_PATH\" 2>/dev/null; then\n  echo \"Subscription\
+                    \ found for operator $OPERATOR in namespace $NAMESPACE. Backing\
+                    \ it up to $SUB_JSON_PATH...\"\n  jq 'del(.status) | del(.metadata.creationTimestamp)\
+                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
+                    \ | del(.metadata.uid)' \"$SUB_JSON_PATH\" > \"${SUB_JSON_PATH}.tmp\"\
+                    \ && mv \"${SUB_JSON_PATH}.tmp\" \"$SUB_JSON_PATH\"\n  echo \"\
+                    Deleting subscription for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  oc delete subscriptions -n \"$NAMESPACE\" \"$OPERATOR\" ||\
+                    \ echo \"Failed to delete subscription for operator $OPERATOR.\"\
+                    \n  echo \"Re-creating subscription for operator $OPERATOR in\
+                    \ namespace $NAMESPACE...\"\n  oc create -f \"$SUB_JSON_PATH\"\
+                    \nelse\n  echo \"No subscription found for operator $OPERATOR\
+                    \ in namespace $NAMESPACE. Skipping re-creation.\"\nfi\n\noc -n\
+                    \ \"$NAMESPACE\" delete cronjob sre-operator-reinstall || true\n\
+                    oc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role ||\
+                    \ true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

This cronjob currently exits early because it can't find a csv, we need it to go through with the olm dance regardless of what resources exist and what resources don't exist. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
