### PR TITLE
feat(OSD-27684): Remove aggregation from backplane permission RBAC

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -24,24 +24,502 @@ spec:
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:
-                        aggregationRule:
-                            clusterRoleSelectors:
-                                - matchExpressions:
-                                    - key: rbac.authorization.k8s.io/aggregate-to-view
-                                      operator: In
-                                      values:
-                                        - "true"
-                                    - key: kubernetes.io/bootstrapping
-                                      operator: DoesNotExist
-                                - matchExpressions:
-                                    - key: managed.openshift.io/aggregate-to-dedicated-readers
-                                      operator: In
-                                      values:
-                                        - "true"
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: ClusterRole
                         metadata:
                             name: backplane-readers-cluster
+                        rules:
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - clusterserviceversions
+                                - catalogsources
+                                - installplans
+                                - subscriptions
+                                - operatorgroups
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - packages.operators.coreos.com
+                              resources:
+                                - packagemanifests
+                                - packagemanifests/icon
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - packages.operators.coreos.com
+                              resources:
+                                - packagemanifests
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - image.openshift.io
+                              resources:
+                                - imagestreamimages
+                                - imagestreammappings
+                                - imagestreams
+                                - imagestreamtags
+                                - imagetags
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - image.openshift.io
+                              resources:
+                                - imagestreams/layers
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - namespaces
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - ""
+                                - project.openshift.io
+                              resources:
+                                - projects
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - metrics.k8s.io
+                              resources:
+                                - pods
+                                - nodes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - snapshot.storage.k8s.io
+                              resources:
+                                - volumesnapshots
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - build.openshift.io
+                              resources:
+                                - buildconfigs
+                                - buildconfigs/webhooks
+                                - builds
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - build.openshift.io
+                              resources:
+                                - builds/log
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - build.openshift.io
+                              resources:
+                                - jenkins
+                              verbs:
+                                - view
+                            - apiGroups:
+                                - ""
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs
+                                - deploymentconfigs/scale
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - apps.openshift.io
+                              resources:
+                                - deploymentconfigs/log
+                                - deploymentconfigs/status
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - image.openshift.io
+                              resources:
+                                - imagestreams/status
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - quota.openshift.io
+                              resources:
+                                - appliedclusterresourcequotas
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - route.openshift.io
+                              resources:
+                                - routes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - route.openshift.io
+                              resources:
+                                - routes/status
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - template.openshift.io
+                              resources:
+                                - processedtemplates
+                                - templateconfigs
+                                - templateinstances
+                                - templates
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - build.openshift.io
+                              resources:
+                                - buildlogs
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - resourcequotausages
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - nodes
+                                - persistentvolumes
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - quota.openshift.io
+                              resources:
+                                - clusterresourcequotas
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - ""
+                                - authorization.openshift.io
+                              resources:
+                                - clusterpolicybindings
+                              verbs:
+                                - get
+                                - list
+                            - apiGroups:
+                                - metrics.k8s.io
+                              resources:
+                                - nodes
+                                - pods
+                              verbs:
+                                - list
+                            - apiGroups:
+                                - coordination.k8s.io
+                              resources:
+                                - leases
+                              verbs:
+                                - get
+                            - apiGroups:
+                                - admissionregistration.k8s.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apiextensions.k8s.io
+                              resources:
+                                - customresourcedefinitions
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - apiregistration.k8s.io
+                              resources:
+                                - apiservices
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - authentication.k8s.io
+                              resources:
+                                - tokenreviews
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - authorization.openshift.io
+                              resources:
+                                - clusterrolebindings
+                                - clusterroles
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - autoscaling.openshift.io
+                              resources:
+                                - clusterautoscalers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - config.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - console.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - flowcontrol.apiserver.k8s.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - image.openshift.io
+                              resources:
+                                - images
+                                - imagesignatures
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - imageregistry.operator.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - metal3.io
+                              resources:
+                                - provisionings
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - migration.k8s.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - network.openshift.io
+                              resources:
+                                - clusternetworks
+                                - hostsubnets
+                                - netnamespaces
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - networking.k8s.io
+                              resources:
+                                - ingressclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - node.k8s.io
+                              resources:
+                                - runtimeclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - operator.openshift.io
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - policy
+                              resources:
+                                - podsecuritypolicies
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - project.openshift.io
+                              resources:
+                                - projectrequests
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - rbac.authorization.k8s.io
+                              resources:
+                                - clusterroles
+                                - clusterrolebindings
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - samples.operator.openshift.io
+                              resources:
+                                - configs
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - scheduling.k8s.io
+                              resources:
+                                - priorityclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - security.openshift.io
+                              resources:
+                                - securitycontextconstraints
+                                - rangeallocations
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - snapshot.storage.k8s.io
+                              resources:
+                                - volumesnapshotcontents
+                                - volumesnapshotclasses
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - storage.k8s.io
+                              resources:
+                                - storageclasses
+                                - volumeattachments
+                                - csinodes
+                                - csidrivers
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - template.openshift.io
+                              resources:
+                                - brokertemplateinstances
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - user.openshift.io
+                              resources:
+                                - groups
+                                - identities
+                                - users
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - operators.coreos.com
+                              resources:
+                                - operators
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - machineconfiguration.openshift.io
+                              resources:
+                                - machineconfigpools
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                            - apiGroups:
+                                - monitoring.coreos.com
+                              resourceNames:
+                                - k8s
+                              resources:
+                                - prometheuses/api
+                              verbs:
+                                - get
+                                - create
+                                - update
+                            - apiGroups:
+                                - package-operator.run
+                              resources:
+                                - '*'
+                              verbs:
+                                - get
+                                - list
+                                - watch
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/backplane/10-backplane-readers-cluster.ClusterRole.yml
+++ b/deploy/backplane/10-backplane-readers-cluster.ClusterRole.yml
@@ -2,18 +2,495 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: backplane-readers-cluster
-aggregationRule:
-  clusterRoleSelectors:
-    # aggregate all "view" scope rbac
-    - matchExpressions:
-        - key: rbac.authorization.k8s.io/aggregate-to-view
-          operator: In
-          values:
-            - "true"
-        - key: kubernetes.io/bootstrapping
-          operator: DoesNotExist
-    - matchExpressions:
-        - key: managed.openshift.io/aggregate-to-dedicated-readers
-          operator: In
-          values:
-            - "true"
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  - catalogsources
+  - installplans
+  - subscriptions
+  - operatorgroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - packages.operators.coreos.com
+  resources:
+  - packagemanifests
+  - packagemanifests/icon
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - packages.operators.coreos.com
+  resources:
+  - packagemanifests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreamimages
+  - imagestreammappings
+  - imagestreams
+  - imagestreamtags
+  - imagetags
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams/layers
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - buildconfigs/webhooks
+  - builds
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - builds/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - build.openshift.io
+  resources:
+  - jenkins
+  verbs:
+  - view
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  - deploymentconfigs/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs/log
+  - deploymentconfigs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - image.openshift.io
+  resources:
+  - imagestreams/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - quota.openshift.io
+  resources:
+  - appliedclusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - route.openshift.io
+  resources:
+  - routes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - template.openshift.io
+  resources:
+  - processedtemplates
+  - templateconfigs
+  - templateinstances
+  - templates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildlogs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotausages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - quota.openshift.io
+  resources:
+  - clusterresourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  - authorization.openshift.io
+  resources:
+  - clusterpolicybindings
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - authorization.openshift.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.openshift.io
+  resources:
+  - clusterautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - console.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - images
+  - imagesignatures
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - imageregistry.operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metal3.io
+  resources:
+  - provisionings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - migration.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - network.openshift.io
+  resources:
+  - clusternetworks
+  - hostsubnets
+  - netnamespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projectrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - samples.operator.openshift.io
+  resources:
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  - rangeallocations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  - csinodes
+  - csidrivers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - brokertemplateinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  - identities
+  - users
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - operators
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resourceNames:
+  - k8s
+  resources:
+  - prometheuses/api
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - package-operator.run
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4817,24 +4817,502 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
-                  aggregationRule:
-                    clusterRoleSelectors:
-                    - matchExpressions:
-                      - key: rbac.authorization.k8s.io/aggregate-to-view
-                        operator: In
-                        values:
-                        - 'true'
-                      - key: kubernetes.io/bootstrapping
-                        operator: DoesNotExist
-                    - matchExpressions:
-                      - key: managed.openshift.io/aggregate-to-dedicated-readers
-                        operator: In
-                        values:
-                        - 'true'
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
                   metadata:
                     name: backplane-readers-cluster
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - clusterserviceversions
+                    - catalogsources
+                    - installplans
+                    - subscriptions
+                    - operatorgroups
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    - packagemanifests/icon
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreamimages
+                    - imagestreammappings
+                    - imagestreams
+                    - imagestreamtags
+                    - imagetags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/layers
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshots
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - builds/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - view
+                  - apiGroups:
+                    - ''
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/log
+                    - deploymentconfigs/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - template.openshift.io
+                    resources:
+                    - processedtemplates
+                    - templateconfigs
+                    - templateinstances
+                    - templates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotausages
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    - persistentvolumes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    resources:
+                    - clusterpolicybindings
+                    verbs:
+                    - get
+                    - list
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - nodes
+                    - pods
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - admissionregistration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiregistration.k8s.io
+                    resources:
+                    - apiservices
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - clusterrolebindings
+                    - clusterroles
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - clusterautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - console.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - flowcontrol.apiserver.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - images
+                    - imagesignatures
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - imageregistry.operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metal3.io
+                    resources:
+                    - provisionings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - migration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - network.openshift.io
+                    resources:
+                    - clusternetworks
+                    - hostsubnets
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingressclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - node.k8s.io
+                    resources:
+                    - runtimeclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - podsecuritypolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - samples.operator.openshift.io
+                    resources:
+                    - configs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - scheduling.k8s.io
+                    resources:
+                    - priorityclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    - rangeallocations
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshotcontents
+                    - volumesnapshotclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    - volumeattachments
+                    - csinodes
+                    - csidrivers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - brokertemplateinstances
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - operators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resourceNames:
+                    - k8s
+                    resources:
+                    - prometheuses/api
+                    verbs:
+                    - get
+                    - create
+                    - update
+                  - apiGroups:
+                    - package-operator.run
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -9285,20 +9763,498 @@ objects:
       kind: ClusterRole
       metadata:
         name: backplane-readers-cluster
