### PR TITLE
CronJob to reinstall RMO

### DIFF
--- a/deploy/osd-route-monitor-operator-reinstall/01-openshift-route-monitor-operator.ServiceAccount.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/01-openshift-route-monitor-operator.ServiceAccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-route-monitor-operator

--- a/deploy/osd-route-monitor-operator-reinstall/02-openshift-route-monitor-operator.Role.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/02-openshift-route-monitor-operator.Role.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-route-monitor-operator
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+- apiGroups:
+  - "batch"
+  resources:
+  - cronjobs
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete

--- a/deploy/osd-route-monitor-operator-reinstall/03-openshift-route-monitor-operator.RoleBinding.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/03-openshift-route-monitor-operator.RoleBinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-route-monitor-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-route-monitor-operator

--- a/deploy/osd-route-monitor-operator-reinstall/04-openshift-route-monitor-operator.CronJob.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/04-openshift-route-monitor-operator.CronJob.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-route-monitor-operator
+spec:
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 100
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+          - name: operator-reinstaller
+            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+            imagePullPolicy: Always
+            command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -euxo pipefail
+              NAMESPACE=openshift-route-monitor-operator
+              OPERATOR=route-monitor-operator.v0.1.719-gd3500fe
+
+              # Look for a CSV, then perform the reinstall if found. If you want to _always_ reinstall, remove this check and just keep the logic inside the "if"
+              CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -o name | grep "$OPERATOR")
+              if [[ ! -z "$CSV_FOUND" ]]; then
+                # The OLM dance
+                # delete all installplans
+                oc get installplans.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete installplan.operators.coreos.com -n $NAMESPACE
+                # get subscription
+                oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json
+                # delete subscription
+                oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR
+                # create subscription using the following json
+                oc create -f /tmp/sub.json
+                # delete all CSVs
+                oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+              fi
+              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
+              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
+              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
+              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
+              exit 0

--- a/deploy/osd-route-monitor-operator-reinstall/README.md
+++ b/deploy/osd-route-monitor-operator-reinstall/README.md
@@ -1,0 +1,5 @@
+# Overview
+
+When upgrading RMO from version `0.1.719-gd3500fe` to `0.1.738-ga0d7c58` it was found that only 30% of the fleet upgraded to the correct version.
+
+This `SelectorSyncSet` will be used to force a re-install of RMO if a cluster is still running the older `0.1.719-gd3500fe` version.

--- a/deploy/osd-route-monitor-operator-reinstall/config.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"
+


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
We released RMO version `0.1.738-ga0d7c58` yesterday but only 30% of the fleet upgraded to this newer version.
This PR adds a one time CronJob to cleanup older installs of RMO matching version `0.1.719-gd3500fe` 

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/OSD-28723

### Special notes for your reviewer:

https://redhat-internal.slack.com/archives/G01DC1VRAGK/p1741701811783649 

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster

We don't have any stage clusters in error, but I was able to execute each step of the cronjob bash logic manually against a production cluster that was in error.

```
$ oc get pods -n $NAMESPACE route-monitor-operator-controller-manager-6f4c5d75b8-z22gw -o yaml | grep route-monitor-operator.v0.1.719-gd3500fe
      value: route-monitor-operator.v0.1.719-gd3500fe

$ NAMESPACE=openshift-route-monitor-operator

$ OPERATOR=route-monitor-operator

$ CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com -o name | grep "$OPERATOR")

$echo $CSV_FOUND
clusterserviceversion.operators.coreos.com/route-monitor-operator.v0.1.719-gd3500fe

$ oc get installplans.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete installplan.operators.coreos.com -n $NAMESPACE
No resources found in openshift-route-monitor-operator namespace.

$ oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json

$ cat /tmp/sub.json
{
  "apiVersion": "operators.coreos.com/v1alpha1",
  "kind": "Subscription",
  "metadata": {
    "annotations": {
      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"Subscription\",\"metadata\":{\"annotations\":{},\"labels\":{\"hive.openshift.io/managed\":\"true\"},\"name\":\"route-monitor-operator\",\"namespace\":\"openshift-route-monitor-operator\"},\"spec\":{\"channel\":\"production\",\"name\":\"route-monitor-operator\",\"source\":\"route-monitor-operator-registry\",\"sourceNamespace\":\"openshift-route-monitor-operator\"}}\n"
    },
    "labels": {
      "hive.openshift.io/managed": "true",
      "operators.coreos.com/route-monitor-operator.openshift-route-monitor-operator": ""
    },
    "name": "route-monitor-operator",
    "namespace": "openshift-route-monitor-operator"
  },
  "spec": {
    "channel": "production",
    "name": "route-monitor-operator",
    "source": "route-monitor-operator-registry",
    "sourceNamespace": "openshift-route-monitor-operator"
  }
}

$  oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR
subscription.operators.coreos.com "route-monitor-operator" deleted

$ ocm backplane elevate "OSD-28723" -- create -f /tmp/sub.json
subscription.operators.coreos.com/route-monitor-operator created

$ oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
clusterserviceversion.operators.coreos.com "route-monitor-operator.v0.1.719-gd3500fe" deleted

$ oc get pods -n $NAMESPACE
NAME                                                         READY   STATUS    RESTARTS   AGE
blackbox-exporter-94b6f84b4-lptvg                            1/1     Running   0          35d
route-monitor-operator-controller-manager-85dd4459d7-hr84z   1/1     Running   0          2m45s
route-monitor-operator-registry-mtgj4                        1/1     Running   0          21h

$ oc get pods -n $NAMESPACE route-monitor-operator-controller-manager-85dd4459d7-hr84z -o yaml | grep route-monitor-operator.v0.1.738-ga0d7c58
      value: route-monitor-operator.v0.1.738-ga0d7c58
```

- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
