### PR TITLE
Fix OCMAgentResponseFailureServiceLogsSRE alert

### DIFF
--- a/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-ocm-agent-operator.PrometheusRule.yaml
@@ -11,8 +11,8 @@ spec:
   - name: sre-ocm-agent-operator-alerts
     rules:
     - alert: OCMAgentResponseFailureServiceLogsSRE
-      # Alert if the OCM agent response failure metric has been set for an hour average window
-      expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m]) == 1
+      # Alert if the OCM agent response failure metric has been set for an hour
+      expr: ocm_agent_response_failure{ocm_service="service_logs"} == 1
       for: 60m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39864,8 +39864,7 @@ objects:
         - name: sre-ocm-agent-operator-alerts
           rules:
           - alert: OCMAgentResponseFailureServiceLogsSRE
-            expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m])
-              == 1
+            expr: ocm_agent_response_failure{ocm_service="service_logs"} == 1
             for: 60m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39864,8 +39864,7 @@ objects:
         - name: sre-ocm-agent-operator-alerts
           rules:
           - alert: OCMAgentResponseFailureServiceLogsSRE
-            expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m])
-              == 1
+            expr: ocm_agent_response_failure{ocm_service="service_logs"} == 1
             for: 60m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39864,8 +39864,7 @@ objects:
         - name: sre-ocm-agent-operator-alerts
           rules:
           - alert: OCMAgentResponseFailureServiceLogsSRE
-            expr: avg_over_time(ocm_agent_response_failure{ocm_service="service_logs"}[60m])
-              == 1
+            expr: ocm_agent_response_failure{ocm_service="service_logs"} == 1
             for: 60m
             labels:
               severity: critical


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
The current alert will not resolve unless it's been successful for an hour. We don't need to use the avg over time when we are also setting the "for" stanza

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
