### PR TITLE
OSD-27299: Making sure operators installed in user workload namespaces are ignored in case the same operator is installed in an openshift namespace

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
@@ -22,4 +22,10 @@ spec:
                   subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
           record:
-            sre:operators:succeeded
+            sre:operators:succeeded:raw
+        - expr:
+            # making sure that operators installed in user workload namespaces are ignored in case the same operator is installed in an openshift namespace
+            sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
+            or on(_id, name)
+            sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
+          record: sre:operators:succeeded

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40554,6 +40554,9 @@ objects:
               "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
               package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
+            record: sre:operators:succeeded:raw
+          - expr: sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
+              or on(_id, name) sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
             record: sre:operators:succeeded
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40554,6 +40554,9 @@ objects:
               "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
               package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
+            record: sre:operators:succeeded:raw
+          - expr: sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
+              or on(_id, name) sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
             record: sre:operators:succeeded
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40554,6 +40554,9 @@ objects:
               "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
               package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
               )
+            record: sre:operators:succeeded:raw
+          - expr: sre:operators:succeeded:raw{exported_namespace =~ "openshift-.*"}
+              or on(_id, name) sre:operators:succeeded:raw{exported_namespace !~ "openshift-.*"}
             record: sre:operators:succeeded
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?

We don't want to show operators installed by the customer in the `osd` dashboard

### Which Jira/Github issue(s) this PR fixes?

[OSD-27299](https://issues.redhat.com//browse/OSD-27299)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] Not a FedRamp change