### PR TITLE
Revert "SDCICD-1254: remove osd-cluster-metadata"

### DIFF
--- a/deploy/osd-cluster-metadata/10-osd-cluster-metadata.openshift-config.ConfigMap.yaml
+++ b/deploy/osd-cluster-metadata/10-osd-cluster-metadata.openshift-config.ConfigMap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: osd-cluster-metadata
+  namespace: openshift-config
+data:
+  api.openshift.com_ccs: "{{ fromCDLabel \"api.openshift.com/ccs\" }}"
+  api.openshift.com_channel-group: "{{ fromCDLabel \"api.openshift.com/channel-group\" }}"
+  api.openshift.com_environment: "{{ fromCDLabel \"api.openshift.com/environment\" }}"
+  hive.openshift.io_cluster-platform: "{{ fromCDLabel \"hive.openshift.io/cluster-platform\" }}"
+  hive.openshift.io_cluster-region: "{{ fromCDLabel \"hive.openshift.io/cluster-region\" }}"

--- a/deploy/osd-cluster-metadata/config.yaml
+++ b/deploy/osd-cluster-metadata/config.yaml
@@ -1,0 +1,4 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  enableResourceTemplates: true
+  resourceApplyMode: "Sync"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36530,6 +36530,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-metadata
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    enableResourceTemplates: true
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-cluster-metadata
+        namespace: openshift-config
+      data:
+        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
+        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
+          }}'
+        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
+          }}'
+        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
+          }}'
+        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
+          }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36530,6 +36530,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-metadata
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    enableResourceTemplates: true
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-cluster-metadata
+        namespace: openshift-config
+      data:
+        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
+        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
+          }}'
+        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
+          }}'
+        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
+          }}'
+        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
+          }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36530,6 +36530,36 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-cluster-metadata
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+    resourceApplyMode: Sync
+    enableResourceTemplates: true
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: osd-cluster-metadata
+        namespace: openshift-config
+      data:
+        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
+        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
+          }}'
+        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
+          }}'
+        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
+          }}'
+        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
+          }}'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This reverts commit 5ccc7950a22e7e831acd91d4b9f24d0dfb30eb05.

### What type of PR is this?

Bug - the osd-cluster-metadata configmap is still needed, but is no longer delivered via RVMO.

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

Fixes OSDE2E tests.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
