### PR TITLE
ROX-27758: Allow ACS team read secured cluster namespace secrets

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -860,6 +860,39 @@ spec:
                             - apiGroup: rbac.authorization.k8s.io
                               kind: Group
                               name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
+                            name: backplane-acs-rhacs-secured-cluster
+                            namespace: rhacs-secured-cluster
+                        rules:
+                            - apiGroups:
+                                - ""
+                              resources:
+                                - secrets
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-acs-rhacs-secured-cluster
+                            namespace: rhacs-secured-cluster
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-acs-rhacs-secured-cluster
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
                 pruneObjectBehavior: DeleteIfCreated
                 remediationAction: enforce
                 severity: low

--- a/deploy/backplane/acs/07-acs-rhacs-secured-cluster-role.yml
+++ b/deploy/backplane/acs/07-acs-rhacs-secured-cluster-role.yml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-acs-rhacs-secured-cluster
+  namespace: rhacs-secured-cluster
+rules:
+# ACS SRE can view ACS secured cluster secrets
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/backplane/acs/07-acs-rhacs-secured-cluster-rolebinding.yml
+++ b/deploy/backplane/acs/07-acs-rhacs-secured-cluster-rolebinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-acs-rhacs-secured-cluster
+  namespace: rhacs-secured-cluster
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-acs-rhacs-secured-cluster

--- a/docs/backplane/requirements/acs/10-acs-managed-service.md
+++ b/docs/backplane/requirements/acs/10-acs-managed-service.md
@@ -193,4 +193,8 @@ Permissions at cluster scope.
 * patch persistentvolumeclaims
 * patch statefulsets
 
+## backplane-acs-rhacs-secured-cluster: `rhacs-secured-cluster`
+
+* view secrets (required for operating ACS secured cluster)
+
 **Note** Please update this document as addional permisions are requested, thank you.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1787,6 +1787,39 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-rhacs-secured-cluster
+                    namespace: rhacs-secured-cluster
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-rhacs-secured-cluster
+                    namespace: rhacs-secured-cluster
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-rhacs-secured-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -11083,6 +11116,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -11915,6 +11975,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -12747,6 +12834,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1787,6 +1787,39 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-rhacs-secured-cluster
+                    namespace: rhacs-secured-cluster
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-rhacs-secured-cluster
+                    namespace: rhacs-secured-cluster
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-rhacs-secured-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -11083,6 +11116,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -11915,6 +11975,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -12747,6 +12834,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1787,6 +1787,39 @@ objects:
                   - apiGroup: rbac.authorization.k8s.io
                     kind: Group
                     name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
+                    name: backplane-acs-rhacs-secured-cluster
+                    namespace: rhacs-secured-cluster
+                  rules:
+                  - apiGroups:
+                    - ''
+                    resources:
+                    - secrets
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-acs-rhacs-secured-cluster
+                    namespace: rhacs-secured-cluster
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-acs-rhacs-secured-cluster
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
               pruneObjectBehavior: DeleteIfCreated
               remediationAction: enforce
               severity: low
@@ -11083,6 +11116,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -11915,6 +11975,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:
@@ -12747,6 +12834,33 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
         name: backplane-acs-openshift-gitops
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-acs-rhacs-secured-cluster
+        namespace: rhacs-secured-cluster
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-addon-acs-fleet-shard
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-acs-rhacs-secured-cluster
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?



### Which Jira/Github issue(s) this PR fixes?

ACS team has ACS Central connected to the ACSCS clusters and has secured cluster configured under `rhacs-secured-cluster` namespace. ACS team owns Central of this Secured Cluster instance. The secured cluster requires to fetch secrets to debug or test specific features

Fixes [ROX-27758](https://issues.redhat.com/browse/ROX-27758)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
