### PR TITLE
Removing csheremeta from the owners list

### DIFF
--- a/deploy/bz2068601/OWNERS
+++ b/deploy/bz2068601/OWNERS
@@ -1,3 +1,2 @@
 reviewers:
 - jewzaam
-- csheremeta


### PR DESCRIPTION
Part of [OSD-23946](https://issues.redhat.com/browse/OSD-23946) ticket about removing csheremeta from the owner of the repo