### PR TITLE
Add snapshot resource permissions to ec2 create vol

### DIFF
--- a/resources/sts/4.17/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/4.17/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -49,7 +49,8 @@
         "ec2:CreateVolume"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*"
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
       ],
       "Condition": {
         "StringEquals": {

--- a/resources/sts/4.17/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/4.17/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -49,14 +49,23 @@
         "ec2:CreateVolume"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:volume/*",
-        "arn:aws:ec2:*:*:snapshot/*"
+        "arn:aws:ec2:*:*:volume/*"
       ],
       "Condition": {
         "StringEquals": {
           "aws:RequestTag/red-hat-managed": "true"
         }
       }
+    },
+    {
+      "Sid": "CreateVolumeFromSnapshot",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:snapshot/*"
+      ]
     },
     {
       "Sid": "CreateSnapshotResourceTag",


### PR DESCRIPTION
AWS Implemented a change on 205-01-13 added an additional authorization on the source snapshots for the CreateVolume API. This means that any calls to the CreateVolume API that are resource scoped to "arn:aws:ec2:*:*:volume/*" will fail. We will need at allow ` "arn:*:ec2:*:*:snapshot/*"` resource for the `"ec2:CreateVolume"` calls
 

example

{
    "Effect": "Allow",
    "Action": "ec2:CreateVolume",
    "Resource": "arn:*:ec2:*:*:snapshot/*"
}

This example will grant the EBS CSI Driver access to restore all EBS snapshots in the AWS account (this is the existing behavior on the example policy).