### PR TITLE
SREP-400: Refactor CAPI annotator job

### DIFF
--- a/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
+++ b/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
@@ -74,6 +74,14 @@ data:
       fi
     
       namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
+
+      # If the managedcluster does not have a api.openshift.io/management-cluster label, then it should be skipped. This is
+      # usually because the local cluster + service cluster are registered as "managedcluster"s.
+      if [ "$namespace" = "null" ]; then
+        echo "skipping cluster $clusterID because it is a management or local cluster"
+        break
+      fi
+
       kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
       num=0
       for kind in $kinds;do

--- a/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
+++ b/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: capa-annotator
+  namespace: openshift-capa-annotator
+data:
+  should_patch.py: |
+    import sys
+    # should_patch.py takes two arguments: version and compare_version.
+    # It will then compare the Z stream of version to see if it's >= compare_version,
+    # exiting non-zero if it's not. Exiting non-zero means we need to patch.
+    #
+    # Example:
+    #   # This exits non-zero as the Z stream (10) is not >= 11
+    #   python should_patch.py 4.17.10 11
+    #
+    #   # This exits zero as the Z stream (10) is >= 9
+    #   python should_patch.py 4.17.10 9
+    
+    usage = """usage: python should_patch.py $version $compare_version
+    example: python should_patch.py 4.17.15 14 # exits 0 
+      """
+    
+    def should_patch(version, compare_version):
+        try:
+            x, y, z = version.split('.')
+            if int(z) >= int(compare_version):
+                print(f"don't patch: version {version} is >= x.y.{compare_version}")
+                return False
+            else:
+                print(f"should patch: version {version} is not >= x.y.{compare_version}")
+                return True
+        except ValueError:
+            print(f"could not compare version {version} to {compare_version}, defaulting to should patch")
+            return True
+    
+    def main():
+        if len(sys.argv) != 3:
+            print(usage)
+            sys.exit(1)
+        
+        version = sys.argv[1].rstrip()
+        compare_version = sys.argv[2].rstrip()
+        
+        if should_patch(version, compare_version):
+            sys.exit(1)
+    
+    if __name__=="__main__":
+        main()
+  patch.sh: |
+    #!/bin/bash
+
+    # Required Environment Variables:
+    # - IMAGE
+    # - MAJOR_MINOR_VER
+    # - Z_STREAM_FIXED_VER
+    
+    # Get all manifestwork objects and extract their names
+    managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+    
+    # Loop through each manifestwork object
+    for clusterID in ${managedclusters[@]};do
+      # Extract full version, namespace and name
+      version=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')
+    
+      # Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER
+      # This also handles any case where the script exits non-zero for any other reason, opting to patch as a result.
+      cleanup="false"
+      if python /tmp/scripts/should_patch.py "${version}" "${Z_STREAM_FIXED_VER}"; then
+        echo "cluster ${clusterID} does not need the override because it's Z stream is >= ${Z_STREAM_FIXED_VER}"
+        echo "removing hypershift.openshift.io/capi-provider-aws-image annotation"
+        cleanup="true"
+      fi
+    
+      namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
+      kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
+      num=0
+      for kind in $kinds;do
+        if [[ $kind == "HostedCluster" ]]; then
+            echo "patching cluster: $clusterID"
+    
+            if [[ $cleanup = "true" ]]; then
+              json_payload='[{"op":"remove","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]'
+            else
+              json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
+            fi
+    
+            echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
+            oc patch manifestwork "$clusterID" -n "$namespace" --type='json' -p "$json_payload"
+            echo "-------------------------------------------------------------------------"
+            break
+        fi
+      (( num++))
+      done
+    done

--- a/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
+++ b/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
@@ -1,69 +1,23 @@
----
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: capa-annotator
-  namespace: openshift-capa-annotator
 data:
-  should_patch.py: |
-    import sys
-    # should_patch.py takes two arguments: version and compare_version.
-    # It will then compare the Z stream of version to see if it's >= compare_version,
-    # exiting non-zero if it's not. Exiting non-zero means we need to patch.
-    #
-    # Example:
-    #   # This exits non-zero as the Z stream (10) is not >= 11
-    #   python should_patch.py 4.17.10 11
-    #
-    #   # This exits zero as the Z stream (10) is >= 9
-    #   python should_patch.py 4.17.10 9
-    
-    usage = """usage: python should_patch.py $version $compare_version
-    example: python should_patch.py 4.17.15 14 # exits 0 
-      """
-    
-    def should_patch(version, compare_version):
-        try:
-            x, y, z = version.split('.')
-            if int(z) >= int(compare_version):
-                print(f"don't patch: version {version} is >= x.y.{compare_version}")
-                return False
-            else:
-                print(f"should patch: version {version} is not >= x.y.{compare_version}")
-                return True
-        except ValueError:
-            print(f"could not compare version {version} to {compare_version}, defaulting to should patch")
-            return True
-    
-    def main():
-        if len(sys.argv) != 3:
-            print(usage)
-            sys.exit(1)
-        
-        version = sys.argv[1].rstrip()
-        compare_version = sys.argv[2].rstrip()
-        
-        if should_patch(version, compare_version):
-            sys.exit(1)
-    
-    if __name__=="__main__":
-        main()
   patch.sh: |
-    #!/bin/bash
+    #!/usr/bin/env bash
+
+    # NOTE: If you update this script, run `./generate_configmap.sh`
 
     # Required Environment Variables:
     # - IMAGE
     # - MAJOR_MINOR_VER
     # - Z_STREAM_FIXED_VER
-    
+
     # Get all manifestwork objects and extract their names
     managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-    
+
     # Loop through each manifestwork object
     for clusterID in ${managedclusters[@]};do
       # Extract full version, namespace and name
       version=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')
-    
+
       # Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER
       # This also handles any case where the script exits non-zero for any other reason, opting to patch as a result.
       cleanup="false"
@@ -72,12 +26,12 @@ data:
         echo "removing hypershift.openshift.io/capi-provider-aws-image annotation"
         cleanup="true"
       fi
-    
+
       namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
 
       # If the managedcluster does not have a api.openshift.io/management-cluster label, then it should be skipped. This is
       # usually because the local cluster + service cluster are registered as "managedcluster"s.
-      if [ "$namespace" = "null" ]; then
+      if [ "$namespace" == "null" ]; then
         echo "skipping cluster $clusterID because it is a management or local cluster"
         break
       fi
@@ -87,13 +41,13 @@ data:
       for kind in $kinds;do
         if [[ $kind == "HostedCluster" ]]; then
             echo "patching cluster: $clusterID"
-    
+
             if [[ $cleanup = "true" ]]; then
               json_payload='[{"op":"remove","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]'
             else
               json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
             fi
-    
+
             echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
             oc patch manifestwork "$clusterID" -n "$namespace" --type='json' -p "$json_payload"
             echo "-------------------------------------------------------------------------"
@@ -102,3 +56,26 @@ data:
       (( num++))
       done
     done
