### PR TITLE
[OSD 28223]  Handle worker (node filesystem) alert using ocm-agent

### DIFF
--- a/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
+++ b/deploy/ocm-agent-operator-managednotifications/10-managednotifications-cr.yaml
@@ -65,13 +65,6 @@ spec:
       summary: "Multiple EFS CSI drivers detected"
       logType: Cluster Configuration
     - activeBody: |-
-        Your cluster requires you to take action. The file system usage for a worker node is currently at or above 90% and is predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of space used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
-      name: WorkerNodeFilesystemSpaceFillingUp
-      resendWait: 24
-      severity: Info
-      summary: Worker node is predicted to run out of inodes in 4 hours
-      logType: Cluster Configuration
-    - activeBody: |-
         Your cluster requires you to take action. A workload is been preventing a machine from deleting. The name of the workload can be found by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not taking action can result in higher compute costs as the instance won't terminate until the workload has been moved.
       name: CustomerWorkloadPreventingDrain
       resendWait: 1
@@ -80,13 +73,6 @@ spec:
       logType: Cluster Configuration
       references:
         - "https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring"
-    - activeBody: |-
-        Your cluster requires you to take action. The available file system inodes for a worker node are currently at or below 3% and are predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of inodes used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
-      name: WorkerNodeFilesystemAlmostOutOfFiles
-      resendWait: 24
-      severity: Major
-      summary: "Filesystem has less than 3% inodes left"
-      logType: Cluster Configuration
     - activeBody: |-
         Your cluster currently has at least one unschedulable worker node. This may reduce cluster's effective capacity to schedule pods.
       name: KubeNodeUnschedulableSRE
@@ -111,3 +97,31 @@ spec:
       resendWait: 2
       severity: Major
       summary: "Action required: ${webhook_name} webhook slow to process ${operation} operations"
+    - activeBody: |-
+        Your cluster requires you to take action. The file system space usage for a worker node is currently at or above 90% and is predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of space used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
+      name: WorkerNodeFilesystemSpaceFillingUp
+      resendWait: 24
+      severity: Info
+      summary: "Filesystem is predicted to run out of space within the next 4 hours."
+      logType: Cluster Configuration
+    - activeBody: |-
+        Your cluster requires you to take action. The available file system space for a worker node are currently at or below 3% and are predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of inodes used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
+      name: WorkerNodeFilesystemAlmostOutOfSpace
+      resendWait: 24
+      severity: Major
+      summary: "FFilesystem has less than 3% space left."
+      logType: Cluster Configuration
+    - activeBody: |-
+        Your cluster requires you to take action. The file system inode usage for a worker node is currently at or above 90% and is predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of inode used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
+      name: WorkerNodeFilesystemFilesFillingUp
+      resendWait: 24
+      severity: Info
+      summary: "Worker node is predicted to run out of inodes in 4 hours"
+      logType: Cluster Configuration
+    - activeBody: |-
+        Your cluster requires you to take action. The available file system inodes for a worker node are currently at or below 3% and are predicted to be fully exhausted soon. Without action, this could impact the usability of this node. Please reduce the amount of inodes used on this mountpoint, either by adjusting application configuration or by moving some applications to other nodes.
+      name: WorkerNodeFilesystemAlmostOutOfFiles
+      resendWait: 24
+      severity: Major
+      summary: "Filesystem has less than 3% inodes left"
+      logType: Cluster Configuration

--- a/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-node-filedescriptor-limits.PrometheusRule.yaml
@@ -30,31 +30,81 @@ spec:
         message: "Kernel is predicted to exhaust file descriptors limit soon."
   - name: sre-controlplane-node-filesystem-space-filling-upstream
     rules:
+      # This is the same as the upstream alert, but groups by node type: worker node or non-worker node
+      # Original source: https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules-1.14/node-exporter.yaml#L27C1-L146C27
     - alert: ControlPlaneNodeFilesystemSpaceFillingUp
