### PR TITLE
Revert PR 'OSD-26790: Adding UpgradeNotificationFailedSRE alert' due …

### DIFF
--- a/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-managed-upgrade-operator.PrometheusRule.yaml
@@ -62,12 +62,3 @@ spec:
       annotations:
         summary: "UpgradeConfig has not successfully synced in 4 hours."
         description: "This clusters UpgradeConfig has not been synced in 4 hours and may be out of date"
-    - alert: UpgradeStateNotificationFailureSRE
-      expr: upgrade_notification_failed == 1
-      for: 30m
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
-      annotations:
-        summary: "Cluster failed to notify {{ $labels.event }}"
-        description: "Cluster has not able to notify {{ $labels.event }} state for more than 30 minutes"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39636,16 +39636,6 @@ objects:
               summary: UpgradeConfig has not successfully synced in 4 hours.
               description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
-          - alert: UpgradeStateNotificationFailureSRE
-            expr: upgrade_notification_failed == 1
-            for: 30m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: Cluster failed to notify {{ $labels.event }}
-              description: Cluster has not able to notify {{ $labels.event }} state
-                for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39636,16 +39636,6 @@ objects:
               summary: UpgradeConfig has not successfully synced in 4 hours.
               description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
-          - alert: UpgradeStateNotificationFailureSRE
-            expr: upgrade_notification_failed == 1
-            for: 30m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: Cluster failed to notify {{ $labels.event }}
-              description: Cluster has not able to notify {{ $labels.event }} state
-                for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39636,16 +39636,6 @@ objects:
               summary: UpgradeConfig has not successfully synced in 4 hours.
               description: This clusters UpgradeConfig has not been synced in 4 hours
                 and may be out of date
-          - alert: UpgradeStateNotificationFailureSRE
-            expr: upgrade_notification_failed == 1
-            for: 30m
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-            annotations:
-              summary: Cluster failed to notify {{ $labels.event }}
-              description: Cluster has not able to notify {{ $labels.event }} state
-                for more than 30 minutes
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
This reverts "[OSD-26790](https://issues.redhat.com//browse/OSD-26790): Adding UpgradeNotificationFailedSRE alert" (https://github.com/openshift/managed-cluster-config/pull/2359) due to [TRT-2010](https://issues.redhat.com/browse/TRT-2010) requiring all new alerts (PrometheusRules) needing a runbook_url property.