### PR TITLE
OSD-22577: Fixing sre-managed-notification-alerts-for-customer-webhooks rule to make sure it can be sync down from hive

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
@@ -20,15 +20,14 @@ spec:
             "type", "mutating", "type", "admit"),
           "webhook_name", "$0", "name", ".*")
         ) * on(webhook_name) group_left(service_namespace, service_name) (
-          kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace !~ "openshift-.*"} or
+          kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace !~ "openshift-.*"} or on(webhook_name)
           kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace !~ "openshift-.*"}
         ) > 1
       for: 15m
       labels:
         severity: warning
-        namespace: openshift-monitoring
         send_managed_notification: "true"
         managed_notification_template: "SlowCustomerWebhook"
         duration_threshold: "1 second"
       annotations:
-        message: "{{ labels.webhook_name }} webhook is slow on {{ labels.operation }} operations"
+        message: "{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation }} operations"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40549,17 +40549,16 @@ objects:
               \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
               , \"$0\", \"name\", \".*\")\n) * on(webhook_name) group_left(service_namespace,\
               \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"} or\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
+              \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"}\n) > 1"
             for: 15m
             labels:
               severity: warning
-              namespace: openshift-monitoring
               send_managed_notification: 'true'
               managed_notification_template: SlowCustomerWebhook
               duration_threshold: 1 second
             annotations:
-              message: '{{ labels.webhook_name }} webhook is slow on {{ labels.operation
+              message: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
                 }} operations'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40549,17 +40549,16 @@ objects:
               \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
               , \"$0\", \"name\", \".*\")\n) * on(webhook_name) group_left(service_namespace,\
               \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"} or\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
+              \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"}\n) > 1"
             for: 15m
             labels:
               severity: warning
-              namespace: openshift-monitoring
               send_managed_notification: 'true'
               managed_notification_template: SlowCustomerWebhook
               duration_threshold: 1 second
             annotations:
-              message: '{{ labels.webhook_name }} webhook is slow on {{ labels.operation
+              message: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
                 }} operations'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40549,17 +40549,16 @@ objects:
               \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
               , \"$0\", \"name\", \".*\")\n) * on(webhook_name) group_left(service_namespace,\
               \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"} or\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
+              \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"}\n) > 1"
             for: 15m
             labels:
               severity: warning
-              namespace: openshift-monitoring
               send_managed_notification: 'true'
               managed_notification_template: SlowCustomerWebhook
               duration_threshold: 1 second
             annotations:
-              message: '{{ labels.webhook_name }} webhook is slow on {{ labels.operation
+              message: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
                 }} operations'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
SelectorSyncSet named `sre-prometheus-ocm-agent` is broken because of this bug

### Which Jira/Github issue(s) this PR fixes?
Part of [OSD-22577](https://issues.redhat.com//browse/OSD-22577)

### Special notes for your reviewer:
Bug introduced by the following PR which focused on the Prometheus expression:
https://github.com/openshift/managed-cluster-config/pull/2322

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [X] Not a FedRAMP change