+  should_patch.py: "#!/usr/bin/env python3\n\n# NOTE: If you update this script, run
+    `./generate_configmap.sh`\n\nimport sys\n\n# should_patch.py takes two arguments:
+    version and compare_version.\n# It will then compare the Z stream of version to
+    see if it's >= compare_version,\n# exiting non-zero if it's not. Exiting non-zero
+    means we need to patch.\n#\n# Example:\n#   # This exits non-zero as the Z stream
+    (10) is not >= 11\n#   python should_patch.py 4.17.10 11\n#\n#   # This exits
+    zero as the Z stream (10) is >= 9\n#   python should_patch.py 4.17.10 9\n\nusage
+    = \"\"\"usage: python should_patch.py $version $compare_version\nexample: python
+    should_patch.py 4.17.15 14 # exits 0 \n\"\"\"\n\ndef should_patch(version, compare_version):\n
+    \   try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n
+    \           print(f\"don't patch: version {version} is >= x.y.{compare_version}\")\n
+    \           return False\n        else:\n            print(f\"should patch: version
+    {version} is not >= x.y.{compare_version}\")\n            return True\n    except
+    ValueError:\n        print(f\"could not compare version {version} to {compare_version},
+    defaulting to should patch\")\n        return True\n\ndef main():\n    if len(sys.argv)
+    != 3:\n        print(usage)\n        sys.exit(1)\n\n    version = sys.argv[1].rstrip()\n
+    \   compare_version = sys.argv[2].rstrip()\n\n    if should_patch(version, compare_version):\n
+    \       sys.exit(1)\n\nif __name__==\"__main__\":\n    main()\n"
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: capa-annotator
+  namespace: openshift-capa-annotator

--- a/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
+++ b/deploy/osd-25821-capa-annotator/04-ConfigMap.yaml
@@ -10,6 +10,12 @@ data:
     # - MAJOR_MINOR_VER
     # - Z_STREAM_FIXED_VER
 
+    # Ensure we have python available before running further logic
+    if ! command -v python &>/dev/null; then
+      echo "ERROR: python not found, required for this script to run"
+      exit 1
+    fi
+
     # Get all manifestwork objects and extract their names
     managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
@@ -31,7 +37,7 @@ data:
 
       # If the managedcluster does not have a api.openshift.io/management-cluster label, then it should be skipped. This is
       # usually because the local cluster + service cluster are registered as "managedcluster"s.
-      if [ "$namespace" == "null" ]; then
+      if [ "$namespace" == "null" ] || [ "$namespace" == "" ]; then
         echo "skipping cluster $clusterID because it is a management or local cluster"
         break
       fi

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-14.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-14.yaml
@@ -45,7 +45,7 @@ spec:
                 - name: MAJOR_MINOR_VER
                   value: "4.14"
                 - name: Z_STREAM_FIXED_VER
-                  value: "4.14.41"
+                  value: "41"
               volumeMounts:
                 - name: scripts
                   mountPath: /tmp/scripts

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-14.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-14.yaml
@@ -32,7 +32,7 @@ spec:
           containers:
             - name: capa-annotator
               image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
@@ -40,37 +40,23 @@ spec:
                     - ALL
                 runAsNonRoot: true
               env:
-                - name: IMAGE
-                  # 4.14.41
+                - name: IMAGE # 4.14.41
                   value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8ef2860fe69648046ee92a0d5b272fe17ec1a0bee000c27af21bc4a7dade8394
                 - name: MAJOR_MINOR_VER
                   value: "4.14"
+                - name: Z_STREAM_FIXED_VER
+                  value: "4.14.41"
+              volumeMounts:
+                - name: scripts
+                  mountPath: /tmp/scripts
               command:
                 - /bin/bash
               args:
-                - -c
-                - |
-                  # Get all manifestwork objects and extract their names
-                  managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-                  # Loop through each manifestwork object
-                  for clusterID in ${managedclusters[@]};do 
-                    # Extract namespace and name
-                    namespace=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
-                    kinds=$(oc get manifestwork -n $namespace $clusterID -o json | jq -r '.spec.workload.manifests[].kind')
-                    num=0 
-                    for kind in $kinds;do 
-                      if [[ $kind == "HostedCluster" ]]; then
-                          echo $clusterID
-                          #~1 escapes / in bash
-                          json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
-                          echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
-                          oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload"
-                          echo "-------------------------------------------------------------------------"
-                          break
-                      fi
-                    (( num++))
-                    done
-                  done
+                - /tmp/scripts/patch.sh
+          volumes:
+            - name: scripts
+              configMap:
+                name: capa-annotator
           serviceAccountName: capa-annotator
           automountServiceAccountToken: true
           restartPolicy: Never

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-15.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-15.yaml
@@ -32,7 +32,7 @@ spec:
           containers:
             - name: capa-annotator
               image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-              imagePullPolicy: Always
+              imagePullPolicy: IfNotPresent
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
@@ -40,37 +40,23 @@ spec:
                     - ALL
                 runAsNonRoot: true
               env:
-                - name: IMAGE
-                  # 4.15.39
+                - name: IMAGE # 4.15.39
                   value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
                 - name: MAJOR_MINOR_VER
                   value: "4.15"
+                - name: Z_STREAM_FIXED_VER
+                  value: "4.15.39"
+              volumeMounts:
+                - name: scripts
+                  mountPath: /tmp/scripts
               command:
                 - /bin/bash
               args:
-                - -c
-                - |
-                  # Get all manifestwork objects and extract their names
-                  managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-                  # Loop through each manifestwork object
-                  for clusterID in ${managedclusters[@]};do 
-                    # Extract namespace and name
-                    namespace=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
-                    kinds=$(oc get manifestwork -n $namespace $clusterID -o json | jq -r '.spec.workload.manifests[].kind')
-                    num=0 
-                    for kind in $kinds;do 
-                      if [[ $kind == "HostedCluster" ]]; then
-                          echo $clusterID
-                          #~1 escapes / in bash
-                          json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
-                          echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
-                          oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload"
-                          echo "-------------------------------------------------------------------------"
-                          break
-                      fi
-                    (( num++))
-                    done
-                  done
+                - /tmp/scripts/patch.sh
+          volumes:
+            - name: scripts
+              configMap:
+                name: capa-annotator
           serviceAccountName: capa-annotator
           automountServiceAccountToken: true
           restartPolicy: Never

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-15.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-15.yaml
@@ -45,7 +45,7 @@ spec:
                 - name: MAJOR_MINOR_VER
                   value: "4.15"
                 - name: Z_STREAM_FIXED_VER
-                  value: "4.15.39"
+                  value: "39"
               volumeMounts:
                 - name: scripts
                   mountPath: /tmp/scripts

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-16.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-16.yaml
@@ -45,7 +45,7 @@ spec:
               - name: MAJOR_MINOR_VER
                 value: "4.16"
               - name: Z_STREAM_FIXED_VER
-                value: "4.16.23"
+                value: "23"
             volumeMounts:
               - name: scripts
                 mountPath: /tmp/scripts

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-16.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-16.yaml
@@ -32,7 +32,7 @@ spec:
           containers:
           - name: capa-annotator
             image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
@@ -40,37 +40,23 @@ spec:
                 - ALL
               runAsNonRoot: true
             env:
-              - name: IMAGE
-                # 4.16.23
+              - name: IMAGE # 4.16.23
                 value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fbad492113bbe9763af4b04be533473dea08ffdd759a288a697b41c7aafa4d5e
               - name: MAJOR_MINOR_VER
                 value: "4.16"
+              - name: Z_STREAM_FIXED_VER
+                value: "4.16.23"
+            volumeMounts:
+              - name: scripts
+                mountPath: /tmp/scripts
             command:
-            - /bin/bash
+              - /bin/bash
             args:
-            - -c
-            - |
-              # Get all manifestwork objects and extract their names
-              managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-              # Loop through each manifestwork object
-              for clusterID in ${managedclusters[@]};do 
-                # Extract namespace and name
-                namespace=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
-                kinds=$(oc get manifestwork -n $namespace $clusterID -o json | jq -r '.spec.workload.manifests[].kind')
-                num=0 
-                for kind in $kinds;do 
-                  if [[ $kind == "HostedCluster" ]]; then
-                      echo $clusterID
-                      #~1 escapes / in bash
-                      json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
-                      echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
-                      oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload"
-                      echo "-------------------------------------------------------------------------"
-                      break
-                  fi
-                (( num++))
-                done
-              done
+              - /tmp/scripts/patch.sh
+          volumes:
+            - name: scripts
+              configMap:
+                name: capa-annotator
           serviceAccountName: capa-annotator
           automountServiceAccountToken: true
           restartPolicy: Never

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-17.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-17.yaml
@@ -46,7 +46,7 @@ spec:
               - name: MAJOR_MINOR_VER
                 value: "4.17"
               - name: Z_STREAM_FIXED_VER
-                value: "4.17.4"
+                value: "4"
             volumeMounts:
               - name: scripts
                 mountPath: /tmp/scripts

--- a/deploy/osd-25821-capa-annotator/10-CronJob-4-17.yaml
+++ b/deploy/osd-25821-capa-annotator/10-CronJob-4-17.yaml
@@ -33,7 +33,7 @@ spec:
           containers:
           - name: capa-annotator
             image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
@@ -45,32 +45,19 @@ spec:
                 value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4
               - name: MAJOR_MINOR_VER
                 value: "4.17"
+              - name: Z_STREAM_FIXED_VER
+                value: "4.17.4"
+            volumeMounts:
+              - name: scripts
+                mountPath: /tmp/scripts
             command:
-            - /bin/bash
+              - /bin/bash
             args:
-            - -c
-            - |
-              # Get all manifestwork objects and extract their names
-              managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-              # Loop through each manifestwork object
-              for clusterID in ${managedclusters[@]};do 
-                # Extract namespace and name
-                namespace=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
-                kinds=$(oc get manifestwork -n $namespace $clusterID -o json | jq -r '.spec.workload.manifests[].kind')
-                num=0 
-                for kind in $kinds;do 
-                  if [[ $kind == "HostedCluster" ]]; then
-                      echo $clusterID
-                      #~1 escapes / in bash
-                      json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
-                      echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
-                      oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload"
-                      echo "-------------------------------------------------------------------------"
-                      break
-                  fi
-                (( num++))
-                done
-              done
+              - /tmp/scripts/patch.sh
+          volumes:
+            - name: scripts
+              configMap:
+                name: capa-annotator
           serviceAccountName: capa-annotator
           automountServiceAccountToken: true
           restartPolicy: Never

--- a/deploy/osd-25821-capa-annotator/README.md
+++ b/deploy/osd-25821-capa-annotator/README.md
@@ -7,14 +7,19 @@ to run a custom version of the `capi-provider` for AWS.
 
 The primary logic is nested in a `CronJob` that runs periodically, enumerating clusters and deciding
 if it should patch or not. This logic includes a Python script `should_patch.py` that does a `semver` comparison
-to only patch clusters where the Z stream is not patched.
+to only patch clusters where the Z stream is not patched, as well as a shell script `patch.sh`.
 
 Any cluster `>=` the patched version will _not_ be patched. In addition, the job will then remove any override annotation,
 allowing the `control-plane-operator` to match the version of the cluster as normal.
 
 The Python script is bundled in a single `ConfigMap` that is referenced across each `CronJob`.
 
-The source is `should_patch.py`, so if changes are made there, **ensure to update the `ConfigMap` as well.**
+## Making Changes to Scripts
+
+If you make a change to either `should_patch.py` or `patch.sh`, run the included generator script to update the ConfigMap.
+
+    ./generate_configmap.sh
+    make
 
 ## Testing
 

--- a/deploy/osd-25821-capa-annotator/README.md
+++ b/deploy/osd-25821-capa-annotator/README.md
@@ -1,0 +1,25 @@
+# OSD-25821-capa-annotator
+
+This contains a SelectorSyncSet config that targets `ServiceClusters` to patch `ManifestWork`s with an annotation
+to run a custom version of the `capi-provider` for AWS.
+
+## Logic
+
+The primary logic is nested in a `CronJob` that runs periodically, enumerating clusters and deciding
+if it should patch or not. This logic includes a Python script `should_patch.py` that does a `semver` comparison
+to only patch clusters where the Z stream is not patched.
+
+Any cluster `>=` the patched version will _not_ be patched. In addition, the job will then remove any override annotation,
+allowing the `control-plane-operator` to match the version of the cluster as normal.
+
+The Python script is bundled in a single `ConfigMap` that is referenced across each `CronJob`.
+
+The source is `should_patch.py`, so if changes are made there, **ensure to update the `ConfigMap` as well.**
+
+## Testing
+
+The included Python script has a set of unit tests you can run to validate its logic.
+
+``
+python -m unittest tests.py
+``

--- a/deploy/osd-25821-capa-annotator/generate_configmap.sh
+++ b/deploy/osd-25821-capa-annotator/generate_configmap.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo "Generating 04-ConfigMap.yaml from files: should_patch.py, patch.sh"
+oc create configmap capa-annotator -n openshift-capa-annotator \
+  --from-file should_patch.py --from-file patch.sh --dry-run=client -o yaml > 04-ConfigMap.yaml
+
+echo "Complete!"

--- a/deploy/osd-25821-capa-annotator/patch.sh
+++ b/deploy/osd-25821-capa-annotator/patch.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# NOTE: If you update this script, run `./generate_configmap.sh`
 
 # Required Environment Variables:
 # - IMAGE
@@ -26,7 +28,7 @@ for clusterID in ${managedclusters[@]};do
 
   # If the managedcluster does not have a api.openshift.io/management-cluster label, then it should be skipped. This is
   # usually because the local cluster + service cluster are registered as "managedcluster"s.
-  if [ "$namespace" = "null" ]; then
+  if [ "$namespace" == "null" ]; then
     echo "skipping cluster $clusterID because it is a management or local cluster"
     break
   fi

--- a/deploy/osd-25821-capa-annotator/patch.sh
+++ b/deploy/osd-25821-capa-annotator/patch.sh
@@ -7,6 +7,12 @@
 # - MAJOR_MINOR_VER
 # - Z_STREAM_FIXED_VER
 
+# Ensure we have python available before running further logic
+if ! command -v python &>/dev/null; then
+  echo "ERROR: python not found, required for this script to run"
+  exit 1
+fi
+
 # Get all manifestwork objects and extract their names
 managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
@@ -28,7 +34,7 @@ for clusterID in ${managedclusters[@]};do
 
   # If the managedcluster does not have a api.openshift.io/management-cluster label, then it should be skipped. This is
   # usually because the local cluster + service cluster are registered as "managedcluster"s.
-  if [ "$namespace" == "null" ]; then
+  if [ "$namespace" == "null" ] || [ "$namespace" == "" ]; then
     echo "skipping cluster $clusterID because it is a management or local cluster"
     break
   fi

--- a/deploy/osd-25821-capa-annotator/patch.sh
+++ b/deploy/osd-25821-capa-annotator/patch.sh
@@ -23,6 +23,14 @@ for clusterID in ${managedclusters[@]};do
   fi
 
   namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
+
+  # If the managedcluster does not have a api.openshift.io/management-cluster label, then it should be skipped. This is
+  # usually because the local cluster + service cluster are registered as "managedcluster"s.
+  if [ "$namespace" = "null" ]; then
+    echo "skipping cluster $clusterID because it is a management or local cluster"
+    break
+  fi
+
   kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
   num=0
   for kind in $kinds;do

--- a/deploy/osd-25821-capa-annotator/patch.sh
+++ b/deploy/osd-25821-capa-annotator/patch.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Required Environment Variables:
+# - IMAGE
+# - MAJOR_MINOR_VER
+# - Z_STREAM_FIXED_VER
+
+# Get all manifestwork objects and extract their names
+managedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+# Loop through each manifestwork object
+for clusterID in ${managedclusters[@]};do
+  # Extract full version, namespace and name
+  version=$(oc get managedclusters $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')
+
+  # Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER
+  # This also handles any case where the script exits non-zero for any other reason, opting to patch as a result.
+  cleanup="false"
+  if python /tmp/scripts/should_patch.py "${version}" "${Z_STREAM_FIXED_VER}"; then
+    echo "cluster ${clusterID} does not need the override because it's Z stream is >= ${Z_STREAM_FIXED_VER}"
+    echo "removing hypershift.openshift.io/capi-provider-aws-image annotation"
+    cleanup="true"
+  fi
+
+  namespace=$(oc get managedclusters "$clusterID" -o json | jq -r '.metadata.labels["api.openshift.com/management-cluster"]')
+  kinds=$(oc get manifestwork -n "$namespace" "$clusterID" -o json | jq -r '.spec.workload.manifests[].kind')
+  num=0
+  for kind in $kinds;do
+    if [[ $kind == "HostedCluster" ]]; then
+        echo "patching cluster: $clusterID"
+
+        if [[ $cleanup = "true" ]]; then
+          json_payload='[{"op":"remove","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]'
+        else
+          json_payload='[{"op":"replace","path":"/spec/workload/manifests/'"$num"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image","value":"'"$IMAGE"'"}]'
+        fi
+
+        echo "oc patch manifestwork $clusterID -n $namespace --type='json' -p "$json_payload""
+        oc patch manifestwork "$clusterID" -n "$namespace" --type='json' -p "$json_payload"
+        echo "-------------------------------------------------------------------------"
+        break
+    fi
+  (( num++))
+  done
+done

--- a/deploy/osd-25821-capa-annotator/should_patch.py
+++ b/deploy/osd-25821-capa-annotator/should_patch.py
@@ -1,0 +1,43 @@
+import sys
+
+# should_patch.py takes two arguments: version and compare_version.
+# It will then compare the Z stream of version to see if it's >= compare_version,
+# exiting non-zero if it's not. Exiting non-zero means we need to patch.
+#
+# Example:
+#   # This exits non-zero as the Z stream (10) is not >= 11
+#   python should_patch.py 4.17.10 11
+#
+#   # This exits zero as the Z stream (10) is >= 9
+#   python should_patch.py 4.17.10 9
+
+usage = """usage: python should_patch.py $version $compare_version
+example: python should_patch.py 4.17.15 14 # exits 0 
+"""
+
+def should_patch(version, compare_version):
+    try:
+        x, y, z = version.split('.')
+        if int(z) >= int(compare_version):
+            print(f"don't patch: version {version} is >= x.y.{compare_version}")
+            return False
+        else:
+            print(f"should patch: version {version} is not >= x.y.{compare_version}")
+            return True
+    except ValueError:
+        print(f"could not compare version {version} to {compare_version}, defaulting to should patch")
+        return True
+
+def main():
+    if len(sys.argv) != 3:
+        print(usage)
+        sys.exit(1)
+
+    version = sys.argv[1].rstrip()
+    compare_version = sys.argv[2].rstrip()
+
+    if should_patch(version, compare_version):
+        sys.exit(1)
+
+if __name__=="__main__":
+    main()

--- a/deploy/osd-25821-capa-annotator/should_patch.py
+++ b/deploy/osd-25821-capa-annotator/should_patch.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+# NOTE: If you update this script, run `./generate_configmap.sh`
+
 import sys
 
 # should_patch.py takes two arguments: version and compare_version.

--- a/deploy/osd-25821-capa-annotator/tests.py
+++ b/deploy/osd-25821-capa-annotator/tests.py
@@ -1,0 +1,38 @@
+import unittest
+
+from should_patch import should_patch
+
+class TestShouldPatch(unittest.TestCase):
+
+    def test_version_greater_than_compare_version(self):
+        # Test where z stream version is greater than compare_version
+        result = should_patch("4.15.15", "10")
+        self.assertFalse(result)  # No patch needed, should return False
+
+    def test_version_equal_to_compare_version(self):
+        # Test where z stream version is equal to compare_version
+        result = should_patch("4.15.10", "10")
+        self.assertFalse(result)  # No patch needed, should return False
+
+    def test_version_less_than_compare_version(self):
+        # Test where z stream version is less than compare_version
+        result = should_patch("4.15.5", "10")
+        self.assertTrue(result)  # Patch needed, should return True
+
+    def test_version_is_zero(self):
+        # Test where z stream version is zero
+        result = should_patch("4.15.0", "5")
+        self.assertTrue(result)  # Patch needed, should return True
+
+    def test_non_integer_version(self):
+        # Test where parsing version fails, assert we default to patching
+        result = should_patch("10.5.y", "10")
+        self.assertTrue(result)
+
+    def test_non_integer_compare_version(self):
+        # Test where parsing compare_version fails, assert we default to patching
+        result = should_patch("10", "10.5y")
+        self.assertTrue(result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28903,6 +28903,60 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: capa-annotator
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: capa-annotator
+        namespace: openshift-capa-annotator
+      data:
+        should_patch.py: "import sys\n# should_patch.py takes two arguments: version\
+          \ and compare_version.\n# It will then compare the Z stream of version to\
+          \ see if it's >= compare_version,\n# exiting non-zero if it's not. Exiting\
+          \ non-zero means we need to patch.\n#\n# Example:\n#   # This exits non-zero\
+          \ as the Z stream (10) is not >= 11\n#   python should_patch.py 4.17.10\
+          \ 11\n#\n#   # This exits zero as the Z stream (10) is >= 9\n#   python\
+          \ should_patch.py 4.17.10 9\n\nusage = \"\"\"usage: python should_patch.py\
+          \ $version $compare_version\nexample: python should_patch.py 4.17.15 14\
+          \ # exits 0 \n  \"\"\"\n\ndef should_patch(version, compare_version):\n\
+          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
+          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
+          )\n            return False\n        else:\n            print(f\"should\
+          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
+          \    return True\n    except ValueError:\n        print(f\"could not compare\
+          \ version {version} to {compare_version}, defaulting to should patch\")\n\
+          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
+          \  print(usage)\n        sys.exit(1)\n    \n    version = sys.argv[1].rstrip()\n\
+          \    compare_version = sys.argv[2].rstrip()\n    \n    if should_patch(version,\
+          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
+          \    main()\n"
+        patch.sh: "#!/bin/bash\n\n# Required Environment Variables:\n# - IMAGE\n#\
+          \ - MAJOR_MINOR_VER\n# - Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects\
+          \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+          \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
+          \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
+          \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
+          \ $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')\n\n  #\
+          \ Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER\n\
+          \  # This also handles any case where the script exits non-zero for any\
+          \ other reason, opting to patch as a result.\n  cleanup=\"false\"\n  if\
+          \ python /tmp/scripts/should_patch.py \"${version}\" \"${Z_STREAM_FIXED_VER}\"\
+          ; then\n    echo \"cluster ${clusterID} does not need the override because\
+          \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/capi-provider-aws-image\
+          \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
+          \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
+          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
+          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
+          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
+          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
+          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
+          $num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
+          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\
+          \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\n      \
+          \  oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
+          \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+          \n        break\n    fi\n  (( num++))\n  done\ndone\n"
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
@@ -28939,7 +28993,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -28951,27 +29005,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8ef2860fe69648046ee92a0d5b272fe17ec1a0bee000c27af21bc4a7dade8394
                   - name: MAJOR_MINOR_VER
                     value: '4.14'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.14.41
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29011,7 +29057,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29023,27 +29069,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
                   - name: MAJOR_MINOR_VER
                     value: '4.15'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.15.39
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29083,7 +29121,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29095,27 +29133,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fbad492113bbe9763af4b04be533473dea08ffdd759a288a697b41c7aafa4d5e
                   - name: MAJOR_MINOR_VER
                     value: '4.16'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.16.23
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29155,7 +29185,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29167,27 +29197,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4
                   - name: MAJOR_MINOR_VER
                     value: '4.17'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.17.4
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28944,12 +28944,16 @@ objects:
           \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/capi-provider-aws-image\
           \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
           \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
-          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
-          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
-          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
-          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
-          $num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
+          \ label, then it should be skipped. This is\n  # usually because the local\
+          \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
+          \ [ \"$namespace\" = \"null\" ]; then\n    echo \"skipping cluster $clusterID\
+          \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
+          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
+          \ ]]; then\n        echo \"patching cluster: $clusterID\"\n\n        if\
+          \ [[ $cleanup = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\"\
+          ,\"path\":\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
           :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28904,34 +28904,11 @@ objects:
         kind: ClusterRole
         name: capa-annotator
     - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: capa-annotator
-        namespace: openshift-capa-annotator
       data:
-        should_patch.py: "import sys\n# should_patch.py takes two arguments: version\
-          \ and compare_version.\n# It will then compare the Z stream of version to\
-          \ see if it's >= compare_version,\n# exiting non-zero if it's not. Exiting\
-          \ non-zero means we need to patch.\n#\n# Example:\n#   # This exits non-zero\
-          \ as the Z stream (10) is not >= 11\n#   python should_patch.py 4.17.10\
-          \ 11\n#\n#   # This exits zero as the Z stream (10) is >= 9\n#   python\
-          \ should_patch.py 4.17.10 9\n\nusage = \"\"\"usage: python should_patch.py\
-          \ $version $compare_version\nexample: python should_patch.py 4.17.15 14\
-          \ # exits 0 \n  \"\"\"\n\ndef should_patch(version, compare_version):\n\
-          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
-          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
-          )\n            return False\n        else:\n            print(f\"should\
-          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
-          \    return True\n    except ValueError:\n        print(f\"could not compare\
-          \ version {version} to {compare_version}, defaulting to should patch\")\n\
-          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
-          \  print(usage)\n        sys.exit(1)\n    \n    version = sys.argv[1].rstrip()\n\
-          \    compare_version = sys.argv[2].rstrip()\n    \n    if should_patch(version,\
-          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
-          \    main()\n"
-        patch.sh: "#!/bin/bash\n\n# Required Environment Variables:\n# - IMAGE\n#\
-          \ - MAJOR_MINOR_VER\n# - Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects\
-          \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+        patch.sh: "#!/usr/bin/env bash\n\n# NOTE: If you update this script, run `./generate_configmap.sh`\n\
+          \n# Required Environment Variables:\n# - IMAGE\n# - MAJOR_MINOR_VER\n# -\
+          \ Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects and extract their\
+          \ names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
           \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
@@ -28947,7 +28924,7 @@ objects:
           ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
           \ label, then it should be skipped. This is\n  # usually because the local\
           \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
-          \ [ \"$namespace\" = \"null\" ]; then\n    echo \"skipping cluster $clusterID\
+          \ [ \"$namespace\" == \"null\" ]; then\n    echo \"skipping cluster $clusterID\
           \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
           \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
           \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
@@ -28961,6 +28938,32 @@ objects:
           \  oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
           \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
           \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+        should_patch.py: "#!/usr/bin/env python3\n\n# NOTE: If you update this script,\
+          \ run `./generate_configmap.sh`\n\nimport sys\n\n# should_patch.py takes\
+          \ two arguments: version and compare_version.\n# It will then compare the\
+          \ Z stream of version to see if it's >= compare_version,\n# exiting non-zero\
+          \ if it's not. Exiting non-zero means we need to patch.\n#\n# Example:\n\
+          #   # This exits non-zero as the Z stream (10) is not >= 11\n#   python\
+          \ should_patch.py 4.17.10 11\n#\n#   # This exits zero as the Z stream (10)\
+          \ is >= 9\n#   python should_patch.py 4.17.10 9\n\nusage = \"\"\"usage:\
+          \ python should_patch.py $version $compare_version\nexample: python should_patch.py\
+          \ 4.17.15 14 # exits 0 \n\"\"\"\n\ndef should_patch(version, compare_version):\n\
+          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
+          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
+          )\n            return False\n        else:\n            print(f\"should\
+          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
+          \    return True\n    except ValueError:\n        print(f\"could not compare\
+          \ version {version} to {compare_version}, defaulting to should patch\")\n\
+          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
+          \  print(usage)\n        sys.exit(1)\n\n    version = sys.argv[1].rstrip()\n\
+          \    compare_version = sys.argv[2].rstrip()\n\n    if should_patch(version,\
+          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
+          \    main()\n"
+      kind: ConfigMap
+      metadata:
+        creationTimestamp: null
+        name: capa-annotator
+        namespace: openshift-capa-annotator
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -28907,8 +28907,11 @@ objects:
       data:
         patch.sh: "#!/usr/bin/env bash\n\n# NOTE: If you update this script, run `./generate_configmap.sh`\n\
           \n# Required Environment Variables:\n# - IMAGE\n# - MAJOR_MINOR_VER\n# -\
-          \ Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects and extract their\
-          \ names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+          \ Z_STREAM_FIXED_VER\n\n# Ensure we have python available before running\
+          \ further logic\nif ! command -v python &>/dev/null; then\n  echo \"ERROR:\
+          \ python not found, required for this script to run\"\n  exit 1\nfi\n\n\
+          # Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
+          \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
           \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
@@ -28924,13 +28927,14 @@ objects:
           ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
           \ label, then it should be skipped. This is\n  # usually because the local\
           \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
-          \ [ \"$namespace\" == \"null\" ]; then\n    echo \"skipping cluster $clusterID\
-          \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
-          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
-          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
-          \ ]]; then\n        echo \"patching cluster: $clusterID\"\n\n        if\
-          \ [[ $cleanup = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\"\
-          ,\"path\":\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          \ [ \"$namespace\" == \"null\" ] || [ \"$namespace\" == \"\" ]; then\n \
+          \   echo \"skipping cluster $clusterID because it is a management or local\
+          \ cluster\"\n    break\n  fi\n\n  kinds=$(oc get manifestwork -n \"$namespace\"\
+          \ \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n  num=0\n\
+          \  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\" ]]; then\n\
+          \        echo \"patching cluster: $clusterID\"\n\n        if [[ $cleanup\
+          \ = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\",\"path\"\
+          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
           :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29006,7 +29006,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.14'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.14.41
+                    value: '41'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29070,7 +29070,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.15'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.15.39
+                    value: '39'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29134,7 +29134,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.16'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.16.23
+                    value: '23'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29198,7 +29198,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.17'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.17.4
+                    value: '4'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28903,6 +28903,60 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: capa-annotator
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: capa-annotator
+        namespace: openshift-capa-annotator
+      data:
+        should_patch.py: "import sys\n# should_patch.py takes two arguments: version\
+          \ and compare_version.\n# It will then compare the Z stream of version to\
+          \ see if it's >= compare_version,\n# exiting non-zero if it's not. Exiting\
+          \ non-zero means we need to patch.\n#\n# Example:\n#   # This exits non-zero\
+          \ as the Z stream (10) is not >= 11\n#   python should_patch.py 4.17.10\
+          \ 11\n#\n#   # This exits zero as the Z stream (10) is >= 9\n#   python\
+          \ should_patch.py 4.17.10 9\n\nusage = \"\"\"usage: python should_patch.py\
+          \ $version $compare_version\nexample: python should_patch.py 4.17.15 14\
+          \ # exits 0 \n  \"\"\"\n\ndef should_patch(version, compare_version):\n\
+          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
+          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
+          )\n            return False\n        else:\n            print(f\"should\
+          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
+          \    return True\n    except ValueError:\n        print(f\"could not compare\
+          \ version {version} to {compare_version}, defaulting to should patch\")\n\
+          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
+          \  print(usage)\n        sys.exit(1)\n    \n    version = sys.argv[1].rstrip()\n\
+          \    compare_version = sys.argv[2].rstrip()\n    \n    if should_patch(version,\
+          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
+          \    main()\n"
+        patch.sh: "#!/bin/bash\n\n# Required Environment Variables:\n# - IMAGE\n#\
+          \ - MAJOR_MINOR_VER\n# - Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects\
+          \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+          \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
+          \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
+          \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
+          \ $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')\n\n  #\
+          \ Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER\n\
+          \  # This also handles any case where the script exits non-zero for any\
+          \ other reason, opting to patch as a result.\n  cleanup=\"false\"\n  if\
+          \ python /tmp/scripts/should_patch.py \"${version}\" \"${Z_STREAM_FIXED_VER}\"\
+          ; then\n    echo \"cluster ${clusterID} does not need the override because\
+          \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/capi-provider-aws-image\
+          \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
+          \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
+          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
+          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
+          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
+          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
+          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
+          $num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
+          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\
+          \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\n      \
+          \  oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
+          \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+          \n        break\n    fi\n  (( num++))\n  done\ndone\n"
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
@@ -28939,7 +28993,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -28951,27 +29005,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8ef2860fe69648046ee92a0d5b272fe17ec1a0bee000c27af21bc4a7dade8394
                   - name: MAJOR_MINOR_VER
                     value: '4.14'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.14.41
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29011,7 +29057,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29023,27 +29069,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
                   - name: MAJOR_MINOR_VER
                     value: '4.15'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.15.39
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29083,7 +29121,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29095,27 +29133,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fbad492113bbe9763af4b04be533473dea08ffdd759a288a697b41c7aafa4d5e
                   - name: MAJOR_MINOR_VER
                     value: '4.16'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.16.23
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29155,7 +29185,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29167,27 +29197,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4
                   - name: MAJOR_MINOR_VER
                     value: '4.17'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.17.4
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28944,12 +28944,16 @@ objects:
           \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/capi-provider-aws-image\
           \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
           \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
-          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
-          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
-          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
-          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
-          $num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
+          \ label, then it should be skipped. This is\n  # usually because the local\
+          \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
+          \ [ \"$namespace\" = \"null\" ]; then\n    echo \"skipping cluster $clusterID\
+          \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
+          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
+          \ ]]; then\n        echo \"patching cluster: $clusterID\"\n\n        if\
+          \ [[ $cleanup = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\"\
+          ,\"path\":\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
           :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28904,34 +28904,11 @@ objects:
         kind: ClusterRole
         name: capa-annotator
     - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: capa-annotator
-        namespace: openshift-capa-annotator
       data:
-        should_patch.py: "import sys\n# should_patch.py takes two arguments: version\
-          \ and compare_version.\n# It will then compare the Z stream of version to\
-          \ see if it's >= compare_version,\n# exiting non-zero if it's not. Exiting\
-          \ non-zero means we need to patch.\n#\n# Example:\n#   # This exits non-zero\
-          \ as the Z stream (10) is not >= 11\n#   python should_patch.py 4.17.10\
-          \ 11\n#\n#   # This exits zero as the Z stream (10) is >= 9\n#   python\
-          \ should_patch.py 4.17.10 9\n\nusage = \"\"\"usage: python should_patch.py\
-          \ $version $compare_version\nexample: python should_patch.py 4.17.15 14\
-          \ # exits 0 \n  \"\"\"\n\ndef should_patch(version, compare_version):\n\
-          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
-          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
-          )\n            return False\n        else:\n            print(f\"should\
-          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
-          \    return True\n    except ValueError:\n        print(f\"could not compare\
-          \ version {version} to {compare_version}, defaulting to should patch\")\n\
-          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
-          \  print(usage)\n        sys.exit(1)\n    \n    version = sys.argv[1].rstrip()\n\
-          \    compare_version = sys.argv[2].rstrip()\n    \n    if should_patch(version,\
-          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
-          \    main()\n"
-        patch.sh: "#!/bin/bash\n\n# Required Environment Variables:\n# - IMAGE\n#\
-          \ - MAJOR_MINOR_VER\n# - Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects\
-          \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+        patch.sh: "#!/usr/bin/env bash\n\n# NOTE: If you update this script, run `./generate_configmap.sh`\n\
+          \n# Required Environment Variables:\n# - IMAGE\n# - MAJOR_MINOR_VER\n# -\
+          \ Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects and extract their\
+          \ names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
           \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
@@ -28947,7 +28924,7 @@ objects:
           ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
           \ label, then it should be skipped. This is\n  # usually because the local\
           \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
-          \ [ \"$namespace\" = \"null\" ]; then\n    echo \"skipping cluster $clusterID\
+          \ [ \"$namespace\" == \"null\" ]; then\n    echo \"skipping cluster $clusterID\
           \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
           \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
           \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
@@ -28961,6 +28938,32 @@ objects:
           \  oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
           \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
           \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+        should_patch.py: "#!/usr/bin/env python3\n\n# NOTE: If you update this script,\
+          \ run `./generate_configmap.sh`\n\nimport sys\n\n# should_patch.py takes\
+          \ two arguments: version and compare_version.\n# It will then compare the\
+          \ Z stream of version to see if it's >= compare_version,\n# exiting non-zero\
+          \ if it's not. Exiting non-zero means we need to patch.\n#\n# Example:\n\
+          #   # This exits non-zero as the Z stream (10) is not >= 11\n#   python\
+          \ should_patch.py 4.17.10 11\n#\n#   # This exits zero as the Z stream (10)\
+          \ is >= 9\n#   python should_patch.py 4.17.10 9\n\nusage = \"\"\"usage:\
+          \ python should_patch.py $version $compare_version\nexample: python should_patch.py\
+          \ 4.17.15 14 # exits 0 \n\"\"\"\n\ndef should_patch(version, compare_version):\n\
+          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
+          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
+          )\n            return False\n        else:\n            print(f\"should\
+          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
+          \    return True\n    except ValueError:\n        print(f\"could not compare\
+          \ version {version} to {compare_version}, defaulting to should patch\")\n\
+          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
+          \  print(usage)\n        sys.exit(1)\n\n    version = sys.argv[1].rstrip()\n\
+          \    compare_version = sys.argv[2].rstrip()\n\n    if should_patch(version,\
+          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
+          \    main()\n"
+      kind: ConfigMap
+      metadata:
+        creationTimestamp: null
+        name: capa-annotator
+        namespace: openshift-capa-annotator
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -28907,8 +28907,11 @@ objects:
       data:
         patch.sh: "#!/usr/bin/env bash\n\n# NOTE: If you update this script, run `./generate_configmap.sh`\n\
           \n# Required Environment Variables:\n# - IMAGE\n# - MAJOR_MINOR_VER\n# -\
-          \ Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects and extract their\
-          \ names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+          \ Z_STREAM_FIXED_VER\n\n# Ensure we have python available before running\
+          \ further logic\nif ! command -v python &>/dev/null; then\n  echo \"ERROR:\
+          \ python not found, required for this script to run\"\n  exit 1\nfi\n\n\
+          # Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
+          \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
           \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
@@ -28924,13 +28927,14 @@ objects:
           ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
           \ label, then it should be skipped. This is\n  # usually because the local\
           \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
-          \ [ \"$namespace\" == \"null\" ]; then\n    echo \"skipping cluster $clusterID\
-          \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
-          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
-          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
-          \ ]]; then\n        echo \"patching cluster: $clusterID\"\n\n        if\
-          \ [[ $cleanup = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\"\
-          ,\"path\":\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          \ [ \"$namespace\" == \"null\" ] || [ \"$namespace\" == \"\" ]; then\n \
+          \   echo \"skipping cluster $clusterID because it is a management or local\
+          \ cluster\"\n    break\n  fi\n\n  kinds=$(oc get manifestwork -n \"$namespace\"\
+          \ \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n  num=0\n\
+          \  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\" ]]; then\n\
+          \        echo \"patching cluster: $clusterID\"\n\n        if [[ $cleanup\
+          \ = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\",\"path\"\
+          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
           :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29006,7 +29006,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.14'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.14.41
+                    value: '41'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29070,7 +29070,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.15'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.15.39
+                    value: '39'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29134,7 +29134,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.16'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.16.23
+                    value: '23'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29198,7 +29198,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.17'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.17.4
+                    value: '4'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28903,6 +28903,60 @@ objects:
         apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: capa-annotator
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: capa-annotator
+        namespace: openshift-capa-annotator
+      data:
+        should_patch.py: "import sys\n# should_patch.py takes two arguments: version\
+          \ and compare_version.\n# It will then compare the Z stream of version to\
+          \ see if it's >= compare_version,\n# exiting non-zero if it's not. Exiting\
+          \ non-zero means we need to patch.\n#\n# Example:\n#   # This exits non-zero\
+          \ as the Z stream (10) is not >= 11\n#   python should_patch.py 4.17.10\
+          \ 11\n#\n#   # This exits zero as the Z stream (10) is >= 9\n#   python\
+          \ should_patch.py 4.17.10 9\n\nusage = \"\"\"usage: python should_patch.py\
+          \ $version $compare_version\nexample: python should_patch.py 4.17.15 14\
+          \ # exits 0 \n  \"\"\"\n\ndef should_patch(version, compare_version):\n\
+          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
+          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
+          )\n            return False\n        else:\n            print(f\"should\
+          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
+          \    return True\n    except ValueError:\n        print(f\"could not compare\
+          \ version {version} to {compare_version}, defaulting to should patch\")\n\
+          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
+          \  print(usage)\n        sys.exit(1)\n    \n    version = sys.argv[1].rstrip()\n\
+          \    compare_version = sys.argv[2].rstrip()\n    \n    if should_patch(version,\
+          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
+          \    main()\n"
+        patch.sh: "#!/bin/bash\n\n# Required Environment Variables:\n# - IMAGE\n#\
+          \ - MAJOR_MINOR_VER\n# - Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects\
+          \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+          \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
+          \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
+          \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
+          \ $clusterID -o json | jq -r '.metadata.labels.openshiftVersion')\n\n  #\
+          \ Only patch the image if the clusters Z stream version is < $Z_STREAM_FIXED_VER\n\
+          \  # This also handles any case where the script exits non-zero for any\
+          \ other reason, opting to patch as a result.\n  cleanup=\"false\"\n  if\
+          \ python /tmp/scripts/should_patch.py \"${version}\" \"${Z_STREAM_FIXED_VER}\"\
+          ; then\n    echo \"cluster ${clusterID} does not need the override because\
+          \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/capi-provider-aws-image\
+          \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
+          \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
+          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
+          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
+          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
+          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
+          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
+          $num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
+          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\
+          \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\n      \
+          \  oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
+          \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
+          \n        break\n    fi\n  (( num++))\n  done\ndone\n"
     - apiVersion: batch/v1
       kind: CronJob
       metadata:
@@ -28939,7 +28993,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -28951,27 +29005,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8ef2860fe69648046ee92a0d5b272fe17ec1a0bee000c27af21bc4a7dade8394
                   - name: MAJOR_MINOR_VER
                     value: '4.14'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.14.41
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29011,7 +29057,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29023,27 +29069,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:4a7be4ea33b2321f0f5302cd2664cc99dc1fa1e02db7d9aa979247f1b8826039
                   - name: MAJOR_MINOR_VER
                     value: '4.15'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.15.39
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29083,7 +29121,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29095,27 +29133,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fbad492113bbe9763af4b04be533473dea08ffdd759a288a697b41c7aafa4d5e
                   - name: MAJOR_MINOR_VER
                     value: '4.16'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.16.23
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never
@@ -29155,7 +29185,7 @@ objects:
                 containers:
                 - name: capa-annotator
                   image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-                  imagePullPolicy: Always
+                  imagePullPolicy: IfNotPresent
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -29167,27 +29197,19 @@ objects:
                     value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:f614ef855220f2381217c31b8cb94c05ef20edf3ca23b5efa0be1b957cdde3a4
                   - name: MAJOR_MINOR_VER
                     value: '4.17'
+                  - name: Z_STREAM_FIXED_VER
+                    value: 4.17.4
+                  volumeMounts:
+                  - name: scripts
+                    mountPath: /tmp/scripts
                   command:
                   - /bin/bash
                   args:
-                  - -c
-                  - "# Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
-                    \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
-                    \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\
-                    # Loop through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\
-                    \ \n  # Extract namespace and name\n  namespace=$(oc get managedclusters\
-                    \ $clusterID -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-                    ]')\n  kinds=$(oc get manifestwork -n $namespace $clusterID -o\
-                    \ json | jq -r '.spec.workload.manifests[].kind')\n  num=0 \n\
-                    \  for kind in $kinds;do \n    if [[ $kind == \"HostedCluster\"\
-                    \ ]]; then\n        echo $clusterID\n        #~1 escapes / in\
-                    \ bash\n        json_payload='[{\"op\":\"replace\",\"path\":\"\
-                    /spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
-                    ,\"value\":\"'\"$IMAGE\"'\"}]'\n        echo \"oc patch manifestwork\
-                    \ $clusterID -n $namespace --type='json' -p \"$json_payload\"\"\
-                    \n        oc patch manifestwork $clusterID -n $namespace --type='json'\
-                    \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
-                    \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+                  - /tmp/scripts/patch.sh
+                volumes:
+                - name: scripts
+                  configMap:
+                    name: capa-annotator
                 serviceAccountName: capa-annotator
                 automountServiceAccountToken: true
                 restartPolicy: Never

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28944,12 +28944,16 @@ objects:
           \ it's Z stream is >= ${Z_STREAM_FIXED_VER}\"\n    echo \"removing hypershift.openshift.io/capi-provider-aws-image\
           \ annotation\"\n    cleanup=\"true\"\n  fi\n\n  namespace=$(oc get managedclusters\
           \ \"$clusterID\" -o json | jq -r '.metadata.labels[\"api.openshift.com/management-cluster\"\
-          ]')\n  kinds=$(oc get manifestwork -n \"$namespace\" \"$clusterID\" -o json\
-          \ | jq -r '.spec.workload.manifests[].kind')\n  num=0\n  for kind in $kinds;do\n\
-          \    if [[ $kind == \"HostedCluster\" ]]; then\n        echo \"patching\
-          \ cluster: $clusterID\"\n\n        if [[ $cleanup = \"true\" ]]; then\n\
-          \          json_payload='[{\"op\":\"remove\",\"path\":\"/spec/workload/manifests/'\"\
-          $num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
+          \ label, then it should be skipped. This is\n  # usually because the local\
+          \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
+          \ [ \"$namespace\" = \"null\" ]; then\n    echo \"skipping cluster $clusterID\
+          \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
+          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
+          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
+          \ ]]; then\n        echo \"patching cluster: $clusterID\"\n\n        if\
+          \ [[ $cleanup = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\"\
+          ,\"path\":\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
           :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28904,34 +28904,11 @@ objects:
         kind: ClusterRole
         name: capa-annotator
     - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: capa-annotator
-        namespace: openshift-capa-annotator
       data:
-        should_patch.py: "import sys\n# should_patch.py takes two arguments: version\
-          \ and compare_version.\n# It will then compare the Z stream of version to\
-          \ see if it's >= compare_version,\n# exiting non-zero if it's not. Exiting\
-          \ non-zero means we need to patch.\n#\n# Example:\n#   # This exits non-zero\
-          \ as the Z stream (10) is not >= 11\n#   python should_patch.py 4.17.10\
-          \ 11\n#\n#   # This exits zero as the Z stream (10) is >= 9\n#   python\
-          \ should_patch.py 4.17.10 9\n\nusage = \"\"\"usage: python should_patch.py\
-          \ $version $compare_version\nexample: python should_patch.py 4.17.15 14\
-          \ # exits 0 \n  \"\"\"\n\ndef should_patch(version, compare_version):\n\
-          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
-          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
-          )\n            return False\n        else:\n            print(f\"should\
-          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
-          \    return True\n    except ValueError:\n        print(f\"could not compare\
-          \ version {version} to {compare_version}, defaulting to should patch\")\n\
-          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
-          \  print(usage)\n        sys.exit(1)\n    \n    version = sys.argv[1].rstrip()\n\
-          \    compare_version = sys.argv[2].rstrip()\n    \n    if should_patch(version,\
-          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
-          \    main()\n"
-        patch.sh: "#!/bin/bash\n\n# Required Environment Variables:\n# - IMAGE\n#\
-          \ - MAJOR_MINOR_VER\n# - Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects\
-          \ and extract their names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+        patch.sh: "#!/usr/bin/env bash\n\n# NOTE: If you update this script, run `./generate_configmap.sh`\n\
+          \n# Required Environment Variables:\n# - IMAGE\n# - MAJOR_MINOR_VER\n# -\
+          \ Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects and extract their\
+          \ names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
           \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
@@ -28947,7 +28924,7 @@ objects:
           ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
           \ label, then it should be skipped. This is\n  # usually because the local\
           \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
-          \ [ \"$namespace\" = \"null\" ]; then\n    echo \"skipping cluster $clusterID\
+          \ [ \"$namespace\" == \"null\" ]; then\n    echo \"skipping cluster $clusterID\
           \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
           \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
           \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
@@ -28961,6 +28938,32 @@ objects:
           \  oc patch manifestwork \"$clusterID\" -n \"$namespace\" --type='json'\
           \ -p \"$json_payload\"\n        echo \"-------------------------------------------------------------------------\"\
           \n        break\n    fi\n  (( num++))\n  done\ndone\n"
+        should_patch.py: "#!/usr/bin/env python3\n\n# NOTE: If you update this script,\
+          \ run `./generate_configmap.sh`\n\nimport sys\n\n# should_patch.py takes\
+          \ two arguments: version and compare_version.\n# It will then compare the\
+          \ Z stream of version to see if it's >= compare_version,\n# exiting non-zero\
+          \ if it's not. Exiting non-zero means we need to patch.\n#\n# Example:\n\
+          #   # This exits non-zero as the Z stream (10) is not >= 11\n#   python\
+          \ should_patch.py 4.17.10 11\n#\n#   # This exits zero as the Z stream (10)\
+          \ is >= 9\n#   python should_patch.py 4.17.10 9\n\nusage = \"\"\"usage:\
+          \ python should_patch.py $version $compare_version\nexample: python should_patch.py\
+          \ 4.17.15 14 # exits 0 \n\"\"\"\n\ndef should_patch(version, compare_version):\n\
+          \    try:\n        x, y, z = version.split('.')\n        if int(z) >= int(compare_version):\n\
+          \            print(f\"don't patch: version {version} is >= x.y.{compare_version}\"\
+          )\n            return False\n        else:\n            print(f\"should\
+          \ patch: version {version} is not >= x.y.{compare_version}\")\n        \
+          \    return True\n    except ValueError:\n        print(f\"could not compare\
+          \ version {version} to {compare_version}, defaulting to should patch\")\n\
+          \        return True\n\ndef main():\n    if len(sys.argv) != 3:\n      \
+          \  print(usage)\n        sys.exit(1)\n\n    version = sys.argv[1].rstrip()\n\
+          \    compare_version = sys.argv[2].rstrip()\n\n    if should_patch(version,\
+          \ compare_version):\n        sys.exit(1)\n\nif __name__==\"__main__\":\n\
+          \    main()\n"
+      kind: ConfigMap
+      metadata:
+        creationTimestamp: null
+        name: capa-annotator
+        namespace: openshift-capa-annotator
     - apiVersion: batch/v1
       kind: CronJob
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -28907,8 +28907,11 @@ objects:
       data:
         patch.sh: "#!/usr/bin/env bash\n\n# NOTE: If you update this script, run `./generate_configmap.sh`\n\
           \n# Required Environment Variables:\n# - IMAGE\n# - MAJOR_MINOR_VER\n# -\
-          \ Z_STREAM_FIXED_VER\n\n# Get all manifestwork objects and extract their\
-          \ names\nmanagedclusters=$(oc get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
+          \ Z_STREAM_FIXED_VER\n\n# Ensure we have python available before running\
+          \ further logic\nif ! command -v python &>/dev/null; then\n  echo \"ERROR:\
+          \ python not found, required for this script to run\"\n  exit 1\nfi\n\n\
+          # Get all manifestwork objects and extract their names\nmanagedclusters=$(oc\
+          \ get managedclusters -l openshiftVersion-major-minor=${MAJOR_MINOR_VER}\
           \ -o jsonpath='{range .items[*]}{.metadata.name}{\"\\n\"}{end}')\n\n# Loop\
           \ through each manifestwork object\nfor clusterID in ${managedclusters[@]};do\n\
           \  # Extract full version, namespace and name\n  version=$(oc get managedclusters\
@@ -28924,13 +28927,14 @@ objects:
           ]')\n\n  # If the managedcluster does not have a api.openshift.io/management-cluster\
           \ label, then it should be skipped. This is\n  # usually because the local\
           \ cluster + service cluster are registered as \"managedcluster\"s.\n  if\
-          \ [ \"$namespace\" == \"null\" ]; then\n    echo \"skipping cluster $clusterID\
-          \ because it is a management or local cluster\"\n    break\n  fi\n\n  kinds=$(oc\
-          \ get manifestwork -n \"$namespace\" \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n\
-          \  num=0\n  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\"\
-          \ ]]; then\n        echo \"patching cluster: $clusterID\"\n\n        if\
-          \ [[ $cleanup = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\"\
-          ,\"path\":\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
+          \ [ \"$namespace\" == \"null\" ] || [ \"$namespace\" == \"\" ]; then\n \
+          \   echo \"skipping cluster $clusterID because it is a management or local\
+          \ cluster\"\n    break\n  fi\n\n  kinds=$(oc get manifestwork -n \"$namespace\"\
+          \ \"$clusterID\" -o json | jq -r '.spec.workload.manifests[].kind')\n  num=0\n\
+          \  for kind in $kinds;do\n    if [[ $kind == \"HostedCluster\" ]]; then\n\
+          \        echo \"patching cluster: $clusterID\"\n\n        if [[ $cleanup\
+          \ = \"true\" ]]; then\n          json_payload='[{\"op\":\"remove\",\"path\"\
+          :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           }]'\n        else\n          json_payload='[{\"op\":\"replace\",\"path\"\
           :\"/spec/workload/manifests/'\"$num\"'/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image\"\
           ,\"value\":\"'\"$IMAGE\"'\"}]'\n        fi\n\n        echo \"oc patch manifestwork\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29006,7 +29006,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.14'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.14.41
+                    value: '41'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29070,7 +29070,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.15'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.15.39
+                    value: '39'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29134,7 +29134,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.16'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.16.23
+                    value: '23'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts
@@ -29198,7 +29198,7 @@ objects:
                   - name: MAJOR_MINOR_VER
                     value: '4.17'
                   - name: Z_STREAM_FIXED_VER
-                    value: 4.17.4
+                    value: '4'
                   volumeMounts:
                   - name: scripts
                     mountPath: /tmp/scripts


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This is a refactor of the CAPI annotator job that we run on the fleet to ensure HCP clusters work with and without the ability to tag ENIs on `RunInstances` calls.

The following changes have been made, with inspiration from the work done in https://github.com/openshift/managed-cluster-config/pull/2353

* Only pin the image for clusters that are in the affected range.
* Unpin clusters once they upgrade out of the affected range.
* Consolidate the logic + scripts into a single ConfigMap. Changes to the scripts need to be copied to the `04-ConfigMap.yaml` by running `generate_configmap.sh`

Given we have north of 500 clusters in the affected Z stream ranges, we will need to run this job for some time. By adding the ability to remove the pin when not needed, we ensure new CAPI changes are applied to the fleet.


### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/SREP-400

### Special notes for your reviewer:
I have tested this on a service cluster in staging to confirm the logic works, where it patches affected clusters, removes the patch for clusters that don't need it, and handles MCs and SCs being skipped. See below for some logs.

**Note** As with the previous PKI operator job, we get a `The request is invalid` when the job runs subsequently after removing the annotation. The OCP API rejects the patch since the annotation doesn't exist. We could add an additional guard here to check for it first, but I see no harm in this.

```
> oc logs -f capa-annotator-4-16-29139550-rjfqw -n openshift-capa-annotator
don't patch: version 4.16.41 is >= x.y.23
cluster 2j1d7tra4n5oj1t2t0deerarn1k9oc6e does not need the override because it's Z stream is >= 23
removing hypershift.openshift.io/capi-provider-aws-image annotation
patching cluster: 2j1d7tra4n5oj1t2t0deerarn1k9oc6e
oc patch manifestwork 2j1d7tra4n5oj1t2t0deerarn1k9oc6e -n hs-mc-kbj34s6bg --type='json' -p [{"op":"remove","path":"/spec/workload/manifests/0/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]
The request is invalid: the server rejected our request due to an error in our request
-------------------------------------------------------------------------
don't patch: version 4.16.40 is >= x.y.23
cluster hs-mc-jm0nah7n0 does not need the override because it's Z stream is >= 23
removing hypershift.openshift.io/capi-provider-aws-image annotation
skipping cluster hs-mc-jm0nah7n0 because it is a management or local cluster
```

```
> oc logs -f capa-annotator-29139550-thh2h -n openshift-capa-annotator
don't patch: version 4.17.4 is >= x.y.4
cluster 2f93ch1ksbg6kd3v3bmtsedbp0jsn1jm does not need the override because it's Z stream is >= 4
removing hypershift.openshift.io/capi-provider-aws-image annotation
patching cluster: 2f93ch1ksbg6kd3v3bmtsedbp0jsn1jm
oc patch manifestwork 2f93ch1ksbg6kd3v3bmtsedbp0jsn1jm -n hs-mc-kbj34s6bg --type='json' -p [{"op":"remove","path":"/spec/workload/manifests/6/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]
The request is invalid: the server rejected our request due to an error in our request
-------------------------------------------------------------------------
don't patch: version 4.17.4 is >= x.y.4
cluster 2f9a6kv1nkjm1985helf1188vb8e9ej1 does not need the override because it's Z stream is >= 4
removing hypershift.openshift.io/capi-provider-aws-image annotation
patching cluster: 2f9a6kv1nkjm1985helf1188vb8e9ej1
oc patch manifestwork 2f9a6kv1nkjm1985helf1188vb8e9ej1 -n hs-mc-kbj34s6bg --type='json' -p [{"op":"remove","path":"/spec/workload/manifests/6/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]
The request is invalid: the server rejected our request due to an error in our request
-------------------------------------------------------------------------
don't patch: version 4.17.4 is >= x.y.4
cluster 2f9b9f88vrtl0vpiubck9ha515b8q2l7 does not need the override because it's Z stream is >= 4
removing hypershift.openshift.io/capi-provider-aws-image annotation
patching cluster: 2f9b9f88vrtl0vpiubck9ha515b8q2l7
oc patch manifestwork 2f9b9f88vrtl0vpiubck9ha515b8q2l7 -n hs-mc-kbj34s6bg --type='json' -p [{"op":"remove","path":"/spec/workload/manifests/6/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]
The request is invalid: the server rejected our request due to an error in our request
-------------------------------------------------------------------------
don't patch: version 4.17.4 is >= x.y.4
cluster 2fac28tjclnvobgrt8l34624g33eg1m1 does not need the override because it's Z stream is >= 4
removing hypershift.openshift.io/capi-provider-aws-image annotation
patching cluster: 2fac28tjclnvobgrt8l34624g33eg1m1
oc patch manifestwork 2fac28tjclnvobgrt8l34624g33eg1m1 -n hs-mc-kbj34s6bg --type='json' -p [{"op":"remove","path":"/spec/workload/manifests/6/metadata/annotations/hypershift.openshift.io~1capi-provider-aws-image"}]
The request is invalid: the server rejected our request due to an error in our request
-------------------------------------------------------------------------
```

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
