### PR TITLE
Reinstall RMO in - Revert "RMO OLM dance cron job removal"

### DIFF
--- a/deploy/rmo-olm-dance/00-roles.yaml
+++ b/deploy/rmo-olm-dance/00-roles.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-route-monitor-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-route-monitor-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  - catalogsources
+  - operatorgroups
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "ocmagent.managed.openshift.io"
+  resources:
+  - managednotifications
+  - managedfleetnotifications
+  verbs:
+  - list
+  - get
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-route-monitor-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-route-monitor-operator
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-route-monitor-operator

--- a/deploy/rmo-olm-dance/01-cronjob.yaml
+++ b/deploy/rmo-olm-dance/01-cronjob.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-route-monitor-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-route-monitor-operator
+              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -o name | grep route-monitor-operator) || true
+              if [[ ! -z "$CSV_FOUND" ]]; then
+                # Take backup of the files to be recreated
+                oc -n "$NAMESPACE" get subscriptions.operators.coreos.com route-monitor-operator -oyaml > /tmp/01-route-monitor-operator-subs.yaml
+                oc -n "$NAMESPACE" get catalogsources.operators.coreos.com route-monitor-operator-registry -oyaml > /tmp/02-route-monitor-operator-registry.yaml
+                oc -n "$NAMESPACE" get operatorgroups.operators.coreos.com route-monitor-operator -oyaml > /tmp/03-route-monitor-operator-og.yaml
+                oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com | grep route-monitor-operator | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+                oc -n "$NAMESPACE" delete installplan.operators.coreos.com -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=""
+                oc -n "$NAMESPACE" delete subscriptions.operators.coreos.com route-monitor-operator
+                oc -n "$NAMESPACE" delete catalogsources.operators.coreos.com route-monitor-operator-registry
+                oc -n "$NAMESPACE" delete operatorgroups.operators.coreos.com route-monitor-operator
+                # Recreate the resources to re-install the operator
+                oc -n "$NAMESPACE" create -f /tmp/01-route-monitor-operator-subs.yaml
+                oc -n "$NAMESPACE" create -f /tmp/02-route-monitor-operator-registry.yaml
+                oc -n "$NAMESPACE" create -f /tmp/03-route-monitor-operator-og.yaml
+              fi
+              # Prevent the job from -rerunning
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              oc -n "$NAMESPACE" delete rolebinding/sre-operator-reinstall-rb role/sre-operator-reinstall-role || true
+              exit 0

