### PR TITLE
Fix oao olm dance csv/installplan listing

### DIFF
--- a/deploy/osd-26960/01-cronjob.yaml
+++ b/deploy/osd-26960/01-cronjob.yaml
@@ -31,11 +31,10 @@ spec:
 
                   # Path for temporary subscription JSON backup
                   SUB_JSON_PATH="/tmp/sub.json"
-    
-                  # The OLM dance
 
+                  # The OLM dance
                   # Delete CSVs if they exist
-                  CSV_LIST=$(oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
+                  CSV_LIST=$(oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE" --no-headers | grep "$OPERATOR" | awk '{print $1}' || echo "")
                   if [[ -n "$CSV_LIST" ]]; then
                     echo "Deleting CSVs for operator $OPERATOR in namespace $NAMESPACE..."
                     echo "$CSV_LIST" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com -n "$NAMESPACE" {}
@@ -44,7 +43,7 @@ spec:
                   fi
 
                   # Delete InstallPlans if they exist
-                  INSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
+                  INSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com -n "$NAMESPACE" --no-headers | grep "$OPERATOR" | awk '{print $1}' || echo "")
                   if [[ -n "$INSTALLPLAN_LIST" ]]; then
                     echo "Deleting InstallPlans for operator $OPERATOR in namespace $NAMESPACE..."
                     echo "$INSTALLPLAN_LIST" | xargs -r -I {} oc delete installplans.operators.coreos.com -n "$NAMESPACE" {}
@@ -64,6 +63,7 @@ spec:
                     echo "No subscription found for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation."
                   fi
 
+                  # Clean up associated resources
                   oc -n "$NAMESPACE" delete cronjob.batch sre-operator-reinstall || true
                   oc -n "$NAMESPACE" delete roles.authorization.openshift.io sre-operator-reinstall-role || true
                   oc -n "$NAMESPACE" delete rolebindings.authorization.openshift.io sre-operator-reinstall-rb || true

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27245,21 +27245,22 @@ objects:
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
                     OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
                     \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
-                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
-                    \ $1}')\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo \"Deleting CSVs\
-                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  echo\
-                    \ \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
+                    # Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" --no-headers | grep \"$OPERATOR\" | awk '{print\
+                    \ $1}' || echo \"\")\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo\
+                    \ \"Deleting CSVs for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  echo \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
                     \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No CSVs found for operator\
                     \ $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete InstallPlans\
                     \ if they exist\nINSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
-                    \ $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n  echo \"Deleting\
-                    \ InstallPlans for operator $OPERATOR in namespace $NAMESPACE...\"\
-                    \n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I {} oc delete installplans.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No InstallPlans found for\
-                    \ operator $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete\
-                    \ and re-create fresh subscription if it exists\nif oc get subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" --no-headers | grep \"$OPERATOR\" | awk '{print\
+                    \ $1}' || echo \"\")\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
+                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
+                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
+                    \ {} oc delete installplans.operators.coreos.com -n \"$NAMESPACE\"\
+                    \ {}\nelse\n  echo \"No InstallPlans found for operator $OPERATOR\
+                    \ in namespace $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh\
+                    \ subscription if it exists\nif oc get subscriptions.operators.coreos.com\
                     \ -n \"$NAMESPACE\" \"$OPERATOR\" -o json > \"$SUB_JSON_PATH\"\
                     \ 2>/dev/null; then\n  echo \"Subscription found for operator\
                     \ $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH...\"\
@@ -27273,12 +27274,12 @@ objects:
                     \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  oc create\
                     \ -f \"$SUB_JSON_PATH\"\nelse\n  echo \"No subscription found\
                     \ for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation.\"\
-                    \nfi\n\noc -n \"$NAMESPACE\" delete cronjob.batch sre-operator-reinstall\
-                    \ || true\noc -n \"$NAMESPACE\" delete roles.authorization.openshift.io\
-                    \ sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\" delete\
-                    \ rolebindings.authorization.openshift.io sre-operator-reinstall-rb\
-                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\n"
+                    \nfi\n\n# Clean up associated resources\noc -n \"$NAMESPACE\"\
+                    \ delete cronjob.batch sre-operator-reinstall || true\noc -n \"\
+                    $NAMESPACE\" delete roles.authorization.openshift.io sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebindings.authorization.openshift.io\
+                    \ sre-operator-reinstall-rb || true\noc -n \"$NAMESPACE\" delete\
+                    \ serviceaccount sre-operator-reinstall-sa || true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27245,21 +27245,22 @@ objects:
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
                     OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
                     \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
-                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
-                    \ $1}')\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo \"Deleting CSVs\
-                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  echo\
-                    \ \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
+                    # Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" --no-headers | grep \"$OPERATOR\" | awk '{print\
+                    \ $1}' || echo \"\")\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo\
+                    \ \"Deleting CSVs for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  echo \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
                     \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No CSVs found for operator\
                     \ $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete InstallPlans\
                     \ if they exist\nINSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
