### PR TITLE
Remove architects from TL alias

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -24,6 +24,3 @@ approvers:
 - typeid
 - xiaoyu74
 - zmird-r
-maintainers:
-- jewzaam
-- jharrington22

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,10 +16,7 @@ aliases:
     - ravitri
     - clcollins
   srep-team-leads:
-    - cblecker
-    - jharrington22
     - rogbas
-    - jewzaam
     - fahlmant
     - dustman9000
     - wanghaoran1988


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Removes @cblecker, @jewzaam, and @jharrington22 from the TL alias in OWNERS_ALIASES. This ensures that review pings go to the right group. For folders where architect oversight is needed, there are other aliases that are actively used, so this is redundant.