### PR TITLE
Add restart to ssm install

### DIFF
--- a/deploy/aws-ssm-agent/01-machineconfig.yaml
+++ b/deploy/aws-ssm-agent/01-machineconfig.yaml
@@ -25,6 +25,9 @@ spec:
           ExecStart=/usr/sbin/restorecon /etc/systemd/system/amazon-ssm-agent.service
           ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
           Restart=on-failure
+          RestartSec=30s
+          StartLimitBurst=5
+          StartLimitIntervalSec=300s
 
           [Install]
           WantedBy=multi-user.target

--- a/deploy/aws-ssm-agent/01-machineconfig.yaml
+++ b/deploy/aws-ssm-agent/01-machineconfig.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version:  3.2.0
+      version: 3.2.0
     systemd:
       units:
       - name: 99-install-ssm-agent.service
@@ -24,6 +24,7 @@ spec:
           ExecStart=/usr/bin/rpm-ostree install --apply-live --assumeyes --idempotent https://s3.us-east-1.amazonaws.com/amazon-ssm-us-east-1/latest/linux_amd64/amazon-ssm-agent.rpm
           ExecStart=/usr/sbin/restorecon /etc/systemd/system/amazon-ssm-agent.service
           ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
+          Restart=on-failure
 
           [Install]
           WantedBy=multi-user.target

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10181,6 +10181,14 @@ objects:
 
                 ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
 
+                Restart=on-failure
+
+                RestartSec=30s
+
+                StartLimitBurst=5
+
+                StartLimitIntervalSec=300s
+
 
                 [Install]
 

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10181,6 +10181,14 @@ objects:
 
                 ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
 
+                Restart=on-failure
+
+                RestartSec=30s
+
+                StartLimitBurst=5
+
+                StartLimitIntervalSec=300s
+
 
                 [Install]
 

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10181,6 +10181,14 @@ objects:
 
                 ExecStart=/usr/bin/systemctl enable amazon-ssm-agent --now
 
+                Restart=on-failure
+
+                RestartSec=30s
+
+                StartLimitBurst=5
+
+                StartLimitIntervalSec=300s
+
 
                 [Install]
 


### PR DESCRIPTION
### What type of PR is this?
bug/feature

### What this PR does / why we need it?

It adds a retry-on-failure to the systemd unit that installs SSM on MC clusters, which should be supported since systemd version 244 - the 4.16.40 version on MCs is running:

```
systemctl --version
systemd 252 (252-32.el9_4.7)
```

### Which Jira/Github issue(s) this PR fixes?

No open issue, but sometimes SSM won't work and it's likely because it was not correctly installed - this change should retry an install on failures.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