-      aggregationRule:
-        clusterRoleSelectors:
-        - matchExpressions:
-          - key: rbac.authorization.k8s.io/aggregate-to-view
-            operator: In
-            values:
-            - 'true'
-          - key: kubernetes.io/bootstrapping
-            operator: DoesNotExist
-        - matchExpressions:
-          - key: managed.openshift.io/aggregate-to-dedicated-readers
-            operator: In
-            values:
-            - 'true'
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - catalogsources
+        - installplans
+        - subscriptions
+        - operatorgroups
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - packages.operators.coreos.com
+        resources:
+        - packagemanifests
+        - packagemanifests/icon
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - packages.operators.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreamimages
+        - imagestreammappings
+        - imagestreams
+        - imagestreamtags
+        - imagetags
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreams/layers
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        - project.openshift.io
+        resources:
+        - projects
+        verbs:
+        - get
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - pods
+        - nodes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshots
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - buildconfigs
+        - buildconfigs/webhooks
+        - builds
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - builds/log
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - build.openshift.io
+        resources:
+        - jenkins
+        verbs:
+        - view
+      - apiGroups:
+        - ''
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        - deploymentconfigs/scale
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs/log
+        - deploymentconfigs/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreams/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        resources:
+        - appliedclusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - route.openshift.io
+        resources:
+        - routes/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - template.openshift.io
+        resources:
+        - processedtemplates
+        - templateconfigs
+        - templateinstances
+        - templates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - buildlogs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - resourcequotausages
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        - persistentvolumes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        resources:
+        - clusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - authorization.openshift.io
+        resources:
+        - clusterpolicybindings
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - nodes
+        - pods
+        verbs:
+        - list
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
+      - apiGroups:
+        - admissionregistration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiregistration.k8s.io
+        resources:
+        - apiservices
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - clusterrolebindings
+        - clusterroles
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - clusterautoscalers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - flowcontrol.apiserver.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        - imagesignatures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - imageregistry.operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - metal3.io
+        resources:
+        - provisionings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - migration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - clusternetworks
+        - hostsubnets
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - ingressclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - node.k8s.io
+        resources:
+        - runtimeclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - project.openshift.io
+        resources:
+        - projectrequests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - samples.operator.openshift.io
+        resources:
+        - configs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - scheduling.k8s.io
+        resources:
+        - priorityclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        - rangeallocations
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshotcontents
+        - volumesnapshotclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - storage.k8s.io
+        resources:
+        - storageclasses
+        - volumeattachments
+        - csinodes
+        - csidrivers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - template.openshift.io
+        resources:
+        - brokertemplateinstances
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - groups
+        - identities
+        - users
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - machineconfigpools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resourceNames:
+        - k8s
+        resources:
+        - prometheuses/api
+        verbs:
+        - get
+        - create
+        - update
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4817,24 +4817,502 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
-                  aggregationRule:
-                    clusterRoleSelectors:
-                    - matchExpressions:
-                      - key: rbac.authorization.k8s.io/aggregate-to-view
-                        operator: In
-                        values:
-                        - 'true'
-                      - key: kubernetes.io/bootstrapping
-                        operator: DoesNotExist
-                    - matchExpressions:
-                      - key: managed.openshift.io/aggregate-to-dedicated-readers
-                        operator: In
-                        values:
-                        - 'true'
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
                   metadata:
                     name: backplane-readers-cluster
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - clusterserviceversions
+                    - catalogsources
+                    - installplans
+                    - subscriptions
+                    - operatorgroups
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    - packagemanifests/icon
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreamimages
+                    - imagestreammappings
+                    - imagestreams
+                    - imagestreamtags
+                    - imagetags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/layers
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshots
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - builds/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - view
+                  - apiGroups:
+                    - ''
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/log
+                    - deploymentconfigs/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - template.openshift.io
+                    resources:
+                    - processedtemplates
+                    - templateconfigs
+                    - templateinstances
+                    - templates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotausages
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    - persistentvolumes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    resources:
+                    - clusterpolicybindings
+                    verbs:
+                    - get
+                    - list
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - nodes
+                    - pods
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - admissionregistration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiregistration.k8s.io
+                    resources:
+                    - apiservices
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - clusterrolebindings
+                    - clusterroles
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - clusterautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - console.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - flowcontrol.apiserver.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - images
+                    - imagesignatures
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - imageregistry.operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metal3.io
+                    resources:
+                    - provisionings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - migration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - network.openshift.io
+                    resources:
+                    - clusternetworks
+                    - hostsubnets
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingressclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - node.k8s.io
+                    resources:
+                    - runtimeclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - podsecuritypolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - samples.operator.openshift.io
+                    resources:
+                    - configs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - scheduling.k8s.io
+                    resources:
+                    - priorityclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    - rangeallocations
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshotcontents
+                    - volumesnapshotclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    - volumeattachments
+                    - csinodes
+                    - csidrivers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - brokertemplateinstances
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - operators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resourceNames:
+                    - k8s
+                    resources:
+                    - prometheuses/api
+                    verbs:
+                    - get
+                    - create
+                    - update
+                  - apiGroups:
+                    - package-operator.run
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -9285,20 +9763,498 @@ objects:
       kind: ClusterRole
       metadata:
         name: backplane-readers-cluster
