### PR TITLE
OCM-16226 | feat: add 'iam:GetUser' to hcp installer policy

### DIFF
--- a/resources/sts/hypershift/sts_hcp_installer_permission_policy.json
+++ b/resources/sts/hypershift/sts_hcp_installer_permission_policy.json
@@ -22,6 +22,7 @@
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "iam:GetOpenIDConnectProvider",
                 "iam:GetRole",
+                "iam:GetUser",
                 "route53:GetHostedZone",
                 "route53:ListHostedZones",
                 "route53:ListHostedZonesByName",


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This allows to include verification of the 'rosa_creator_arn' cluster property to ensure that the populated user is valid and exists in the customer account

### Which Jira/Github issue(s) this PR fixes?

_Fixes #[OCM-16226](https://issues.redhat.com//browse/OCM-16226)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
