### PR TITLE
OSD-28074: obo removal cronjob

### DIFF
--- a/deploy/obo-removal/01-ClusterRole.yaml
+++ b/deploy/obo-removal/01-ClusterRole.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-observability-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-observability-operator
+rules:
+  - apiGroups:
+      - "operators.coreos.com"
+    resources:
+      - clusterserviceversions
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - list
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-observability-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-observability-operator
+subjects:
+  - kind: ServiceAccount
+    name: sre-operator-reinstall-sa
+    namespace: openshift-observability-operator

--- a/deploy/obo-removal/02-CronJob.yaml
+++ b/deploy/obo-removal/02-CronJob.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-obo-uninstall
+  namespace: openshift-observability-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+            - name: operator-reinstaller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  #!/bin/bash
+                  set -euxo pipefail
+                  NAMESPACE=openshift-observability-operator
+                  oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com | grep "^observability-operator" | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+                  exit 0

--- a/deploy/obo-removal/README.md
+++ b/deploy/obo-removal/README.md
@@ -1,0 +1,3 @@
+# https://issues.redhat.com/browse/OSD-28074
+
+OBO removal from OSD/ROSA classic. 

--- a/deploy/obo-removal/config.yaml
+++ b/deploy/obo-removal/config.yaml
@@ -1,0 +1,17 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: NotIn
+      values: ["management-cluster", "service-cluster"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/addon-managed-api-service-internal
+      operator: NotIn
+      values: ["true"]
+    - key: api.openshift.com/addon-managed-api-service
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26759,6 +26759,131 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: obo-removal
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/addon-managed-api-service-internal
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/addon-managed-api-service
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-obo-uninstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-observability-operator
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    | grep "^observability-operator" | awk ''{print $1}'' | xargs
+                    oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+
+                    exit 0'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26759,6 +26759,131 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: obo-removal
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/addon-managed-api-service-internal
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/addon-managed-api-service
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-obo-uninstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-observability-operator
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    | grep "^observability-operator" | awk ''{print $1}'' | xargs
+                    oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+
+                    exit 0'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26759,6 +26759,131 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: obo-removal
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/addon-managed-api-service-internal
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/addon-managed-api-service
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-obo-uninstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '* * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - '#!/bin/bash
+
+                    set -euxo pipefail
+
+                    NAMESPACE=openshift-observability-operator
+
+                    oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com
+                    | grep "^observability-operator" | awk ''{print $1}'' | xargs
+                    oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+
+                    exit 0'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
cronjob that deploys on all ROSA/OSD clusters that are not fedramp/mc/sc/RHOAM. This is part of the migration of OBO to COO.

### What type of PR is this?
cleanup

### What this PR does / why we need it?

cronjob that deploys on all ROSA/OSD clusters that are not fedramp/mc/sc/RHOAM. This is part of the migration of OBO to COO.

### Which Jira/Github issue(s) this PR fixes?

Partially fixes https://issues.redhat.com/browse/OSD-28074


### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
