### PR TITLE
Enabling RBAC for Lease in MUO namespace for SREP

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -343,6 +343,23 @@ spec:
                         apiVersion: rbac.authorization.k8s.io/v1
                         kind: Role
                         metadata:
+                            name: backplane-srep-muo
+                            namespace: openshift-managed-upgrade-operator
+                        rules:
+                            - apiGroups:
+                                - coordination.k8s.io
+                              resources:
+                                - leases
+                              verbs:
+                                - get
+                                - list
+                                - watch
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: Role
+                        metadata:
                             name: backplane-srep-mustgather
                             namespace: openshift-must-gather-operator
                         rules:
@@ -359,6 +376,22 @@ spec:
                               verbs:
                                 - create
                                 - delete
+                    - complianceType: mustonlyhave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: backplane-srep-muo
+                            namespace: openshift-managed-upgrade-operator
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: Role
+                            name: backplane-srep-muo
+                        subjects:
+                            - apiGroup: rbac.authorization.k8s.io
+                              kind: Group
+                              name: system:serviceaccounts:openshift-backplane-srep
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/srep/10-srep-muo.Role.yml
+++ b/deploy/backplane/srep/10-srep-muo.Role.yml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backplane-srep-muo
+  namespace: openshift-managed-upgrade-operator
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+### END

--- a/deploy/backplane/srep/20-srep-muo.RoleBinding.yml
+++ b/deploy/backplane/srep/20-srep-muo.RoleBinding.yml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backplane-srep-muo
+  namespace: openshift-managed-upgrade-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:openshift-backplane-srep
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: backplane-srep-muo

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4959,6 +4959,23 @@ objects:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
                   metadata:
+                    name: backplane-srep-muo
+                    namespace: openshift-managed-upgrade-operator
+                  rules:
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
                     name: backplane-srep-mustgather
                     namespace: openshift-must-gather-operator
                   rules:
@@ -4975,6 +4992,22 @@ objects:
                     verbs:
                     - create
                     - delete
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-muo
+                    namespace: openshift-managed-upgrade-operator
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-muo
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -24488,6 +24521,20 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
+        name: backplane-srep-muo
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
         name: backplane-srep-mustgather
         namespace: openshift-must-gather-operator
       rules:
@@ -24504,6 +24551,19 @@ objects:
         verbs:
         - create
         - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-muo
+        namespace: openshift-managed-upgrade-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-muo
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4959,6 +4959,23 @@ objects:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
                   metadata:
+                    name: backplane-srep-muo
+                    namespace: openshift-managed-upgrade-operator
+                  rules:
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
                     name: backplane-srep-mustgather
                     namespace: openshift-must-gather-operator
                   rules:
@@ -4975,6 +4992,22 @@ objects:
                     verbs:
                     - create
                     - delete
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-muo
+                    namespace: openshift-managed-upgrade-operator
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-muo
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -24488,6 +24521,20 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
+        name: backplane-srep-muo
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
         name: backplane-srep-mustgather
         namespace: openshift-must-gather-operator
       rules:
@@ -24504,6 +24551,19 @@ objects:
         verbs:
         - create
         - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-muo
+        namespace: openshift-managed-upgrade-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-muo
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4959,6 +4959,23 @@ objects:
                   apiVersion: rbac.authorization.k8s.io/v1
                   kind: Role
                   metadata:
+                    name: backplane-srep-muo
+                    namespace: openshift-managed-upgrade-operator
+                  rules:
+                  - apiGroups:
+                    - coordination.k8s.io
+                    resources:
+                    - leases
+                    verbs:
+                    - get
+                    - list
+                    - watch
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: Role
+                  metadata:
                     name: backplane-srep-mustgather
                     namespace: openshift-must-gather-operator
                   rules:
@@ -4975,6 +4992,22 @@ objects:
                     verbs:
                     - create
                     - delete
+              - complianceType: mustonlyhave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: backplane-srep-muo
+                    namespace: openshift-managed-upgrade-operator
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: Role
+                    name: backplane-srep-muo
+                  subjects:
+                  - apiGroup: rbac.authorization.k8s.io
+                    kind: Group
+                    name: system:serviceaccounts:openshift-backplane-srep
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -24488,6 +24521,20 @@ objects:
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
+        name: backplane-srep-muo
+        namespace: openshift-managed-upgrade-operator
+      rules:
+      - apiGroups:
+        - coordination.k8s.io
+        resources:
+        - leases
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
         name: backplane-srep-mustgather
         namespace: openshift-must-gather-operator
       rules:
@@ -24504,6 +24551,19 @@ objects:
         verbs:
         - create
         - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: backplane-srep-muo
+        namespace: openshift-managed-upgrade-operator
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: system:serviceaccounts:openshift-backplane-srep
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: backplane-srep-muo
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:


### PR DESCRIPTION
### What type of PR is this?

This PR adds few basic RBAC permissions for SRE to be able to triage `Lease` related issues (if any) for MUO.

### What this PR does / why we need it?
Based on PR https://github.com/openshift/managed-upgrade-operator/pull/517 MUO moved from Configmap based leader-election to Lease based. Incase there are any issues where the Lease isn't updated with the right MUO pod holderIdentity then SRE should be able to atleast get/list/watch the lease resource in `openshift-managed-upgrade-operator` namespace without elevation. For deletion though, elevation will be required so is not included in this list.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [SREP-366](https://issues.redhat.com/browse/SREP-366)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
