### PR TITLE
remove uncessary loadbalancer permissions

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_shared_vpc_route_53_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_shared_vpc_route_53_credentials_policy.json
@@ -5,7 +5,6 @@
       "Sid": "ReadPermissions",
       "Effect": "Allow",
       "Action": [
-        "elasticloadbalancing:DescribeLoadBalancers",
         "route53:GetHostedZone",
         "route53:ListResourceRecordSets",
         "route53:ListHostedZones",


### PR DESCRIPTION
The describe load balancer permissions are not required on the VPC owner account on a shared VPC setup. They are used by ocm with a different role in the Hosted Cluster account to do pre-flight checks. 