### PR TITLE
allowing HCP settings to FedRAMP

### DIFF
--- a/deploy/backplane/cee/hypershift/management-cluster/config.yaml
+++ b/deploy/backplane/cee/hypershift/management-cluster/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: ["management-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/deploy/backplane/cee/hypershift/service-cluster/config.yaml
+++ b/deploy/backplane/cee/hypershift/service-cluster/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type 
     operator: In
     values: ["service-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/config.yaml
+++ b/deploy/backplane/hybridsre-hcp/hypershift/management-cluster/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: ["management-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/deploy/backplane/srep/fedramp/30-srep-fedramp.SubjectPermission.yml
+++ b/deploy/backplane/srep/fedramp/30-srep-fedramp.SubjectPermission.yml
@@ -7,9 +7,9 @@ spec:
   permissions:
   - clusterRoleName: backplane-srep-admins-project
     namespacesAllowedRegex: "(^keycloak$|^keycloak-.*|^goalert$)"
-    namespacesDeniedRegex: openshift-backplane-cluster-admin    
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
   - clusterRoleName: dedicated-readers
     namespacesAllowedRegex: "(^keycloak$|^keycloak-.*|^goalert$)"
-    namespacesDeniedRegex: openshift-backplane-cluster-admin    
+    namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/deploy/backplane/srep/hypershift/management-cluster/config.yaml
+++ b/deploy/backplane/srep/hypershift/management-cluster/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: ["management-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/deploy/backplane/srep/hypershift/service-cluster/config.yaml
+++ b/deploy/backplane/srep/hypershift/service-cluster/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type 
     operator: In
     values: ["service-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/deploy/sre-prometheus/management-cluster/config.yaml
+++ b/deploy/sre-prometheus/management-cluster/config.yaml
@@ -4,9 +4,6 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: ["management-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]
   - key: api.openshift.com/sts
     operator: In
     values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -12985,10 +12985,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -13084,10 +13080,6 @@ objects:
         operator: In
         values:
         - service-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -13428,10 +13420,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -24249,10 +24237,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -24425,10 +24409,6 @@ objects:
         operator: In
         values:
         - service-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -40884,10 +40864,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: api.openshift.com/sts
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -12985,10 +12985,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -13084,10 +13080,6 @@ objects:
         operator: In
         values:
         - service-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -13428,10 +13420,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -24249,10 +24237,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -24425,10 +24409,6 @@ objects:
         operator: In
         values:
         - service-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -40884,10 +40864,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: api.openshift.com/sts
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -12985,10 +12985,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -13084,10 +13080,6 @@ objects:
         operator: In
         values:
         - service-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -13428,10 +13420,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -24249,10 +24237,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -24425,10 +24409,6 @@ objects:
         operator: In
         values:
         - service-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -40884,10 +40864,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: api.openshift.com/sts
         operator: In
         values:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_  
cleanup

### What this PR does / why we need it?
This deploys some management and service cluster setting to FedRAMP.

### Which Jira/Github issue(s) this PR fixes?
This is preparing for the backplane-api upgrade for HCP.  This also adds some prometheus data to the management cluster.  

_Fixes #_

### Special notes for your reviewer:  
These only target clusters matching service or management cluster labels in FedRAMP.  This should be no impact to anything outside of management and service clusters in FedRAMP.  

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
