### PR TITLE
swap to job and fix some logic

### DIFF
--- a/deploy/osd-route-monitor-operator-reinstall/04-openshift-route-monitor-operator.CronJob.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/04-openshift-route-monitor-operator.CronJob.yaml
@@ -1,30 +1,26 @@
 ---
 apiVersion: batch/v1
-kind: CronJob
+kind: Job
 metadata:
   name: sre-operator-reinstall
   namespace: openshift-route-monitor-operator
 spec:
-  failedJobsHistoryLimit: 1
-  successfulJobsHistoryLimit: 3
-  concurrencyPolicy: Replace
-  schedule: "*/30 * * * *"
-  jobTemplate:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  template:
     spec:
-      ttlSecondsAfterFinished: 100
-      template:
-        spec:
-          serviceAccountName: sre-operator-reinstall-sa
-          restartPolicy: Never
-          containers:
-          - name: operator-reinstaller
-            image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-            imagePullPolicy: Always
-            command:
-            - sh
-            - -c
-            - |
-              #!/bin/bash
+      restartPolicy: OnFailure
+      containers:
+      - name: sre-operator-reinstall
+        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        serviceAccount: sre-operator-reinstall-sa
+        serviceAccountName: sre-operator-reinstall-sa
+        command:
+        - sh
+        - -c
+        - |
+          #!/bin/bash
               set -euxo pipefail
               NAMESPACE=openshift-route-monitor-operator
               OPERATOR=route-monitor-operator
@@ -34,7 +30,7 @@ spec:
               if [[ ! -z "$CSV_FOUND" ]]; then
                 # The OLM dance
                 # delete all installplans (if found) (the true is so we don't fail set -e)
-                installplans=$(oc get installplans.operators.coreos.com -n "$NAMESPACE" | grep "$OPERATOR" || true | awk '{print $1}')
+                installplans=$(oc get installplans.operators.coreos.com -n "$NAMESPACE" --no-headers | awk '{print $1}' | grep "$OPERATOR" || true | awk '{print $1}')
                 if [[ -n "$installplans" ]]; then
                   echo "$installplans" | xargs oc delete installplan.operators.coreos.com -n "$NAMESPACE"
                 fi
@@ -45,10 +41,6 @@ spec:
                 # create subscription using the following json
                 oc create -f /tmp/sub.json
                 # delete all CSVs
-                oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+                oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
               fi
-              oc -n "$NAMESPACE" delete cronjob sre-operator-reinstall || true
-              oc -n "$NAMESPACE" delete role sre-operator-reinstall-role || true
-              oc -n "$NAMESPACE" delete rolebinding sre-operator-reinstall-rb || true
-              oc -n "$NAMESPACE" delete serviceaccount sre-operator-reinstall-sa || true
               exit 0

--- a/deploy/osd-route-monitor-operator-reinstall/04-openshift-route-monitor-operator.CronJob.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/04-openshift-route-monitor-operator.CronJob.yaml
@@ -8,14 +8,16 @@ spec:
   backoffLimit: 6
   completions: 1
   parallelism: 1
+  ttlSecondsAfterFinished: 600 # Cleanup job after 10 minutes
+  activeDeadlineSeconds: 300 # Kill the job pod if it runs for longer than 5 minutes
   template:
     spec:
       restartPolicy: OnFailure
+      serviceAccount: sre-operator-reinstall-sa
+      serviceAccountName: sre-operator-reinstall-sa
       containers:
       - name: sre-operator-reinstall
         image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-        serviceAccount: sre-operator-reinstall-sa
-        serviceAccountName: sre-operator-reinstall-sa
         command:
         - sh
         - -c

--- a/deploy/osd-route-monitor-operator-reinstall/config.yaml
+++ b/deploy/osd-route-monitor-operator-reinstall/config.yaml
@@ -1,8 +1,8 @@
 deploymentMode: SelectorSyncSet
 selectorSyncSet:
+  resourceApplyMode: "Sync"
   matchExpressions:
   - key: api.openshift.com/fedramp
     operator: NotIn
     values:
       - "true"
-

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -35494,54 +35494,48 @@ objects:
         name: sre-operator-reinstall-sa
         namespace: openshift-route-monitor-operator
     - apiVersion: batch/v1