-      # this is the same as the upstream alert, but groups only for controlplane nodes
-      expr: |-
-        (node_filesystem_files_free{fstype!="",job="node-exporter"} / node_filesystem_files{fstype!="",job="node-exporter"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!="",job="node-exporter"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!="",job="node-exporter"} == 0)
-        * on (instance) group_left ()group by (instance) (
+      annotations:
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          space left and is filling up fast.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+        summary: Filesystem is predicted to run out of space within the next 4 hours.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 10
+        and
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"}[6h], 4*60*60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+        ) * on (instance) group_left () group by (instance) (
           label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
         )
       for: 1h
       labels:
         severity: critical
         namespace: openshift-monitoring
+    - alert: ControlPlaneNodeFilesystemAlmostOutOfSpace
       annotations:
-        message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up fast.
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          space left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+        summary: Filesystem has less than 3% space left.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 3
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+        ) * on (instance) group_left () group by (instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 30m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+    - alert: ControlPlaneNodeFilesystemFilesFillingUp
+      annotations:
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          inodes left and is filling up fast.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
         summary: Filesystem is predicted to run out of inodes within the next 4 hours.
+      expr: |
+        (
+          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 20
+        and
+          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"}[6h], 4*60*60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+        ) * on (instance) group_left () group by (instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 1h
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
     - alert: ControlPlaneNodeFilesystemAlmostOutOfFiles
       annotations:
-        message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          inodes left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
         summary: Filesystem has less than 3% inodes left.
-      # This is the same as the upstream alert, but groups by node type: worker node or non-worker node
-      # Original source: https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules-1.14/node-exporter.yaml#L133C1-L146C27
-      expr: |-
+      expr: |
         (
-          node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 3
+          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 3
         and
-          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
         ) * on (instance) group_left () group by (instance) (
           label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
         )

--- a/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-ocm-agent.PrometheusRule.yaml
@@ -75,25 +75,6 @@ spec:
         send_managed_notification: "true"
       annotations:
         message: "Kernel is predicted to exhaust file descriptors limit soon."
-    - alert: WorkerNodeFilesystemSpaceFillingUp
-      # This is the same as the upstream alert, but groups by the whether it's a worker node or notification
-      expr: |-
-        (node_filesystem_files_free{fstype!="",job="node-exporter"} / node_filesystem_files{fstype!="",job="node-exporter"} * 100 < 20 and predict_linear(node_filesystem_files_free{fstype!="",job="node-exporter"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!="",job="node-exporter"} == 0)
-        * on (instance) group_left ()group by(instance) (
-          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
-        )
-        unless
-        group by(instance) (
-          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
-        )
-      for: 1h
-      labels:
-        severity: critical
-        namespace: openshift-monitoring
-        managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
-        send_managed_notification: "true"
-      annotations:
-        message: "Filesystem is predicted to run out of inodes within the next 4 hours."
     - alert: CustomerWorkloadPreventingDrainSRE
       # This alert will fire when a node is unscheduleable and is failing to drain for an extended period of time based on a customer workload that's failing to drain
       # This alert will NOT fire if there is an ongoing upgrade, or if the node is not deleting.
@@ -122,20 +103,111 @@ spec:
         send_managed_notification: "true"
       annotations:
         message: "A non-openshift workload is preventing a node from draining."
+
+# This is the same as the upstream alert, but groups by the whether it's a worker node or notification
+    - alert: WorkerNodeFilesystemSpaceFillingUp
+      annotations:
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          space left and is filling up fast.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+        summary: Filesystem is predicted to run out of space within the next 4 hours.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 10
+        and
+          predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"}[6h], 4*60*60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+        )
+        * on (instance) group_left ()group by(instance) (
+          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+        unless
+        group by(instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 1h
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+        send_managed_notification: "true"
+
+    - alert: WorkerNodeFilesystemAlmostOutOfSpace
+      annotations:
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          space left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+        summary: Filesystem has less than 3% space left.
+      expr: |
+        (
+          node_filesystem_avail_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_size_bytes{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 3
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+        )
+        * on (instance) group_left ()group by(instance) (
+          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+        unless
+        group by(instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 30m
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: WorkerNodeFilesystemAlmostOutOfSpace
+        send_managed_notification: "true"
+
+    - alert: WorkerNodeFilesystemFilesFillingUp
+      annotations:
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          inodes left and is filling up fast.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+        summary: Filesystem is predicted to run out of inodes within the next 4 hours.
+      expr: |
+        (
+          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 20
+        and
+          predict_linear(node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"}[6h], 4*60*60) < 0
+        and
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+        )
+        * on (instance) group_left ()group by(instance) (
+          label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+        unless
+        group by(instance) (
+          label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
+        )
+      for: 1h
+      labels:
+        severity: critical
+        namespace: openshift-monitoring
+        managed_notification_template: WorkerNodeFilesystemFilesFillingUp
+        send_managed_notification: "true"
+
     - alert: WorkerNodeFilesystemAlmostOutOfFiles
       annotations:
-        message: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.
+        description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+          }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available
+          inodes left.
+        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
         summary: Filesystem has less than 3% inodes left.
-      # This is the same as the upstream alert, but groups by node type: worker node or non-worker node
-      # Original source: https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules-1.14/node-exporter.yaml#L133C1-L146C27
-      expr: |-
+      expr: |
         (
-          node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 3
+          node_filesystem_files_free{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} / node_filesystem_files{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} * 100 < 3
         and
-          node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
-        ) * on (instance) group_left () group by (instance) (
+          node_filesystem_readonly{job="node-exporter",fstype!="",mountpoint!~"/var/lib/ibmc-s3fs.*"} == 0
+        )
+        * on (instance) group_left ()group by(instance) (
           label_replace(kube_node_role{role!~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
-        ) unless group by(instance) (
+        )
+        unless
+        group by(instance) (
           label_replace(kube_node_role{role=~"infra|control-plane|master"}, "instance", "$1", "node", "(.*)")
         )
       for: 1h
@@ -144,3 +216,4 @@ spec:
         namespace: openshift-monitoring
         managed_notification_template: WorkerNodeFilesystemAlmostOutOfFiles
         send_managed_notification: "true"
+  

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26641,17 +26641,6 @@ objects:
           severity: Warning
           summary: Multiple EFS CSI drivers detected
           logType: Cluster Configuration
-        - activeBody: Your cluster requires you to take action. The file system usage
-            for a worker node is currently at or above 90% and is predicted to be
-            fully exhausted soon. Without action, this could impact the usability
-            of this node. Please reduce the amount of space used on this mountpoint,
-            either by adjusting application configuration or by moving some applications
-            to other nodes.
-          name: WorkerNodeFilesystemSpaceFillingUp
-          resendWait: 24
-          severity: Info
-          summary: Worker node is predicted to run out of inodes in 4 hours
-          logType: Cluster Configuration
         - activeBody: Your cluster requires you to take action. A workload is been
             preventing a machine from deleting. The name of the workload can be found
             by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
@@ -26664,17 +26653,6 @@ objects:
           logType: Cluster Configuration
           references:
           - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
-        - activeBody: Your cluster requires you to take action. The available file
-            system inodes for a worker node are currently at or below 3% and are predicted
-            to be fully exhausted soon. Without action, this could impact the usability
-            of this node. Please reduce the amount of inodes used on this mountpoint,
-            either by adjusting application configuration or by moving some applications
-            to other nodes.
-          name: WorkerNodeFilesystemAlmostOutOfFiles
-          resendWait: 24
-          severity: Major
-          summary: Filesystem has less than 3% inodes left
-          logType: Cluster Configuration
         - activeBody: Your cluster currently has at least one unschedulable worker
             node. This may reduce cluster's effective capacity to schedule pods.
           name: KubeNodeUnschedulableSRE
@@ -26710,6 +26688,50 @@ objects:
           severity: Major
           summary: 'Action required: ${webhook_name} webhook slow to process ${operation}
             operations'
+        - activeBody: Your cluster requires you to take action. The file system space
+            usage for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of space used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemSpaceFillingUp
+          resendWait: 24
+          severity: Info
+          summary: Filesystem is predicted to run out of space within the next 4 hours.
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The available file
+            system space for a worker node are currently at or below 3% and are predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inodes used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemAlmostOutOfSpace
+          resendWait: 24
+          severity: Major
+          summary: FFilesystem has less than 3% space left.
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The file system inode
+            usage for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inode used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemFilesFillingUp
+          resendWait: 24
+          severity: Info
+          summary: Worker node is predicted to run out of inodes in 4 hours
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The available file
+            system inodes for a worker node are currently at or below 3% and are predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inodes used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemAlmostOutOfFiles
+          resendWait: 24
+          severity: Major
+          summary: Filesystem has less than 3% inodes left
+          logType: Cluster Configuration
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -39764,34 +39786,83 @@ objects:
         - name: sre-controlplane-node-filesystem-space-filling-upstream
           rules:
           - alert: ControlPlaneNodeFilesystemSpaceFillingUp
-            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
-              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
-              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
-              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
-              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
-              \ by (instance) (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+              summary: Filesystem is predicted to run out of space within the next
+                4 hours.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 10\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance)\
+              \ group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
             for: 1h
             labels:
               severity: critical
               namespace: openshift-monitoring
+          - alert: ControlPlaneNodeFilesystemAlmostOutOfSpace
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left and is
-                filling up fast.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance) group_left\
+              \ () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+          - alert: ControlPlaneNodeFilesystemFilesFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
               summary: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+            expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance)\
+              \ group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
           - alert: ControlPlaneNodeFilesystemAlmostOutOfFiles
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
               summary: Filesystem has less than 3% inodes left.
             expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
-              \"} / node_filesystem_files{job=\"node-exporter\",fstype!=\"\"} * 100\
-              \ < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
-              \"} == 0\n) * on (instance) group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance) group_left\
+              \ () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
               infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
+              )\n)\n"
             for: 1h
             labels:
               severity: critical
@@ -41843,25 +41914,6 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
-          - alert: WorkerNodeFilesystemSpaceFillingUp
-            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
-              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
-              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
-              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
-              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
-              \ by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
-              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
-            for: 1h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
-              send_managed_notification: 'true'
-            annotations:
-              message: Filesystem is predicted to run out of inodes within the next
-                4 hours.
           - alert: CustomerWorkloadPreventingDrainSRE
             expr: "(\n  (\n    kube_node_spec_unschedulable > 0\n    unless\n    ignoring(node,container,endpoint,job,namespace,service)\n\
               \    sum(mapi_machine_set_status_replicas{name=~\".*upgrade$\"}) > 0\n\
@@ -41877,19 +41929,96 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: A non-openshift workload is preventing a node from draining.
+          - alert: WorkerNodeFilesystemSpaceFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+              summary: Filesystem is predicted to run out of space within the next
+                4 hours.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 10\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance)\
+              \ group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+              send_managed_notification: 'true'
+          - alert: WorkerNodeFilesystemAlmostOutOfSpace
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance) group_left\
+              \ ()group by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemAlmostOutOfSpace
+              send_managed_notification: 'true'
+          - alert: WorkerNodeFilesystemFilesFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+              summary: Filesystem is predicted to run out of inodes within the next
+                4 hours.
+            expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance)\
+              \ group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemFilesFillingUp
+              send_managed_notification: 'true'
           - alert: WorkerNodeFilesystemAlmostOutOfFiles
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
               summary: Filesystem has less than 3% inodes left.
             expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
-              \"} / node_filesystem_files{job=\"node-exporter\",fstype!=\"\"} * 100\
-              \ < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
-              \"} == 0\n) * on (instance) group_left () group by (instance) (\n  label_replace(kube_node_role{role!~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n) unless group by(instance) (\n  label_replace(kube_node_role{role=~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance) group_left\
+              \ ()group by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\n"
             for: 1h
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26641,17 +26641,6 @@ objects:
           severity: Warning
           summary: Multiple EFS CSI drivers detected
           logType: Cluster Configuration
-        - activeBody: Your cluster requires you to take action. The file system usage
-            for a worker node is currently at or above 90% and is predicted to be
-            fully exhausted soon. Without action, this could impact the usability
-            of this node. Please reduce the amount of space used on this mountpoint,
-            either by adjusting application configuration or by moving some applications
-            to other nodes.
-          name: WorkerNodeFilesystemSpaceFillingUp
-          resendWait: 24
-          severity: Info
-          summary: Worker node is predicted to run out of inodes in 4 hours
-          logType: Cluster Configuration
         - activeBody: Your cluster requires you to take action. A workload is been
             preventing a machine from deleting. The name of the workload can be found
             by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
@@ -26664,17 +26653,6 @@ objects:
           logType: Cluster Configuration
           references:
           - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
-        - activeBody: Your cluster requires you to take action. The available file
-            system inodes for a worker node are currently at or below 3% and are predicted
-            to be fully exhausted soon. Without action, this could impact the usability
-            of this node. Please reduce the amount of inodes used on this mountpoint,
-            either by adjusting application configuration or by moving some applications
-            to other nodes.
-          name: WorkerNodeFilesystemAlmostOutOfFiles
-          resendWait: 24
-          severity: Major
-          summary: Filesystem has less than 3% inodes left
-          logType: Cluster Configuration
         - activeBody: Your cluster currently has at least one unschedulable worker
             node. This may reduce cluster's effective capacity to schedule pods.
           name: KubeNodeUnschedulableSRE
@@ -26710,6 +26688,50 @@ objects:
           severity: Major
           summary: 'Action required: ${webhook_name} webhook slow to process ${operation}
             operations'
+        - activeBody: Your cluster requires you to take action. The file system space
+            usage for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of space used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemSpaceFillingUp
+          resendWait: 24
+          severity: Info
+          summary: Filesystem is predicted to run out of space within the next 4 hours.
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The available file
+            system space for a worker node are currently at or below 3% and are predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inodes used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemAlmostOutOfSpace
+          resendWait: 24
+          severity: Major
+          summary: FFilesystem has less than 3% space left.
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The file system inode
+            usage for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inode used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemFilesFillingUp
+          resendWait: 24
+          severity: Info
+          summary: Worker node is predicted to run out of inodes in 4 hours
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The available file
+            system inodes for a worker node are currently at or below 3% and are predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inodes used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemAlmostOutOfFiles
+          resendWait: 24
+          severity: Major
+          summary: Filesystem has less than 3% inodes left
+          logType: Cluster Configuration
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -39764,34 +39786,83 @@ objects:
         - name: sre-controlplane-node-filesystem-space-filling-upstream
           rules:
           - alert: ControlPlaneNodeFilesystemSpaceFillingUp
-            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
-              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
-              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
-              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
-              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
-              \ by (instance) (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+              summary: Filesystem is predicted to run out of space within the next
+                4 hours.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 10\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance)\
+              \ group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
             for: 1h
             labels:
               severity: critical
               namespace: openshift-monitoring
+          - alert: ControlPlaneNodeFilesystemAlmostOutOfSpace
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left and is
-                filling up fast.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance) group_left\
+              \ () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+          - alert: ControlPlaneNodeFilesystemFilesFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
               summary: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+            expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance)\
+              \ group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
           - alert: ControlPlaneNodeFilesystemAlmostOutOfFiles
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
               summary: Filesystem has less than 3% inodes left.
             expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
-              \"} / node_filesystem_files{job=\"node-exporter\",fstype!=\"\"} * 100\
-              \ < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
-              \"} == 0\n) * on (instance) group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance) group_left\
+              \ () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
               infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
+              )\n)\n"
             for: 1h
             labels:
               severity: critical
