### PR TITLE
OSD-28970 add 6 metrics for central observility

### DIFF
--- a/deploy/management-cluster-prometheus-metrics/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/management-cluster-prometheus-metrics/50-GENERATED-cluster-monitoring-config.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    prometheusK8s:
+      remoteWrite:
+      - url: ${OBSERVATORIUM_URL}
+        oauth2:
+          clientId:
+            secret:
+              key: client-id
+              name: observatorium-credentials
+          clientSecret:
+            key: client-secret
+            name: observatorium-credentials
+          tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+        remoteTimeout: 30s
+        writeRelabelConfigs:
+        - sourceLabels:
+          - __name__
+          action: keep
+          regex: (package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)
+        queueConfig:
+          capacity: 2500
+          maxShards: 1000
+          minShards: 1
+          maxSamplesPerSend: 2000
+          batchSendDeadline: 60s
+          minBackoff: 30ms
+          maxBackoff: 1m
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      retention: 11d
+      retentionSize: 90GB
+      volumeClaimTemplate:
+        metadata:
+          name: prometheus-data
+        spec:
+          resources:
+            requests:
+              storage: 100Gi
+    alertmanagerMain:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      volumeClaimTemplate:
+        metadata:
+          name: alertmanager-data
+        spec:
+          resources:
+            requests:
+              storage: 10Gi
+    telemeterClient:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+      telemeterServerURL: ${TELEMETER_SERVER_URL}
+    prometheusOperator:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    k8sPrometheusAdapter:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    kubeStateMetrics:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    openshiftStateMetrics:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    thanosQuerier:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    monitoringPlugin:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists

--- a/deploy/management-cluster-prometheus-metrics/config.yaml
+++ b/deploy/management-cluster-prometheus-metrics/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/sts
+    operator: In
+    values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-sector
+    operator: NotIn
+    values: ["ibm-infra"]

--- a/deploy/sre-prometheus/centralized-observability/100-sre-internal-slo-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-internal-slo-recording-rules.PrometheusRule.yaml
@@ -12,3 +12,15 @@ spec:
       rules:
         - expr: sre:telemetry:managed_labels * on (version) group_left(alerts, upgradeconfig_name, preceding_version, stream) label_replace(upgradeoperator_upgrade_result, "sre", "true", "", "")
           record: sre:slo:upgradeoperator_upgrade_result
+        - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name) upgradeoperator_upgrade_started_timestamp
+          record: sre:slo:upgradeoperator_upgrade_started_timestamp
+        - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name) upgradeoperator_upgrade_completed_timestamp
+          record: sre:slo:upgradeoperator_upgrade_completed_timestamp
+        - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name) upgradeoperator_controlplane_upgrade_started_timestamp
+          record: sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp
+        - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name) upgradeoperator_controlplane_upgrade_completed_timestamp
+          record: sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp
+        - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name) upgradeoperator_workernode_upgrade_started_timestamp
+          record: sre:slo:upgradeoperator_workernode_upgrade_started_timestamp
+        - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name) upgradeoperator_workernode_upgrade_completed_timestamp
+          record: sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26479,6 +26479,72 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: management-cluster-prometheus-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: obo-removal-for-sc-clusters
   spec:
     clusterDeploymentSelector:
@@ -40536,6 +40602,24 @@ objects:
               preceding_version, stream) label_replace(upgradeoperator_upgrade_result,
               "sre", "true", "", "")
             record: sre:slo:upgradeoperator_upgrade_result
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_upgrade_completed_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_controlplane_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_controlplane_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_workernode_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_workernode_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_workernode_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26479,6 +26479,72 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: management-cluster-prometheus-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: obo-removal-for-sc-clusters
   spec:
     clusterDeploymentSelector:
@@ -40536,6 +40602,24 @@ objects:
               preceding_version, stream) label_replace(upgradeoperator_upgrade_result,
               "sre", "true", "", "")
             record: sre:slo:upgradeoperator_upgrade_result
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_upgrade_completed_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_controlplane_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_controlplane_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_workernode_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_workernode_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_workernode_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26479,6 +26479,72 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: management-cluster-prometheus-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/sts
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: obo-removal-for-sc-clusters
   spec:
     clusterDeploymentSelector:
@@ -40536,6 +40602,24 @@ objects:
               preceding_version, stream) label_replace(upgradeoperator_upgrade_result,
               "sre", "true", "", "")
             record: sre:slo:upgradeoperator_upgrade_result
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_upgrade_completed_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_controlplane_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_controlplane_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_workernode_upgrade_started_timestamp
+            record: sre:slo:upgradeoperator_workernode_upgrade_started_timestamp
+          - expr: sre:telemetry:managed_labels * on (_id) group_left(upgradeconfig_name)
+              upgradeoperator_workernode_upgrade_completed_timestamp
+            record: sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
add 6 metrics for central observility

- sre:slo:upgradeoperator_upgrade_started_timestamp 
- sre:slo:upgradeoperator_upgrade_completed_timestamp 
- sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp 
- sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp 
- sre:slo:upgradeoperator_workernode_upgrade_started_timestamp 
- sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp

### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature

### What this PR does / why we need it?
add 6 metrics for central observility

### Which Jira/Github issue(s) this PR fixes?
[OSD-28970](https://issues.redhat.com//browse/OSD-28970)
_Fixes #_

### Special notes for your reviewer:
NA
### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
