### PR TITLE
docs: update oauth-templates docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In OSD, managed-cluster-config sets a [key named `branding` to `dedicated`](http
 
 ## OAuth Templates
 
-Docs TBA.
+The OAuth templates are HTML files that are used to customize the login page of the OpenShift web console. These templates are built from the [oauth-templates](https://github.com/openshift/oauth-templates/) repository. managed-cluster-config overrides the default templates with custom ones that are stored in this repository. To update the templates, refer to the REAMDE in the [OSD](./source/html/osd/README.md) and [ROSA](./source/html/rosa/README.md) directories for more information.
 
 ## Resource Quotas
 

--- a/source/html/osd/README.md
+++ b/source/html/osd/README.md
@@ -1,6 +1,6 @@
 Source for these templates is here:
-* https://openshift.github.io/oauth-templates/od/errors.html
-* https://openshift.github.io/oauth-templates/od/login.html
-* https://openshift.github.io/oauth-templates/od/providers.html
+* https://github.com/openshift/oauth-templates
 
-To stuff them in the correct place in this repo run `make generate-oauth-templates`.
+Follow the [instructions](https://github.com/openshift/oauth-templates#red-hat-openshift-dedicated-and-red-hat-openshift-service-on-aws-rosa) on the oauth-templates repo to build the templates.
+
+Build the templates and copy them to this folder. To stuff them in the correct place in this repo run `make generate-oauth-templates`.

--- a/source/html/rosa/README.md
+++ b/source/html/rosa/README.md
@@ -1,16 +1,6 @@
 Source for these templates is here:
-* https://openshift.github.io/oauth-templates/rosa/errors.html
-* https://openshift.github.io/oauth-templates/rosa/login.html
-* https://openshift.github.io/oauth-templates/rosa/providers.html
+* https://github.com/openshift/oauth-templates
 
-### PS
-Note that providers.html is a bit different than upstream because the upstream is missing
+Follow the [instructions](https://github.com/openshift/oauth-templates#red-hat-openshift-dedicated-and-red-hat-openshift-service-on-aws-rosa) on the oauth-templates repo to build the templates.
 
-```html
-{{ if ne $provider.Name "kube:admin" }}
-{{ end }}
-```
-
-same for osd, too...
-
-To stuff them in the correct place in this repo run `make generate-oauth-templates`.
+Build the templates and copy them to this folder. To stuff them in the correct place in this repo run `make generate-oauth-templates`.


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

docs

### What this PR does / why we need it?

https://openshift.github.io/oauth-templates/ is outdated since the OpenShift org doesn't allow GitHub actions to run. You will need to rebuild the templates by hand. 

### Which Jira/Github issue(s) this PR fixes?

n/a

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
