### PR TITLE
Maint(OSD-29242): exclude openshift-cluster-observability-operator fr…

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -22,7 +22,7 @@ spec:
       expr: |-
         max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~"openshift-.*"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~"openshift-.*"} )
         unless on(namespace)
-          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)"}
+          kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)"}
       for: 15m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40200,7 +40200,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40200,7 +40200,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }"
             for: 15m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40200,7 +40200,7 @@ objects:
             expr: "max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~\"\
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
-              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv)\"\
+              openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }"
             for: 15m
             labels:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

We don't care about PDBs in `openshift-cluster-observability-operator`, this is a customer installed operator via the hub. 
As a little background, cluster-observability-operator (COO) used to be observability-operator (OBO). It changed name recently as it moved into the operatorhub. We already had OBO in the list of namespaces we don't check PDBs on. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_https://issues.redhat.com/browse/OSD-29242

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
