### PR TITLE
OSD-21709: Fix new SlowCustomerWebhookSRE PrometheusRule for conformance

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
@@ -30,4 +30,5 @@ spec:
         managed_notification_template: "SlowCustomerWebhook"
         duration_threshold: "1 second"
       annotations:
-        message: "{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation }} operations"
+        summary: Customer defined admission webhook is slow.
+        description: "{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation }} operations"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40558,7 +40558,8 @@ objects:
               managed_notification_template: SlowCustomerWebhook
               duration_threshold: 1 second
             annotations:
-              message: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
+              summary: Customer defined admission webhook is slow.
+              description: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
                 }} operations'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40558,7 +40558,8 @@ objects:
               managed_notification_template: SlowCustomerWebhook
               duration_threshold: 1 second
             annotations:
-              message: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
+              summary: Customer defined admission webhook is slow.
+              description: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
                 }} operations'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40558,7 +40558,8 @@ objects:
               managed_notification_template: SlowCustomerWebhook
               duration_threshold: 1 second
             annotations:
-              message: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
+              summary: Customer defined admission webhook is slow.
+              description: '{{ $labels.webhook_name }} webhook is slow on {{ $labels.operation
                 }} operations'
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
PrometheusRules without the proper configuration cause the ROSA CI jobs to fail conformance. There is currently an allowlist that is ignoring a lot of existing rules in this repo, but anything new needs to be setup properly.

### Which Jira/Github issue(s) this PR fixes?

[OSD-21709](https://issues.redhat.com/browse/OSD-21709)

### Special notes for your reviewer:

See issue here https://redhat-internal.slack.com/archives/C07QEA1PDFX/p1737566663076689

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
