### PR TITLE
Add S3 permission for image registry wildcard path

### DIFF
--- a/resources/sts/4.18/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
+++ b/resources/sts/4.18/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
@@ -43,6 +43,7 @@
       ],
       "Resource": [
         "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}-*/*",
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}?/*",
         "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}/*"
       ]
     }


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Feature  

### What this PR does / why we need it?
Updating a managed policy with an additional entry to allow for a longer AWS region.

### Which Jira/Github issue(s) this PR fixes?
This is on-going HCP work for FedRAMP

_Fixes #_

### Special notes for your reviewer:
After meeting with AWS, we have determined we do not need to alter the commercial vs GovCloud partition.  When AWS adds it to gov-cloud, their process will update the ARNs.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
