### PR TITLE
HOLD: OSD-26956: Reinstall managed-upgrade-operator

### DIFF
--- a/deploy/reinstall-muo/01-ClusterRole.yaml
+++ b/deploy/reinstall-muo/01-ClusterRole.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-managed-upgrade-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-managed-upgrade-operator
+rules:
+  - apiGroups:
+      - "operators.coreos.com"
+    resources:
+      - clusterserviceversions
+      - subscriptions
+      - installplans
+    verbs:
+      - list
+      - get
+      - delete
+      - create
+  - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - list
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-managed-upgrade-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: sre-operator-reinstall-sa
+    namespace: openshift-managed-upgrade-operator

--- a/deploy/reinstall-muo/02-CronJob.yaml
+++ b/deploy/reinstall-muo/02-CronJob.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-managed-upgrade-operator
+spec:
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 100
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+            - name: operator-reinstaller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  #!/bin/bash
+                  set -euxo pipefail
+                  NAMESPACE=openshift-managed-upgrade-operator
+                  OPERATOR=managed-upgrade-operator
+
+                  # Perform a reinstall regardless, as we have some clusters with no MUO running now.
+                  if [[ ! -z "true" ]]; then
+                    oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+                    # delete all installplans
+                    oc get installplans.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete installplan.operators.coreos.com -n $NAMESPACE
+                    # get subscription
+                    oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json
+                    # delete subscription
+                    oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR
+                    # create subscription using the following json
+                    oc create -f /tmp/sub.json
+                  fi
+                  oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+                  oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+                  oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+                  oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+                  exit 0

--- a/deploy/reinstall-muo/config.yaml
+++ b/deploy/reinstall-muo/config.yaml
@@ -1,0 +1,11 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: hive.openshift.io/version-major-minor
+      operator: In
+      values: ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16", "4.17"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -38405,6 +38405,139 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: reinstall-muo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-managed-upgrade-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-managed-upgrade-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 100
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-managed-upgrade-operator\n\
+                    OPERATOR=managed-upgrade-operator\n\n# Perform a reinstall regardless,\
+                    \ as we have some clusters with no MUO running now.\nif [[ ! -z\
+                    \ \"true\" ]]; then\n  oc get clusterserviceversions.operators.coreos.com\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    \  # delete all installplans\n  oc get installplans.operators.coreos.com\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete installplan.operators.coreos.com -n $NAMESPACE\n  # get\
+                    \ subscription\n  oc get subscription.operators.coreos.com -n\
+                    \ $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
+                    \ | del(.metadata.uid)' > /tmp/sub.json\n  # delete subscription\n\
+                    \  oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\n\
+                    \  # create subscription using the following json\n  oc create\
+                    \ -f /tmp/sub.json\nfi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -38405,6 +38405,139 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: reinstall-muo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-managed-upgrade-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-managed-upgrade-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 100
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-managed-upgrade-operator\n\
+                    OPERATOR=managed-upgrade-operator\n\n# Perform a reinstall regardless,\
+                    \ as we have some clusters with no MUO running now.\nif [[ ! -z\
+                    \ \"true\" ]]; then\n  oc get clusterserviceversions.operators.coreos.com\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    \  # delete all installplans\n  oc get installplans.operators.coreos.com\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete installplan.operators.coreos.com -n $NAMESPACE\n  # get\
+                    \ subscription\n  oc get subscription.operators.coreos.com -n\
+                    \ $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
+                    \ | del(.metadata.uid)' > /tmp/sub.json\n  # delete subscription\n\
+                    \  oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\n\
+                    \  # create subscription using the following json\n  oc create\
+                    \ -f /tmp/sub.json\nfi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -38405,6 +38405,139 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: reinstall-muo
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-managed-upgrade-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-managed-upgrade-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-managed-upgrade-operator
+      spec:
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/30 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 100
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-managed-upgrade-operator\n\
+                    OPERATOR=managed-upgrade-operator\n\n# Perform a reinstall regardless,\
+                    \ as we have some clusters with no MUO running now.\nif [[ ! -z\
+                    \ \"true\" ]]; then\n  oc get clusterserviceversions.operators.coreos.com\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    \  # delete all installplans\n  oc get installplans.operators.coreos.com\
+                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
+                    \ delete installplan.operators.coreos.com -n $NAMESPACE\n  # get\
+                    \ subscription\n  oc get subscription.operators.coreos.com -n\
+                    \ $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
+                    \ | del(.metadata.uid)' > /tmp/sub.json\n  # delete subscription\n\
+                    \  oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\n\
+                    \  # create subscription using the following json\n  oc create\
+                    \ -f /tmp/sub.json\nfi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
+                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
+                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
+                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
+                    \ || true\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This follows the [SOP](https://github.com/openshift/ops-sop/blob/master/v4/knowledge_base/reinstall-operator.md) for reinstalling an operator to fix issues we are seeing with `managed-upgrade-operator` following a recent reinstall promotion that left some clusters in a broken state.

Staging this in case we need it to ensure the reinstall steps are followed. The previous version of this used an outdated PR as a reference, and did not fix the `subscription` when re-creating it, referencing an old `InstallPlan`.

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-26956

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