-                    \ $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n  echo \"Deleting\
-                    \ InstallPlans for operator $OPERATOR in namespace $NAMESPACE...\"\
-                    \n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I {} oc delete installplans.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No InstallPlans found for\
-                    \ operator $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete\
-                    \ and re-create fresh subscription if it exists\nif oc get subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" --no-headers | grep \"$OPERATOR\" | awk '{print\
+                    \ $1}' || echo \"\")\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
+                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
+                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
+                    \ {} oc delete installplans.operators.coreos.com -n \"$NAMESPACE\"\
+                    \ {}\nelse\n  echo \"No InstallPlans found for operator $OPERATOR\
+                    \ in namespace $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh\
+                    \ subscription if it exists\nif oc get subscriptions.operators.coreos.com\
                     \ -n \"$NAMESPACE\" \"$OPERATOR\" -o json > \"$SUB_JSON_PATH\"\
                     \ 2>/dev/null; then\n  echo \"Subscription found for operator\
                     \ $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH...\"\
@@ -27273,12 +27274,12 @@ objects:
                     \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  oc create\
                     \ -f \"$SUB_JSON_PATH\"\nelse\n  echo \"No subscription found\
                     \ for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation.\"\
-                    \nfi\n\noc -n \"$NAMESPACE\" delete cronjob.batch sre-operator-reinstall\
-                    \ || true\noc -n \"$NAMESPACE\" delete roles.authorization.openshift.io\
-                    \ sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\" delete\
-                    \ rolebindings.authorization.openshift.io sre-operator-reinstall-rb\
-                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\n"
+                    \nfi\n\n# Clean up associated resources\noc -n \"$NAMESPACE\"\
+                    \ delete cronjob.batch sre-operator-reinstall || true\noc -n \"\
+                    $NAMESPACE\" delete roles.authorization.openshift.io sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebindings.authorization.openshift.io\
+                    \ sre-operator-reinstall-rb || true\noc -n \"$NAMESPACE\" delete\
+                    \ serviceaccount sre-operator-reinstall-sa || true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27245,21 +27245,22 @@ objects:
                   - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-ocm-agent-operator\n\
                     OPERATOR=ocm-agent-operator\n\n# Path for temporary subscription\
                     \ JSON backup\nSUB_JSON_PATH=\"/tmp/sub.json\"\n\n# The OLM dance\n\
-                    \n# Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
-                    \ $1}')\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo \"Deleting CSVs\
-                    \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  echo\
-                    \ \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
+                    # Delete CSVs if they exist\nCSV_LIST=$(oc get clusterserviceversions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" --no-headers | grep \"$OPERATOR\" | awk '{print\
+                    \ $1}' || echo \"\")\nif [[ -n \"$CSV_LIST\" ]]; then\n  echo\
+                    \ \"Deleting CSVs for operator $OPERATOR in namespace $NAMESPACE...\"\
+                    \n  echo \"$CSV_LIST\" | xargs -r -I {} oc delete clusterserviceversions.operators.coreos.com\
                     \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No CSVs found for operator\
                     \ $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete InstallPlans\
                     \ if they exist\nINSTALLPLAN_LIST=$(oc get installplans.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" | grep \"$OPERATOR\" || true | awk '{print\
-                    \ $1}')\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n  echo \"Deleting\
-                    \ InstallPlans for operator $OPERATOR in namespace $NAMESPACE...\"\
-                    \n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I {} oc delete installplans.operators.coreos.com\
-                    \ -n \"$NAMESPACE\" {}\nelse\n  echo \"No InstallPlans found for\
-                    \ operator $OPERATOR in namespace $NAMESPACE.\"\nfi\n\n# Delete\
-                    \ and re-create fresh subscription if it exists\nif oc get subscriptions.operators.coreos.com\
+                    \ -n \"$NAMESPACE\" --no-headers | grep \"$OPERATOR\" | awk '{print\
+                    \ $1}' || echo \"\")\nif [[ -n \"$INSTALLPLAN_LIST\" ]]; then\n\
+                    \  echo \"Deleting InstallPlans for operator $OPERATOR in namespace\
+                    \ $NAMESPACE...\"\n  echo \"$INSTALLPLAN_LIST\" | xargs -r -I\
+                    \ {} oc delete installplans.operators.coreos.com -n \"$NAMESPACE\"\
+                    \ {}\nelse\n  echo \"No InstallPlans found for operator $OPERATOR\
+                    \ in namespace $NAMESPACE.\"\nfi\n\n# Delete and re-create fresh\
+                    \ subscription if it exists\nif oc get subscriptions.operators.coreos.com\
                     \ -n \"$NAMESPACE\" \"$OPERATOR\" -o json > \"$SUB_JSON_PATH\"\
                     \ 2>/dev/null; then\n  echo \"Subscription found for operator\
                     \ $OPERATOR in namespace $NAMESPACE. Backing it up to $SUB_JSON_PATH...\"\
@@ -27273,12 +27274,12 @@ objects:
                     \ for operator $OPERATOR in namespace $NAMESPACE...\"\n  oc create\
                     \ -f \"$SUB_JSON_PATH\"\nelse\n  echo \"No subscription found\
                     \ for operator $OPERATOR in namespace $NAMESPACE. Skipping re-creation.\"\
-                    \nfi\n\noc -n \"$NAMESPACE\" delete cronjob.batch sre-operator-reinstall\
-                    \ || true\noc -n \"$NAMESPACE\" delete roles.authorization.openshift.io\
-                    \ sre-operator-reinstall-role || true\noc -n \"$NAMESPACE\" delete\
-                    \ rolebindings.authorization.openshift.io sre-operator-reinstall-rb\
-                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\n"
+                    \nfi\n\n# Clean up associated resources\noc -n \"$NAMESPACE\"\
+                    \ delete cronjob.batch sre-operator-reinstall || true\noc -n \"\
+                    $NAMESPACE\" delete roles.authorization.openshift.io sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebindings.authorization.openshift.io\
+                    \ sre-operator-reinstall-rb || true\noc -n \"$NAMESPACE\" delete\
+                    \ serviceaccount sre-operator-reinstall-sa || true\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

One last awkward PR to fix the install plan listing. Had tested on the situation we mostly have on production where the csv & IP don't exist, but found that this doesn't work when there is a csv and IP. We'd still want to olm dance in that case. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
