### PR TITLE
[OSD-29363] Move metrics-server to infra nodes

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
@@ -111,3 +111,10 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists

--- a/deploy/cluster-monitoring-config-non-uwm/clusters-v4.5/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/clusters-v4.5/50-GENERATED-cluster-monitoring-config.yaml
@@ -111,6 +111,13 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     grafana:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -111,3 +111,10 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists

--- a/deploy/cluster-monitoring-config-non-uwm/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
@@ -111,6 +111,13 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     grafana:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -111,3 +111,10 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists

--- a/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -111,3 +111,10 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists

--- a/deploy/cluster-monitoring-config/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/pre-4.11/50-GENERATED-cluster-monitoring-config.yaml
@@ -111,6 +111,13 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     grafana:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -86,3 +86,10 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24957,6 +24957,8 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -25028,6 +25030,8 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -25085,6 +25089,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -25153,6 +25159,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -25223,6 +25231,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -25295,6 +25305,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -25370,6 +25382,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -32827,6 +32841,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24957,6 +24957,8 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -25028,6 +25030,8 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -25085,6 +25089,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -25153,6 +25159,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -25223,6 +25231,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -25295,6 +25305,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -25370,6 +25382,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -32827,6 +32841,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24957,6 +24957,8 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -25028,6 +25030,8 @@ objects:
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -25085,6 +25089,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -25153,6 +25159,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -25223,6 +25231,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -25295,6 +25305,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -25370,6 +25382,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -32827,6 +32841,8 @@ objects:
           \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1

--- a/resources/cluster-monitoring-config/config.yaml
+++ b/resources/cluster-monitoring-config/config.yaml
@@ -107,3 +107,10 @@ monitoringPlugin:
     - effect: NoSchedule
       key: node-role.kubernetes.io/infra
       operator: Exists
+metricsServer:
+  nodeSelector:
+    node-role.kubernetes.io/infra: ""
+  tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      operator: Exists


### PR DESCRIPTION
Moves the metrics-server to infra nodes instead of depending on worker nodes to run it.

### What type of PR is this?
bug

### What this PR does / why we need it?

Currently the metrics-server deployment of the monitoring stack is only schedulable on worker nodes.
This can fail if there are no worker nodes, or if they are overloaded or unschedulable.
As this is part of the platform monitoring stack it should not depend on worker nodes.

### Which Jira/Github issue(s) this PR fixes?

Fixes [OSD-29363](https://issues.redhat.com//browse/OSD-29363)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