@@ -41843,25 +41914,6 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
-          - alert: WorkerNodeFilesystemSpaceFillingUp
-            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
-              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
-              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
-              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
-              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
-              \ by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
-              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
-            for: 1h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
-              send_managed_notification: 'true'
-            annotations:
-              message: Filesystem is predicted to run out of inodes within the next
-                4 hours.
           - alert: CustomerWorkloadPreventingDrainSRE
             expr: "(\n  (\n    kube_node_spec_unschedulable > 0\n    unless\n    ignoring(node,container,endpoint,job,namespace,service)\n\
               \    sum(mapi_machine_set_status_replicas{name=~\".*upgrade$\"}) > 0\n\
@@ -41877,19 +41929,96 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: A non-openshift workload is preventing a node from draining.
+          - alert: WorkerNodeFilesystemSpaceFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+              summary: Filesystem is predicted to run out of space within the next
+                4 hours.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 10\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance)\
+              \ group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+              send_managed_notification: 'true'
+          - alert: WorkerNodeFilesystemAlmostOutOfSpace
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance) group_left\
+              \ ()group by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemAlmostOutOfSpace
+              send_managed_notification: 'true'
+          - alert: WorkerNodeFilesystemFilesFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+              summary: Filesystem is predicted to run out of inodes within the next
+                4 hours.
+            expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance)\
+              \ group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemFilesFillingUp
+              send_managed_notification: 'true'
           - alert: WorkerNodeFilesystemAlmostOutOfFiles
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
               summary: Filesystem has less than 3% inodes left.
             expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
