### PR TITLE
Disable updated boot images for 4.17 and 4.18

### DIFF
--- a/deploy/osd-machine-configuration-ami/config.yaml
+++ b/deploy/osd-machine-configuration-ami/config.yaml
@@ -1,0 +1,6 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: hive.openshift.io/version-major-minor
+      operator: In
+      values: ["4.17", "4.18"]

--- a/deploy/osd-machine-configuration-ami/disable-updated-boot-images.MachineConfiguration.yaml
+++ b/deploy/osd-machine-configuration-ami/disable-updated-boot-images.MachineConfiguration.yaml
@@ -1,0 +1,7 @@
+apiVersion: operator.openshift.io/v1
+applyMode: AlwaysApply
+kind: MachineConfiguration
+name: cluster
+namespace: openshift-machine-config-operator
+patch: '{"spec":{"managedBootImages":{"machineManagers":[]}}}'
+patchType: merge

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34871,6 +34871,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-machine-configuration-ami
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.17'
+        - '4.18'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: MachineConfiguration
+      name: cluster
+      namespace: openshift-machine-config-operator
+      patch: '{"spec":{"managedBootImages":{"machineManagers":[]}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-managed-resources
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34871,6 +34871,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-machine-configuration-ami
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.17'
+        - '4.18'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: MachineConfiguration
+      name: cluster
+      namespace: openshift-machine-config-operator
+      patch: '{"spec":{"managedBootImages":{"machineManagers":[]}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-managed-resources
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34871,6 +34871,33 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-machine-configuration-ami
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.17'
+        - '4.18'
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: operator.openshift.io/v1
+      applyMode: AlwaysApply
+      kind: MachineConfiguration
+      name: cluster
+      namespace: openshift-machine-config-operator
+      patch: '{"spec":{"managedBootImages":{"machineManagers":[]}}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-managed-resources
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Disable the update boot image feature so that MCO doesn't replace the worker node AMIs we install clusters with. 

https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/machine_configuration/mco-update-boot-images#mco-update-boot-images-disable_machine-configs-configure

For 4.19+ we will apply this manifest at install time with [OCM-16382 ](https://issues.redhat.com/browse/OCM-16382 )

### Which Jira/Github issue(s) this PR fixes?

_Fixes # [OSD-30391](https://issues.redhat.com//browse/OSD-30391)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
