### PR TITLE
Removes dangling console branding config from hcp

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-removal.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-removal.Policy.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: rosa-console-legacy-branding-removal
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: rosa-console-legacy-branding-removal
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: ServiceAccount
+                        metadata:
+                            name: legacy-brand-migration
+                            namespace: openshift-console
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRole
+                        metadata:
+                            name: legacy-brand-migration
+                        rules:
+                            - apiGroups:
+                                - operator.openshift.io
+                              resources:
+                                - consoles
+                              verbs:
+                                - get
+                                - list
+                                - patch
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: ClusterRoleBinding
+                        metadata:
+                            name: legacy-brand-migration
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: legacy-brand-migration
+                        subjects:
+                            - kind: ServiceAccount
+                              name: legacy-brand-migration
+                              namespace: openshift-console
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        data:
+                            entrypoint: "#!/bin/bash\n\necho \"This cronjob removes the legacy brand configuration if present, otherwise exits cleanly as a noop\"\n\noc patch console.operator cluster --type json --patch '[{\"op\": \"replace\", \"path\": \"/spec/customization/customProductName\", \"value\": null},{\"op\": \"replace\", \"path\": \"/spec/customization/customLogoFile\", \"value\": null}]' "
+                        kind: ConfigMap
+                        metadata:
+                            name: remove-legacy-brand-config
+                            namespace: openshift-console
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: batch/v1
+                        kind: CronJob
+                        metadata:
+                            name: rosa-legacy-brand-migration
+                            namespace: openshift-console
+                        spec:
+                            concurrencyPolicy: Replace
+                            failedJobsHistoryLimit: 3
+                            jobTemplate:
+                                spec:
+                                    template:
+                                        metadata:
+                                            annotations:
+                                                openshift.io/required-scc: restricted-v2
+                                        spec:
+                                            containers:
+                                                - command:
+                                                    - /bin/sh
+                                                    - -c
+                                                    - /etc/config/entrypoint
+                                                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                                                  name: rosa-legacy-brand-migration
+                                                  volumeMounts:
+                                                    - mountPath: /etc/config
+                                                      name: legacy-brand-migration
+                                                      readOnly: true
+                                            restartPolicy: Never
+                                            serviceAccountName: legacy-brand-migration
+                                            volumes:
+                                                - configMap:
+                                                    defaultMode: 493
+                                                    name: remove-legacy-brand-config
+                                                  name: legacy-brand-migration
+                                    ttlSecondsAfterFinished: 86400
+                            schedule: '*/15 * * * *'
+                            successfulJobsHistoryLimit: 1
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+    remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-rosa-console-legacy-branding-removal
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-rosa-console-legacy-branding-removal
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-rosa-console-legacy-branding-removal
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: rosa-console-legacy-branding-removal

--- a/deploy/rosa-console-legacy-branding-removal/00-legacy-brand-removal.ServiceAccount.yaml
+++ b/deploy/rosa-console-legacy-branding-removal/00-legacy-brand-removal.ServiceAccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: legacy-brand-migration
+  namespace: openshift-console
+

--- a/deploy/rosa-console-legacy-branding-removal/01-legacy-brand-removal.ClusterRole.yaml
+++ b/deploy/rosa-console-legacy-branding-removal/01-legacy-brand-removal.ClusterRole.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: legacy-brand-migration
+rules:
+- apiGroups:
+  - "operator.openshift.io"
+  resources:
+  - consoles
+  verbs:
+  - get
+  - list
+  - patch
+

--- a/deploy/rosa-console-legacy-branding-removal/01-legacy-brand-removal.ClusterRoleBinding.yaml
+++ b/deploy/rosa-console-legacy-branding-removal/01-legacy-brand-removal.ClusterRoleBinding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: legacy-brand-migration
+subjects:
+- kind: ServiceAccount
+  name: legacy-brand-migration
+  namespace: openshift-console
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: legacy-brand-migration

--- a/deploy/rosa-console-legacy-branding-removal/05-legacy-brand-removal.ConfigMap.yaml
+++ b/deploy/rosa-console-legacy-branding-removal/05-legacy-brand-removal.ConfigMap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: remove-legacy-brand-config
+  namespace: openshift-console
+data:
+  entrypoint: |-
+    #!/bin/bash
+
+    echo "This cronjob removes the legacy brand configuration if present, otherwise exits cleanly as a noop"
+
+    oc patch console.operator cluster --type json --patch '[{"op": "replace", "path": "/spec/customization/customProductName", "value": null},{"op": "replace", "path": "/spec/customization/customLogoFile", "value": null}]' 

