### PR TITLE
Remove RHOBS_URL template variable that is no longer in use

### DIFF
--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -24,8 +24,6 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
-- name: RHOBS_URL
-  required: true
 - name: ENV
   required: true
 - name: OBSERVATORIUM_URL

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -24,8 +24,6 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
-- name: RHOBS_URL
-  required: true
 - name: ENV
   required: true
 - name: OBSERVATORIUM_URL

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -24,8 +24,6 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
-- name: RHOBS_URL
-  required: true
 - name: ENV
   required: true
 - name: OBSERVATORIUM_URL

--- a/scripts/templates/template.yaml
+++ b/scripts/templates/template.yaml
@@ -24,8 +24,6 @@ parameters:
   required: true
 - name: SEGMENT_API_KEY
   required: true
-- name: RHOBS_URL
-  required: true
 - name: ENV
   required: true
 - name: OBSERVATORIUM_URL


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?
Remove RHOBS_URL that is no longer in use.

### Which Jira/Github issue(s) this PR fixes?
_Fixes APPSRE-11851_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
