### PR TITLE
fix(OSD-27630): automated limited support should work from the moment a HCP is available

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
@@ -16,10 +16,10 @@ spec:
           annotations:
             description: "Customer cloud environment is unreachable from the management cluster due to invalid aws credentials"
             summary: "Cluster has invalid AWS credentials"
-          # Clusters tend to have their `hypershift_cluster_invalid_aws_creds` set to > 0 while the cluster didn't finish the installation, thus we check
-          # that the cluster is not rolling out in our expression (= hypershift_cluster_initial_rolling_out_duration_seconds does not exist)
-          # hypershift_cluster_initial_rolling_out_duration_seconds stops being emitted once the cluster is rolled out
-          expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace, source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m])) > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
+          # Clusters tend to have their `hypershift_cluster_invalid_aws_creds` set to > 0 while the HCP didn't finish the installation, thus we check
+          # that the HCP is not rolling out in our expression (= hypershift_cluster_waiting_initial_avaibility_duration_seconds does not exist)
+          # hypershift_cluster_waiting_initial_avaibility_duration_seconds stops being emitted once the HCP is rolled out
+          expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace, source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m])) > 0 unless on (exported_namespace) hypershift_cluster_waiting_initial_avaibility_duration_seconds unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
           for: 4m # api-ErrorBudgetBurn is our highest SLA and triggers after 5 minutes of CrashLooping kube-apiserver pods. KAS pods can CrashLoop due to missing OIDC/invalid AWS permissions. To reduce self-resolving alerts, we need the limited support to be in place before the alert triggers.
           labels:
             severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40959,7 +40959,7 @@ objects:
               summary: Cluster has invalid AWS credentials
             expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace,
               source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
-              > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
+              > 0 unless on (exported_namespace) hypershift_cluster_waiting_initial_avaibility_duration_seconds
               unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
             for: 4m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40959,7 +40959,7 @@ objects:
               summary: Cluster has invalid AWS credentials
             expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace,
               source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
-              > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
+              > 0 unless on (exported_namespace) hypershift_cluster_waiting_initial_avaibility_duration_seconds
               unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
             for: 4m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40959,7 +40959,7 @@ objects:
               summary: Cluster has invalid AWS credentials
             expr: sum by (mc_name, _mc_id, sector, region, env, namespace, exported_namespace,
               source, _id) (last_over_time(hypershift_cluster_invalid_aws_creds[10m]))
-              > 0 unless on (exported_namespace) hypershift_cluster_initial_rolling_out_duration_seconds
+              > 0 unless on (exported_namespace) hypershift_cluster_waiting_initial_avaibility_duration_seconds
               unless on (exported_namespace) last_over_time(hypershift_cluster_deleting_duration_seconds[10m])
             for: 4m
             labels:


### PR DESCRIPTION

### What type of PR is this?
bug

### What this PR does / why we need it?

We have found that in some cases, the alert doesn't trigger because `hypershift_cluster_initial_rolling_out_duration_seconds` is still progressing. This happens for clusters where customers break the access right after installing the cluster but before the dataplane spin-up can complete, as `hypershift_cluster_initial_rolling_out_duration_seconds`  relies on an initial `version` of the HostedCluster, which is only set the moment all cluster operators are available on that version. This results in SRE getting `api-ErrorBudgetBurn` alerts for clusters where the MC infrastructure can't access the customer's AWS account access.

Instead of using this metric, which represents the state of the inital version roll-out, we should use the availability of the hosted control plane: `hypershift_cluster_waiting_initial_avaibility_duration_seconds`. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_https://issues.redhat.com/browse/OSD-27630

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