-      aggregationRule:
-        clusterRoleSelectors:
-        - matchExpressions:
-          - key: rbac.authorization.k8s.io/aggregate-to-view
-            operator: In
-            values:
-            - 'true'
-          - key: kubernetes.io/bootstrapping
-            operator: DoesNotExist
-        - matchExpressions:
-          - key: managed.openshift.io/aggregate-to-dedicated-readers
-            operator: In
-            values:
-            - 'true'
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - catalogsources
+        - installplans
+        - subscriptions
+        - operatorgroups
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - packages.operators.coreos.com
+        resources:
+        - packagemanifests
+        - packagemanifests/icon
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - packages.operators.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreamimages
+        - imagestreammappings
+        - imagestreams
+        - imagestreamtags
+        - imagetags
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreams/layers
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        - project.openshift.io
+        resources:
+        - projects
+        verbs:
+        - get
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - pods
+        - nodes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshots
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - buildconfigs
+        - buildconfigs/webhooks
+        - builds
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - builds/log
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - build.openshift.io
+        resources:
+        - jenkins
+        verbs:
+        - view
+      - apiGroups:
+        - ''
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        - deploymentconfigs/scale
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs/log
+        - deploymentconfigs/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreams/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        resources:
+        - appliedclusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - route.openshift.io
+        resources:
+        - routes/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - template.openshift.io
+        resources:
+        - processedtemplates
+        - templateconfigs
+        - templateinstances
+        - templates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - buildlogs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - resourcequotausages
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        - persistentvolumes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        resources:
+        - clusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - authorization.openshift.io
+        resources:
+        - clusterpolicybindings
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - nodes
+        - pods
+        verbs:
+        - list
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
+      - apiGroups:
+        - admissionregistration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiregistration.k8s.io
+        resources:
+        - apiservices
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - clusterrolebindings
+        - clusterroles
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - clusterautoscalers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - flowcontrol.apiserver.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        - imagesignatures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - imageregistry.operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - metal3.io
+        resources:
+        - provisionings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - migration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - clusternetworks
+        - hostsubnets
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - ingressclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - node.k8s.io
+        resources:
+        - runtimeclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - project.openshift.io
+        resources:
+        - projectrequests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - samples.operator.openshift.io
+        resources:
+        - configs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - scheduling.k8s.io
+        resources:
+        - priorityclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        - rangeallocations
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshotcontents
+        - volumesnapshotclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - storage.k8s.io
+        resources:
+        - storageclasses
+        - volumeattachments
+        - csinodes
+        - csidrivers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - template.openshift.io
+        resources:
+        - brokertemplateinstances
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - groups
+        - identities
+        - users
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - machineconfigpools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resourceNames:
+        - k8s
+        resources:
+        - prometheuses/api
+        verbs:
+        - get
+        - create
+        - update
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4817,24 +4817,502 @@ objects:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
-                  aggregationRule:
-                    clusterRoleSelectors:
-                    - matchExpressions:
-                      - key: rbac.authorization.k8s.io/aggregate-to-view
-                        operator: In
-                        values:
-                        - 'true'
-                      - key: kubernetes.io/bootstrapping
-                        operator: DoesNotExist
-                    - matchExpressions:
-                      - key: managed.openshift.io/aggregate-to-dedicated-readers
-                        operator: In
-                        values:
-                        - 'true'
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: ClusterRole
                   metadata:
                     name: backplane-readers-cluster
