### PR TITLE
Updating retentionSize from 90GB to 85 GB for remaining files

### DIFF
--- a/deploy/management-cluster-prometheus-metrics/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/management-cluster-prometheus-metrics/50-GENERATED-cluster-monitoring-config.yaml
@@ -39,7 +39,7 @@ data:
         key: node-role.kubernetes.io/infra
         operator: Exists
       retention: 11d
-      retentionSize: 90GB
+      retentionSize: 85GB
       volumeClaimTemplate:
         metadata:
           name: prometheus-data

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27100,7 +27100,7 @@ objects:
           \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
           \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27100,7 +27100,7 @@ objects:
           \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
           \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27100,7 +27100,7 @@ objects:
           \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
           \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\n  retention: 11d\n  retentionSize: 90GB\n  volumeClaimTemplate:\n\
+          \    operator: Exists\n  retention: 11d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
           \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
           \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\


### PR DESCRIPTION
### What type of PR is this?
Part of [SREP-363](https://issues.redhat.com/browse/SREP-363) ticket about reducing the retentionSize from 90GB to 85 GB. It has missed these updated retentionsize file changes through `make` cmd. Therefore, i had to update it manually.
### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
