### PR TITLE
OSD-28722: re-add view aggregation to SRE-P service cluster access

### DIFF
--- a/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/hypershift/service-cluster/20-srep.SubjectPermission.yml
@@ -6,6 +6,8 @@ metadata:
 spec:
   clusterPermissions:
   - backplane-srep-service-cluster-cluster
+  # permit get at global scope https://issues.redhat.com/browse/OSD-15997
+  - view
   permissions:
   - clusterRoleName: backplane-srep-service-cluster-project
     namespacesAllowedRegex: "(^uhc.*|^ocm.*|^klusterlet.*)"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24551,6 +24551,7 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24551,6 +24551,7 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24551,6 +24551,7 @@ objects:
       spec:
         clusterPermissions:
         - backplane-srep-service-cluster-cluster
+        - view
         permissions:
         - clusterRoleName: backplane-srep-service-cluster-project
           namespacesAllowedRegex: (^uhc.*|^ocm.*|^klusterlet.*)


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This PR reverts https://github.com/openshift/managed-cluster-config/pull/2295 and re-adds the `view` aggregation for SRE-P on service clusters. 

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/OSD-28722 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
