### PR TITLE
Copy hcp policies forward and fix small typo in zero egress ECR permi…

### DIFF
--- a/resources/sts/4.17/hypershift/sts_hcp_worker_instance_permission_policy.json
+++ b/resources/sts/4.17/hypershift/sts_hcp_worker_instance_permission_policy.json
@@ -26,7 +26,7 @@
                 "ecr:BatchGetImage",
                 "ecr:ListTagsForResource"
             ],
-            "Resource": "*"
+            "Resource": "*",
             "Condition": {
                 "StringEquals": {
                     "aws:ResourceTag/red-hat-managed": "true"

--- a/resources/sts/4.18/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/4.18/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -58,6 +58,16 @@
       }
     },
     {
+      "Sid": "CreateVolumeFromSnapshot",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:snapshot/*"
+      ]
+    },
+    {
       "Sid": "CreateSnapshotResourceTag",
       "Effect": "Allow",
       "Action": [

--- a/resources/sts/4.18/hypershift/sts_hcp_worker_instance_permission_policy.json
+++ b/resources/sts/4.18/hypershift/sts_hcp_worker_instance_permission_policy.json
@@ -2,12 +2,36 @@
     "Version": "2012-10-17",
     "Statement": [
         {
+            "Sid": "EC2DescribeInstancesRegions",
+            "Effect": "Allow",
+            "Action": ["ec2:DescribeInstances", "ec2:DescribeRegions"],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ECRGetAuthorizationToken",
+            "Effect": "Allow",
+            "Action": ["ecr:GetAuthorizationToken"],
+            "Resource": "*"
+        },
+        {
+            "Sid": "ECRReadOnlyAccessRedHatManaged",
             "Effect": "Allow",
             "Action": [
-                "ec2:DescribeInstances",
-                "ec2:DescribeRegions"
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:GetRepositoryPolicy",
+                "ecr:DescribeRepositories",
+                "ecr:ListImages",
+                "ecr:DescribeImages",
+                "ecr:BatchGetImage",
+                "ecr:ListTagsForResource"
             ],
-            "Resource": "*"
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceTag/red-hat-managed": "true"
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
Small typo fix for ECR permissions in the HCP worker policy, and ensuring the hypershift policies are copied foreward