### PR TITLE
Remove control plane operator image pin annotation from all clusters

### DIFF
--- a/deploy/ocpbugs-48519/04-ConfigMap.yaml
+++ b/deploy/ocpbugs-48519/04-ConfigMap.yaml
@@ -63,31 +63,19 @@ data:
     
     # Loop through each manifestwork object
     for clusterID in ${managedclusters[@]};do
-      # Extract full version, namespace and name
-      version=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')
-    
-      # Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER
-      # This also handles any case where the script exits non-zero for any other reason, opting to patch as a result.
-      cleanup="false"
-      if python /tmp/scripts/should_patch.py "${version}" "${Z_STREAM_FIXED_VER}"; then
-        echo "cluster ${clusterID} does not need the override because it's Z stream is >= ${Z_STREAM_FIXED_VER}"
-        echo "removing hypershift.openshift.io/control-plane-operator-image annotation"
-        cleanup="true"
-      fi
+      # Clean up annotation due to upgrade bug in OCPBUGS-52819
+      # Removing annotation for all versions as kube apiserver arguments prevent control plane operator image from comming up
+      # after upgrade has started, this causes pods to crashloop see incident #itn-2025-00060
     
       namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
       kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
       num=0
       for kind in $kinds;do
         if [[ $kind == "HostedCluster" ]]; then
-            echo "patching cluster: $clusterID"
+            echo "removing annotation for cluster: $clusterID"
+
+            json_payload='[{"op":"remove","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image"}]'
     
-            if [[ $cleanup = "true" ]]; then
-              json_payload='[{"op":"remove","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image"}]'
-            else 
-              json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image","value":"'"$IMAGE"'"}]'
-            fi
-            
             echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
             oc patch manifestwork "$clusterID" -n "$namespace" --type='json' -p "$json_payload"
             echo "-------------------------------------------------------------------------"
@@ -96,6 +84,3 @@ data:
       (( num++))
       done
     done
-    
-    
-    

--- a/deploy/ocpbugs-48519/04-ConfigMap.yaml
+++ b/deploy/ocpbugs-48519/04-ConfigMap.yaml
@@ -65,9 +65,15 @@ data:
     for clusterID in ${managedclusters[@]};do
       # Clean up annotation due to upgrade bug in OCPBUGS-52819
       # Removing annotation for all versions as kube apiserver arguments prevent control plane operator image from comming up
-      # after upgrade has started, this causes pods to crashloop see incident #itn-2025-00060
+      # after upgrade has started, this causes pods to crashloop see incident #itn-2025-00060 
     
       namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
+      # On a service clusters api.openshift.com/management-cluster will be null for management clusters and local-cluster
+      # skip these
+      if [[ $namespace == "null" ]]; then
+        continue
+      fi
+
       kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
       num=0
       for kind in $kinds;do

--- a/deploy/ocpbugs-48519/patch.sh
+++ b/deploy/ocpbugs-48519/patch.sh
@@ -10,30 +10,18 @@ managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR
 
 # Loop through each manifestwork object
 for clusterID in ${managedclusters[@]};do
-  # Extract full version, namespace and name
-  version=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')
-
-  # Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER
-  # This also handles any case where the script exits non-zero for any other reason, opting to patch as a result.
-  cleanup="false"
-  if python /tmp/scripts/should_patch.py "${version}" "${Z_STREAM_FIXED_VER}"; then
-    echo "cluster ${clusterID} does not need the override because it's Z stream is >= ${Z_STREAM_FIXED_VER}"
-    echo "removing hypershift.openshift.io/control-plane-operator-image annotation"
-    cleanup="true"
-  fi
+  # Clean up annotation due to upgrade bug in OCPBUGS-52819
+  # Removing annotation for all versions as kube apiserver arguments prevent control plane operator image from comming up
+  # after upgrade has started, this causes pods to crashloop see incident #itn-2025-00060
 
   namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
   kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
   num=0
   for kind in $kinds;do
     if [[ $kind == "HostedCluster" ]]; then
-        echo "patching cluster: $clusterID"
+        echo "removing annotation for cluster: $clusterID"
 
-        if [[ $cleanup = "true" ]]; then
-          json_payload='[{"op":"remove","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image"}]'
-        else
-          json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image","value":"'"$IMAGE"'"}]'
-        fi
+        json_payload='[{"op":"remove","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image"}]'
 
         echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
         oc patch manifestwork "$clusterID" -n "$namespace" --type='json' -p "$json_payload"

--- a/deploy/ocpbugs-48519/patch.sh
+++ b/deploy/ocpbugs-48519/patch.sh
@@ -15,6 +15,12 @@ for clusterID in ${managedclusters[@]};do
   # after upgrade has started, this causes pods to crashloop see incident #itn-2025-00060
 
   namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
