### PR TITLE
OSD-29478 - Update version list to include 4.15 in machine config for Production

### DIFF
--- a/deploy/osd-fedramp-machineconfig/prod/pre-4.15/config.yaml
+++ b/deploy/osd-fedramp-machineconfig/prod/pre-4.15/config.yaml
@@ -11,4 +11,4 @@ selectorSyncSet:
         - "production"
     - key: hive.openshift.io/version-major-minor
       operator: In
-      values: ["4.11", "4.12", "4.13", "4.14"]
+      values: ["4.11", "4.12", "4.13", "4.14", "4.15"]


### PR DESCRIPTION
What type of PR is this?
(bug/feature/cleanup/documentation)
Feature

What this PR does / why we need it?
FedRAMP is moving to 4.15

Which Jira/Github issue(s) this PR fixes?
[OSD-29478](https://issues.redhat.com/browse/OSD-29478)

Fixes #

Special notes for your reviewer:
This config ensures this setting is only applied to FedRAMP clusters.

Pre-checks (if applicable):
 Tested latest changes against a cluster

 Included documentation changes with PR

 If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

matchExpressions:
- key: api.openshift.com/fedramp
  operator: NotIn
  values: ["true"]