### PR TITLE
[OSD-30126] Deploy otel in FedRAMP

### DIFF
--- a/deploy/backplane/lpsre/dynatrace/otel/config.yaml
+++ b/deploy/backplane/lpsre/dynatrace/otel/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: ["management-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/deploy/backplane/srep/dynatrace/opentelemetry/config.yaml
+++ b/deploy/backplane/srep/dynatrace/opentelemetry/config.yaml
@@ -4,6 +4,3 @@ selectorSyncSet:
   - key: ext-hypershift.openshift.io/cluster-type
     operator: In
     values: ["management-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -25089,10 +25089,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -29334,10 +29330,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -25089,10 +25089,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -29334,10 +29330,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -25089,10 +25089,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1
@@ -29334,10 +29330,6 @@ objects:
         operator: In
         values:
         - management-cluster
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION


### What type of PR is this?
feature

### What this PR does / why we need it?
The goal of this MR is to enable the openshift-opentelemetry-operator namespace and corresponding operators on MCs in FedRAMP.
### Which Jira/Github issue(s) this PR fixes?
[OSD-30126](https://issues.redhat.com//browse/OSD-30126)
_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
