### PR TITLE
allow management clusters to upgrade more than one node at a time

### DIFF
--- a/deploy/management-cluster-node-update-concurrency/50-machineconfigpool-worker-concurrent-node-upgrade.patch.yaml
+++ b/deploy/management-cluster-node-update-concurrency/50-machineconfigpool-worker-concurrent-node-upgrade.patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+name: worker
+applyMode: Sync
+patch: '{"spec":{"maxUnavailable":2}}'
+patchType: merge

--- a/deploy/management-cluster-node-update-concurrency/config.yaml
+++ b/deploy/management-cluster-node-update-concurrency/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: ext-hypershift.openshift.io/cluster-sector
+    operator: NotIn
+    values: ["ibm-infra"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -26958,6 +26958,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: management-cluster-node-update-concurrency
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfigPool
+      name: worker
+      applyMode: Sync
+      patch: '{"spec":{"maxUnavailable":2}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: management-cluster-prometheus-metrics
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -26958,6 +26958,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: management-cluster-node-update-concurrency
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfigPool
+      name: worker
+      applyMode: Sync
+      patch: '{"spec":{"maxUnavailable":2}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: management-cluster-prometheus-metrics
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -26958,6 +26958,35 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: management-cluster-node-update-concurrency
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: NotIn
+        values:
+        - ibm-infra
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfigPool
+      name: worker
+      applyMode: Sync
+      patch: '{"spec":{"maxUnavailable":2}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: management-cluster-prometheus-metrics
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
We're starting with just two at a time, but will definitely increase the value once we prove the principle.  MachineConfigPools natively have the ability to upgrade more than one at time. PodDisruptionBudgets ensure that any workload pods retain enough availability.  This will have a significant impact cluster upgrade speed.  HCP does use PDBs correctly.

/assign @cdoan1 