### PR TITLE
Rescope capa

### DIFF
--- a/resources/sts/4.17/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.17/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -166,8 +166,7 @@
         "ec2:RunInstances"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:instance/*",
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws:ec2:*:*:instance/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -182,6 +181,7 @@
         "ec2:RunInstances"
       ],
       "Resource": [
+        "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:subnet/*",
         "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:volume/*"

--- a/resources/sts/4.18/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/4.18/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -166,8 +166,7 @@
         "ec2:RunInstances"
       ],
       "Resource": [
-        "arn:aws:ec2:*:*:instance/*",
-        "arn:aws:ec2:*:*:network-interface/*"
+        "arn:aws:ec2:*:*:instance/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -182,6 +181,7 @@
         "ec2:RunInstances"
       ],
       "Resource": [
+        "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:subnet/*",
         "arn:aws:ec2:*:*:security-group/*",
         "arn:aws:ec2:*:*:volume/*"


### PR DESCRIPTION
### What type of PR is this?
This rescopes the capa managed policy in order to remove the requirement of a request tag on ENI that is conditioned in the run-instances call. 
