### PR TITLE
OSD-22577: Fixing sre-managed-notification-alerts-for-customer-webhooks rule to avoid OCM agent to duplicate notifications

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
@@ -13,12 +13,14 @@ spec:
     - alert: SlowCustomerWebhookSRE
       expr: |-
         (
-          label_replace(
+          max by (webhook_name, operation, type) (
             label_replace(
-              increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) /
-                increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),
-            "type", "mutating", "type", "admit"),
-          "webhook_name", "$0", "name", ".*")
+              label_replace(
+                increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) /
+                  increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),
+              "type", "mutating", "type", "admit"),
+            "webhook_name", "$0", "name", ".*")
+          )
         ) * on(webhook_name) group_left(service_namespace, service_name) (
           kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace !~ "openshift-.*"} or on(webhook_name)
           kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace !~ "openshift-.*"}

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40544,10 +40544,11 @@ objects:
         - name: customer-webhooks
           rules:
           - alert: SlowCustomerWebhookSRE
-            expr: "(\n  label_replace(\n    label_replace(\n      increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
-              \ /\n        increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
-              \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
-              , \"$0\", \"name\", \".*\")\n) * on(webhook_name) group_left(service_namespace,\
+            expr: "(\n  max by (webhook_name, operation, type) (\n    label_replace(\n\
+              \      label_replace(\n        increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
+              \ /\n          increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
+              \      \"type\", \"mutating\", \"type\", \"admit\"),\n    \"webhook_name\"\
+              , \"$0\", \"name\", \".*\")\n  )\n) * on(webhook_name) group_left(service_namespace,\
               \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"}\n) > 1"

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40544,10 +40544,11 @@ objects:
         - name: customer-webhooks
           rules:
           - alert: SlowCustomerWebhookSRE
-            expr: "(\n  label_replace(\n    label_replace(\n      increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
-              \ /\n        increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
-              \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
-              , \"$0\", \"name\", \".*\")\n) * on(webhook_name) group_left(service_namespace,\
+            expr: "(\n  max by (webhook_name, operation, type) (\n    label_replace(\n\
+              \      label_replace(\n        increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
+              \ /\n          increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
+              \      \"type\", \"mutating\", \"type\", \"admit\"),\n    \"webhook_name\"\
+              , \"$0\", \"name\", \".*\")\n  )\n) * on(webhook_name) group_left(service_namespace,\
               \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"}\n) > 1"

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40544,10 +40544,11 @@ objects:
         - name: customer-webhooks
           rules:
           - alert: SlowCustomerWebhookSRE
-            expr: "(\n  label_replace(\n    label_replace(\n      increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
-              \ /\n        increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
-              \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
-              , \"$0\", \"name\", \".*\")\n) * on(webhook_name) group_left(service_namespace,\
+            expr: "(\n  max by (webhook_name, operation, type) (\n    label_replace(\n\
+              \      label_replace(\n        increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
+              \ /\n          increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
+              \      \"type\", \"mutating\", \"type\", \"admit\"),\n    \"webhook_name\"\
+              , \"$0\", \"name\", \".*\")\n  )\n) * on(webhook_name) group_left(service_namespace,\
               \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
               \ !~ \"openshift-.*\"}\n) > 1"


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
This PR avoid the OCM agent to send the notification twice to the customer

### Which Jira/Github issue(s) this PR fixes?

[OSD-22577](https://issues.redhat.com//browse/OSD-22577)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [X] not a FEDRAMP change
