### PR TITLE
Add rosa-legacy-brand-migration cronjob with priority class and resource requests

### DIFF
--- a/deploy/rosa-console-legacy-branding-removal/10-legacy-brand-removal.CronJob.yaml
+++ b/deploy/rosa-console-legacy-branding-removal/10-legacy-brand-removal.CronJob.yaml
@@ -19,6 +19,7 @@ spec:
         spec:
           serviceAccountName: legacy-brand-migration
           restartPolicy: Never
+          priorityClassName: "system-cluster-critical"
           containers:
             - name: rosa-legacy-brand-migration
               image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
@@ -27,6 +28,10 @@ spec:
                 - name: legacy-brand-migration
                   mountPath: /etc/config
                   readOnly: true
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
           volumes:
             - name: legacy-brand-migration
               configMap:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -36679,36 +36679,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-cluster-metadata
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
-    enableResourceTemplates: true
-    resources:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: osd-cluster-metadata
-        namespace: openshift-config
-      data:
-        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
-        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
-          }}'
-        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
-          }}'
-        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
-          }}'
-        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
-          }}'
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -36679,36 +36679,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-cluster-metadata
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
-    enableResourceTemplates: true
-    resources:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: osd-cluster-metadata
-        namespace: openshift-config
-      data:
-        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
-        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
-          }}'
-        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
-          }}'
-        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
-          }}'
-        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
-          }}'
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -36679,36 +36679,6 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
-    name: osd-cluster-metadata
-  spec:
-    clusterDeploymentSelector:
-      matchLabels:
-        api.openshift.com/managed: 'true'
-    resourceApplyMode: Sync
-    enableResourceTemplates: true
-    resources:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: osd-cluster-metadata
-        namespace: openshift-config
-      data:
-        api.openshift.com_ccs: '{{ fromCDLabel "api.openshift.com/ccs" }}'
-        api.openshift.com_channel-group: '{{ fromCDLabel "api.openshift.com/channel-group"
-          }}'
-        api.openshift.com_environment: '{{ fromCDLabel "api.openshift.com/environment"
-          }}'
-        hive.openshift.io_cluster-platform: '{{ fromCDLabel "hive.openshift.io/cluster-platform"
-          }}'
-        hive.openshift.io_cluster-region: '{{ fromCDLabel "hive.openshift.io/cluster-region"
-          }}'
-- apiVersion: hive.openshift.io/v1
-  kind: SelectorSyncSet
-  metadata:
-    labels:
-      managed.openshift.io/gitHash: ${IMAGE_TAG}
-      managed.openshift.io/gitRepoName: ${REPO_NAME}
-      managed.openshift.io/osd: 'true'
     name: osd-cluster-ready
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
Reintroduces the rosa-legacy-brand-migration cronjob from reverted commit c19fb54
Adds priorityClassName and resource requests to resolve conformance issues

