### PR TITLE
Force CAMO to re-install w/ `olm.skipRange` annotations 

### DIFF
--- a/deploy/configure-alertmanager-operator-reinstall/config.yaml
+++ b/deploy/configure-alertmanager-operator-reinstall/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/deploy/configure-alertmanager-operator-reinstall/job.yaml
+++ b/deploy/configure-alertmanager-operator-reinstall/job.yaml
@@ -63,7 +63,24 @@ spec:
               NAMESPACE="openshift-monitoring"
               OPERATOR="configure-alertmanager-operator"
 
+              # Export a clean version of the Subscription then delete it, if it exists
+              recreate_subscription=true
+              if oc get subscription.operators.coreos.com -n "$NAMESPACE" "$OPERATOR"; then
+                oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json
+                oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR
+              else
+                recreate_subscription=false
+              fi
+
               # Delete all ClusterServiceVersions
               oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE" --no-headers | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
+
+              # Delete all InstallPlans
+              oc get installplans.operators.coreos.com -n "$NAMESPACE" --no-headers | grep $OPERATOR | awk '{print $1}' | xargs oc delete installplan.operators.coreos.com -n "$NAMESPACE"
+
+              # Recreate the subscription that was exported earlier, if it exists
+              if [ $recreate_subscription == "true" ]; then
+                oc create -f /tmp/sub.json
+              fi
 
               exit 0

--- a/deploy/configure-alertmanager-operator-reinstall/job.yaml
+++ b/deploy/configure-alertmanager-operator-reinstall/job.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: <operator-namespace>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: <operator-namespace>
+rules:
+- apiGroups:
+  - "operators.coreos.com"
+  resources:
+  - clusterserviceversions
+  - subscriptions
+  - installplans
+  verbs:
+  - list
+  - get
+  - delete
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: <operator-namespace>
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: <operator-namespace>
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-monitoring
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 300 # Kill the job pod if it runs for longer than 5 minutes
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: sre-operator-reinstall-sa
+      containers:
+      - name: sre-operator-reinstall
+        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        command:
+            - sh
+            - -c
+            - |
+              #!/bin/bash
+              set -uxo pipefail
+              NAMESPACE="openshift-monitoring"
+              OPERATOR="configure-alertmanager-operator"
+
+              # Delete all ClusterServiceVersions
+              oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE" --no-headers | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
+
+              exit 0

--- a/deploy/configure-alertmanager-operator-reinstall/job.yaml
+++ b/deploy/configure-alertmanager-operator-reinstall/job.yaml
@@ -3,13 +3,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: sre-operator-reinstall-sa
-  namespace: <operator-namespace>
+  namespace: openshift-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: sre-operator-reinstall-role
-  namespace: <operator-namespace>
+  namespace: openshift-monitoring
 rules:
 - apiGroups:
   - "operators.coreos.com"
@@ -27,7 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: sre-operator-reinstall-rb
-  namespace: <operator-namespace>
+  namespace: openshift-monitoring
 roleRef:
   kind: Role
   name: sre-operator-reinstall-role
@@ -35,7 +35,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: sre-operator-reinstall-sa
-  namespace: <operator-namespace>
+  namespace: openshift-monitoring
 ---
 apiVersion: batch/v1
 kind: Job

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25381,6 +25381,99 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: configure-alertmanager-operator-reinstall
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-monitoring
+      spec:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        activeDeadlineSeconds: 300
+        template:
+          spec:
+            restartPolicy: OnFailure
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - '#!/bin/bash
+
+                set -uxo pipefail
+
+                NAMESPACE="openshift-monitoring"
+
+                OPERATOR="configure-alertmanager-operator"
+
+
+                # Delete all ClusterServiceVersions
+
+                oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE"
+                --no-headers | grep $OPERATOR | awk ''{print $1}'' | xargs oc delete
+                clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
+
+
+                exit 0
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: crio-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25448,25 +25448,24 @@ objects:
               command:
               - sh
               - -c
-              - '#!/bin/bash
-
-                set -uxo pipefail
-
-                NAMESPACE="openshift-monitoring"
-
-                OPERATOR="configure-alertmanager-operator"
-
-
-                # Delete all ClusterServiceVersions
-
-                oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE"
-                --no-headers | grep $OPERATOR | awk ''{print $1}'' | xargs oc delete
-                clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
-
-
-                exit 0
-
-                '
+              - "#!/bin/bash\nset -uxo pipefail\nNAMESPACE=\"openshift-monitoring\"\
+                \nOPERATOR=\"configure-alertmanager-operator\"\n\n# Export a clean\
+                \ version of the Subscription then delete it, if it exists\nrecreate_subscription=true\n\
+                if oc get subscription.operators.coreos.com -n \"$NAMESPACE\" \"$OPERATOR\"\
+                ; then\n  oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\
+                \ -o json | jq 'del(.status) | del(.metadata.creationTimestamp) |\
+                \ del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n  oc delete subscription.operators.coreos.com -n\
+                \ $NAMESPACE $OPERATOR\nelse\n  recreate_subscription=false\nfi\n\n\
+                # Delete all ClusterServiceVersions\noc get clusterserviceversions.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete clusterserviceversions.operators.coreos.com -n\
+                \ $NAMESPACE --wait=false\n\n# Delete all InstallPlans\noc get installplans.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n\n# Recreate the subscription that was exported earlier, if it exists\n\
+                if [ $recreate_subscription == \"true\" ]; then\n  oc create -f /tmp/sub.json\n\
+                fi\n\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25381,6 +25381,99 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: configure-alertmanager-operator-reinstall
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-monitoring
+      spec:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        activeDeadlineSeconds: 300
+        template:
+          spec:
+            restartPolicy: OnFailure
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - '#!/bin/bash
+
+                set -uxo pipefail
+
+                NAMESPACE="openshift-monitoring"
+
+                OPERATOR="configure-alertmanager-operator"
+
+
+                # Delete all ClusterServiceVersions
+
+                oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE"
+                --no-headers | grep $OPERATOR | awk ''{print $1}'' | xargs oc delete
+                clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
+
+
+                exit 0
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: crio-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25448,25 +25448,24 @@ objects:
               command:
               - sh
               - -c