-              \"} / node_filesystem_files{job=\"node-exporter\",fstype!=\"\"} * 100\
-              \ < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
-              \"} == 0\n) * on (instance) group_left () group by (instance) (\n  label_replace(kube_node_role{role!~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n) unless group by(instance) (\n  label_replace(kube_node_role{role=~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance) group_left\
+              \ ()group by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\n"
             for: 1h
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26641,17 +26641,6 @@ objects:
           severity: Warning
           summary: Multiple EFS CSI drivers detected
           logType: Cluster Configuration
-        - activeBody: Your cluster requires you to take action. The file system usage
-            for a worker node is currently at or above 90% and is predicted to be
-            fully exhausted soon. Without action, this could impact the usability
-            of this node. Please reduce the amount of space used on this mountpoint,
-            either by adjusting application configuration or by moving some applications
-            to other nodes.
-          name: WorkerNodeFilesystemSpaceFillingUp
-          resendWait: 24
-          severity: Info
-          summary: Worker node is predicted to run out of inodes in 4 hours
-          logType: Cluster Configuration
         - activeBody: Your cluster requires you to take action. A workload is been
             preventing a machine from deleting. The name of the workload can be found
             by looking at the 'pods_preventing_node_drain' metric in Prometheus. Not
@@ -26664,17 +26653,6 @@ objects:
           logType: Cluster Configuration
           references:
           - https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/nodes/working-with-pods#nodes-pods-pod-distruption-about_nodes-pods-configuring
