### PR TITLE
SREP-699 removing gcp-pfilestore-csi-driver-controller-pdb from SRE alerting

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -23,6 +23,8 @@ spec:
         max by(namespace, poddisruptionbudget) ( kube_poddisruptionbudget_status_current_healthy{namespace=~"openshift-.*"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~"openshift-.*"} )
         unless on(namespace)
           kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)"}
+        unless on(poddisruptionbudget)
+          kube_poddisruptionbudget_labels{poddisruptionbudget=~"gcp-filestore-csi-driver-controller-pdb"}
       for: 15m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40789,7 +40789,8 @@ objects:
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
-              }"
+              }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
+              gcp-filestore-csi-driver-controller-pdb\"}"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40789,7 +40789,8 @@ objects:
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
-              }"
+              }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
+              gcp-filestore-csi-driver-controller-pdb\"}"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40789,7 +40789,8 @@ objects:
               openshift-.*\"} < kube_poddisruptionbudget_status_desired_healthy{namespace=~\"\
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
-              }"
+              }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
+              gcp-filestore-csi-driver-controller-pdb\"}"
             for: 15m
             labels:
               severity: critical


### PR DESCRIPTION
customer installed operator shouldn't send alerts due to misconfiguration by the customer

### What type of PR is this?
bug

### What this PR does / why we need it?
Removes a specific PDB from the SRE alerting, the namespace clause would remove all CSI drivers, we still want to be alerted on inssues with the default GCP PD CSI Driver (or AWS CSI drivers) while we ignore the one installed by the customer.

The PDB alert has been triggered by a misconfiguration, or rather lack of configuration on  the customer side and isn't actionable by SRE in any way.

### Which Jira/Github issue(s) this PR fixes?

_Fixes [SREP-699](https://issues.redhat.com//browse/SREP-699)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