+                  rules:
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - clusterserviceversions
+                    - catalogsources
+                    - installplans
+                    - subscriptions
+                    - operatorgroups
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    - packagemanifests/icon
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - packages.operators.coreos.com
+                    resources:
+                    - packagemanifests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreamimages
+                    - imagestreammappings
+                    - imagestreams
+                    - imagestreamtags
+                    - imagetags
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/layers
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - namespaces
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - ''
+                    - project.openshift.io
+                    resources:
+                    - projects
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - pods
+                    - nodes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshots
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - buildconfigs
+                    - buildconfigs/webhooks
+                    - builds
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - builds/log
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - build.openshift.io
+                    resources:
+                    - jenkins
+                    verbs:
+                    - view
+                  - apiGroups:
+                    - ''
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs
+                    - deploymentconfigs/scale
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - apps.openshift.io
+                    resources:
+                    - deploymentconfigs/log
+                    - deploymentconfigs/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - image.openshift.io
+                    resources:
+                    - imagestreams/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    resources:
+                    - appliedclusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - route.openshift.io
+                    resources:
+                    - routes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - route.openshift.io
+                    resources:
+                    - routes/status
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - template.openshift.io
+                    resources:
+                    - processedtemplates
+                    - templateconfigs
+                    - templateinstances
+                    - templates
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - build.openshift.io
+                    resources:
+                    - buildlogs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - resourcequotausages
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - nodes
+                    - persistentvolumes
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - quota.openshift.io
+                    resources:
+                    - clusterresourcequotas
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - ''
+                    - authorization.openshift.io
+                    resources:
+                    - clusterpolicybindings
+                    verbs:
+                    - get
+                    - list
+                  - apiGroups:
+                    - metrics.k8s.io
+                    resources:
+                    - nodes
+                    - pods
+                    verbs:
+                    - list
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                  - apiGroups:
+                    - admissionregistration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiextensions.k8s.io
+                    resources:
+                    - customresourcedefinitions
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - apiregistration.k8s.io
+                    resources:
+                    - apiservices
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authentication.k8s.io
+                    resources:
+                    - tokenreviews
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - authorization.openshift.io
+                    resources:
+                    - clusterrolebindings
+                    - clusterroles
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - autoscaling.openshift.io
+                    resources:
+                    - clusterautoscalers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - config.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - console.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - flowcontrol.apiserver.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - image.openshift.io
+                    resources:
+                    - images
+                    - imagesignatures
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - imageregistry.operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - metal3.io
+                    resources:
+                    - provisionings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - migration.k8s.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - network.openshift.io
+                    resources:
+                    - clusternetworks
+                    - hostsubnets
+                    - netnamespaces
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - networking.k8s.io
+                    resources:
+                    - ingressclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - node.k8s.io
+                    resources:
+                    - runtimeclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - policy
+                    resources:
+                    - podsecuritypolicies
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - project.openshift.io
+                    resources:
+                    - projectrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - rbac.authorization.k8s.io
+                    resources:
+                    - clusterroles
+                    - clusterrolebindings
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - samples.operator.openshift.io
+                    resources:
+                    - configs
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - scheduling.k8s.io
+                    resources:
+                    - priorityclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - security.openshift.io
+                    resources:
+                    - securitycontextconstraints
+                    - rangeallocations
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - snapshot.storage.k8s.io
+                    resources:
+                    - volumesnapshotcontents
+                    - volumesnapshotclasses
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - storage.k8s.io
+                    resources:
+                    - storageclasses
+                    - volumeattachments
+                    - csinodes
+                    - csidrivers
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - template.openshift.io
+                    resources:
+                    - brokertemplateinstances
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - user.openshift.io
+                    resources:
+                    - groups
+                    - identities
+                    - users
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - operators.coreos.com
+                    resources:
+                    - operators
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - machineconfiguration.openshift.io
+                    resources:
+                    - machineconfigpools
+                    verbs:
+                    - get
+                    - list
+                    - watch
+                  - apiGroups:
+                    - monitoring.coreos.com
+                    resourceNames:
+                    - k8s
+                    resources:
+                    - prometheuses/api
+                    verbs:
+                    - get
+                    - create
+                    - update
+                  - apiGroups:
+                    - package-operator.run
+                    resources:
+                    - '*'
+                    verbs:
+                    - get
+                    - list
+                    - watch
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -9285,20 +9763,498 @@ objects:
       kind: ClusterRole
       metadata:
         name: backplane-readers-cluster