-        - activeBody: Your cluster requires you to take action. The available file
-            system inodes for a worker node are currently at or below 3% and are predicted
-            to be fully exhausted soon. Without action, this could impact the usability
-            of this node. Please reduce the amount of inodes used on this mountpoint,
-            either by adjusting application configuration or by moving some applications
-            to other nodes.
-          name: WorkerNodeFilesystemAlmostOutOfFiles
-          resendWait: 24
-          severity: Major
-          summary: Filesystem has less than 3% inodes left
-          logType: Cluster Configuration
         - activeBody: Your cluster currently has at least one unschedulable worker
             node. This may reduce cluster's effective capacity to schedule pods.
           name: KubeNodeUnschedulableSRE
@@ -26710,6 +26688,50 @@ objects:
           severity: Major
           summary: 'Action required: ${webhook_name} webhook slow to process ${operation}
             operations'
+        - activeBody: Your cluster requires you to take action. The file system space
+            usage for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of space used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemSpaceFillingUp
+          resendWait: 24
+          severity: Info
+          summary: Filesystem is predicted to run out of space within the next 4 hours.
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The available file
+            system space for a worker node are currently at or below 3% and are predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inodes used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemAlmostOutOfSpace
+          resendWait: 24
+          severity: Major
+          summary: FFilesystem has less than 3% space left.
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The file system inode
+            usage for a worker node is currently at or above 90% and is predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inode used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemFilesFillingUp
+          resendWait: 24
+          severity: Info
+          summary: Worker node is predicted to run out of inodes in 4 hours
+          logType: Cluster Configuration
+        - activeBody: Your cluster requires you to take action. The available file
+            system inodes for a worker node are currently at or below 3% and are predicted
+            to be fully exhausted soon. Without action, this could impact the usability
+            of this node. Please reduce the amount of inodes used on this mountpoint,
+            either by adjusting application configuration or by moving some applications
+            to other nodes.
+          name: WorkerNodeFilesystemAlmostOutOfFiles
+          resendWait: 24
+          severity: Major
+          summary: Filesystem has less than 3% inodes left
+          logType: Cluster Configuration
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1
       kind: ManagedNotification
       metadata:
