### PR TITLE
OCM-1468 | feat: add getoidcprovider permission to 4.20 policy

### DIFF
--- a/resources/sts/4.20/sts_installer_permission_policy.json
+++ b/resources/sts/4.20/sts_installer_permission_policy.json
@@ -119,6 +119,7 @@
                 "iam:DeleteInstanceProfile",
                 "iam:GetInstanceProfile",
                 "iam:TagInstanceProfile",
+                "iam:GetOpenIDConnectProvider",
                 "iam:GetRole",
                 "iam:GetRolePolicy",
                 "iam:GetUser",


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
feature

### What this PR does / why we need it?
ocm needs to validate oidc provider exists or not before user perform some actions such as create nodepool. Currently the policy for hypershift already has such permission(https://github.com/openshift/managed-cluster-config/blob/master/resources/sts/hypershift/sts_hcp_installer_permission_policy.json#L23), but missed in policy for classic ones.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_https://issues.redhat.com/browse/OCM-1468

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