--- a/deploy/rosa-console-legacy-branding-removal/10-legacy-brand-removal.CronJob.yaml
+++ b/deploy/rosa-console-legacy-branding-removal/10-legacy-brand-removal.CronJob.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: rosa-legacy-brand-migration
+  namespace: openshift-console
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          annotations:
+            openshift.io/required-scc: restricted-v2
+        spec:
+          serviceAccountName: legacy-brand-migration
+          restartPolicy: Never
+          containers:
+            - name: rosa-legacy-brand-migration
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              command: [ "/bin/sh", "-c", "/etc/config/entrypoint" ]
+              volumeMounts:
+                - name: legacy-brand-migration
+                  mountPath: /etc/config
+                  readOnly: true
+          volumes:
+            - name: legacy-brand-migration
+              configMap:
+                name: remove-legacy-brand-config
+                defaultMode: 0755
+

--- a/deploy/rosa-console-legacy-branding-removal/config.yaml
+++ b/deploy/rosa-console-legacy-branding-removal/config.yaml
@@ -1,0 +1,4 @@
+policy:
+  destination: "acm-policies"
+  complianceType: "musthave"
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10291,6 +10291,155 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-console-legacy-branding-removal
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ServiceAccount
+                  metadata:
+                    name: legacy-brand-migration
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: legacy-brand-migration
+                  rules:
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - consoles
+                    verbs:
+                    - get
+                    - list
+                    - patch
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: legacy-brand-migration
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: legacy-brand-migration
+                  subjects:
+                  - kind: ServiceAccount
+                    name: legacy-brand-migration
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  data:
+                    entrypoint: '#!/bin/bash
+
+
+                      echo "This cronjob removes the legacy brand configuration if
+                      present, otherwise exits cleanly as a noop"
+
+
+                      oc patch console.operator cluster --type json --patch ''[{"op":
+                      "replace", "path": "/spec/customization/customProductName",
+                      "value": null},{"op": "replace", "path": "/spec/customization/customLogoFile",
+                      "value": null}]'' '
+                  kind: ConfigMap
+                  metadata:
+                    name: remove-legacy-brand-config
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: batch/v1
+                  kind: CronJob
+                  metadata:
+                    name: rosa-legacy-brand-migration
+                    namespace: openshift-console
+                  spec:
+                    concurrencyPolicy: Replace
+                    failedJobsHistoryLimit: 3
+                    jobTemplate:
+                      spec:
+                        template:
+                          metadata:
+                            annotations:
+                              openshift.io/required-scc: restricted-v2
+                          spec:
+                            containers:
+                            - command:
+                              - /bin/sh
+                              - -c
+                              - /etc/config/entrypoint
+                              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                              name: rosa-legacy-brand-migration
+                              volumeMounts:
+                              - mountPath: /etc/config
+                                name: legacy-brand-migration
+                                readOnly: true
+                            restartPolicy: Never
+                            serviceAccountName: legacy-brand-migration
+                            volumes:
+                            - configMap:
+                                defaultMode: 493
+                                name: remove-legacy-brand-config
+                              name: legacy-brand-migration
+                        ttlSecondsAfterFinished: 86400
+                    schedule: '*/15 * * * *'
+                    successfulJobsHistoryLimit: 1
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-console-legacy-branding-removal
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-console-legacy-branding-removal
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
@@ -44062,6 +44211,102 @@ objects:
         creationTimestamp: null
         name: rosa-brand-logo
         namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: rosa-console-legacy-branding-removal
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: legacy-brand-migration
+        namespace: openshift-console
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: legacy-brand-migration
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - consoles
+        verbs:
+        - get
+        - list
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: legacy-brand-migration
+      subjects:
+      - kind: ServiceAccount
+        name: legacy-brand-migration
+        namespace: openshift-console
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: legacy-brand-migration
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: remove-legacy-brand-config
+        namespace: openshift-console
+      data:
+        entrypoint: '#!/bin/bash
+
+
+          echo "This cronjob removes the legacy brand configuration if present, otherwise
+          exits cleanly as a noop"
+
+
+          oc patch console.operator cluster --type json --patch ''[{"op": "replace",
+          "path": "/spec/customization/customProductName", "value": null},{"op": "replace",
+          "path": "/spec/customization/customLogoFile", "value": null}]'' '
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: rosa-legacy-brand-migration
+        namespace: openshift-console
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: '*/15 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            template:
+              metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
+              spec:
+                serviceAccountName: legacy-brand-migration
+                restartPolicy: Never
+                containers:
+                - name: rosa-legacy-brand-migration
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  command:
+                  - /bin/sh
+                  - -c
+                  - /etc/config/entrypoint
+                  volumeMounts:
+                  - name: legacy-brand-migration
+                    mountPath: /etc/config
+                    readOnly: true
+                volumes:
+                - name: legacy-brand-migration
+                  configMap:
+                    name: remove-legacy-brand-config
+                    defaultMode: 493
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10291,6 +10291,155 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-console-legacy-branding-removal
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ServiceAccount
+                  metadata:
+                    name: legacy-brand-migration
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: legacy-brand-migration
+                  rules:
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - consoles
+                    verbs:
+                    - get
+                    - list
+                    - patch
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: legacy-brand-migration
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: legacy-brand-migration
+                  subjects:
+                  - kind: ServiceAccount
+                    name: legacy-brand-migration
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  data:
+                    entrypoint: '#!/bin/bash
+
+
+                      echo "This cronjob removes the legacy brand configuration if
+                      present, otherwise exits cleanly as a noop"
+
+
+                      oc patch console.operator cluster --type json --patch ''[{"op":
+                      "replace", "path": "/spec/customization/customProductName",
+                      "value": null},{"op": "replace", "path": "/spec/customization/customLogoFile",
+                      "value": null}]'' '
+                  kind: ConfigMap
+                  metadata:
+                    name: remove-legacy-brand-config
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: batch/v1
+                  kind: CronJob
+                  metadata:
+                    name: rosa-legacy-brand-migration
+                    namespace: openshift-console
+                  spec:
+                    concurrencyPolicy: Replace
+                    failedJobsHistoryLimit: 3
+                    jobTemplate:
+                      spec:
+                        template:
+                          metadata:
+                            annotations:
+                              openshift.io/required-scc: restricted-v2
+                          spec:
+                            containers:
+                            - command:
+                              - /bin/sh
+                              - -c
+                              - /etc/config/entrypoint
+                              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                              name: rosa-legacy-brand-migration
+                              volumeMounts:
+                              - mountPath: /etc/config
+                                name: legacy-brand-migration
+                                readOnly: true
+                            restartPolicy: Never
+                            serviceAccountName: legacy-brand-migration
+                            volumes:
+                            - configMap:
+                                defaultMode: 493
+                                name: remove-legacy-brand-config
+                              name: legacy-brand-migration
+                        ttlSecondsAfterFinished: 86400
+                    schedule: '*/15 * * * *'
+                    successfulJobsHistoryLimit: 1
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-console-legacy-branding-removal
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-console-legacy-branding-removal
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
@@ -44062,6 +44211,102 @@ objects:
         creationTimestamp: null
         name: rosa-brand-logo
         namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: rosa-console-legacy-branding-removal
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: legacy-brand-migration
+        namespace: openshift-console
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: legacy-brand-migration
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - consoles
+        verbs:
+        - get
+        - list
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: legacy-brand-migration
+      subjects:
+      - kind: ServiceAccount
+        name: legacy-brand-migration
+        namespace: openshift-console
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: legacy-brand-migration
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: remove-legacy-brand-config
+        namespace: openshift-console
+      data:
+        entrypoint: '#!/bin/bash
+
+
+          echo "This cronjob removes the legacy brand configuration if present, otherwise
+          exits cleanly as a noop"
+
+
+          oc patch console.operator cluster --type json --patch ''[{"op": "replace",
+          "path": "/spec/customization/customProductName", "value": null},{"op": "replace",
+          "path": "/spec/customization/customLogoFile", "value": null}]'' '
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: rosa-legacy-brand-migration
+        namespace: openshift-console
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: '*/15 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            template:
+              metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
+              spec:
+                serviceAccountName: legacy-brand-migration
+                restartPolicy: Never
+                containers:
+                - name: rosa-legacy-brand-migration
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  command:
+                  - /bin/sh
+                  - -c
+                  - /etc/config/entrypoint
+                  volumeMounts:
+                  - name: legacy-brand-migration
+                    mountPath: /etc/config
+                    readOnly: true
+                volumes:
+                - name: legacy-brand-migration
+                  configMap:
+                    name: remove-legacy-brand-config
+                    defaultMode: 493
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10291,6 +10291,155 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: rosa-console-legacy-branding-removal
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: ServiceAccount
+                  metadata:
+                    name: legacy-brand-migration
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRole
+                  metadata:
+                    name: legacy-brand-migration
+                  rules:
+                  - apiGroups:
+                    - operator.openshift.io
+                    resources:
+                    - consoles
+                    verbs:
+                    - get
+                    - list
+                    - patch
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: ClusterRoleBinding
+                  metadata:
+                    name: legacy-brand-migration
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: legacy-brand-migration
+                  subjects:
+                  - kind: ServiceAccount
+                    name: legacy-brand-migration
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  data:
+                    entrypoint: '#!/bin/bash
+
+
+                      echo "This cronjob removes the legacy brand configuration if
+                      present, otherwise exits cleanly as a noop"
+
+
+                      oc patch console.operator cluster --type json --patch ''[{"op":
+                      "replace", "path": "/spec/customization/customProductName",
+                      "value": null},{"op": "replace", "path": "/spec/customization/customLogoFile",
+                      "value": null}]'' '
+                  kind: ConfigMap
+                  metadata:
+                    name: remove-legacy-brand-config
+                    namespace: openshift-console
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: batch/v1
+                  kind: CronJob
+                  metadata:
+                    name: rosa-legacy-brand-migration
+                    namespace: openshift-console
+                  spec:
+                    concurrencyPolicy: Replace
+                    failedJobsHistoryLimit: 3
+                    jobTemplate:
+                      spec:
+                        template:
+                          metadata:
+                            annotations:
+                              openshift.io/required-scc: restricted-v2
+                          spec:
+                            containers:
+                            - command:
+                              - /bin/sh
+                              - -c
+                              - /etc/config/entrypoint
+                              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                              name: rosa-legacy-brand-migration
+                              volumeMounts:
+                              - mountPath: /etc/config
+                                name: legacy-brand-migration
+                                readOnly: true
+                            restartPolicy: Never
+                            serviceAccountName: legacy-brand-migration
+                            volumes:
+                            - configMap:
+                                defaultMode: 493
+                                name: remove-legacy-brand-config
+                              name: legacy-brand-migration
+                        ttlSecondsAfterFinished: 86400
+                    schedule: '*/15 * * * *'
+                    successfulJobsHistoryLimit: 1
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-rosa-console-legacy-branding-removal
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-rosa-console-legacy-branding-removal
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: rosa-console-legacy-branding-removal
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: rosa-ingress-certificate-check
         namespace: openshift-acm-policies
       spec:
