### PR TITLE
allow acm-policies SSS to deploy to FedRAMP clusters

### DIFF
--- a/deploy/acm-policies/config.yaml
+++ b/deploy/acm-policies/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: ["service-cluster","management-cluster-v2"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -920,10 +920,6 @@ objects:
         values:
         - service-cluster
         - management-cluster-v2
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -920,10 +920,6 @@ objects:
         values:
         - service-cluster
         - management-cluster-v2
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -920,10 +920,6 @@ objects:
         values:
         - service-cluster
         - management-cluster-v2
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
_feature_
[OCM-13426](https://issues.redhat.com/browse/OCM-13426?atlOrigin=eyJpIjoiYjM0MTA4MzUyYTYxNDVkY2IwMzVjOGQ3ZWQ3NzMwM2QiLCJwIjoianN3LWdpdGxhYlNNLWludCJ9)

### What this PR does / why we need it?

This PR allows the acm-policies selector syncset to be deployed to FedRAMP clusters. This is a necessary dependency to support ROSA HCP clusters

### Which Jira/Github issue(s) this PR fixes?

[OCM-13426](https://issues.redhat.com//browse/OCM-13426)

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
