### PR TITLE
OSD-27692: Making sure that the new crontab cleaning up backplane remediation RBACs can run successfully - correcting the cronjob script

### DIFF
--- a/deploy/osd-delete-backplane-remediation-rbacs/20-delete-backplane-remediation-rbacs.CronJob.yaml
+++ b/deploy/osd-delete-backplane-remediation-rbacs/20-delete-backplane-remediation-rbacs.CronJob.yaml
@@ -36,33 +36,37 @@ spec:
                 - /bin/bash
                 - -c
                 - |
-                  now=$(date +%s);
-                  expiryMins=720;
-                  for line in $(oc get rolebinding -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers);do
+                  now=$(date +%s)
+                  expiryMins=720
+                  lines=$(oc get rolebinding -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers)
+                  [[ -z "$lines" ]] || while read line
+                  do
                     ns=$(echo "$line" | awk '{print $1}')
                     rolebinding=$(echo "$line" | awk '{print $2}')
-                    creation=$(date -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                    creation=$(date -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s')
                     if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
                       oc delete rolebinding $rolebinding -n $ns
                     fi
-                  done;
-                  for line in $(oc get role -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers);do
+                  done <<< "$lines"
+                  lines=$(oc get role -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers)
+                  [[ -z "$lines" ]] || while read line
+                  do
                     ns=$(echo "$line" | awk '{print $1}')
                     role=$(echo "$line" | awk '{print $2}')
-                    creation=$(date -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                    creation=$(date -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s')
                     if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
                       oc delete role $role -n $ns
                     fi
-                  done;
-                  for clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation --no-headers | awk '{print $1}');do
-                    creation=$(date -d $(oc get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                  done <<< "$lines"
+                  for clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation -o custom-columns=:.metadata.name --no-headers);do
+                    creation=$(date -d $(oc get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}') '+%s')
                     if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
                       oc delete clusterrolebinding $clusterrolebinding
                     fi
-                  done;
-                  for clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation --no-headers | awk '{print $1}');do
-                    creation=$(date -d $(oc get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}') '+%s');
+                  done
+                  for clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation -o custom-columns=:.metadata.name --no-headers);do
+                    creation=$(date -d $(oc get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}') '+%s')
                     if [[ $(expr $((now-creation)) \> $expiryMins \* 60) == 1 ]]; then
                       oc delete clusterrole $clusterrole
                     fi
-                  done;
+                  done

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32356,31 +32356,33 @@ objects:
                   args:
                   - /bin/bash
                   - -c
-                  - "now=$(date +%s);\nexpiryMins=720;\nfor line in $(oc get rolebinding\
-                    \ -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
-                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
-                    \  rolebinding=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
-                    \ -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                  - "now=$(date +%s)\nexpiryMins=720\nlines=$(oc get rolebinding -A\
+                    \ -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers)\n[[ -z \"$lines\" ]] || while read line\ndo\n\
+                    \  ns=$(echo \"$line\" | awk '{print $1}')\n  rolebinding=$(echo\
+                    \ \"$line\" | awk '{print $2}')\n  creation=$(date -d $(oc get\
+                    \ rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete rolebinding $rolebinding -n\
-                    \ $ns\n  fi\ndone;\nfor line in $(oc get role -A -l managed.openshift.io/remediation\
-                    \ -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers);do\n\
-                    \  ns=$(echo \"$line\" | awk '{print $1}')\n  role=$(echo \"$line\"\
-                    \ | awk '{print $2}')\n  creation=$(date -d $(oc get role $role\
-                    \ -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');\n\
-                    \  if [[ $(expr $((now-creation)) \\> $expiryMins \\* 60) == 1\
-                    \ ]]; then\n    oc delete role $role -n $ns\n  fi\ndone;\nfor\
-                    \ clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation\
-                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
-                    \ get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    \ $ns\n  fi\ndone <<< \"$lines\"\nlines=$(oc get role -A -l managed.openshift.io/remediation\
+                    \ -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers)\n\
+                    [[ -z \"$lines\" ]] || while read line\ndo\n  ns=$(echo \"$line\"\
+                    \ | awk '{print $1}')\n  role=$(echo \"$line\" | awk '{print $2}')\n\
+                    \  creation=$(date -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete role $role -n $ns\n  fi\ndone\
+                    \ <<< \"$lines\"\nfor clusterrolebinding in $(oc get clusterrolebinding\
+                    \ -l managed.openshift.io/remediation -o custom-columns=:.metadata.name\
+                    \ --no-headers);do\n  creation=$(date -d $(oc get clusterrolebinding\
+                    \ $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete clusterrolebinding $clusterrolebinding\n\
-                    \  fi\ndone;\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
-                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
-                    \ get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    \  fi\ndone\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
+                    \ -o custom-columns=:.metadata.name --no-headers);do\n  creation=$(date\
+                    \ -d $(oc get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete clusterrole $clusterrole\n\
-                    \  fi\ndone;\n"
+                    \  fi\ndone\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32356,31 +32356,33 @@ objects:
                   args:
                   - /bin/bash
                   - -c
-                  - "now=$(date +%s);\nexpiryMins=720;\nfor line in $(oc get rolebinding\
-                    \ -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
-                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
-                    \  rolebinding=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
-                    \ -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                  - "now=$(date +%s)\nexpiryMins=720\nlines=$(oc get rolebinding -A\
+                    \ -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers)\n[[ -z \"$lines\" ]] || while read line\ndo\n\
+                    \  ns=$(echo \"$line\" | awk '{print $1}')\n  rolebinding=$(echo\
+                    \ \"$line\" | awk '{print $2}')\n  creation=$(date -d $(oc get\
+                    \ rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete rolebinding $rolebinding -n\
-                    \ $ns\n  fi\ndone;\nfor line in $(oc get role -A -l managed.openshift.io/remediation\
-                    \ -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers);do\n\
-                    \  ns=$(echo \"$line\" | awk '{print $1}')\n  role=$(echo \"$line\"\
-                    \ | awk '{print $2}')\n  creation=$(date -d $(oc get role $role\
-                    \ -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');\n\
-                    \  if [[ $(expr $((now-creation)) \\> $expiryMins \\* 60) == 1\
-                    \ ]]; then\n    oc delete role $role -n $ns\n  fi\ndone;\nfor\
-                    \ clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation\
-                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
-                    \ get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    \ $ns\n  fi\ndone <<< \"$lines\"\nlines=$(oc get role -A -l managed.openshift.io/remediation\
+                    \ -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers)\n\
+                    [[ -z \"$lines\" ]] || while read line\ndo\n  ns=$(echo \"$line\"\
+                    \ | awk '{print $1}')\n  role=$(echo \"$line\" | awk '{print $2}')\n\
+                    \  creation=$(date -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete role $role -n $ns\n  fi\ndone\
+                    \ <<< \"$lines\"\nfor clusterrolebinding in $(oc get clusterrolebinding\
+                    \ -l managed.openshift.io/remediation -o custom-columns=:.metadata.name\
+                    \ --no-headers);do\n  creation=$(date -d $(oc get clusterrolebinding\
+                    \ $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete clusterrolebinding $clusterrolebinding\n\
-                    \  fi\ndone;\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
-                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
-                    \ get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    \  fi\ndone\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
+                    \ -o custom-columns=:.metadata.name --no-headers);do\n  creation=$(date\
+                    \ -d $(oc get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete clusterrole $clusterrole\n\
-                    \  fi\ndone;\n"
+                    \  fi\ndone\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32356,31 +32356,33 @@ objects:
                   args:
                   - /bin/bash
                   - -c
-                  - "now=$(date +%s);\nexpiryMins=720;\nfor line in $(oc get rolebinding\
-                    \ -A -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
-                    \ --no-headers);do\n  ns=$(echo \"$line\" | awk '{print $1}')\n\
-                    \  rolebinding=$(echo \"$line\" | awk '{print $2}')\n  creation=$(date\
-                    \ -d $(oc get rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                  - "now=$(date +%s)\nexpiryMins=720\nlines=$(oc get rolebinding -A\
+                    \ -l managed.openshift.io/remediation -o custom-columns=:.metadata.namespace,:.metadata.name\
+                    \ --no-headers)\n[[ -z \"$lines\" ]] || while read line\ndo\n\
+                    \  ns=$(echo \"$line\" | awk '{print $1}')\n  rolebinding=$(echo\
+                    \ \"$line\" | awk '{print $2}')\n  creation=$(date -d $(oc get\
+                    \ rolebinding $rolebinding -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete rolebinding $rolebinding -n\
-                    \ $ns\n  fi\ndone;\nfor line in $(oc get role -A -l managed.openshift.io/remediation\
-                    \ -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers);do\n\
-                    \  ns=$(echo \"$line\" | awk '{print $1}')\n  role=$(echo \"$line\"\
-                    \ | awk '{print $2}')\n  creation=$(date -d $(oc get role $role\
-                    \ -n $ns -o jsonpath='{.metadata.creationTimestamp}') '+%s');\n\
-                    \  if [[ $(expr $((now-creation)) \\> $expiryMins \\* 60) == 1\
-                    \ ]]; then\n    oc delete role $role -n $ns\n  fi\ndone;\nfor\
-                    \ clusterrolebinding in $(oc get clusterrolebinding -l managed.openshift.io/remediation\
-                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
-                    \ get clusterrolebinding $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    \ $ns\n  fi\ndone <<< \"$lines\"\nlines=$(oc get role -A -l managed.openshift.io/remediation\
+                    \ -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers)\n\
+                    [[ -z \"$lines\" ]] || while read line\ndo\n  ns=$(echo \"$line\"\
+                    \ | awk '{print $1}')\n  role=$(echo \"$line\" | awk '{print $2}')\n\
+                    \  creation=$(date -d $(oc get role $role -n $ns -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    * 60) == 1 ]]; then\n    oc delete role $role -n $ns\n  fi\ndone\
+                    \ <<< \"$lines\"\nfor clusterrolebinding in $(oc get clusterrolebinding\
+                    \ -l managed.openshift.io/remediation -o custom-columns=:.metadata.name\
+                    \ --no-headers);do\n  creation=$(date -d $(oc get clusterrolebinding\
+                    \ $clusterrolebinding -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete clusterrolebinding $clusterrolebinding\n\
-                    \  fi\ndone;\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
-                    \ --no-headers | awk '{print $1}');do\n  creation=$(date -d $(oc\
-                    \ get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
-                    \ '+%s');\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
+                    \  fi\ndone\nfor clusterrole in $(oc get clusterrole -l managed.openshift.io/remediation\
+                    \ -o custom-columns=:.metadata.name --no-headers);do\n  creation=$(date\
+                    \ -d $(oc get clusterrole $clusterrole -o jsonpath='{.metadata.creationTimestamp}')\
+                    \ '+%s')\n  if [[ $(expr $((now-creation)) \\> $expiryMins \\\
                     * 60) == 1 ]]; then\n    oc delete clusterrole $clusterrole\n\
-                    \  fi\ndone;\n"
+                    \  fi\ndone\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
https://github.com/openshift/managed-cluster-config/pull/2368 was merged too rapidly - The cronjob shell script wasn't yet fully tested after the refactor which consisted in not iterating anymore when deleting namespaced scoped resources (`role` & `rolebinding`)

### Which Jira/Github issue(s) this PR fixes?

Complete [OSD-27692](https://issues.redhat.com//browse/OSD-27692)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] Not a FedRamp change