@@ -39764,34 +39786,83 @@ objects:
         - name: sre-controlplane-node-filesystem-space-filling-upstream
           rules:
           - alert: ControlPlaneNodeFilesystemSpaceFillingUp
-            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
-              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
-              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
-              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
-              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
-              \ by (instance) (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+              summary: Filesystem is predicted to run out of space within the next
+                4 hours.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 10\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance)\
+              \ group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
             for: 1h
             labels:
               severity: critical
               namespace: openshift-monitoring
+          - alert: ControlPlaneNodeFilesystemAlmostOutOfSpace
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left and is
-                filling up fast.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance) group_left\
+              \ () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+          - alert: ControlPlaneNodeFilesystemFilesFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
               summary: Filesystem is predicted to run out of inodes within the next
                 4 hours.
+            expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance)\
+              \ group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
           - alert: ControlPlaneNodeFilesystemAlmostOutOfFiles
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
               summary: Filesystem has less than 3% inodes left.
             expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
-              \"} / node_filesystem_files{job=\"node-exporter\",fstype!=\"\"} * 100\
-              \ < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
-              \"} == 0\n) * on (instance) group_left () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n) * on (instance) group_left\
+              \ () group by (instance) (\n  label_replace(kube_node_role{role=~\"\
               infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
