### PR TITLE
ROX-29954: Add packplane permissions for the gitopsinstallation CRD

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -478,6 +478,7 @@ spec:
                                 - centrals
                                 - securedclusters
                                 - fleetshards
+                                - gitopsinstallations
                               verbs:
                                 - get
                                 - list

--- a/deploy/backplane/acs/01-acs-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/acs/01-acs-admins-project.ClusterRole.yaml
@@ -11,6 +11,7 @@ rules:
   - centrals
   - securedclusters
   - fleetshards
+  - gitopsinstallations
   verbs:
   - get
   - list

--- a/docs/backplane/requirements/acs/10-acs-managed-service.md
+++ b/docs/backplane/requirements/acs/10-acs-managed-service.md
@@ -17,6 +17,7 @@ than enough for the current needs.
 - The `AcsFleetShard` addon installs the resources needed to run an ACS-CS DataPlane cluster:
   - It installs `fleetshard` which is responsible for creating the tenant namespaces.
   - It installs supporting resources, such as monitoring, logging.
+  - It installs `gitopsinstallation`, which in turn deploys Openshift Gitops Operator on a cluster
 - The `AcsFleetShard` addon is *only* installed on those clusters. It will *never* be installed on customer clusters.
 - These clusters are *only* accessible by internal staff, such as SRE and ACS-CS team members. Customers will *not* have access to these clusters.
 - Each tenant gets its own namespace, `Central` instance, `Route` and DNS record.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -1975,6 +1975,7 @@ objects:
                     - centrals
                     - securedclusters
                     - fleetshards
+                    - gitopsinstallations
                     verbs:
                     - get
                     - list
@@ -11329,6 +11330,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list
@@ -12161,6 +12163,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list
@@ -12993,6 +12996,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -1975,6 +1975,7 @@ objects:
                     - centrals
                     - securedclusters
                     - fleetshards
+                    - gitopsinstallations
                     verbs:
                     - get
                     - list
@@ -11329,6 +11330,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list
@@ -12161,6 +12163,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list
@@ -12993,6 +12996,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -1975,6 +1975,7 @@ objects:
                     - centrals
                     - securedclusters
                     - fleetshards
+                    - gitopsinstallations
                     verbs:
                     - get
                     - list
@@ -11329,6 +11330,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list
@@ -12161,6 +12163,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list
@@ -12993,6 +12996,7 @@ objects:
         - centrals
         - securedclusters
         - fleetshards
+        - gitopsinstallations
         verbs:
         - get
         - list


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
Add read permission to the ACS team for the new ACS fleetshard operator's CRD - `GitopsInstallation`.

### Which Jira/Github issue(s) this PR fixes?

Fixes [ROX-29954](https://issues.redhat.com//browse/ROX-29954)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