-              - '#!/bin/bash
-
-                set -uxo pipefail
-
-                NAMESPACE="openshift-monitoring"
-
-                OPERATOR="configure-alertmanager-operator"
-
-
-                # Delete all ClusterServiceVersions
-
-                oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE"
-                --no-headers | grep $OPERATOR | awk ''{print $1}'' | xargs oc delete
-                clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
-
-
-                exit 0
-
-                '
+              - "#!/bin/bash\nset -uxo pipefail\nNAMESPACE=\"openshift-monitoring\"\
+                \nOPERATOR=\"configure-alertmanager-operator\"\n\n# Export a clean\
+                \ version of the Subscription then delete it, if it exists\nrecreate_subscription=true\n\
+                if oc get subscription.operators.coreos.com -n \"$NAMESPACE\" \"$OPERATOR\"\
+                ; then\n  oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\
+                \ -o json | jq 'del(.status) | del(.metadata.creationTimestamp) |\
+                \ del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n  oc delete subscription.operators.coreos.com -n\
+                \ $NAMESPACE $OPERATOR\nelse\n  recreate_subscription=false\nfi\n\n\
+                # Delete all ClusterServiceVersions\noc get clusterserviceversions.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete clusterserviceversions.operators.coreos.com -n\
+                \ $NAMESPACE --wait=false\n\n# Delete all InstallPlans\noc get installplans.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n\n# Recreate the subscription that was exported earlier, if it exists\n\
+                if [ $recreate_subscription == \"true\" ]; then\n  oc create -f /tmp/sub.json\n\
+                fi\n\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25381,6 +25381,99 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: configure-alertmanager-operator-reinstall
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-monitoring
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-monitoring
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-monitoring
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-monitoring
+      spec:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        activeDeadlineSeconds: 300
+        template:
+          spec:
+            restartPolicy: OnFailure
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - '#!/bin/bash
+
+                set -uxo pipefail
+
+                NAMESPACE="openshift-monitoring"
+
+                OPERATOR="configure-alertmanager-operator"
+
+
+                # Delete all ClusterServiceVersions
+
+                oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE"
+                --no-headers | grep $OPERATOR | awk ''{print $1}'' | xargs oc delete
+                clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
+
+
+                exit 0
+
+                '
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: crio-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25448,25 +25448,24 @@ objects:
               command:
               - sh
               - -c
-              - '#!/bin/bash
-
-                set -uxo pipefail
-
-                NAMESPACE="openshift-monitoring"
-
-                OPERATOR="configure-alertmanager-operator"
-
-
-                # Delete all ClusterServiceVersions
-
-                oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE"
-                --no-headers | grep $OPERATOR | awk ''{print $1}'' | xargs oc delete
-                clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
-
-
-                exit 0
-
-                '
+              - "#!/bin/bash\nset -uxo pipefail\nNAMESPACE=\"openshift-monitoring\"\
+                \nOPERATOR=\"configure-alertmanager-operator\"\n\n# Export a clean\
+                \ version of the Subscription then delete it, if it exists\nrecreate_subscription=true\n\
+                if oc get subscription.operators.coreos.com -n \"$NAMESPACE\" \"$OPERATOR\"\
+                ; then\n  oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR\
+                \ -o json | jq 'del(.status) | del(.metadata.creationTimestamp) |\
+                \ del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n  oc delete subscription.operators.coreos.com -n\
+                \ $NAMESPACE $OPERATOR\nelse\n  recreate_subscription=false\nfi\n\n\
+                # Delete all ClusterServiceVersions\noc get clusterserviceversions.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete clusterserviceversions.operators.coreos.com -n\
+                \ $NAMESPACE --wait=false\n\n# Delete all InstallPlans\noc get installplans.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n\n# Recreate the subscription that was exported earlier, if it exists\n\
+                if [ $recreate_subscription == \"true\" ]; then\n  oc create -f /tmp/sub.json\n\
+                fi\n\nexit 0\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
This PR force deletes `configure-alertmanager-operator` Subscription and CSVs so that they will be re-generated with `olm.skipRange` annotations. This will unblock all the clusters stuck on `0.1.663-gf9b036b` and will result in the fleet upgrading to `0.1.699-gf37ca8d`

CAMO Code Change: https://github.com/openshift/configure-alertmanager-operator/pull/411
CAMO Promotion: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/139193 
CAMO PD Graph: https://inscope.corp.redhat.com/catalog/default/component/configure-alertmanager-operator/rollout

### Which Jira/Github issue(s) this PR fixes?

Updates: [OSD-28836](https://issues.redhat.com//browse/OSD-28836)

### Special notes for your reviewer:

n/a

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
