### PR TITLE
[FRSTRAT-186] replicate ROSA HCP image registry wildcard to create bucket

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_image_registry_operator_permission_policy.json
@@ -28,6 +28,7 @@
       ],
       "Resource": [
         "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}-*",
+        "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}?",
         "arn:aws:s3:::*-image-registry-${aws:RequestedRegion}"
       ]
     },


### PR DESCRIPTION
### What type of PR is this?
_bug/risk_

### What this PR does / why we need it?

This PR ensures that the extra wildcard previously applied to the PutObject permissions in the cluster image registry policy for hypershift also is applied to the CreateBucket permissions. Otherwise, CIRO will be unable to create the backing S3 buckets necessary to run Image Registry cluster operator on Hosted Clusters in AWS GovCloud.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #FRSTRAT-186_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
