### PR TITLE
Init NOO SlectorSyncSet for MCs

### DIFF
--- a/deploy/network-observability-operator/hypershift-mc/00-mc-Namespace.yaml
+++ b/deploy/network-observability-operator/hypershift-mc/00-mc-Namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    hypershift.openshift.io/monitoring: "true"
+  name: netobserv

--- a/deploy/network-observability-operator/hypershift-mc/02-mc-Subscription.yaml
+++ b/deploy/network-observability-operator/hypershift-mc/02-mc-Subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: netobserv-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: netobserv-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/deploy/network-observability-operator/hypershift-mc/10-mc-NetworkPolicy.yaml
+++ b/deploy/network-observability-operator/hypershift-mc/10-mc-NetworkPolicy.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-hostnetwork
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-netobserv-privileged-namespace
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: netobserv-privileged
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-openshift-console-namespace
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-console
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-openshift-monitoring-namespace
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/deploy/network-observability-operator/hypershift-mc/20-mc-FlowCollector.yaml
+++ b/deploy/network-observability-operator/hypershift-mc/20-mc-FlowCollector.yaml
@@ -1,0 +1,139 @@
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      logLevel: info
+      metrics:
+        server:
+          tls:
+            insecureSkipVerify: false
+            type: Disabled
+          port: 9400
+      cacheMaxFlows: 100000
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: 50m
+          memory: 100Mi
+      sampling: 50
+      imagePullPolicy: IfNotPresent
+      excludeInterfaces:
+      - lo
+      kafkaBatchSize: 10485760
+      cacheActiveTimeout: 5s
+      interfaces: [ ]
+      features:
+        - PacketDrop
+        - DNSTracking
+        - FlowRTT
+      privileged: true
+    ipfix:
+      cacheActiveTimeout: 20s
+      cacheMaxFlows: 400
+      clusterNetworkOperator:
+        namespace: openshift-network-operator
+      forceSampleAll: false
+      ovnKubernetes:
+        containerName: ovnkube-node
+        daemonSetName: ovnkube-node
+        namespace: ovn-kubernetes
+      sampling: 400
+    type: eBPF
+  consolePlugin:
+    logLevel: info
+    advanced:
+      port: 9001
+      register: true
+    enable: false
+    resources:
+      limits:
+        memory: 100Mi
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    portNaming:
+      enable: true
+      portNames:
+        '3100': loki
+    quickFilters:
+    - default: true
+      filter:
+        flow_layer: '"app"'
+      name: Applications
+    - filter:
+        flow_layer: '"infra"'
+      name: Infrastructure
+    - default: true
+      filter:
+        dst_kind: '"Pod"'
+        src_kind: '"Pod"'
+      name: Pods network
+    - filter:
+        dst_kind: '"Service"'
+      name: Services network
+    imagePullPolicy: IfNotPresent
+    autoscaler:
+      maxReplicas: 3
+      metrics:
+      - resource:
+          target:
+            averageUtilization: 50
+            type: Utilization
+          name: cpu
+        type: Resource
+      minReplicas: 1
+      status: Disabled
+    replicas: 3
+  deploymentModel: Direct
+  exporters: [ ]
+  loki:
+    enable: false
+  processor:
+    logLevel: info
+    advanced:
+      port: 2055
+      conversationTerminatingTimeout: 5s
+      conversationEndTimeout: 10s
+      profilePort: 6060
+      enableKubeProbes: true
+      healthPort: 8080
+      dropUnusedFields: true
+      conversationHeartbeatInterval: 30s
+    metrics:
+      disableAlerts: [ ]
+      server:
+        tls:
+          insecureSkipVerify: false
+          type: Disabled
+        port: 9401
+    resources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 50m
+        memory: 100Mi
+    multiClusterDeployment: false
+    kafkaConsumerQueueCapacity: 1000
+    imagePullPolicy: IfNotPresent
+    kafkaConsumerAutoscaler:
+      maxReplicas: 3
+      status: Disabled
+    logTypes: Flows
+    kafkaConsumerReplicas: 3
+    kafkaConsumerBatchSize: 10485760
+    addZone: false
+  prometheus:
+    querier:
+      manual:
+        tls:
+          enable: false
+          insecureSkipVerify: false
+        url: 'http://prometheus:9090'
+      mode: Auto
+      timeout: 30s
+      enable: true
+  namespace: netobserv

--- a/deploy/network-observability-operator/hypershift-mc/30-mc-servicemonitor.yaml
+++ b/deploy/network-observability-operator/hypershift-mc/30-mc-servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: netobserv-metrics-monitor-dynatrace
+  namespace: netobserv
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/certs/configmap_openshift-monitoring_serving-certs-ca-bundle_service-ca.crt
+      serverName: netobserv-metrics-service.netobserv.svc
+  selector:
+    matchLabels:
+      control-plane: controller-manager