--- a/deploy/rmo-olm-dance/config.yaml
+++ b/deploy/rmo-olm-dance/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16", "4.17"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/rmo-olm-dance/readme.md
+++ b/deploy/rmo-olm-dance/readme.md
@@ -1,0 +1,3 @@
+# README
+
+This cronjob is a fix for promoting RMO to latest version

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -37501,6 +37501,159 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rmo-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-route-monitor-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - managednotifications
+        - managedfleetnotifications
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-route-monitor-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-route-monitor-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
+                    CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -o name | grep route-monitor-operator) || true\nif [[ ! -z \"\
+                    $CSV_FOUND\" ]]; then\n  # Take backup of the files to be recreated\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ route-monitor-operator -oyaml > /tmp/01-route-monitor-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get catalogsources.operators.coreos.com\
+                    \ route-monitor-operator-registry -oyaml > /tmp/02-route-monitor-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get operatorgroups.operators.coreos.com\
+                    \ route-monitor-operator -oyaml > /tmp/03-route-monitor-operator-og.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ | grep route-monitor-operator | awk '{print $1}' | xargs oc\
+                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    \  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                    \ route-monitor-operator\n  oc -n \"$NAMESPACE\" delete catalogsources.operators.coreos.com\
+                    \ route-monitor-operator-registry\n  oc -n \"$NAMESPACE\" delete\
+                    \ operatorgroups.operators.coreos.com route-monitor-operator\n\
+                    \  # Recreate the resources to re-install the operator\n  oc -n\
+                    \ \"$NAMESPACE\" create -f /tmp/01-route-monitor-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/02-route-monitor-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/03-route-monitor-operator-og.yaml\n\
+                    fi\n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete serviceaccount sre-operator-reinstall-sa || true\noc\
+                    \ -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosa-console-branding
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -37501,6 +37501,159 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rmo-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-route-monitor-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - managednotifications
+        - managedfleetnotifications
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-route-monitor-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-route-monitor-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
+                    CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -o name | grep route-monitor-operator) || true\nif [[ ! -z \"\
+                    $CSV_FOUND\" ]]; then\n  # Take backup of the files to be recreated\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ route-monitor-operator -oyaml > /tmp/01-route-monitor-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get catalogsources.operators.coreos.com\
+                    \ route-monitor-operator-registry -oyaml > /tmp/02-route-monitor-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get operatorgroups.operators.coreos.com\
+                    \ route-monitor-operator -oyaml > /tmp/03-route-monitor-operator-og.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ | grep route-monitor-operator | awk '{print $1}' | xargs oc\
+                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    \  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                    \ route-monitor-operator\n  oc -n \"$NAMESPACE\" delete catalogsources.operators.coreos.com\
+                    \ route-monitor-operator-registry\n  oc -n \"$NAMESPACE\" delete\
+                    \ operatorgroups.operators.coreos.com route-monitor-operator\n\
+                    \  # Recreate the resources to re-install the operator\n  oc -n\
+                    \ \"$NAMESPACE\" create -f /tmp/01-route-monitor-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/02-route-monitor-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/03-route-monitor-operator-og.yaml\n\
+                    fi\n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete serviceaccount sre-operator-reinstall-sa || true\noc\
+                    \ -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosa-console-branding
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -37501,6 +37501,159 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rmo-olm-dance
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-route-monitor-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        - catalogsources
+        - operatorgroups
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ocmagent.managed.openshift.io
+        resources:
+        - managednotifications
+        - managedfleetnotifications
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-route-monitor-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-route-monitor-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-route-monitor-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-route-monitor-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
+                    CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ -o name | grep route-monitor-operator) || true\nif [[ ! -z \"\
+                    $CSV_FOUND\" ]]; then\n  # Take backup of the files to be recreated\n\
+                    \  oc -n \"$NAMESPACE\" get subscriptions.operators.coreos.com\
+                    \ route-monitor-operator -oyaml > /tmp/01-route-monitor-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get catalogsources.operators.coreos.com\
+                    \ route-monitor-operator-registry -oyaml > /tmp/02-route-monitor-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get operatorgroups.operators.coreos.com\
+                    \ route-monitor-operator -oyaml > /tmp/03-route-monitor-operator-og.yaml\n\
+                    \  oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ | grep route-monitor-operator | awk '{print $1}' | xargs oc\
+                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    \  oc -n \"$NAMESPACE\" delete installplan.operators.coreos.com\
+                    \ -l operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator=\"\
+                    \"\n  oc -n \"$NAMESPACE\" delete subscriptions.operators.coreos.com\
+                    \ route-monitor-operator\n  oc -n \"$NAMESPACE\" delete catalogsources.operators.coreos.com\
+                    \ route-monitor-operator-registry\n  oc -n \"$NAMESPACE\" delete\
+                    \ operatorgroups.operators.coreos.com route-monitor-operator\n\
+                    \  # Recreate the resources to re-install the operator\n  oc -n\
+                    \ \"$NAMESPACE\" create -f /tmp/01-route-monitor-operator-subs.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/02-route-monitor-operator-registry.yaml\n\
+                    \  oc -n \"$NAMESPACE\" create -f /tmp/03-route-monitor-operator-og.yaml\n\
+                    fi\n# Prevent the job from -rerunning\noc -n \"$NAMESPACE\" delete\
+                    \ cronjob sre-operator-reinstall || true\noc -n \"$NAMESPACE\"\
+                    \ delete serviceaccount sre-operator-reinstall-sa || true\noc\
+                    \ -n \"$NAMESPACE\" delete rolebinding/sre-operator-reinstall-rb\
+                    \ role/sre-operator-reinstall-role || true\nexit 0"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: rosa-console-branding
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Reverts openshift/managed-cluster-config#2312

`openshift-route-monitor-operator` is broken in staging again, see context in https://redhat-internal.slack.com/archives/CFJD1NZFT/p1737474525671449

This reverts this last reinstall PR so we can reinstall it again on staging.