### PR TITLE
SREP-699 removing aws-efs-csi-driver-controller-pdb from SRE alerting

### DIFF
--- a/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-sre-podDisruptionBudget.PrometheusRule.yaml
@@ -24,7 +24,7 @@ spec:
         unless on(namespace)
           kube_poddisruptionbudget_labels{namespace=~"openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)"}
         unless on(poddisruptionbudget)
-          kube_poddisruptionbudget_labels{poddisruptionbudget=~"gcp-filestore-csi-driver-controller-pdb"}
+          kube_poddisruptionbudget_labels{poddisruptionbudget=~"gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb"}
       for: 15m
       labels:
         severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40763,7 +40763,7 @@ objects:
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
-              gcp-filestore-csi-driver-controller-pdb\"}"
+              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"}"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -40763,7 +40763,8 @@ objects:
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
-              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"}"
+              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"\
+              }"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40763,7 +40763,7 @@ objects:
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
-              gcp-filestore-csi-driver-controller-pdb\"}"
+              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"}"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -40763,7 +40763,8 @@ objects:
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
-              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"}"
+              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"\
+              }"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40763,7 +40763,7 @@ objects:
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
-              gcp-filestore-csi-driver-controller-pdb\"}"
+              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"}"
             for: 15m
             labels:
               severity: critical

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -40763,7 +40763,8 @@ objects:
               openshift-.*\"} )\nunless on(namespace)\n  kube_poddisruptionbudget_labels{namespace=~\"\
               openshift-(logging|user-workload-monitoring|operators|kyverno|cnv|observability-operator|mtv|cluster-observability-operator)\"\
               }\nunless on(poddisruptionbudget)\n  kube_poddisruptionbudget_labels{poddisruptionbudget=~\"\
-              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"}"
+              gcp-filestore-csi-driver-controller-pdb|aws-efs-csi-driver-controller-pdb\"\
+              }"
             for: 15m
             labels:
               severity: critical


### PR DESCRIPTION
The aws-efs-csi-driver-controller is customer installed operator. This is causing false positive alerts.

### What type of PR is this?
bug

### What this PR does / why we need it?

The current situation alerts on customer installed operator causing false positive alerts.
The PR removes the AWS EFS CSI driver operator from the alerting rules.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/SREP-852

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
