### PR TITLE
OSD-26790: Adding UpgradeNotificationFailedSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -62,3 +62,12 @@ spec:
       annotations:
         summary: "UpgradeConfig has not successfully synced in 4 hours."
         description: "This clusters UpgradeConfig has not been synced in 4 hours and may be out of date"
+    - alert: UpgradeStateNotificationFailureSRE
+      expr: upgrade_notification_failed == 1
+      for: 30m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+      annotations:
+        summary: "Cluster failed to notify {{ $labels.event }}"
+        description: "Cluster has not able to notify {{ $labels.event }} state for more than 30 minutes"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39587,6 +39587,16 @@ objects:
               summary: UpgradeConfig has not successfully synced in 4 hours.
               description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
+          - alert: UpgradeStateNotificationFailureSRE
+            expr: upgrade_notification_failed == 1
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              summary: Cluster failed to notify {{ $labels.event }}
+              description: Cluster has not able to notify {{ $labels.event }} state 
+                for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39595,7 +39595,7 @@ objects:
               namespace: openshift-monitoring
             annotations:
               summary: Cluster failed to notify {{ $labels.event }}
-              description: Cluster has not able to notify {{ $labels.event }} state 
+              description: Cluster has not able to notify {{ $labels.event }} state
                 for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39587,6 +39587,16 @@ objects:
               summary: UpgradeConfig has not successfully synced in 4 hours.
               description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
+          - alert: UpgradeStateNotificationFailureSRE
+            expr: upgrade_notification_failed == 1
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              summary: Cluster failed to notify {{ $labels.event }}
+              description: Cluster has not able to notify {{ $labels.event }} state 
+                for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39595,7 +39595,7 @@ objects:
               namespace: openshift-monitoring
             annotations:
               summary: Cluster failed to notify {{ $labels.event }}
-              description: Cluster has not able to notify {{ $labels.event }} state 
+              description: Cluster has not able to notify {{ $labels.event }} state
                 for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39587,6 +39587,16 @@ objects:
               summary: UpgradeConfig has not successfully synced in 4 hours.
               description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
+          - alert: UpgradeStateNotificationFailureSRE
+            expr: upgrade_notification_failed == 1
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              summary: Cluster failed to notify {{ $labels.event }}
+              description: Cluster has not able to notify {{ $labels.event }} state 
+                for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39595,7 +39595,7 @@ objects:
               namespace: openshift-monitoring
             annotations:
               summary: Cluster failed to notify {{ $labels.event }}
-              description: Cluster has not able to notify {{ $labels.event }} state 
+              description: Cluster has not able to notify {{ $labels.event }} state
                 for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

TLDR: When the user gets banned (OR) PS has been rotated in a middle of the upgrade, the upgrade will stall. We're creating a metric if MUO unable to notify it's state to the OCM. This metric will help us to track via PD, so that we can unblock the upgrade.

In previous [PR-494](https://github.com/openshift/managed-upgrade-operator/pull/494), we'd implemented the logic to enable upgrade_notification_failed metric. In this PR, we're triggering UpgradeNotificationFailedSRE alert, if we cluster unable to notify it's state more than 30 mins

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-26790](https://issues.redhat.com//browse/OSD-26790)