+  # On a service clusters api.openshift.com/management-cluster will be null for management clusters and local-cluster
+  # skip these
+  if [[ $namespace == "null" ]]; then
+    continue
+  fi
+
   kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
   num=0
   for kind in $kinds;do

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27789,29 +27789,21 @@ objects:
           \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
-          \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
-          \ $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')\n\n  #\
-          \ Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER\n\
-          \  # This also handles any case where the script exits non-zero for any\
-          \ other reason, opting to patch as a result.\n  cleanup=\"false\"\n  if\
-          \ python /tmp/scripts/should_patch.py \"${version}\" \"${Z_STREAM_FIXED_VER}\"\
-          ; then\n    echo \"cluster ${clusterID} does not need the override because\
-          \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/control-plane-operator-image\
-          \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
-          \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
-          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
-          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
-          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
-          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
+          \  # Clean up annotation due to upgrade bug in OCPBUGS-52819\n  # Removing\
+          \ annotation for all versions as kube apiserver arguments prevent control\
+          \ plane operator image from comming up\n  # after upgrade has started, this\
+          \ causes pods to crashloop see incident #itn-2025-00060\n\n  namespace=$(oc\
+          \ get managedclusters \"$clusterID\" -o json | jq -r '.metadata.labels[\"\
+          api.openshift.com/management-cluster\"]')\n  kinds=$(oc get manifestwork\
+          \ -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
+          \ ]]; then\n        echo \"removing annotation for cluster: $clusterID\"\
+          \n\n        json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
           $num\"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image\"\
-          }]'\n        else \n          json_payload='[{\"op\":\"replace\",\"path\"\
-          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image\"\
-          ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n        \n        echo \"oc\
-          \ patch manifestwork $clusterID -n $namespace --type='json' -p \"$json_payload\"\
-          \"\n        oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
-          \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-          \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+          }]'\n\n        echo \"oc patch manifestwork $clusterID -n $namespace --type='json'\
+          \ -p \"$json_payload\"\"\n        oc patch manifestwork \"$clusterID\" -n\
+          \ \"$namespace\" --type='json' -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+          \n        break\n    fi\n  (( num++))\n  done\ndone"
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27792,10 +27792,12 @@ objects:
           \  # Clean up annotation due to upgrade bug in OCPBUGS-52819\n  # Removing\
           \ annotation for all versions as kube apiserver arguments prevent control\
           \ plane operator image from comming up\n  # after upgrade has started, this\
-          \ causes pods to crashloop see incident #itn-2025-00060\n\n  namespace=$(oc\
+          \ causes pods to crashloop see incident #itn-2025-00060 \n\n  namespace=$(oc\
           \ get managedclusters \"$clusterID\" -o json | jq -r '.metadata.labels[\"\
-          api.openshift.com/management-cluster\"]')\n  kinds=$(oc get manifestwork\
-          \ -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          api.openshift.com/management-cluster\"]')\n  # On a service clusters api.openshift.com/management-cluster\
+          \ will be null for management clusters and local-cluster\n  # skip these\n\
+          \  if [[ $namespace == \"null\" ]]; then\n    continue\n  fi\n\n  kinds=$(oc\
+          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
           \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
           \ ]]; then\n        echo \"removing annotation for cluster: $clusterID\"\
           \n\n        json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27789,29 +27789,21 @@ objects:
           \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
-          \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
-          \ $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')\n\n  #\
-          \ Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER\n\
-          \  # This also handles any case where the script exits non-zero for any\
-          \ other reason, opting to patch as a result.\n  cleanup=\"false\"\n  if\
-          \ python /tmp/scripts/should_patch.py \"${version}\" \"${Z_STREAM_FIXED_VER}\"\
-          ; then\n    echo \"cluster ${clusterID} does not need the override because\
-          \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/control-plane-operator-image\
-          \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
-          \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
-          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
-          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
-          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
-          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
+          \  # Clean up annotation due to upgrade bug in OCPBUGS-52819\n  # Removing\
+          \ annotation for all versions as kube apiserver arguments prevent control\
+          \ plane operator image from comming up\n  # after upgrade has started, this\
+          \ causes pods to crashloop see incident #itn-2025-00060\n\n  namespace=$(oc\
+          \ get managedclusters \"$clusterID\" -o json | jq -r '.metadata.labels[\"\
+          api.openshift.com/management-cluster\"]')\n  kinds=$(oc get manifestwork\
+          \ -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
+          \ ]]; then\n        echo \"removing annotation for cluster: $clusterID\"\
+          \n\n        json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
           $num\"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image\"\
-          }]'\n        else \n          json_payload='[{\"op\":\"replace\",\"path\"\
-          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image\"\
-          ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n        \n        echo \"oc\
-          \ patch manifestwork $clusterID -n $namespace --type='json' -p \"$json_payload\"\
-          \"\n        oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
-          \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-          \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+          }]'\n\n        echo \"oc patch manifestwork $clusterID -n $namespace --type='json'\
+          \ -p \"$json_payload\"\"\n        oc patch manifestwork \"$clusterID\" -n\
+          \ \"$namespace\" --type='json' -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+          \n        break\n    fi\n  (( num++))\n  done\ndone"
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27792,10 +27792,12 @@ objects:
           \  # Clean up annotation due to upgrade bug in OCPBUGS-52819\n  # Removing\
           \ annotation for all versions as kube apiserver arguments prevent control\
           \ plane operator image from comming up\n  # after upgrade has started, this\
