### PR TITLE
Add resourcemanager.projects.get permission to support role in 4.17 and 4.18 w…

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -566,6 +566,7 @@ support:
         - monitoring.metricDescriptors.list
         - monitoring.timeSeries.list
         - observability.scopes.get
+        - resourcemanager.projects.get
         - resourcemanager.projects.getIamPolicy
         - resourcemanager.tagKeys.get
         - resourcemanager.tagKeys.list

--- a/resources/wif/4.18/vanilla.yaml
+++ b/resources/wif/4.18/vanilla.yaml
@@ -566,6 +566,7 @@ support:
         - monitoring.metricDescriptors.list
         - monitoring.timeSeries.list
         - observability.scopes.get
+        - resourcemanager.projects.get
         - resourcemanager.projects.getIamPolicy
         - resourcemanager.tagKeys.get
         - resourcemanager.tagKeys.list


### PR DESCRIPTION
The permission grants access to the name of the billing account associated with the project, there might have been changes to the UI since this permission has become a prerequisite to check information related to other resources, the gcloud CLI remains unaffected.

The permission allows the retrieval of the following metadata:
```
createTime: '2024-05-30T11:39:57.768747Z'
lifecycleState: ACTIVE
name: <project-name>
parent:
  id: <folder-id>
  type: folder
projectId: <project-id>
projectNumber: <project-number>

```