### PR TITLE
OSD-29046: Fixing SlowCustomerWebhookSRE, Not to trigger if service name missing

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/100-customer-webooks.PrometheusRule.yaml
@@ -40,7 +40,7 @@ spec:
       expr: |-
         webhook:max_duration
         * on(type, webhook_name) group_left(service_namespace, service_name)
-        webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io", service_namespace !~ "openshift-.*"}
+        webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io", service_namespace !~ "openshift-.*", service_name !~ ""}
         > 1
       for: 15m
       labels:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -41631,7 +41631,7 @@ objects:
               * on(type, webhook_name) group_left(service_namespace, service_name)
 
               webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io",
-              service_namespace !~ "openshift-.*"}
+              service_namespace !~ "openshift-.*", service_name !~ ""}
 
               > 1'
             for: 15m

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -41631,7 +41631,7 @@ objects:
               * on(type, webhook_name) group_left(service_namespace, service_name)
 
               webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io",
-              service_namespace !~ "openshift-.*"}
+              service_namespace !~ "openshift-.*", service_name !~ ""}
 
               > 1'
             for: 15m

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -41631,7 +41631,7 @@ objects:
               * on(type, webhook_name) group_left(service_namespace, service_name)
 
               webhook:configuration_service{webhook_name !~ ".*\\.openshift\\.io",
-              service_namespace !~ "openshift-.*"}
+              service_namespace !~ "openshift-.*", service_name !~ ""}
 
               > 1'
             for: 15m


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?

**Problem statement:**
ocm-agent tries to send the SL for slowcustomerwebhookSRE alert & it gets failed because of missing service_name label. Also ocm-agent keeps on re-sending SL & triggered OCMAgentResponseFailureServiceLogsSRE.

The Service name is the one contain actual webhook causing the delay issue. in order to unblock OCMAgentResponseFailureServiceLogsSRE alert, Changing alert not to triggger if service name is missing

For more details refer: https://redhat-internal.slack.com/archives/C01JJKHC0CF/p1744795698368939?thread_ts=1744121845.696969&cid=C01JJKHC0CF

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_
https://issues.redhat.com/browse/OSD-29046