-      kind: CronJob
+      kind: Job
       metadata:
         name: sre-operator-reinstall
         namespace: openshift-route-monitor-operator
       spec:
-        failedJobsHistoryLimit: 1
-        successfulJobsHistoryLimit: 3
-        concurrencyPolicy: Replace
-        schedule: '*/30 * * * *'
-        jobTemplate:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        ttlSecondsAfterFinished: 600
+        activeDeadlineSeconds: 300
+        template:
           spec:
-            ttlSecondsAfterFinished: 100
-            template:
-              spec:
-                serviceAccountName: sre-operator-reinstall-sa
-                restartPolicy: Never
-                containers:
-                - name: operator-reinstaller
-                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
-                  command:
-                  - sh
-                  - -c
-                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
-                    OPERATOR=route-monitor-operator\n\n# Look for a CSV, then perform\
-                    \ the reinstall if found. If you want to _always_ reinstall, remove\
-                    \ this check and just keep the logic inside the \"if\"\nCSV_FOUND=$(oc\
-                    \ -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
-                    \ -o name | grep \"$OPERATOR\")\nif [[ ! -z \"$CSV_FOUND\" ]];\
-                    \ then\n  # The OLM dance\n  # delete all installplans (if found)\
-                    \ (the true is so we don't fail set -e)\n  installplans=$(oc get\
-                    \ installplans.operators.coreos.com -n \"$NAMESPACE\" | grep \"\
-                    $OPERATOR\" || true | awk '{print $1}')\n  if [[ -n \"$installplans\"\
-                    \ ]]; then\n    echo \"$installplans\" | xargs oc delete installplan.operators.coreos.com\
-                    \ -n \"$NAMESPACE\"\n  fi\n  # get subscription\n  oc get subscription.operators.coreos.com\
-                    \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
-                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
-                    \ | del(.metadata.uid)' > /tmp/sub.json\n  # delete subscription\n\
-                    \  oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\n\
-                    \  # create subscription using the following json\n  oc create\
-                    \ -f /tmp/sub.json\n  # delete all CSVs\n  oc get clusterserviceversions.operators.coreos.com\
-                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
-                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
-                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
-                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
-                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
-                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\nexit 0\n"
+            restartPolicy: OnFailure
+            serviceAccount: sre-operator-reinstall-sa
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\n    set -euxo pipefail\n    NAMESPACE=openshift-route-monitor-operator\n\
+                \    OPERATOR=route-monitor-operator\n\n    # Look for a CSV, then\
+                \ perform the reinstall if found. If you want to _always_ reinstall,\
+                \ remove this check and just keep the logic inside the \"if\"\n  \
+                \  CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                \ -o name | grep \"$OPERATOR\")\n    if [[ ! -z \"$CSV_FOUND\" ]];\
+                \ then\n      # The OLM dance\n      # delete all installplans (if\
+                \ found) (the true is so we don't fail set -e)\n      installplans=$(oc\
+                \ get installplans.operators.coreos.com -n \"$NAMESPACE\" --no-headers\
+                \ | awk '{print $1}' | grep \"$OPERATOR\" || true | awk '{print $1}')\n\
+                \      if [[ -n \"$installplans\" ]]; then\n        echo \"$installplans\"\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n      fi\n      # get subscription\n      oc get subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                \ | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n      # delete subscription\n      oc delete subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR\n      # create subscription using the following\
+                \ json\n      oc create -f /tmp/sub.json\n      # delete all CSVs\n\
+                \      oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE\
+                \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com\
+                \ -n $NAMESPACE --wait=false\n    fi\n    exit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -35494,54 +35494,48 @@ objects:
         name: sre-operator-reinstall-sa
         namespace: openshift-route-monitor-operator
     - apiVersion: batch/v1
-      kind: CronJob
+      kind: Job
       metadata:
         name: sre-operator-reinstall
         namespace: openshift-route-monitor-operator
       spec:
-        failedJobsHistoryLimit: 1
-        successfulJobsHistoryLimit: 3
-        concurrencyPolicy: Replace
-        schedule: '*/30 * * * *'
-        jobTemplate:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        ttlSecondsAfterFinished: 600
+        activeDeadlineSeconds: 300
+        template:
           spec:
