### PR TITLE
OSD-27279: Ensure ClusterMonitoringErrorBudgetBurnSRE alert excludes user-workload-monitoring failure reasons

### DIFF
--- a/deploy/sre-prometheus/monitoring/100-cluster-monitoring-error-budget-burn.yaml
+++ b/deploy/sre-prometheus/monitoring/100-cluster-monitoring-error-budget-burn.yaml
@@ -10,13 +10,13 @@ spec:
   groups:
   - name: sre-cluster-monitoring-error-budget-burn
     rules:
-    # Substitues ClusterOperatorDown{name="monitoring"} as part of https://issues.redhat.com/browse/OSD-19769
+    # Substitutes ClusterOperatorDown{name="monitoring"} as part of https://issues.redhat.com/browse/OSD-19769
     # Specifically ignore UserWorkload as part of this alert, we will look at that in another error
     - alert: ClusterMonitoringErrorBudgetBurnSRE
       expr: |
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m])) ) > (14.4 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m])) ) > (14.4 * (1 - 0.983))
           and
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h])) ) > (14.4 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h])) ) > (14.4 * (1 - 0.983))
       for: 2m
       labels:
         long_window: 1h
@@ -29,9 +29,9 @@ spec:
         message: "High error budget burn for the monitoring cluster operator (current value: {{ $value }})"
     - alert: ClusterMonitoringErrorBudgetBurnSRE
       expr: |
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m])) ) > (6 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m])) ) > (6 * (1 - 0.983))
           and
-          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h])) ) > (6 * (1 - 0.983))
+          1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h])) / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h])) ) > (6 * (1 - 0.983))
       for: 15m
       labels:
         long_window: 6h

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39713,14 +39713,14 @@ objects:
         - name: sre-cluster-monitoring-error-budget-burn
           rules:
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m]))
               ) > (14.4 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h]))
               ) > (14.4 * (1 - 0.983))
 
               '
@@ -39736,14 +39736,14 @@ objects:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m]))
               ) > (6 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h]))
               ) > (6 * (1 - 0.983))
 
               '

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39713,14 +39713,14 @@ objects:
         - name: sre-cluster-monitoring-error-budget-burn
           rules:
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m]))
               ) > (14.4 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h]))
               ) > (14.4 * (1 - 0.983))
 
               '
@@ -39736,14 +39736,14 @@ objects:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m]))
               ) > (6 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h]))
               ) > (6 * (1 - 0.983))
 
               '

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39713,14 +39713,14 @@ objects:
         - name: sre-cluster-monitoring-error-budget-burn
           rules:
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[5m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[5m]))
               ) > (14.4 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[1h]))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[1h]))
               ) > (14.4 * (1 - 0.983))
 
               '
@@ -39736,14 +39736,14 @@ objects:
               message: 'High error budget burn for the monitoring cluster operator
                 (current value: {{ $value }})'
           - alert: ClusterMonitoringErrorBudgetBurnSRE
-            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[30m]))
+            expr: '1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[30m]))
               ) > (6 * (1 - 0.983))
 
               and
 
-              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
-              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~"UserWorkload.*"}[6h]))
+              1 - ( sum(sum_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h]))
+              / sum(count_over_time(cluster_operator_up{name="monitoring",reason!~".*UserWorkload.*"}[6h]))
               ) > (6 * (1 - 0.983))
 
               '


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

We are currently being paged for `ClusterMonitoringErrorBudgetBurnSRE` even when the reason is an issue with the customer's UWM stack. Based on this [commit](https://github.com/openshift/managed-cluster-config/commit/6e8aae3b4711f13276adc8e4b642d712d13c879b#diff-51cf7e84af79c0ddc6db3ca4171c8b06df42b8a76e6f879b6d137c46181d2fb5R15), it would seem we meant to _exclude_ reasons that are like `reason!~".*UserWorkload.*"` for SRE alerts, and _include_ those only for the customer specific ones.

This PR updates our rules to take that into account and should prevent SRE from being paged.

Sample [alert](https://redhat.pagerduty.com/incidents/Q2LZFIGV1KZVZ2).

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-27279

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
