### PR TITLE
Add Zero Egress managed policy updates

### DIFF
--- a/resources/sts/4.17/hypershift/sts_hcp_worker_instance_permission_policy.json
+++ b/resources/sts/4.17/hypershift/sts_hcp_worker_instance_permission_policy.json
@@ -2,12 +2,36 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "EC2DescribeInstancesRegions",
+            "Effect": "Allow",
+            "Action": ["ec2:DescribeInstances", "ec2:DescribeRegions"],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ECRGetAuthorizationToken",
+            "Effect": "Allow",
+            "Action": ["ecr:GetAuthorizationToken"],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ECRReadOnlyAccessRedHatManaged",
             "Effect": "Allow",
             "Action": [
-                "ec2:DescribeInstances",
-                "ec2:DescribeRegions"
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetRepositoryPolicy",
+                "ecr:DescribeRepositories",
+                "ecr:ListImages",
+                "ecr:DescribeImages",
+                "ecr:BatchGetImage",
+                "ecr:ListTagsForResource"
             ],
             "Resource": "*"
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
Adds ECR read only pull permissions to HCP worker node managed policies from 4.14 onwards. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-27622

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
