### PR TITLE
OSD-27692: Making sure that the new crontab cleaning up backplane remediation RBACs can run successfully - adding back the ClusterRoleBinding

### DIFF
--- a/deploy/osd-delete-backplane-remediation-rbacs/15-delete-backplane-remediation-rbacs.rbac.yaml
+++ b/deploy/osd-delete-backplane-remediation-rbacs/15-delete-backplane-remediation-rbacs.rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: osd-delete-backplane-remediation-rbacs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-delete-backplane-remediation-rbacs
+subjects:
+  - kind: ServiceAccount
+    name: osd-delete-backplane-remediation-rbacs
+    namespace: openshift-backplane

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32307,6 +32307,18 @@ objects:
         - get
         - list
         - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-remediation-rbacs
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32307,6 +32307,18 @@ objects:
         - get
         - list
         - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-remediation-rbacs
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32307,6 +32307,18 @@ objects:
         - get
         - list
         - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: osd-delete-backplane-remediation-rbacs
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-delete-backplane-remediation-rbacs
+      subjects:
+      - kind: ServiceAccount
+        name: osd-delete-backplane-remediation-rbacs
+        namespace: openshift-backplane
     - apiVersion: batch/v1
       kind: CronJob
       metadata:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Follow up of https://github.com/openshift/managed-cluster-config/pull/2386, the `ClusterRoleBinding` couldn't be modified in place, so it was removed; it is now added again.

### Which Jira/Github issue(s) this PR fixes?

Complete [OSD-27692](https://issues.redhat.com//browse/OSD-27692)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] Not a FedRamp change