### PR TITLE
Added sts admin ack for 4.18

### DIFF
--- a/deploy/osd-cluster-acks/sts/4.18/config.yaml
+++ b/deploy/osd-cluster-acks/sts/4.18/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.17"]
+  - key: api.openshift.com/sts
+    operator: In
+    values: ["true"]

--- a/deploy/osd-cluster-acks/sts/4.18/osd-sts-ack_CloudCredential.yaml
+++ b/deploy/osd-cluster-acks/sts/4.18/osd-sts-ack_CloudCredential.yaml
@@ -1,0 +1,6 @@
+apiVersion: operator.openshift.io/v1
+kind: CloudCredential
+name: cluster
+applyMode: AlwaysApply
+patch: '{"metadata":{"annotations":{"cloudcredential.openshift.io/upgradeable-to":"v4.18"}}}'
+patchType: merge


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This fixes [OSD-27689](https://issues.redhat.com//browse/OSD-27689). The SOP also needs to be updated, as it reads now that an admin ack only needs to be created when there are permission differences between 4.17 and 4.18 (there weren't any).
https://github.com/openshift/ops-sop/blob/master/v4/howto/gap-analysis.md#identify-and-put-in-place-upgrade-gates-and-admin-acks

### Which Jira/Github issue(s) this PR fixes?

[OSD-27689](https://issues.redhat.com//browse/OSD-27689)