-            ttlSecondsAfterFinished: 100
-            template:
-              spec:
-                serviceAccountName: sre-operator-reinstall-sa
-                restartPolicy: Never
-                containers:
-                - name: operator-reinstaller
-                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
-                  command:
-                  - sh
-                  - -c
-                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
-                    OPERATOR=route-monitor-operator\n\n# Look for a CSV, then perform\
-                    \ the reinstall if found. If you want to _always_ reinstall, remove\
-                    \ this check and just keep the logic inside the \"if\"\nCSV_FOUND=$(oc\
-                    \ -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
-                    \ -o name | grep \"$OPERATOR\")\nif [[ ! -z \"$CSV_FOUND\" ]];\
-                    \ then\n  # The OLM dance\n  # delete all installplans (if found)\
-                    \ (the true is so we don't fail set -e)\n  installplans=$(oc get\
-                    \ installplans.operators.coreos.com -n \"$NAMESPACE\" | grep \"\
-                    $OPERATOR\" || true | awk '{print $1}')\n  if [[ -n \"$installplans\"\
-                    \ ]]; then\n    echo \"$installplans\" | xargs oc delete installplan.operators.coreos.com\
-                    \ -n \"$NAMESPACE\"\n  fi\n  # get subscription\n  oc get subscription.operators.coreos.com\
-                    \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
-                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
-                    \ | del(.metadata.uid)' > /tmp/sub.json\n  # delete subscription\n\
-                    \  oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\n\
-                    \  # create subscription using the following json\n  oc create\
-                    \ -f /tmp/sub.json\n  # delete all CSVs\n  oc get clusterserviceversions.operators.coreos.com\
-                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
-                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
-                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
-                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
-                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
-                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\nexit 0\n"
+            restartPolicy: OnFailure
+            serviceAccount: sre-operator-reinstall-sa
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\n    set -euxo pipefail\n    NAMESPACE=openshift-route-monitor-operator\n\
+                \    OPERATOR=route-monitor-operator\n\n    # Look for a CSV, then\
+                \ perform the reinstall if found. If you want to _always_ reinstall,\
+                \ remove this check and just keep the logic inside the \"if\"\n  \
+                \  CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                \ -o name | grep \"$OPERATOR\")\n    if [[ ! -z \"$CSV_FOUND\" ]];\
+                \ then\n      # The OLM dance\n      # delete all installplans (if\
+                \ found) (the true is so we don't fail set -e)\n      installplans=$(oc\
+                \ get installplans.operators.coreos.com -n \"$NAMESPACE\" --no-headers\
+                \ | awk '{print $1}' | grep \"$OPERATOR\" || true | awk '{print $1}')\n\
+                \      if [[ -n \"$installplans\" ]]; then\n        echo \"$installplans\"\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n      fi\n      # get subscription\n      oc get subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                \ | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n      # delete subscription\n      oc delete subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR\n      # create subscription using the following\
+                \ json\n      oc create -f /tmp/sub.json\n      # delete all CSVs\n\
+                \      oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE\
+                \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com\
+                \ -n $NAMESPACE --wait=false\n    fi\n    exit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -35494,54 +35494,48 @@ objects:
         name: sre-operator-reinstall-sa
         namespace: openshift-route-monitor-operator
     - apiVersion: batch/v1
-      kind: CronJob
+      kind: Job
       metadata:
         name: sre-operator-reinstall
         namespace: openshift-route-monitor-operator
       spec:
-        failedJobsHistoryLimit: 1
-        successfulJobsHistoryLimit: 3
-        concurrencyPolicy: Replace
-        schedule: '*/30 * * * *'
-        jobTemplate:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        ttlSecondsAfterFinished: 600
+        activeDeadlineSeconds: 300
+        template:
           spec:
