### PR TITLE
[SREP-660] add the required permissions for 4.19+ clusters

### DIFF
--- a/resources/sts/4.19/openshift_machine_api_aws_cloud_credentials_policy.json
+++ b/resources/sts/4.19/openshift_machine_api_aws_cloud_credentials_policy.json
@@ -31,6 +31,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "kms:ReEncrypt*",
         "kms:Decrypt",
         "kms:Encrypt",
         "kms:GenerateDataKey",

--- a/resources/sts/4.20/openshift_machine_api_aws_cloud_credentials_policy.json
+++ b/resources/sts/4.20/openshift_machine_api_aws_cloud_credentials_policy.json
@@ -31,6 +31,7 @@
     {
       "Effect": "Allow",
       "Action": [
+        "kms:ReEncrypt*",
         "kms:Decrypt",
         "kms:Encrypt",
         "kms:GenerateDataKey",


### PR DESCRIPTION
### What type of PR is this?
_(bug)_

### What this PR does / why we need it?
There are new required permissions for machine-api-operator from 4.19+

See: https://github.com/openshift/machine-api-operator/pull/1370

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[SREP-660](https://issues.redhat.com//browse/SREP-660)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