@@ -44062,6 +44211,102 @@ objects:
         creationTimestamp: null
         name: rosa-brand-logo
         namespace: openshift-config
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: rosa-console-legacy-branding-removal
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: legacy-brand-migration
+        namespace: openshift-console
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: legacy-brand-migration
+      rules:
+      - apiGroups:
+        - operator.openshift.io
+        resources:
+        - consoles
+        verbs:
+        - get
+        - list
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: legacy-brand-migration
+      subjects:
+      - kind: ServiceAccount
+        name: legacy-brand-migration
+        namespace: openshift-console
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: legacy-brand-migration
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: remove-legacy-brand-config
+        namespace: openshift-console
+      data:
+        entrypoint: '#!/bin/bash
+
+
+          echo "This cronjob removes the legacy brand configuration if present, otherwise
+          exits cleanly as a noop"
+
+
+          oc patch console.operator cluster --type json --patch ''[{"op": "replace",
+          "path": "/spec/customization/customProductName", "value": null},{"op": "replace",
+          "path": "/spec/customization/customLogoFile", "value": null}]'' '
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: rosa-legacy-brand-migration
+        namespace: openshift-console
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 1
+        concurrencyPolicy: Replace
+        schedule: '*/15 * * * *'
+        jobTemplate:
+          spec:
+            ttlSecondsAfterFinished: 86400
+            template:
+              metadata:
+                annotations:
+                  openshift.io/required-scc: restricted-v2
+              spec:
+                serviceAccountName: legacy-brand-migration
+                restartPolicy: Never
+                containers:
+                - name: rosa-legacy-brand-migration
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  command:
+                  - /bin/sh
+                  - -c
+                  - /etc/config/entrypoint
+                  volumeMounts:
+                  - name: legacy-brand-migration
+                    mountPath: /etc/config
+                    readOnly: true
+                volumes:
+                - name: legacy-brand-migration
+                  configMap:
+                    name: remove-legacy-brand-config
+                    defaultMode: 493
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -41,6 +41,7 @@ directories = [
         'rbac-permissions-operator-config',
         'rosa-console-branding',
         'rosa-console-legacy-branding-configmap',
+        'rosa-console-legacy-branding-removal',
         'rosa-ingress-certificate-policies',
         'rosa-ingress-certificate-check',
         ]


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

cleanup

### What this PR does / why we need it?

This attempts to use a cronjob to clean up the dangling console resources since a json patch won't work in ACM policies.

This is currently untested due to an issue provisioning HCPs in all environments. I am marking this as a draft in case this needs to be handed over while I'm on PTO.

### Which Jira/Github issue(s) this PR fixes?

_Fixes SREP-901_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