-            ttlSecondsAfterFinished: 100
-            template:
-              spec:
-                serviceAccountName: sre-operator-reinstall-sa
-                restartPolicy: Never
-                containers:
-                - name: operator-reinstaller
-                  image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
-                  command:
-                  - sh
-                  - -c
-                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-route-monitor-operator\n\
-                    OPERATOR=route-monitor-operator\n\n# Look for a CSV, then perform\
-                    \ the reinstall if found. If you want to _always_ reinstall, remove\
-                    \ this check and just keep the logic inside the \"if\"\nCSV_FOUND=$(oc\
-                    \ -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
-                    \ -o name | grep \"$OPERATOR\")\nif [[ ! -z \"$CSV_FOUND\" ]];\
-                    \ then\n  # The OLM dance\n  # delete all installplans (if found)\
-                    \ (the true is so we don't fail set -e)\n  installplans=$(oc get\
-                    \ installplans.operators.coreos.com -n \"$NAMESPACE\" | grep \"\
-                    $OPERATOR\" || true | awk '{print $1}')\n  if [[ -n \"$installplans\"\
-                    \ ]]; then\n    echo \"$installplans\" | xargs oc delete installplan.operators.coreos.com\
-                    \ -n \"$NAMESPACE\"\n  fi\n  # get subscription\n  oc get subscription.operators.coreos.com\
-                    \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
-                    \ | del(.metadata.generation) | del(.metadata.resourceVersion)\
-                    \ | del(.metadata.uid)' > /tmp/sub.json\n  # delete subscription\n\
-                    \  oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\n\
-                    \  # create subscription using the following json\n  oc create\
-                    \ -f /tmp/sub.json\n  # delete all CSVs\n  oc get clusterserviceversions.operators.coreos.com\
-                    \ -n $NAMESPACE | grep $OPERATOR | awk '{print $1}' | xargs oc\
-                    \ delete clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
-                    fi\noc -n \"$NAMESPACE\" delete cronjob sre-operator-reinstall\
-                    \ || true\noc -n \"$NAMESPACE\" delete role sre-operator-reinstall-role\
-                    \ || true\noc -n \"$NAMESPACE\" delete rolebinding sre-operator-reinstall-rb\
-                    \ || true\noc -n \"$NAMESPACE\" delete serviceaccount sre-operator-reinstall-sa\
-                    \ || true\nexit 0\n"
+            restartPolicy: OnFailure
+            serviceAccount: sre-operator-reinstall-sa
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\n    set -euxo pipefail\n    NAMESPACE=openshift-route-monitor-operator\n\
+                \    OPERATOR=route-monitor-operator\n\n    # Look for a CSV, then\
+                \ perform the reinstall if found. If you want to _always_ reinstall,\
+                \ remove this check and just keep the logic inside the \"if\"\n  \
+                \  CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                \ -o name | grep \"$OPERATOR\")\n    if [[ ! -z \"$CSV_FOUND\" ]];\
+                \ then\n      # The OLM dance\n      # delete all installplans (if\
+                \ found) (the true is so we don't fail set -e)\n      installplans=$(oc\
+                \ get installplans.operators.coreos.com -n \"$NAMESPACE\" --no-headers\
+                \ | awk '{print $1}' | grep \"$OPERATOR\" || true | awk '{print $1}')\n\
+                \      if [[ -n \"$installplans\" ]]; then\n        echo \"$installplans\"\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n      fi\n      # get subscription\n      oc get subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                \ | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n      # delete subscription\n      oc delete subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR\n      # create subscription using the following\
+                \ json\n      oc create -f /tmp/sub.json\n      # delete all CSVs\n\
+                \      oc get clusterserviceversions.operators.coreos.com -n $NAMESPACE\
+                \ | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com\
+                \ -n $NAMESPACE --wait=false\n    fi\n    exit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

- Swap from `CronJob` to `Job` so logic executes right away 
- Configure Job to delete hung pods after 5 minutes
- Configure Job to self delete after 10 minutes 
- Update SSS to purge created resources when we follow up with a delete PR ([settings](https://github.com/openshift/hive/blob/master/docs/syncset.md#syncset-object-definition))
- Fix a mistake in a grep to ensure we only get the resource name
- Add workaround for `Failed to watch *unstructured.Unstructured: unknown"` when cleaning CSVs

### Which Jira/Github issue(s) this PR fixes?

[OSD-28723](https://issues.redhat.com//browse/OSD-28723)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