+              )\n)\n"
             for: 1h
             labels:
               severity: critical
@@ -41843,25 +41914,6 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: Kernel is predicted to exhaust file descriptors limit soon.
-          - alert: WorkerNodeFilesystemSpaceFillingUp
-            expr: "(node_filesystem_files_free{fstype!=\"\",job=\"node-exporter\"\
-              } / node_filesystem_files{fstype!=\"\",job=\"node-exporter\"} * 100\
-              \ < 20 and predict_linear(node_filesystem_files_free{fstype!=\"\",job=\"\
-              node-exporter\"}[6h], 4 * 60 * 60) < 0 and node_filesystem_readonly{fstype!=\"\
-              \",job=\"node-exporter\"} == 0)\n* on (instance) group_left ()group\
-              \ by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
-              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
-              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)"
-            for: 1h
-            labels:
-              severity: critical
-              namespace: openshift-monitoring
-              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
-              send_managed_notification: 'true'
-            annotations:
-              message: Filesystem is predicted to run out of inodes within the next
-                4 hours.
           - alert: CustomerWorkloadPreventingDrainSRE
             expr: "(\n  (\n    kube_node_spec_unschedulable > 0\n    unless\n    ignoring(node,container,endpoint,job,namespace,service)\n\
               \    sum(mapi_machine_set_status_replicas{name=~\".*upgrade$\"}) > 0\n\
@@ -41877,19 +41929,96 @@ objects:
               send_managed_notification: 'true'
             annotations:
               message: A non-openshift workload is preventing a node from draining.