-          \ causes pods to crashloop see incident #itn-2025-00060\n\n  namespace=$(oc\
+          \ causes pods to crashloop see incident #itn-2025-00060 \n\n  namespace=$(oc\
           \ get managedclusters \"$clusterID\" -o json | jq -r '.metadata.labels[\"\
-          api.openshift.com/management-cluster\"]')\n  kinds=$(oc get manifestwork\
-          \ -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          api.openshift.com/management-cluster\"]')\n  # On a service clusters api.openshift.com/management-cluster\
+          \ will be null for management clusters and local-cluster\n  # skip these\n\
+          \  if [[ $namespace == \"null\" ]]; then\n    continue\n  fi\n\n  kinds=$(oc\
+          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
           \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
           \ ]]; then\n        echo \"removing annotation for cluster: $clusterID\"\
           \n\n        json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27789,29 +27789,21 @@ objects:
           \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
-          \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
-          \ $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')\n\n  #\
-          \ Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER\n\
-          \  # This also handles any case where the script exits non-zero for any\
-          \ other reason, opting to patch as a result.\n  cleanup=\"false\"\n  if\
-          \ python /tmp/scripts/should_patch.py \"${version}\" \"${Z_STREAM_FIXED_VER}\"\
-          ; then\n    echo \"cluster ${clusterID} does not need the override because\
-          \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/control-plane-operator-image\
-          \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
-          \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
-          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
-          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
-          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
-          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
+          \  # Clean up annotation due to upgrade bug in OCPBUGS-52819\n  # Removing\
+          \ annotation for all versions as kube apiserver arguments prevent control\
+          \ plane operator image from comming up\n  # after upgrade has started, this\
+          \ causes pods to crashloop see incident #itn-2025-00060\n\n  namespace=$(oc\
+          \ get managedclusters \"$clusterID\" -o json | jq -r '.metadata.labels[\"\
+          api.openshift.com/management-cluster\"]')\n  kinds=$(oc get manifestwork\
+          \ -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
+          \ ]]; then\n        echo \"removing annotation for cluster: $clusterID\"\
+          \n\n        json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
           $num\"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image\"\
-          }]'\n        else \n          json_payload='[{\"op\":\"replace\",\"path\"\
-          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1control-plane-operator-image\"\
-          ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n        \n        echo \"oc\
-          \ patch manifestwork $clusterID -n $namespace --type='json' -p \"$json_payload\"\
-          \"\n        oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
-          \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-          \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+          }]'\n\n        echo \"oc patch manifestwork $clusterID -n $namespace --type='json'\
+          \ -p \"$json_payload\"\"\n        oc patch manifestwork \"$clusterID\" -n\
+          \ \"$namespace\" --type='json' -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+          \n        break\n    fi\n  (( num++))\n  done\ndone"
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27792,10 +27792,12 @@ objects:
           \  # Clean up annotation due to upgrade bug in OCPBUGS-52819\n  # Removing\
           \ annotation for all versions as kube apiserver arguments prevent control\
           \ plane operator image from comming up\n  # after upgrade has started, this\
-          \ causes pods to crashloop see incident #itn-2025-00060\n\n  namespace=$(oc\
+          \ causes pods to crashloop see incident #itn-2025-00060 \n\n  namespace=$(oc\
           \ get managedclusters \"$clusterID\" -o json | jq -r '.metadata.labels[\"\
-          api.openshift.com/management-cluster\"]')\n  kinds=$(oc get manifestwork\
-          \ -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          api.openshift.com/management-cluster\"]')\n  # On a service clusters api.openshift.com/management-cluster\
+          \ will be null for management clusters and local-cluster\n  # skip these\n\
+          \  if [[ $namespace == \"null\" ]]; then\n    continue\n  fi\n\n  kinds=$(oc\
+          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
           \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
           \ ]]; then\n        echo \"removing annotation for cluster: $clusterID\"\
           \n\n        json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
This PR will remove the control plane operator image pin annotation from all ManifestWork resources on service clusters within the fleet (Originally applied in [SDE-4686](https://issues.redhat.com//browse/SDE-4686)). 

The pinning of the operator version causes a bug where control plans can't upgrade because the control-plane-operator-image lays down a ConfigMap "kas-config" with invalid kube-apiserver arguments causing the kube-apiserver pods to crashloop. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes # OCPBUGS-52819

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
