### PR TITLE
Disable PDB alerts from openshift-mtv namespace

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -22,7 +22,7 @@ spec:
       expr: |-
         max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~"openshift-.*"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~"openshift-.*"} )
         unless on(namespace)
-          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)"}
+          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)"}
       for: 15m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -38433,7 +38433,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -38433,7 +38433,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -38433,7 +38433,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)\"\
               }"
             for: 15m
             labels:


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
Disabling the PDB alerts from openshift-mtv namespace as per https://issues.redhat.com/browse/OSD-27571 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-27571](https://issues.redhat.com/browse/OSD-27571)