### PR TITLE
adds back logo yaml until we can cleanup existing references

### DIFF
--- a/deploy/rosa-console-legacy-branding-configmap/config.yaml
+++ b/deploy/rosa-console-legacy-branding-configmap/config.yaml
@@ -4,7 +4,4 @@ selectorSyncSet:
   - key: api.openshift.com/product
     operator: In
     values: ["rosa"]
-  - key: hive.openshift.io/version-major-minor
-    operator: In
-    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13"]
   applyBehavior: "CreateOrUpdate"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39112,22 +39112,6 @@ objects:
         operator: In
         values:
         - rosa
-      - key: hive.openshift.io/version-major-minor
-        operator: In
-        values:
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '4.5'
-        - '4.6'
-        - '4.7'
-        - '4.8'
-        - '4.9'
-        - '4.10'
-        - '4.11'
-        - '4.12'
-        - '4.13'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39112,22 +39112,6 @@ objects:
         operator: In
         values:
         - rosa
-      - key: hive.openshift.io/version-major-minor
-        operator: In
-        values:
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '4.5'
-        - '4.6'
-        - '4.7'
-        - '4.8'
-        - '4.9'
-        - '4.10'
-        - '4.11'
-        - '4.12'
-        - '4.13'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39112,22 +39112,6 @@ objects:
         operator: In
         values:
         - rosa
-      - key: hive.openshift.io/version-major-minor
-        operator: In
-        values:
-        - '4.1'
-        - '4.2'
-        - '4.3'
-        - '4.4'
-        - '4.5'
-        - '4.6'
-        - '4.7'
-        - '4.8'
-        - '4.9'
-        - '4.10'
-        - '4.11'
-        - '4.12'
-        - '4.13'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

bug

### What this PR does / why we need it?
Resolves ITN-139. Adds back configmap for older clusters that have not been manually migrated.