### PR TITLE
OHSS-41346: Fix NetworkMigrationDelayedSRE prometheus alert

### DIFF
--- a/deploy/sdn-ovn-migration/100-network-live-migration.PrometheusRule.yaml
+++ b/deploy/sdn-ovn-migration/100-network-live-migration.PrometheusRule.yaml
@@ -38,7 +38,7 @@ spec:
   - name: sre-network-live-migration-alerts
     rules:
       - alert: NetworkMigrationDelayedSRE
-        expr: (cluster:usage:network_live_migration_duration > (sum(cluster:node_roles) * 1800))
+        expr: (sum(cluster:usage:network_live_migration_duration) > (sum(cluster:nodes_roles) * 1800))
         for: 1m
         labels:
           severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39216,7 +39216,7 @@ objects:
         - name: sre-network-live-migration-alerts
           rules:
           - alert: NetworkMigrationDelayedSRE
-            expr: (cluster:usage:network_live_migration_duration > (sum(cluster:node_roles)
+            expr: (sum(cluster:usage:network_live_migration_duration) > (sum(cluster:nodes_roles)
               * 1800))
             for: 1m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39216,7 +39216,7 @@ objects:
         - name: sre-network-live-migration-alerts
           rules:
           - alert: NetworkMigrationDelayedSRE
-            expr: (cluster:usage:network_live_migration_duration > (sum(cluster:node_roles)
+            expr: (sum(cluster:usage:network_live_migration_duration) > (sum(cluster:nodes_roles)
               * 1800))
             for: 1m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39216,7 +39216,7 @@ objects:
         - name: sre-network-live-migration-alerts
           rules:
           - alert: NetworkMigrationDelayedSRE
-            expr: (cluster:usage:network_live_migration_duration > (sum(cluster:node_roles)
+            expr: (sum(cluster:usage:network_live_migration_duration) > (sum(cluster:nodes_roles)
               * 1800))
             for: 1m
             labels:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Fixes this alert, which was not firing for a cluster that was delayed in migrating.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OHSS-41346](https://issues.redhat.com/browse/OHSS-41346)

### Special notes for your reviewer:

I validated this works on the cluster that is blocked, see the below screenshots before and after:

**Before**
<img width="1195" alt="Screenshot 2025-02-13 at 12 33 31 PM" src="https://github.com/user-attachments/assets/e4cbc345-22b4-4fad-b625-0f2ceee77248" />

**After**
<img width="1191" alt="Screenshot 2025-02-13 at 12 33 20 PM" src="https://github.com/user-attachments/assets/fdb08726-36d5-456f-9fa2-c9fc4bd945b6" />

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
