### PR TITLE
ROX-29376: allow ACS SRE to view externaldnses

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -463,6 +463,14 @@ spec:
                                 - get
                                 - list
                                 - watch
+                            - apiGroups:
+                                - externaldns.olm.openshift.io
+                              resources:
+                                - externaldnses
+                              verbs:
+                                - get
+                                - list
+                                - watch
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:

--- a/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-cluster.ClusterRole.yaml
@@ -473,3 +473,12 @@ rules:
   - get
   - list
   - watch
+# ACS Team can view ExternalDNSes
+- apiGroups:
+  - externaldns.olm.openshift.io
+  resources:
+  - externaldnses
+  verbs:
+  - get
+  - list
+  - watch

--- a/docs/backplane/requirements/acs/10-acs-managed-service.md
+++ b/docs/backplane/requirements/acs/10-acs-managed-service.md
@@ -115,6 +115,7 @@ Permissions at cluster scope.
 * view clusterobjectdeployments
 * view clusterobjectsets
 * view clusterobjecttemplates
+* view externaldnses
 
 ## backplane-acs-admins-project: `(^redhat-acs-fleetshard$|^rhacs$|^rhacs-.*|^acscs-dataplane-cd$)`
 - ACS team needs read/list/watch access to core `redhat` and `rhacs` objects within their namespaces. This includes Custom Resource objects for ACS Addon.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1960,6 +1960,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - externaldns.olm.openshift.io
+                    resources:
+                    - externaldnses
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -11317,6 +11325,14 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12149,6 +12165,14 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12977,6 +13001,14 @@ objects:
         - clusterobjectdeployments
         - clusterobjectsets
         - clusterobjecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1960,6 +1960,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - externaldns.olm.openshift.io
+                    resources:
+                    - externaldnses
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -11317,6 +11325,14 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12149,6 +12165,14 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12977,6 +13001,14 @@ objects:
         - clusterobjectdeployments
         - clusterobjectsets
         - clusterobjecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1960,6 +1960,14 @@ objects:
                     - get
                     - list
                     - watch
+                  - apiGroups:
+                    - externaldns.olm.openshift.io
+                    resources:
+                    - externaldnses
+                    verbs:
+                    - get
+                    - list
+                    - watch
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -11317,6 +11325,14 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12149,6 +12165,14 @@ objects:
         - get
         - list
         - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
+        verbs:
+        - get
+        - list
+        - watch
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -12977,6 +13001,14 @@ objects:
         - clusterobjectdeployments
         - clusterobjectsets
         - clusterobjecttemplates
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - externaldns.olm.openshift.io
+        resources:
+        - externaldnses
         verbs:
         - get
         - list


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
ACS team needs to access external dnses

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[ROX-29376](https://issues.redhat.com//browse/ROX-29376)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
