### PR TITLE
OSD-28173 add view CSR permissions to dedicated-reader and dedicated-admins to view Node tab

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -911,6 +911,14 @@ spec:
                                 - get
                                 - create
                                 - update
+                            - apiGroups:
+                                - certificates.k8s.io
+                              resources:
+                                - certificatesigningrequests
+                              verbs:
+                                - get
+                                - list
+                                - watch
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
+++ b/deploy/rbac-permissions-operator-config/05-osd-readers.ClusterRole.yaml
@@ -336,3 +336,15 @@ rules:
   - create
   - update
 ### END - Allow viewing observe tab data in console and query the thanos API
+### BEGIN - Allow viewing CSR for Node tab in Console
+# CONSOLE-3899 added CSR handling in the Node tab in console
+# Permission to view CSR is needed in order to load the Node tab
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+### END - Allow viewing CSR for Node tab in Console

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -9129,6 +9129,14 @@ objects:
                     - get
                     - create
                     - update
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -38240,6 +38248,14 @@ objects:
         - get
         - create
         - update
+      - apiGroups:
+        - certificates.k8s.io
+        resources:
+        - certificatesigningrequests
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -9129,6 +9129,14 @@ objects:
                     - get
                     - create
                     - update
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -38240,6 +38248,14 @@ objects:
         - get
         - create
         - update
+      - apiGroups:
+        - certificates.k8s.io
+        resources:
+        - certificatesigningrequests
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -9129,6 +9129,14 @@ objects:
                     - get
                     - create
                     - update
+                  - apiGroups:
+                    - certificates.k8s.io
+                    resources:
+                    - certificatesigningrequests
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -38240,6 +38248,14 @@ objects:
         - get
         - create
         - update
+      - apiGroups:
+        - certificates.k8s.io
+        resources:
+        - certificatesigningrequests
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

With https://github.com/openshift/console/pull/13493/ , it will need CSR read permission to load the Node tab in console. In OSD, dedicated-admins don't have permission to view CSR, thus will fail viewing the Node page in the console.

### Which Jira/Github issue(s) this PR fixes?

[OSD-22575](https://issues.redhat.com//browse/OSD-22575)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