-      aggregationRule:
-        clusterRoleSelectors:
-        - matchExpressions:
-          - key: rbac.authorization.k8s.io/aggregate-to-view
-            operator: In
-            values:
-            - 'true'
-          - key: kubernetes.io/bootstrapping
-            operator: DoesNotExist
-        - matchExpressions:
-          - key: managed.openshift.io/aggregate-to-dedicated-readers
-            operator: In
-            values:
-            - 'true'
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - catalogsources
+        - installplans
+        - subscriptions
+        - operatorgroups
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - packages.operators.coreos.com
+        resources:
+        - packagemanifests
+        - packagemanifests/icon
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - packages.operators.coreos.com
+        resources:
+        - packagemanifests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreamimages
+        - imagestreammappings
+        - imagestreams
+        - imagestreamtags
+        - imagetags
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreams/layers
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        resources:
+        - namespaces
+        verbs:
+        - get
+      - apiGroups:
+        - ''
+        - project.openshift.io
+        resources:
+        - projects
+        verbs:
+        - get
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - pods
+        - nodes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshots
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - buildconfigs
+        - buildconfigs/webhooks
+        - builds
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - builds/log
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - build.openshift.io
+        resources:
+        - jenkins
+        verbs:
+        - view
+      - apiGroups:
+        - ''
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs
+        - deploymentconfigs/scale
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - apps.openshift.io
+        resources:
+        - deploymentconfigs/log
+        - deploymentconfigs/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - image.openshift.io
+        resources:
+        - imagestreams/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        resources:
+        - appliedclusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - route.openshift.io
+        resources:
+        - routes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - route.openshift.io
+        resources:
+        - routes/status
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - template.openshift.io
+        resources:
+        - processedtemplates
+        - templateconfigs
+        - templateinstances
+        - templates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - build.openshift.io
+        resources:
+        - buildlogs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - resourcequotausages
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        - persistentvolumes
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - quota.openshift.io
+        resources:
+        - clusterresourcequotas
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - ''
+        - authorization.openshift.io
+        resources:
+        - clusterpolicybindings
+        verbs:
+        - get
+        - list
+      - apiGroups:
+        - metrics.k8s.io
+        resources:
+        - nodes
+        - pods
+        verbs:
+        - list
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
+      - apiGroups:
+        - admissionregistration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiregistration.k8s.io
+        resources:
+        - apiservices
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authentication.k8s.io
+        resources:
+        - tokenreviews
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - authorization.openshift.io
+        resources:
+        - clusterrolebindings
+        - clusterroles
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - autoscaling.openshift.io
+        resources:
+        - clusterautoscalers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - config.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - console.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - flowcontrol.apiserver.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - image.openshift.io
+        resources:
+        - images
+        - imagesignatures
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - imageregistry.operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - metal3.io
+        resources:
+        - provisionings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - migration.k8s.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - network.openshift.io
+        resources:
+        - clusternetworks
+        - hostsubnets
+        - netnamespaces
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - networking.k8s.io
+        resources:
+        - ingressclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - node.k8s.io
+        resources:
+        - runtimeclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - policy
+        resources:
+        - podsecuritypolicies
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - project.openshift.io
+        resources:
+        - projectrequests
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - samples.operator.openshift.io
+        resources:
+        - configs
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - scheduling.k8s.io
+        resources:
+        - priorityclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - security.openshift.io
+        resources:
+        - securitycontextconstraints
+        - rangeallocations
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - snapshot.storage.k8s.io
+        resources:
+        - volumesnapshotcontents
+        - volumesnapshotclasses
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - storage.k8s.io
+        resources:
+        - storageclasses
+        - volumeattachments
+        - csinodes
+        - csidrivers
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - template.openshift.io
+        resources:
+        - brokertemplateinstances
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - user.openshift.io
+        resources:
+        - groups
+        - identities
+        - users
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - operators
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - machineconfiguration.openshift.io
+        resources:
+        - machineconfigpools
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - monitoring.coreos.com
+        resourceNames:
+        - k8s
+        resources:
+        - prometheuses/api
+        verbs:
+        - get
+        - create
+        - update
+      - apiGroups:
+        - package-operator.run
+        resources:
+        - '*'
+        verbs:
+        - get
+        - list
+        - watch
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?

This PR removes role aggregation for backplane readers. Instead of using aggregation, the permissions are static and explicit. This allows us to properly audit changes in permissions. 

The permissions explicitly added to the role in this PR are the same we currently get through the aggregation on a fresh ROSA cluster.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/OSD-27684

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
