### PR TITLE
Move brand switch to 4.15 to account for race condition during upgrade

### DIFF
--- a/deploy/rosa-console-branding/config.yaml
+++ b/deploy/rosa-console-branding/config.yaml
@@ -6,7 +6,9 @@ selectorSyncSet:
     values: ["rosa"]
   - key: hive.openshift.io/version-major-minor
     operator: NotIn
-    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13"]
+    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13", "4.14"]
+    # Due to a race condition found during testing SREP-901 during cluster upgrades, we do not set the "ROSA" brand
+    # until 4.15
   applyBehavior: "CreateOrUpdate"
   # use Upsert so if this configuration no longer applies it will not delete the resource in cluster . We should never delete console.
   resourceApplyMode: "Upsert"

--- a/deploy/rosa-console-legacy-branding-configmap/config.yaml
+++ b/deploy/rosa-console-legacy-branding-configmap/config.yaml
@@ -6,5 +6,7 @@ selectorSyncSet:
     values: ["rosa"]
   - key: hive.openshift.io/version-major-minor
     operator: In
-    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13"]
+    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13", "4.14"]
+    # Due to a race condition found during testing for SREP-901 for upgrades, we do not remove the legacy brand image
+    # until 4.15
   applyBehavior: "CreateOrUpdate"

--- a/deploy/rosa-console-legacy-branding/config.yaml
+++ b/deploy/rosa-console-legacy-branding/config.yaml
@@ -6,7 +6,9 @@ selectorSyncSet:
     values: ["rosa"]
   - key: hive.openshift.io/version-major-minor
     operator: In
-    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13"]
+    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13", "4.14"]
+    # Due to a race condition found during testing for SREP-901 for upgrades, we do not remove the legacy brand config
+    # until 4.15
   applyBehavior: "CreateOrUpdate"
   # use Upsert so if this configuration no longer applies it will not delete the resource in cluster . We should never delete console.
   resourceApplyMode: "Upsert"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -43774,6 +43774,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     patches:
@@ -43858,6 +43859,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     resources:
@@ -43908,6 +43910,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -43774,6 +43774,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     patches:
@@ -43858,6 +43859,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     resources:
@@ -43908,6 +43910,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -43774,6 +43774,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     patches:
@@ -43858,6 +43859,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Upsert
     applyBehavior: CreateOrUpdate
     resources:
@@ -43908,6 +43910,7 @@ objects:
         - '4.11'
         - '4.12'
         - '4.13'
+        - '4.14'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:


### PR DESCRIPTION
During testing for [SREP-901](https://issues.redhat.com//browse/SREP-901) we found that even though the console CO is reporting 4.14.z and in OCM the cluster is still listed as 4.13.z, the 4.14 syncsets get applied. In this specific case with the console config and the custom brand image, it removes the image configmap without issue but then it cannot apply the config changes because the CR rejects the `brand: rosa` change. This prevents the json patch from removing the additional brand config, which leads to a degraded console operator, which leads to the upgrade stalling. This means there's a good chance we will require SRE intervention on every 4.13 -> 4.14 upgrade.

This commit pushes the configuration to deploy at the 4.14 -> 4.15 upgrade, so that we can _ensure_ that the CRD changes for the console are present before applying them and removing the old configuration, preventing the cluster from becoming stuck.

The other option would be to split the removal patch from the rosa brand patch. This could work, through eventual consistency, since the failing custom brand configuration would be applied in a separate syncset, which would then prevent the console operator from becoming degraded due to the dangling configuration being removed, allowing the upgrade to finish and then once the upgrade has finished the ROSA brand configuration would eventually apply successfully. However, there could then be a brief period of time where customers may see the default OCP brand during an upgrade. Is that the end of the world? Probably not, but just delaying one more y-stream to put the custom configuration I think is a safer overall easier experience that also keeps the codebase a bit easier to maintain going forward.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

Bug

### What this PR does / why we need it?

See description above

### Which Jira/Github issue(s) this PR fixes?

_Fixes [SREP-901](https://issues.redhat.com//browse/SREP-901)_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
