### PR TITLE
[SREP-995] OBO CSV Cleanup CronJob for Hypershift MC clusters

### DIFF
--- a/deploy/obo-removal-for-mc-clusters/01-ClusterRole.yaml
+++ b/deploy/obo-removal-for-mc-clusters/01-ClusterRole.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-observability-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-observability-operator
+rules:
+  - apiGroups:
+      - "operators.coreos.com"
+    resources:
+      - clusterserviceversions
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - "batch"
+    resources:
+      - cronjobs
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - list
+      - get
+      - delete
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - roles
+      - rolebindings
+    verbs:
+      - list
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-observability-operator
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+  namespace: openshift-observability-operator
+subjects:
+  - kind: ServiceAccount
+    name: sre-operator-reinstall-sa
+    namespace: openshift-observability-operator

--- a/deploy/obo-removal-for-mc-clusters/02-CronJob.yaml
+++ b/deploy/obo-removal-for-mc-clusters/02-CronJob.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sre-obo-uninstall
+  namespace: openshift-observability-operator
+spec:
+  ttlSecondsAfterFinished: 100
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "*/10 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: sre-operator-reinstall-sa
+          restartPolicy: Never
+          containers:
+            - name: operator-reinstaller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  #!/bin/bash
+                  set -euxo pipefail
+                  NAMESPACE=openshift-observability-operator
+                  CSV_FOUND=$(oc -n "$NAMESPACE" get clusterserviceversions.operators.coreos.com | grep "^observability-operator") || true
+                  if [[ ! -z "$CSV_FOUND" ]]
+                  then
+                    echo $CSV_FOUND | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE
+                  fi
+                  exit 0

--- a/deploy/obo-removal-for-mc-clusters/README.md
+++ b/deploy/obo-removal-for-mc-clusters/README.md
@@ -1,0 +1,3 @@
+# https://issues.redhat.com/browse/OSD-28131
+
+OBO removal from Hypershift SC clusters.

--- a/deploy/obo-removal-for-mc-clusters/config.yaml
+++ b/deploy/obo-removal-for-mc-clusters/config.yaml
@@ -1,0 +1,8 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -27468,6 +27468,113 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: obo-removal-for-mc-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-obo-uninstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-observability-operator\n\
+                    CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ | grep \"^observability-operator\") || true\nif [[ ! -z \"$CSV_FOUND\"\
+                    \ ]]\nthen\n  echo $CSV_FOUND | awk '{print $1}' | xargs oc delete\
+                    \ clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    fi\nexit 0"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -27468,6 +27468,113 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: obo-removal-for-mc-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-obo-uninstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-observability-operator\n\
+                    CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ | grep \"^observability-operator\") || true\nif [[ ! -z \"$CSV_FOUND\"\
+                    \ ]]\nthen\n  echo $CSV_FOUND | awk '{print $1}' | xargs oc delete\
+                    \ clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    fi\nexit 0"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -27468,6 +27468,113 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: obo-removal-for-mc-clusters
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-observability-operator
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - batch
+        resources:
+        - cronjobs
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - ''
+        resources:
+        - serviceaccounts
+        verbs:
+        - list
+        - get
+        - delete
+      - apiGroups:
+        - rbac.authorization.k8s.io
+        resources:
+        - roles
+        - rolebindings
+        verbs:
+        - list
+        - get
+        - delete
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-observability-operator
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+        namespace: openshift-observability-operator
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-observability-operator
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: sre-obo-uninstall
+        namespace: openshift-observability-operator
+      spec:
+        ttlSecondsAfterFinished: 100
+        failedJobsHistoryLimit: 1
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: '*/10 * * * *'
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                serviceAccountName: sre-operator-reinstall-sa
+                restartPolicy: Never
+                containers:
+                - name: operator-reinstaller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - sh
+                  - -c
+                  - "#!/bin/bash\nset -euxo pipefail\nNAMESPACE=openshift-observability-operator\n\
+                    CSV_FOUND=$(oc -n \"$NAMESPACE\" get clusterserviceversions.operators.coreos.com\
+                    \ | grep \"^observability-operator\") || true\nif [[ ! -z \"$CSV_FOUND\"\
+                    \ ]]\nthen\n  echo $CSV_FOUND | awk '{print $1}' | xargs oc delete\
+                    \ clusterserviceversions.operators.coreos.com -n $NAMESPACE\n\
+                    fi\nexit 0"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: ocm-agent-operator-managedfleetnotifications
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?

This PR adds a cronjob that deploys on all Hypershift MC clusters.
This is part of the migration of OBO to COO.

### Which Jira/Github issue(s) this PR fixes?

Partially implements [SREP-995](https://issues.redhat.com//browse/SREP-995)

### Special notes for your reviewer:

Should (ideally) be merged (in staging) or deployed through app-interface (in prod) after this change:
https://github.com/rhobs/observability-operator/pull/792

Similar to the following crontab deployed in the past on SC clusters:
https://github.com/openshift/managed-cluster-config/pull/2356

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [X] Not a Fedramp change