### PR TITLE
SDCICD-1555: bump version and drop entrypoint

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -13,7 +13,7 @@ spec:
             name: osd-cluster-ready
             labels:
                 # Keep this in sync with image
-                managed.openshift.io/version: "v0.1.134-0659320"
+                managed.openshift.io/version: "v0.1.175-41579df"
             annotations:
                 openshift.io/required-scc: restricted-v2
         spec:
@@ -21,7 +21,6 @@ spec:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/app-sre/osd-cluster-ready@sha256:1457b7562479dff8b0fa61999f002a80199c3ebf811b3564a48a11a06ecefd65"
-              command: ["/root/main"]
+              image: "quay.io/app-sre/osd-cluster-ready@sha256:c447146572e955a73ccd08320851a2488c3e0c3b6ae661e40dd47ed91ce4532e"
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31876,15 +31876,13 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.134-0659320
+              managed.openshift.io/version: v0.1.175-41579df
             annotations:
               openshift.io/required-scc: restricted-v2
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:1457b7562479dff8b0fa61999f002a80199c3ebf811b3564a48a11a06ecefd65
-              command:
-              - /root/main
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c447146572e955a73ccd08320851a2488c3e0c3b6ae661e40dd47ed91ce4532e
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31876,15 +31876,13 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.134-0659320
+              managed.openshift.io/version: v0.1.175-41579df
             annotations:
               openshift.io/required-scc: restricted-v2
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:1457b7562479dff8b0fa61999f002a80199c3ebf811b3564a48a11a06ecefd65
-              command:
-              - /root/main
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c447146572e955a73ccd08320851a2488c3e0c3b6ae661e40dd47ed91ce4532e
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31876,15 +31876,13 @@ objects:
           metadata:
             name: osd-cluster-ready
             labels:
-              managed.openshift.io/version: v0.1.134-0659320
+              managed.openshift.io/version: v0.1.175-41579df
             annotations:
               openshift.io/required-scc: restricted-v2
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/app-sre/osd-cluster-ready@sha256:1457b7562479dff8b0fa61999f002a80199c3ebf811b3564a48a11a06ecefd65
-              command:
-              - /root/main
+              image: quay.io/app-sre/osd-cluster-ready@sha256:c447146572e955a73ccd08320851a2488c3e0c3b6ae661e40dd47ed91ce4532e
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

/cleanup

### What this PR does / why we need it?

the latest build sets the entrypoint, remove setting it from here and bump the image to the latest version

### Which Jira/Github issue(s) this PR fixes?

_Fixes [SDCICD-1555](https://issues.redhat.com//browse/SDCICD-1555)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
