### PR TITLE
Fix olm dance cronjob to use FQDN for objects to delete

### DIFF
--- a/deploy/osd-26960/01-cronjob.yaml
+++ b/deploy/osd-26960/01-cronjob.yaml
@@ -35,36 +35,36 @@ spec:
                   # The OLM dance
 
                   # Delete CSVs if they exist
-                  CSV_LIST=$(oc get csv -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
+                  CSV_LIST=$(oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
                   if [[ -n "$CSV_LIST" ]]; then
                     echo "Deleting CSVs for operator $OPERATOR in namespace $NAMESPACE..."
-                    echo "$CSV_LIST" | xargs -r -I {} oc delete csv -n "$NAMESPACE" {}
+                    echo "$CSV_LIST" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com -n "$NAMESPACE" {}
                   else
                     echo "No CSVs found for operator $OPERATOR in namespace $NAMESPACE."
                   fi
 
                   # Delete InstallPlans if they exist
-                  INSTALLPLAN_LIST=$(oc get installplans -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
+                  INSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
                   if [[ -n "$INSTALLPLAN_LIST" ]]; then
                     echo "Deleting InstallPlans for operator $OPERATOR in namespace $NAMESPACE..."
-                    echo "$INSTALLPLAN_LIST" | xargs -r -I {} oc delete installplan -n "$NAMESPACE" {}
+                    echo "$INSTALLPLAN_LIST" | xargs -r -I {} oc delete installplans.operators.coreos.com -n "$NAMESPACE" {}
                   else
                     echo "No InstallPlans found for operator $OPERATOR in namespace $NAMESPACE."
                   fi
 
                   # Delete and re-create fresh subscription if it exists
-                  if oc get subscription -n "$NAMESPACE" "$OPERATOR" -o json > "$SUB_JSON_PATH" 2>/dev/null; then
+                  if oc get subscriptions.operators.coreos.com -n "$NAMESPACE" "$OPERATOR" -o json > "$SUB_JSON_PATH" 2>/dev/null; then
                     echo "Subscription found for operator $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH..."
                     jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' "$SUB_JSON_PATH" > "${SUB_JSON_PATH}.tmp" && mv "${SUB_JSON_PATH}.tmp" "$SUB_JSON_PATH"
                     echo "Deleting subscription for operator $OPERATOR in namespace $NAMESPACE..."
-                    oc delete subscriptions -n "$NAMESPACE" "$OPERATOR" || echo "Failed to delete subscription for operator $OPERATOR."
+                    oc delete subscriptions.operators.coreos.com -n "$NAMESPACE" "$OPERATOR" || echo "Failed to delete subscription for operator $OPERATOR."
                     echo "Re-creating subscription for operator $OPERATOR in namespace $NAMESPACE..."
                     oc create -f "$SUB_JSON_PATH"
                   else
                     echo "No subscription found for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation."
                   fi
 
-                  oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
-                  oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
-                  oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+                  oc -n "$NAMESPACE" delete cronjob.batch sre-operator-reinstall || true
+                  oc -n "$NAMESPACE" delete roles.authorization.openshift.io sre-operator-reinstall-role || true
+                  oc -n "$NAMESPACE" delete rolebindings.authorization.openshift.io sre-operator-reinstall-rb || true
                   oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27245,37 +27245,38 @@ objects:
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
                     OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
                     \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
-                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get csv -n \"$NAMESPACE\"\
-                    \ | grep \"$OPERATOR\" || true | awk '{print $1}')\nif [[ -n \"\
-                    $CSV_LIST\" ]]; then\n  echo \"Deleting CSVs for operator $OPERATOR\
-                    \ in namespace $NAMESPACE...\"\n  echo \"$CSV_LIST\" | xargs -r\
-                    \ -I {} oc delete csv -n \"$NAMESPACE\" {}\nelse\n  echo \"No\
-                    \ CSVs found for operator $OPERATOR in namespace $NAMESPACE.\"\
-                    \nfi\n\n# Delete InstallPlans if they exist\nINSTALLPLAN_LIST=$(oc\
-                    \ get installplans -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true\
-                    \ | awk '{print $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
-                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
-                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
-                    \ {} oc delete installplan -n \"$NAMESPACE\" {}\nelse\n  echo\
-                    \ \"No InstallPlans found for operator $OPERATOR in namespace\
-                    \ $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh subscription\
-                    \ if it exists\nif oc get subscription -n \"$NAMESPACE\" \"$OPERATOR\"\
-                    \ -o json > \"$SUB_JSON_PATH\" 2>/dev/null; then\n  echo \"Subscription\
-                    \ found for operator $OPERATOR in namespace $NAMESPACE. Backing\
-                    \ it up to $SUB_JSON_PATH...\"\n  jq 'del(.status) | del(.metadata.creationTimestamp)\
-                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
-                    \ | del(.metadata.uid)' \"$SUB_JSON_PATH\" > \"${SUB_JSON_PATH}.tmp\"\
-                    \ && mv \"${SUB_JSON_PATH}.tmp\" \"$SUB_JSON_PATH\"\n  echo \"\
-                    Deleting subscription for operator $OPERATOR in namespace $NAMESPACE...\"\
-                    \n  oc delete subscriptions -n \"$NAMESPACE\" \"$OPERATOR\" ||\
-                    \ echo \"Failed to delete subscription for operator $OPERATOR.\"\
-                    \n  echo \"Re-creating subscription for operator $OPERATOR in\
-                    \ namespace $NAMESPACE...\"\n  oc create -f \"$SUB_JSON_PATH\"\
-                    \nelse\n  echo \"No subscription found for operator $OPERATOR\
-                    \ in namespace $NAMESPACE. Skipping re-creation.\"\nfi\n\noc -n\
-                    \ \"$NAMESPACE\" delete cronjob sre-operator-reinstall || true\n\
-                    oc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role ||\
-                    \ true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
+                    \ $1}')\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo \"Deleting CSVs\
+                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  echo\
+                    \ \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No CSVs found for operator\
+                    \ $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete InstallPlans\
+                    \ if they exist\nINSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
+                    \ $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n  echo \"Deleting\
+                    \ InstallPlans for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I {} oc delete installplans.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No InstallPlans found for\
+                    \ operator $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete\
+                    \ and re-create fresh subscription if it exists\nif oc get subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" \"$OPERATOR\" -o json > \"$SUB_JSON_PATH\"\
+                    \ 2>/dev/null; then\n  echo \"Subscription found for operator\
+                    \ $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH...\"\
+                    \n  jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation)\
+                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' \"$SUB_JSON_PATH\"\
+                    \ > \"${SUB_JSON_PATH}.tmp\" && mv \"${SUB_JSON_PATH}.tmp\" \"\
+                    $SUB_JSON_PATH\"\n  echo \"Deleting subscription for operator\
+                    \ $OPERATOR in namespace $NAMESPACE...\"\n  oc delete subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" \"$OPERATOR\" || echo \"Failed to delete subscription\
+                    \ for operator $OPERATOR.\"\n  echo \"Re-creating subscription\
+                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  oc create\
+                    \ -f \"$SUB_JSON_PATH\"\nelse\n  echo \"No subscription found\
+                    \ for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation.\"\
+                    \nfi\n\noc -n \"$NAMESPACE\" delete cronjob.batch sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete roles.authorization.openshift.io\
+                    \ sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\" delete\
+                    \ rolebindings.authorization.openshift.io sre-operator-reinstall-rb\
                     \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
                     \ || true\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27245,37 +27245,38 @@ objects:
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
                     OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
                     \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
-                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get csv -n \"$NAMESPACE\"\
-                    \ | grep \"$OPERATOR\" || true | awk '{print $1}')\nif [[ -n \"\
-                    $CSV_LIST\" ]]; then\n  echo \"Deleting CSVs for operator $OPERATOR\
-                    \ in namespace $NAMESPACE...\"\n  echo \"$CSV_LIST\" | xargs -r\
-                    \ -I {} oc delete csv -n \"$NAMESPACE\" {}\nelse\n  echo \"No\
-                    \ CSVs found for operator $OPERATOR in namespace $NAMESPACE.\"\
-                    \nfi\n\n# Delete InstallPlans if they exist\nINSTALLPLAN_LIST=$(oc\
-                    \ get installplans -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true\
-                    \ | awk '{print $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
-                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
-                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
-                    \ {} oc delete installplan -n \"$NAMESPACE\" {}\nelse\n  echo\
-                    \ \"No InstallPlans found for operator $OPERATOR in namespace\
-                    \ $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh subscription\
-                    \ if it exists\nif oc get subscription -n \"$NAMESPACE\" \"$OPERATOR\"\
-                    \ -o json > \"$SUB_JSON_PATH\" 2>/dev/null; then\n  echo \"Subscription\
-                    \ found for operator $OPERATOR in namespace $NAMESPACE. Backing\
-                    \ it up to $SUB_JSON_PATH...\"\n  jq 'del(.status) | del(.metadata.creationTimestamp)\
-                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
-                    \ | del(.metadata.uid)' \"$SUB_JSON_PATH\" > \"${SUB_JSON_PATH}.tmp\"\
-                    \ && mv \"${SUB_JSON_PATH}.tmp\" \"$SUB_JSON_PATH\"\n  echo \"\
-                    Deleting subscription for operator $OPERATOR in namespace $NAMESPACE...\"\
-                    \n  oc delete subscriptions -n \"$NAMESPACE\" \"$OPERATOR\" ||\
-                    \ echo \"Failed to delete subscription for operator $OPERATOR.\"\
-                    \n  echo \"Re-creating subscription for operator $OPERATOR in\
-                    \ namespace $NAMESPACE...\"\n  oc create -f \"$SUB_JSON_PATH\"\
-                    \nelse\n  echo \"No subscription found for operator $OPERATOR\
-                    \ in namespace $NAMESPACE. Skipping re-creation.\"\nfi\n\noc -n\
-                    \ \"$NAMESPACE\" delete cronjob sre-operator-reinstall || true\n\
-                    oc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role ||\
-                    \ true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
+                    \ $1}')\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo \"Deleting CSVs\
+                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  echo\
+                    \ \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No CSVs found for operator\
+                    \ $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete InstallPlans\
+                    \ if they exist\nINSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
+                    \ $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n  echo \"Deleting\
+                    \ InstallPlans for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I {} oc delete installplans.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No InstallPlans found for\
+                    \ operator $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete\
+                    \ and re-create fresh subscription if it exists\nif oc get subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" \"$OPERATOR\" -o json > \"$SUB_JSON_PATH\"\
+                    \ 2>/dev/null; then\n  echo \"Subscription found for operator\
+                    \ $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH...\"\
+                    \n  jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation)\
+                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' \"$SUB_JSON_PATH\"\
+                    \ > \"${SUB_JSON_PATH}.tmp\" && mv \"${SUB_JSON_PATH}.tmp\" \"\
+                    $SUB_JSON_PATH\"\n  echo \"Deleting subscription for operator\
+                    \ $OPERATOR in namespace $NAMESPACE...\"\n  oc delete subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" \"$OPERATOR\" || echo \"Failed to delete subscription\
+                    \ for operator $OPERATOR.\"\n  echo \"Re-creating subscription\
+                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  oc create\
+                    \ -f \"$SUB_JSON_PATH\"\nelse\n  echo \"No subscription found\
+                    \ for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation.\"\
+                    \nfi\n\noc -n \"$NAMESPACE\" delete cronjob.batch sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete roles.authorization.openshift.io\
+                    \ sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\" delete\
+                    \ rolebindings.authorization.openshift.io sre-operator-reinstall-rb\
                     \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
                     \ || true\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27245,37 +27245,38 @@ objects:
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
                     OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
                     \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
-                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get csv -n \"$NAMESPACE\"\
-                    \ | grep \"$OPERATOR\" || true | awk '{print $1}')\nif [[ -n \"\
-                    $CSV_LIST\" ]]; then\n  echo \"Deleting CSVs for operator $OPERATOR\
-                    \ in namespace $NAMESPACE...\"\n  echo \"$CSV_LIST\" | xargs -r\
-                    \ -I {} oc delete csv -n \"$NAMESPACE\" {}\nelse\n  echo \"No\
-                    \ CSVs found for operator $OPERATOR in namespace $NAMESPACE.\"\
-                    \nfi\n\n# Delete InstallPlans if they exist\nINSTALLPLAN_LIST=$(oc\
-                    \ get installplans -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true\
-                    \ | awk '{print $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
-                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
-                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
-                    \ {} oc delete installplan -n \"$NAMESPACE\" {}\nelse\n  echo\
-                    \ \"No InstallPlans found for operator $OPERATOR in namespace\
-                    \ $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh subscription\
-                    \ if it exists\nif oc get subscription -n \"$NAMESPACE\" \"$OPERATOR\"\
-                    \ -o json > \"$SUB_JSON_PATH\" 2>/dev/null; then\n  echo \"Subscription\
-                    \ found for operator $OPERATOR in namespace $NAMESPACE. Backing\
-                    \ it up to $SUB_JSON_PATH...\"\n  jq 'del(.status) | del(.metadata.creationTimestamp)\
-                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
-                    \ | del(.metadata.uid)' \"$SUB_JSON_PATH\" > \"${SUB_JSON_PATH}.tmp\"\
-                    \ && mv \"${SUB_JSON_PATH}.tmp\" \"$SUB_JSON_PATH\"\n  echo \"\
-                    Deleting subscription for operator $OPERATOR in namespace $NAMESPACE...\"\
-                    \n  oc delete subscriptions -n \"$NAMESPACE\" \"$OPERATOR\" ||\
-                    \ echo \"Failed to delete subscription for operator $OPERATOR.\"\
-                    \n  echo \"Re-creating subscription for operator $OPERATOR in\
-                    \ namespace $NAMESPACE...\"\n  oc create -f \"$SUB_JSON_PATH\"\
-                    \nelse\n  echo \"No subscription found for operator $OPERATOR\
-                    \ in namespace $NAMESPACE. Skipping re-creation.\"\nfi\n\noc -n\
-                    \ \"$NAMESPACE\" delete cronjob sre-operator-reinstall || true\n\
-                    oc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role ||\
-                    \ true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
+                    \ $1}')\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo \"Deleting CSVs\
+                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  echo\
+                    \ \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No CSVs found for operator\
+                    \ $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete InstallPlans\
+                    \ if they exist\nINSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
+                    \ $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n  echo \"Deleting\
+                    \ InstallPlans for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I {} oc delete installplans.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No InstallPlans found for\
+                    \ operator $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete\
+                    \ and re-create fresh subscription if it exists\nif oc get subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" \"$OPERATOR\" -o json > \"$SUB_JSON_PATH\"\
+                    \ 2>/dev/null; then\n  echo \"Subscription found for operator\
+                    \ $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH...\"\
+                    \n  jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation)\
+                    \ | del(.metadata.resourceVersion) | del(.metadata.uid)' \"$SUB_JSON_PATH\"\
+                    \ > \"${SUB_JSON_PATH}.tmp\" && mv \"${SUB_JSON_PATH}.tmp\" \"\
+                    $SUB_JSON_PATH\"\n  echo \"Deleting subscription for operator\
+                    \ $OPERATOR in namespace $NAMESPACE...\"\n  oc delete subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" \"$OPERATOR\" || echo \"Failed to delete subscription\
+                    \ for operator $OPERATOR.\"\n  echo \"Re-creating subscription\
+                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  oc create\
+                    \ -f \"$SUB_JSON_PATH\"\nelse\n  echo \"No subscription found\
+                    \ for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation.\"\
+                    \nfi\n\noc -n \"$NAMESPACE\" delete cronjob.batch sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete roles.authorization.openshift.io\
+                    \ sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\" delete\
+                    \ rolebindings.authorization.openshift.io sre-operator-reinstall-rb\
                     \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
                     \ || true\n"
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

Previous cronjob missed a part of the fleet that had an other operator installed which results in `subscription` not defaulting to our api type. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
