### PR TITLE
adding a more restrictive wildcard for HCP managed policies

### DIFF
--- a/resources/sts/4.14/fedramp-hypershift/openshift_hcp_image_registry_operator_permission_policy.json
+++ b/resources/sts/4.14/fedramp-hypershift/openshift_hcp_image_registry_operator_permission_policy.json
@@ -27,7 +27,9 @@
         "s3:PutLifecycleConfiguration"
       ],
       "Resource": [
-        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}*"
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}-*",
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}?",
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}"
       ]
     },
     {
@@ -41,7 +43,9 @@
         "s3:PutObject"
       ],
       "Resource": [
-        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}*/*"
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}-*",
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}?",
+        "arn:aws-us-gov:s3:::*-image-registry-${aws:RequestedRegion}"
       ]
     }
   ]


### PR DESCRIPTION
What type of PR is this?
(bug/feature/cleanup/documentation)
Bug

What this PR does / why we need it?
In reference to the changes in https://github.com/openshift/cluster-image-registry-operator/pull/1177, FedRAMP has a slightly different naming for the image registry S3 bucket. IE. 2hfmkb877r2v1j4fne8nqmppftvsp735-image-registry-us-gov-west-1s. The additional character at the end does not allow a matching to the current wildcard.

Which Jira/Github issue(s) this PR fixes?
Fixes #

Special notes for your reviewer:
Pre-checks (if applicable):
 Tested latest changes against a cluster

 Included documentation changes with PR

 If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

matchExpressions:
- key: api.openshift.com/fedramp
  operator: NotIn
  values: ["true"]