### PR TITLE
updating the wildcard path to match fedramp requirements

### DIFF
--- a/resources/sts/4.14/fedramp-hypershift/openshift_hcp_image_registry_operator_permission_policy.json
+++ b/resources/sts/4.14/fedramp-hypershift/openshift_hcp_image_registry_operator_permission_policy.json
@@ -27,8 +27,7 @@
         "s3:PutLifecycleConfiguration"
       ],
       "Resource": [
-        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}-*",
-        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}"
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}*"
       ]
     },
     {
@@ -42,8 +41,7 @@
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}-*/*",
-        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}/*"
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}*/*"
       ]
     }
   ]


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Bug

### What this PR does / why we need it?
In reference to the changes in https://github.com/openshift/cluster-image-registry-operator/pull/1177, FedRAMP has a slightly different naming for the image registry S3 bucket.  IE. `2hfmkb877r2v1j4fne8nqmppftvsp735-image-registry-us-gov-west-1s`.  The additional character at the end does not allow a matching to the current wildcard.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
