### PR TITLE
OSD-27897: Add pki-operator-annotator configuration for 4.16

### DIFF
--- a/deploy/ocpbugs-48519/10-CronJob-4-16.yaml
+++ b/deploy/ocpbugs-48519/10-CronJob-4-16.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pki-operator-annotator-4-16
+  namespace: openshift-pki-operator-annotator
+  annotations:
+    kubernetes.io/description: "Patches 4.16 ManifestWork to fixed pki-operator version https://issues.redhat.com/browse/OSD-27987"
+spec:
+  schedule: "*/5 * * * *" # Every five minutes
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: pki-operator-annotator
+          namespace: openshift-pki-operator-annotator
+          annotations:
+            kubernetes.io/description: "Patches 4.16 ManifestWork to fixed pki-operator version https://issues.redhat.com/browse/OSD-27987"
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                  weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          containers:
+            - name: pki-operator-annotator
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              imagePullPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+              env:
+                # oc adm release info --image-for hypershift quay.io/openshift-release-dev/ocp-release:4.16.34-multi
+                - name: IMAGE
+                  value: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5"
+                # What Y stream this annotator is looking to patch
+                - name: MAJOR_MINOR_VER
+                  value: "4.16"
+                # What Z stream includes the fix, meaning we don't patch at X.Y.Z and later (eg 4.16.34 has the fix)
+                - name: Z_STREAM_FIXED_VER
+                  value: "34"
+              volumeMounts:
+                - name: scripts
+                  mountPath: /tmp/scripts
+              command:
+                - /bin/bash
+              args:
+                - /tmp/scripts/patch.sh
+          volumes:
+            - name: scripts
+              configMap:
+                name: pki-operator-annotator
+          serviceAccountName: pki-operator-annotator
+          automountServiceAccountToken: true
+          restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27808,6 +27808,70 @@ objects:
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
+        name: pki-operator-annotator-4-16
+        namespace: openshift-pki-operator-annotator
+        annotations:
+          kubernetes.io/description: Patches 4.16 ManifestWork to fixed pki-operator
+            version https://issues.redhat.com/browse/OSD-27987
+      spec:
+        schedule: '*/5 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              metadata:
+                name: pki-operator-annotator
+                namespace: openshift-pki-operator-annotator
+                annotations:
+                  kubernetes.io/description: Patches 4.16 ManifestWork to fixed pki-operator
+                    version https://issues.redhat.com/browse/OSD-27987
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: pki-operator-annotator
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  env:
+                  - name: IMAGE
+                    value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+                  - name: MAJOR_MINOR_VER
+                    value: '4.16'
+                  - name: Z_STREAM_FIXED_VER
+                    value: '34'
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
+                  command:
+                  - /bin/bash
+                  args:
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: pki-operator-annotator
+                serviceAccountName: pki-operator-annotator
+                automountServiceAccountToken: true
+                restartPolicy: Never
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
         name: pki-operator-annotator-4-17
         namespace: openshift-pki-operator-annotator
         annotations:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27808,6 +27808,70 @@ objects:
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
+        name: pki-operator-annotator-4-16
+        namespace: openshift-pki-operator-annotator
+        annotations:
+          kubernetes.io/description: Patches 4.16 ManifestWork to fixed pki-operator
+            version https://issues.redhat.com/browse/OSD-27987
+      spec:
+        schedule: '*/5 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              metadata:
+                name: pki-operator-annotator
+                namespace: openshift-pki-operator-annotator
+                annotations:
+                  kubernetes.io/description: Patches 4.16 ManifestWork to fixed pki-operator
+                    version https://issues.redhat.com/browse/OSD-27987
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: pki-operator-annotator
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  env:
+                  - name: IMAGE
+                    value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+                  - name: MAJOR_MINOR_VER
+                    value: '4.16'
+                  - name: Z_STREAM_FIXED_VER
+                    value: '34'
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
+                  command:
+                  - /bin/bash
+                  args:
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: pki-operator-annotator
+                serviceAccountName: pki-operator-annotator
+                automountServiceAccountToken: true
+                restartPolicy: Never
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
         name: pki-operator-annotator-4-17
         namespace: openshift-pki-operator-annotator
         annotations:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27808,6 +27808,70 @@ objects:
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
+        name: pki-operator-annotator-4-16
+        namespace: openshift-pki-operator-annotator
+        annotations:
+          kubernetes.io/description: Patches 4.16 ManifestWork to fixed pki-operator
+            version https://issues.redhat.com/browse/OSD-27987
+      spec:
+        schedule: '*/5 * * * *'
+        concurrencyPolicy: Replace
+        jobTemplate:
+          spec:
+            template:
+              metadata:
+                name: pki-operator-annotator
+                namespace: openshift-pki-operator-annotator
+                annotations:
+                  kubernetes.io/description: Patches 4.16 ManifestWork to fixed pki-operator
+                    version https://issues.redhat.com/browse/OSD-27987
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                containers:
+                - name: pki-operator-annotator
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+                  imagePullPolicy: Always
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    runAsNonRoot: true
+                  env:
+                  - name: IMAGE
+                    value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9c417743007bbefa3909e95284113b1e9a43be9124464f6bbb62676009546da5
+                  - name: MAJOR_MINOR_VER
+                    value: '4.16'
+                  - name: Z_STREAM_FIXED_VER
+                    value: '34'
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
+                  command:
+                  - /bin/bash
+                  args:
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: pki-operator-annotator
+                serviceAccountName: pki-operator-annotator
+                automountServiceAccountToken: true
+                restartPolicy: Never
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
         name: pki-operator-annotator-4-17
         namespace: openshift-pki-operator-annotator
         annotations:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This is a continuation of https://github.com/openshift/managed-cluster-config/pull/2353, adding a CronJob to patch 4.16 clusters to ensure they are remediated to OCPBUGS-48519.

### Which Jira/Github issue(s) this PR fixes?

Fixed [OSD-27987](https://issues.redhat.com/browse/OSD-27987)

### Special notes for your reviewer:
I have deployed this to a few staging service clusters, and made a new 4.16 cluster in stage and confirmed it is working as expected.

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
