### PR TITLE
OSD-27692: New crontab to clean backplane remediation RBACs in case the remediation was not properly deleted

### DIFF
--- a/deploy/osd-delete-backplane-remediation-rbacs/00-delete-backplane-remediation-rbacs.namespace.yml
+++ b/deploy/osd-delete-backplane-remediation-rbacs/00-delete-backplane-remediation-rbacs.namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-backplane

--- a/deploy/osd-delete-backplane-remediation-rbacs/10-delete-backplane-remediation-rbacs.rbac.yaml
+++ b/deploy/osd-delete-backplane-remediation-rbacs/10-delete-backplane-remediation-rbacs.rbac.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-delete-backplane-remediation-rbacs
+  namespace: openshift-backplane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-delete-backplane-remediation-rbacs
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterroles
+      - clusterrolebindings
+    verbs:
+      - get
+      - list
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: osd-delete-backplane-remediation-rbacs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-delete-backplane-remediation-rbacs
+subjects:
+  - kind: ServiceAccount
+    name: osd-backplane
+    namespace: osd-delete-backplane-remediation-rbacs

--- a/deploy/osd-delete-backplane-remediation-rbacs/20-delete-backplane-remediation-rbacs.CronJob.yaml
+++ b/deploy/osd-delete-backplane-remediation-rbacs/20-delete-backplane-remediation-rbacs.CronJob.yaml
@@ -1,0 +1,68 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-delete-backplane-remediation-rbacs
+  namespace: openshift-backplane
+spec:
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      backoffLimit: 12
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - preference:
+                  matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+                weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          restartPolicy: Never
+          serviceAccountName: osd-delete-backplane-remediation-rbacs
+          containers:
+            - name: osd-delete-backplane-remediation-rbacs
+              imagePullPolicy: Always
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              args:
+                - /bin/bash
+                - -c
+                - |
+                  now=$(date +%s);
+                  expiryMins=720;
+                  for line in $(oc get rolebinding -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers);do
+                    ns=$(echo "$line" | awk '{print $1}')
+                    rolebinding=$(echo "$line" | awk '{print $2}')
+                    creation=$(date -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                    if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
+                      oc delete rolebinding $rolebinding -n $ns
+                    fi
+                  done;
+                  for line in $(oc get role oc get role -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers);do
+                    ns=$(echo "$line" | awk '{print $1}')
+                    role=$(echo "$line" | awk '{print $2}')
+                    creation=$(date -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                    if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
+                      oc delete role $role -n $ns
+                    fi
+                  done;
+                  for clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation --no-headers | awk '{print $1}');do
+                    creation=$(date -d $(oc get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                    if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
+                      oc delete clusterrolebinding $clusterrolebinding
+                    fi
+                  done;
+                  for clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation --no-headers | awk '{print $1}');do
+                    creation=$(date -d $(oc get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                    if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
+                      oc delete clusterrole $clusterrole
+                    fi
+                  done;

--- a/deploy/osd-delete-backplane-remediation-rbacs/config.yaml
+++ b/deploy/osd-delete-backplane-remediation-rbacs/config.yaml
@@ -1,0 +1,5 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet: 
+  resourceApplyMode: "Sync"
+policy:
+  destination: "acm-policies"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32295,6 +32295,119 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-remediation-rbacs
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-remediation-rbacs
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: osd-delete-backplane-remediation-rbacs
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            backoffLimit: 12
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-delete-backplane-remediation-rbacs
+                containers:
+                - name: osd-delete-backplane-remediation-rbacs
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "now=$(date +%s);\nexpiryMins=720;\nfor line in $(oc get rolebinding\
+                    \ -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
+                    \  rolebinding=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
+                    \ -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete rolebinding $rolebinding -n\
+                    \ $ns\n  fi\ndone;\nfor line in $(oc get role oc get role -A -l\
+                    \ managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
+                    \  role=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
+                    \ -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete role $role -n $ns\n  fi\ndone;\n\
+                    for clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation\
+                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
+                    \ get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete clusterrolebinding $clusterrolebinding\n\
+                    \  fi\ndone;\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
+                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
+                    \ get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete clusterrole $clusterrole\n\
+                    \  fi\ndone;\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-delete-backplane-script-resources
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32295,6 +32295,119 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-remediation-rbacs
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-remediation-rbacs
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: osd-delete-backplane-remediation-rbacs
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            backoffLimit: 12
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-delete-backplane-remediation-rbacs
+                containers:
+                - name: osd-delete-backplane-remediation-rbacs
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "now=$(date +%s);\nexpiryMins=720;\nfor line in $(oc get rolebinding\
+                    \ -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
+                    \  rolebinding=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
+                    \ -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete rolebinding $rolebinding -n\
+                    \ $ns\n  fi\ndone;\nfor line in $(oc get role oc get role -A -l\
+                    \ managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
+                    \  role=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
+                    \ -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete role $role -n $ns\n  fi\ndone;\n\
+                    for clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation\
+                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
+                    \ get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete clusterrolebinding $clusterrolebinding\n\
+                    \  fi\ndone;\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
+                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
+                    \ get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete clusterrole $clusterrole\n\
+                    \  fi\ndone;\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-delete-backplane-script-resources
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32295,6 +32295,119 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-delete-backplane-remediation-rbacs
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-backplane
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      rules:
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        - clusterroles
+        - clusterrolebindings
+        verbs:
+        - get
+        - list
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-remediation-rbacs
+      subjects:
+      - kind: ServiceAccount
+        name: osd-backplane
+        namespace: osd-delete-backplane-remediation-rbacs
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
+      spec:
+        failedJobsHistoryLimit: 5
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            backoffLimit: 12
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                restartPolicy: Never
+                serviceAccountName: osd-delete-backplane-remediation-rbacs
+                containers:
+                - name: osd-delete-backplane-remediation-rbacs
+                  imagePullPolicy: Always
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  args:
+                  - /bin/bash
+                  - -c
+                  - "now=$(date +%s);\nexpiryMins=720;\nfor line in $(oc get rolebinding\
+                    \ -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
+                    \  rolebinding=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
+                    \ -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete rolebinding $rolebinding -n\
+                    \ $ns\n  fi\ndone;\nfor line in $(oc get role oc get role -A -l\
+                    \ managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
+                    \  role=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
+                    \ -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete role $role -n $ns\n  fi\ndone;\n\
+                    for clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation\
+                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
+                    \ get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete clusterrolebinding $clusterrolebinding\n\
+                    \  fi\ndone;\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
+                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
+                    \ get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete clusterrole $clusterrole\n\
+                    \  fi\ndone;\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-delete-backplane-script-resources
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Remediations created through `ocm-backplane remediation create` need to be deleted once the investigation is finished.
Remediations are normally deleted running or programmatically running (for CAD):
```
ocm-backplane remediation delete
```
If not done, RBAC resources created during `ocm-backplane remediation create` will be leaked forever (except the service account which is already deleted after 720 minutes)

The purpose of this new crontab is to delete any resource:
- Labelled with `managed.openshift.io/remediation` (whatever the value)
- Which is more than 720 minutes == 12 hours old
- Which is of one of this type:
   - `clusterrole`
   - `clusterrolebinding`
   - `role`
   - `rolebinding` 

### Which Jira/Github issue(s) this PR fixes?

_Implemtens [OSD-27692](https://issues.redhat.com//browse/OSD-27692)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] Not a FedRAMP change