### PR TITLE
OSD-28572: Avoiding SlowCustomerWebhookSRE eval to fail when there are several configs for a given webhook name

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
@@ -10,21 +10,38 @@ spec:
   groups:
   - name: customer-webhooks
     rules:
-    - alert: SlowCustomerWebhookSRE
+    - record: webhook:max_duration
+      expr: |-
+        max by (webhook_name, operation, type) (
+          label_replace(
+            label_replace(
+              increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) /
+                increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),
+            "type", "mutating", "type", "admit"),
+          "webhook_name", "$0", "name", ".*")
+        )
+    - record: webhook:configuration_service:raw
+      expr: |-
+        label_replace(
+          kube_validatingwebhookconfiguration_webhook_clientconfig_service,
+          "type", "validating", "", ""
+        ) or label_replace(
+          kube_mutatingwebhookconfiguration_webhook_clientconfig_service,
+          "type", "mutating", "", ""
+        )
+    - record: webhook:configuration_service
       expr: |-
         (
-          max by (webhook_name, operation, type) (
-            label_replace(
-              label_replace(
-                increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m]) /
-                  increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),
-              "type", "mutating", "type", "admit"),
-            "webhook_name", "$0", "name", ".*")
-          )
-        ) * on(webhook_name) group_left(service_namespace, service_name) (
-          kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace !~ "openshift-.*"} or on(webhook_name)
-          kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace !~ "openshift-.*"}
-        ) > 1
+          sgn(count by (type, webhook_name) (webhook:configuration_service:raw) > 1)
+        ) or on (type, webhook_name) (
+          webhook:configuration_service:raw
+        )
+    - alert: SlowCustomerWebhookSRE
+      expr: |-
+        webhook:max_duration
+        * on(type, webhook_name) group_left(service_namespace, service_name)
+        webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io", service_namespace !~ "openshift-.*"}
+        > 1
       for: 15m
       labels:
         severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -41628,15 +41628,29 @@ objects:
         groups:
         - name: customer-webhooks
           rules:
+          - record: webhook:max_duration
+            expr: "max by (webhook_name, operation, type) (\n  label_replace(\n  \
+              \  label_replace(\n      increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
+              \ /\n        increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
+              \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
+              , \"$0\", \"name\", \".*\")\n)"
+          - record: webhook:configuration_service:raw
+            expr: "label_replace(\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service,\n\
+              \  \"type\", \"validating\", \"\", \"\"\n) or label_replace(\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service,\n\
+              \  \"type\", \"mutating\", \"\", \"\"\n)"
+          - record: webhook:configuration_service
+            expr: "(\n  sgn(count by (type, webhook_name) (webhook:configuration_service:raw)\
+              \ > 1)\n) or on (type, webhook_name) (\n  webhook:configuration_service:raw\n\
+              )"
           - alert: SlowCustomerWebhookSRE
-            expr: "(\n  max by (webhook_name, operation, type) (\n    label_replace(\n\
-              \      label_replace(\n        increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
-              \ /\n          increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
-              \      \"type\", \"mutating\", \"type\", \"admit\"),\n    \"webhook_name\"\
-              , \"$0\", \"name\", \".*\")\n  )\n) * on(webhook_name) group_left(service_namespace,\
-              \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"}\n) > 1"
+            expr: 'webhook:max_duration
+
+              * on(type, webhook_name) group_left(service_namespace, service_name)
+
+              webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io",
+              service_namespace !~ "openshift-.*"}
+
+              > 1'
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -41628,15 +41628,29 @@ objects:
         groups:
         - name: customer-webhooks
           rules:
+          - record: webhook:max_duration
+            expr: "max by (webhook_name, operation, type) (\n  label_replace(\n  \
+              \  label_replace(\n      increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
+              \ /\n        increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
+              \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
+              , \"$0\", \"name\", \".*\")\n)"
+          - record: webhook:configuration_service:raw
+            expr: "label_replace(\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service,\n\
+              \  \"type\", \"validating\", \"\", \"\"\n) or label_replace(\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service,\n\
+              \  \"type\", \"mutating\", \"\", \"\"\n)"
+          - record: webhook:configuration_service
+            expr: "(\n  sgn(count by (type, webhook_name) (webhook:configuration_service:raw)\
+              \ > 1)\n) or on (type, webhook_name) (\n  webhook:configuration_service:raw\n\
+              )"
           - alert: SlowCustomerWebhookSRE
-            expr: "(\n  max by (webhook_name, operation, type) (\n    label_replace(\n\
-              \      label_replace(\n        increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
-              \ /\n          increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
-              \      \"type\", \"mutating\", \"type\", \"admit\"),\n    \"webhook_name\"\
-              , \"$0\", \"name\", \".*\")\n  )\n) * on(webhook_name) group_left(service_namespace,\
-              \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"}\n) > 1"
+            expr: 'webhook:max_duration
+
+              * on(type, webhook_name) group_left(service_namespace, service_name)
+
+              webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io",
+              service_namespace !~ "openshift-.*"}
+
+              > 1'
             for: 15m
             labels:
               severity: warning

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -41628,15 +41628,29 @@ objects:
         groups:
         - name: customer-webhooks
           rules:
+          - record: webhook:max_duration
+            expr: "max by (webhook_name, operation, type) (\n  label_replace(\n  \
+              \  label_replace(\n      increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
+              \ /\n        increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
+              \    \"type\", \"mutating\", \"type\", \"admit\"),\n  \"webhook_name\"\
+              , \"$0\", \"name\", \".*\")\n)"
+          - record: webhook:configuration_service:raw
+            expr: "label_replace(\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service,\n\
+              \  \"type\", \"validating\", \"\", \"\"\n) or label_replace(\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service,\n\
+              \  \"type\", \"mutating\", \"\", \"\"\n)"
+          - record: webhook:configuration_service
+            expr: "(\n  sgn(count by (type, webhook_name) (webhook:configuration_service:raw)\
+              \ > 1)\n) or on (type, webhook_name) (\n  webhook:configuration_service:raw\n\
+              )"
           - alert: SlowCustomerWebhookSRE
-            expr: "(\n  max by (webhook_name, operation, type) (\n    label_replace(\n\
-              \      label_replace(\n        increase(apiserver_admission_webhook_admission_duration_seconds_sum[5m])\
-              \ /\n          increase(apiserver_admission_webhook_admission_duration_seconds_count[5m]),\n\
-              \      \"type\", \"mutating\", \"type\", \"admit\"),\n    \"webhook_name\"\
-              , \"$0\", \"name\", \".*\")\n  )\n) * on(webhook_name) group_left(service_namespace,\
-              \ service_name) (\n  kube_validatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"} or on(webhook_name)\n  kube_mutatingwebhookconfiguration_webhook_clientconfig_service{service_namespace\
-              \ !~ \"openshift-.*\"}\n) > 1"
+            expr: 'webhook:max_duration
+
+              * on(type, webhook_name) group_left(service_namespace, service_name)
+
+              webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io",
+              service_namespace !~ "openshift-.*"}
+
+              > 1'
             for: 15m
             labels:
               severity: warning


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
`SlowCustomerWebhookSRE` alert eval may fail when there is more than one time series for the `kube_validatingwebhookconfiguration_webhook_clientconfig_service` or the `kube_mutatingwebhookconfiguration_webhook_clientconfig_service` metric.
This typically happen when the customer gives the same name to several webhooks.

### Which Jira/Github issue(s) this PR fixes?

_Fixes_ [OSD-28572](https://issues.redhat.com//browse/OSD-28572)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] Not intended for the FedRAMP environment