### PR TITLE
Add notice about CAD's backplane requirement

### DIFF
--- a/deploy/backplane/configuration-anomaly-detection/README.md
+++ b/deploy/backplane/configuration-anomaly-detection/README.md
@@ -1,0 +1,12 @@
+# DO NOT EDIT
+
+> This directory must not have any RBAC definitions.
+
+Configuration-Anomaly-Detection uses backplane with dynamically created RBAC to do automated remediations against clusters.
+This directory is to be kept empty, so that CAD does not get any default permissions.
+
+For more information, see:
+
+- https://gitlab.cee.redhat.com/service/backplane-api#remediations
+- https://github.com/openshift/ops-sop/blob/master/v4/troubleshoot/configuration-anomaly-detection.md
+- https://issues.redhat.com/browse/OSD-26478


### PR DESCRIPTION
We have to make sure cad gets no default RBAC from backplane, so that it only has the per remediation scoped down RBAC created by backplane on the fly.

### What type of PR is this?
feature/documentation

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/OSD-26478

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