+          - alert: WorkerNodeFilesystemSpaceFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemSpaceFillingUp.md
+              summary: Filesystem is predicted to run out of space within the next
+                4 hours.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 10\nand\n  predict_linear(node_filesystem_avail_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance)\
+              \ group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemSpaceFillingUp
+              send_managed_notification: 'true'
+          - alert: WorkerNodeFilesystemAlmostOutOfSpace
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available space left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfSpace.md
+              summary: Filesystem has less than 3% space left.
+            expr: "(\n  node_filesystem_avail_bytes{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_size_bytes{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance) group_left\
+              \ ()group by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\n"
+            for: 30m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemAlmostOutOfSpace
+              send_managed_notification: 'true'
+          - alert: WorkerNodeFilesystemFilesFillingUp
+            annotations:
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left and is filling up fast.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemFilesFillingUp.md
+              summary: Filesystem is predicted to run out of inodes within the next
+                4 hours.
+            expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 20\nand\n  predict_linear(node_filesystem_files_free{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"}[6h],\
+              \ 4*60*60) < 0\nand\n  node_filesystem_readonly{job=\"node-exporter\"\
+              ,fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance)\
+              \ group_left ()group by(instance) (\n  label_replace(kube_node_role{role!~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\nunless\ngroup by(instance) (\n  label_replace(kube_node_role{role=~\"\
+              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
+              )\n)\n"
+            for: 1h
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+              managed_notification_template: WorkerNodeFilesystemFilesFillingUp
+              send_managed_notification: 'true'
           - alert: WorkerNodeFilesystemAlmostOutOfFiles
             annotations:
-              message: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-                has only {{ printf "%.2f" $value }}% available inodes left.
+              description: Filesystem on {{ $labels.device }}, mounted on {{ $labels.mountpoint
+                }}, at {{ $labels.instance }} has only {{ printf "%.2f" $value }}%
+                available inodes left.
+              runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/NodeFilesystemAlmostOutOfFiles.md
               summary: Filesystem has less than 3% inodes left.
             expr: "(\n  node_filesystem_files_free{job=\"node-exporter\",fstype!=\"\
-              \"} / node_filesystem_files{job=\"node-exporter\",fstype!=\"\"} * 100\
-              \ < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
-              \"} == 0\n) * on (instance) group_left () group by (instance) (\n  label_replace(kube_node_role{role!~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n) unless group by(instance) (\n  label_replace(kube_node_role{role=~\"\
-              infra|control-plane|master\"}, \"instance\", \"$1\", \"node\", \"(.*)\"\
-              )\n)"
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} / node_filesystem_files{job=\"\
+              node-exporter\",fstype!=\"\",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} *\
+              \ 100 < 3\nand\n  node_filesystem_readonly{job=\"node-exporter\",fstype!=\"\
+              \",mountpoint!~\"/var/lib/ibmc-s3fs.*\"} == 0\n)\n* on (instance) group_left\
+              \ ()group by(instance) (\n  label_replace(kube_node_role{role!~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\nunless\ngroup by(instance)\
+              \ (\n  label_replace(kube_node_role{role=~\"infra|control-plane|master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.*)\")\n)\n"
             for: 1h
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
This PR handles 4 upstream critical alerts and automates it using `ocm-agent`
Upstream alert: https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules-1.14/node-exporter.yaml#L27C1-L146C27

Changes: 
- created an equivalent alert for the worker node that needs to be handled by ocm-agent
- created an equivalent alert for the controlplane and infra node which will page SRE
- created managed notification for the respective alerts

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [OSD-28223](https://issues.redhat.com/browse/OSD-28223)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
