### PR TITLE
OSD-29478 - Update version list to include 4.15 in machine config for integration

### DIFF
--- a/deploy/osd-fedramp-machineconfig/int/pre-4.15/config.yaml
+++ b/deploy/osd-fedramp-machineconfig/int/pre-4.15/config.yaml
@@ -11,4 +11,4 @@ selectorSyncSet:
         - "integration"
     - key: hive.openshift.io/version-major-minor
       operator: In
-      values: ["4.11", "4.12", "4.13", "4.14"]
+      values: ["4.11", "4.12", "4.13", "4.14", "4.15"]

--- a/deploy/osd-fedramp-machineconfig/stg/pre-4.15/config.yaml
+++ b/deploy/osd-fedramp-machineconfig/stg/pre-4.15/config.yaml
@@ -12,4 +12,4 @@ selectorSyncSet:
         - "stage"
     - key: hive.openshift.io/version-major-minor
       operator: In
-      values: ["4.11", "4.12", "4.13", "4.14"]
+      values: ["4.11", "4.12", "4.13", "4.14", "4.15"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32978,6 +32978,7 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -33135,6 +33136,7 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32978,6 +32978,7 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -33135,6 +33136,7 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32978,6 +32978,7 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -33135,6 +33136,7 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Feature  

### What this PR does / why we need it?
FedRAMP is moving to 4.15

### Which Jira/Github issue(s) this PR fixes?
[OSD-29478](https://issues.redhat.com/browse/OSD-29478)

_Fixes #_

### Special notes for your reviewer:
This config ensures this setting is only applied to FedRAMP clusters.  

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