--- a/deploy/network-observability-operator/hypershift-mc/config.yaml
+++ b/deploy/network-observability-operator/hypershift-mc/config.yaml
@@ -1,0 +1,15 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/id
+      operator: In
+      values: ["2f1jfel0o7h687v2ellmepa1tbsgf7mq"] # TEMP Selector for POC (hs-mc-mps583as0)
+    - key: api.openshift.com/environment
+      operator: In
+      values: ["staging"] # Also for POC Phase 2 target only staging (will remove later)
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26759,6 +26759,262 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: network-observability-operator-hypershift-mc
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values:
+        - 2f1jfel0o7h687v2ellmepa1tbsgf7mq
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          hypershift.openshift.io/monitoring: 'true'
+        name: netobserv
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: netobserv-operator
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: netobserv-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: allow-from-hostnetwork
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                policy-group.network.openshift.io/host-network: ''
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-netobserv-privileged-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: netobserv-privileged
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-openshift-console-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-console
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-openshift-monitoring-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-monitoring
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - apiVersion: flows.netobserv.io/v1beta2
+      kind: FlowCollector
+      metadata:
+        name: cluster
+      spec:
+        agent:
+          ebpf:
+            logLevel: info
+            metrics:
+              server:
+                tls:
+                  insecureSkipVerify: false
+                  type: Disabled
+                port: 9400
+            cacheMaxFlows: 100000
+            resources:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 50m
+                memory: 100Mi
+            sampling: 50
+            imagePullPolicy: IfNotPresent
+            excludeInterfaces:
+            - lo
+            kafkaBatchSize: 10485760
+            cacheActiveTimeout: 5s
+            interfaces: []
+            features:
+            - PacketDrop
+            - DNSTracking
+            - FlowRTT
+            privileged: true
+          ipfix:
+            cacheActiveTimeout: 20s
+            cacheMaxFlows: 400
+            clusterNetworkOperator:
+              namespace: openshift-network-operator
+            forceSampleAll: false
+            ovnKubernetes:
+              containerName: ovnkube-node
+              daemonSetName: ovnkube-node
+              namespace: ovn-kubernetes
+            sampling: 400
+          type: eBPF
+        consolePlugin:
+          logLevel: info
+          advanced:
+            port: 9001
+            register: true
+          enable: false
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          portNaming:
+            enable: true
+            portNames:
+              '3100': loki
+          quickFilters:
+          - default: true
+            filter:
+              flow_layer: '"app"'
+            name: Applications
+          - filter:
+              flow_layer: '"infra"'
+            name: Infrastructure
+          - default: true
+            filter:
+              dst_kind: '"Pod"'
+              src_kind: '"Pod"'
+            name: Pods network
+          - filter:
+              dst_kind: '"Service"'
+            name: Services network
+          imagePullPolicy: IfNotPresent
+          autoscaler:
+            maxReplicas: 3
+            metrics:
+            - resource:
+                target:
+                  averageUtilization: 50
+                  type: Utilization
+                name: cpu
+              type: Resource
+            minReplicas: 1
+            status: Disabled
+          replicas: 3
+        deploymentModel: Direct
+        exporters: []
+        loki:
+          enable: false
+        processor:
+          logLevel: info
+          advanced:
+            port: 2055
+            conversationTerminatingTimeout: 5s
+            conversationEndTimeout: 10s
+            profilePort: 6060
+            enableKubeProbes: true
+            healthPort: 8080
+            dropUnusedFields: true
+            conversationHeartbeatInterval: 30s
+          metrics:
+            disableAlerts: []
+            server:
+              tls:
+                insecureSkipVerify: false
+                type: Disabled
+              port: 9401
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          multiClusterDeployment: false
+          kafkaConsumerQueueCapacity: 1000
+          imagePullPolicy: IfNotPresent
+          kafkaConsumerAutoscaler:
+            maxReplicas: 3
+            status: Disabled
+          logTypes: Flows
+          kafkaConsumerReplicas: 3
+          kafkaConsumerBatchSize: 10485760
+          addZone: false
+        prometheus:
+          querier:
+            manual:
+              tls:
+                enable: false
+                insecureSkipVerify: false
+              url: http://prometheus:9090
+            mode: Auto
+            timeout: 30s
+            enable: true
+        namespace: netobserv
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: netobserv-metrics-monitor-dynatrace
+        namespace: netobserv
+      spec:
+        endpoints:
+        - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          interval: 30s
+          path: /metrics
+          port: https
+          scheme: https
+          tlsConfig:
+            caFile: /etc/prometheus/certs/configmap_openshift-monitoring_serving-certs-ca-bundle_service-ca.crt
+            serverName: netobserv-metrics-service.netobserv.svc
+        selector:
+          matchLabels:
+            control-plane: controller-manager
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26759,6 +26759,262 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: network-observability-operator-hypershift-mc
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values:
+        - 2f1jfel0o7h687v2ellmepa1tbsgf7mq
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          hypershift.openshift.io/monitoring: 'true'
+        name: netobserv
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: netobserv-operator
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: netobserv-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: allow-from-hostnetwork
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                policy-group.network.openshift.io/host-network: ''
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-netobserv-privileged-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: netobserv-privileged
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-openshift-console-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-console
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-openshift-monitoring-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-monitoring
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - apiVersion: flows.netobserv.io/v1beta2
+      kind: FlowCollector
+      metadata:
+        name: cluster
+      spec:
+        agent:
+          ebpf:
+            logLevel: info
+            metrics:
+              server:
+                tls:
+                  insecureSkipVerify: false
+                  type: Disabled
+                port: 9400
+            cacheMaxFlows: 100000
+            resources:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 50m
+                memory: 100Mi
+            sampling: 50
+            imagePullPolicy: IfNotPresent
+            excludeInterfaces:
+            - lo
+            kafkaBatchSize: 10485760
+            cacheActiveTimeout: 5s
+            interfaces: []
+            features:
+            - PacketDrop
+            - DNSTracking
+            - FlowRTT
+            privileged: true
+          ipfix:
+            cacheActiveTimeout: 20s
+            cacheMaxFlows: 400
+            clusterNetworkOperator:
+              namespace: openshift-network-operator
+            forceSampleAll: false
+            ovnKubernetes:
+              containerName: ovnkube-node
+              daemonSetName: ovnkube-node
+              namespace: ovn-kubernetes
+            sampling: 400
+          type: eBPF
+        consolePlugin:
+          logLevel: info
+          advanced:
+            port: 9001
+            register: true
+          enable: false
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          portNaming:
+            enable: true
+            portNames:
+              '3100': loki
+          quickFilters:
+          - default: true
+            filter:
+              flow_layer: '"app"'
+            name: Applications
+          - filter:
+              flow_layer: '"infra"'
+            name: Infrastructure
+          - default: true
+            filter:
+              dst_kind: '"Pod"'
+              src_kind: '"Pod"'
+            name: Pods network
+          - filter:
+              dst_kind: '"Service"'
+            name: Services network
+          imagePullPolicy: IfNotPresent
+          autoscaler:
+            maxReplicas: 3
+            metrics:
+            - resource:
+                target:
+                  averageUtilization: 50
+                  type: Utilization
+                name: cpu
+              type: Resource
+            minReplicas: 1
+            status: Disabled
+          replicas: 3
+        deploymentModel: Direct
+        exporters: []
+        loki:
+          enable: false
+        processor:
+          logLevel: info
+          advanced:
+            port: 2055
+            conversationTerminatingTimeout: 5s
+            conversationEndTimeout: 10s
+            profilePort: 6060
+            enableKubeProbes: true
+            healthPort: 8080
+            dropUnusedFields: true
+            conversationHeartbeatInterval: 30s
+          metrics:
+            disableAlerts: []
+            server:
+              tls:
+                insecureSkipVerify: false
+                type: Disabled
+              port: 9401
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          multiClusterDeployment: false
+          kafkaConsumerQueueCapacity: 1000
+          imagePullPolicy: IfNotPresent
+          kafkaConsumerAutoscaler:
+            maxReplicas: 3
+            status: Disabled
+          logTypes: Flows
+          kafkaConsumerReplicas: 3
+          kafkaConsumerBatchSize: 10485760
+          addZone: false
+        prometheus:
+          querier:
+            manual:
+              tls:
+                enable: false
+                insecureSkipVerify: false
+              url: http://prometheus:9090
+            mode: Auto
+            timeout: 30s
+            enable: true
+        namespace: netobserv
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: netobserv-metrics-monitor-dynatrace
+        namespace: netobserv
+      spec:
+        endpoints:
+        - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          interval: 30s
+          path: /metrics
+          port: https
+          scheme: https
+          tlsConfig:
+            caFile: /etc/prometheus/certs/configmap_openshift-monitoring_serving-certs-ca-bundle_service-ca.crt
+            serverName: netobserv-metrics-service.netobserv.svc
+        selector:
+          matchLabels:
+            control-plane: controller-manager
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26759,6 +26759,262 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: network-observability-operator-hypershift-mc
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/id
+        operator: In
+        values:
+        - 2f1jfel0o7h687v2ellmepa1tbsgf7mq
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          hypershift.openshift.io/monitoring: 'true'
+        name: netobserv
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: netobserv-operator
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: netobserv-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: allow-from-hostnetwork
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                policy-group.network.openshift.io/host-network: ''
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-netobserv-privileged-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: netobserv-privileged
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-openshift-console-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-console
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      metadata:
+        name: allow-from-openshift-monitoring-namespace
+      spec:
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                kubernetes.io/metadata.name: openshift-monitoring
+        podSelector: {}
+        policyTypes:
+        - Ingress
+    - apiVersion: flows.netobserv.io/v1beta2
+      kind: FlowCollector
+      metadata:
+        name: cluster
+      spec:
+        agent:
+          ebpf:
+            logLevel: info
+            metrics:
+              server:
+                tls:
+                  insecureSkipVerify: false
+                  type: Disabled
+                port: 9400
+            cacheMaxFlows: 100000
+            resources:
+              limits:
+                memory: 1Gi
+              requests:
+                cpu: 50m
+                memory: 100Mi
+            sampling: 50
+            imagePullPolicy: IfNotPresent
+            excludeInterfaces:
+            - lo
+            kafkaBatchSize: 10485760
+            cacheActiveTimeout: 5s
+            interfaces: []
+            features:
+            - PacketDrop
+            - DNSTracking
+            - FlowRTT
+            privileged: true
+          ipfix:
+            cacheActiveTimeout: 20s
+            cacheMaxFlows: 400
+            clusterNetworkOperator:
+              namespace: openshift-network-operator
+            forceSampleAll: false
+            ovnKubernetes:
+              containerName: ovnkube-node
+              daemonSetName: ovnkube-node
+              namespace: ovn-kubernetes
+            sampling: 400
+          type: eBPF
+        consolePlugin:
+          logLevel: info
+          advanced:
+            port: 9001
+            register: true
+          enable: false
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 50Mi
+          portNaming:
+            enable: true
+            portNames:
+              '3100': loki
+          quickFilters:
+          - default: true
+            filter:
+              flow_layer: '"app"'
+            name: Applications
+          - filter:
+              flow_layer: '"infra"'
+            name: Infrastructure
+          - default: true
+            filter:
+              dst_kind: '"Pod"'
+              src_kind: '"Pod"'
+            name: Pods network
+          - filter:
+              dst_kind: '"Service"'
+            name: Services network
+          imagePullPolicy: IfNotPresent
+          autoscaler:
+            maxReplicas: 3
+            metrics:
+            - resource:
+                target:
+                  averageUtilization: 50
+                  type: Utilization
+                name: cpu
+              type: Resource
+            minReplicas: 1
+            status: Disabled
+          replicas: 3
+        deploymentModel: Direct
+        exporters: []
+        loki:
+          enable: false
+        processor:
+          logLevel: info
+          advanced:
+            port: 2055
+            conversationTerminatingTimeout: 5s
+            conversationEndTimeout: 10s
+            profilePort: 6060
+            enableKubeProbes: true
+            healthPort: 8080
+            dropUnusedFields: true
+            conversationHeartbeatInterval: 30s
+          metrics:
+            disableAlerts: []
+            server:
+              tls:
+                insecureSkipVerify: false
+                type: Disabled
+              port: 9401
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          multiClusterDeployment: false
+          kafkaConsumerQueueCapacity: 1000
+          imagePullPolicy: IfNotPresent
+          kafkaConsumerAutoscaler:
+            maxReplicas: 3
+            status: Disabled
+          logTypes: Flows
+          kafkaConsumerReplicas: 3
+          kafkaConsumerBatchSize: 10485760
+          addZone: false
+        prometheus:
+          querier:
+            manual:
+              tls:
+                enable: false
+                insecureSkipVerify: false
+              url: http://prometheus:9090
+            mode: Auto
+            timeout: 30s
+            enable: true
+        namespace: netobserv
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: netobserv-metrics-monitor-dynatrace
+        namespace: netobserv
+      spec:
+        endpoints:
+        - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          interval: 30s
+          path: /metrics
+          port: https
+          scheme: https
+          tlsConfig:
+            caFile: /etc/prometheus/certs/configmap_openshift-monitoring_serving-certs-ca-bundle_service-ca.crt
+            serverName: netobserv-metrics-service.netobserv.svc
+        selector:
+          matchLabels:
+            control-plane: controller-manager
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Installs the [network-observability-operator](https://github.com/netobserv/network-observability-operator) on MC clusters.

Currently we're only targeting a install on a single MC (hs-mc-mps583as0) and will follow up with future PR's to expand the scope after we validate installs are working as expected. 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-25945

### Special notes for your reviewer:

Tech Plan: https://docs.google.com/document/d/1_2Xpwd-XfpsIDLiXD8cmjFq3fSeUiIxdXdPie-cq5A0 
