### PR TITLE
Added rbhilare to srep-region-leads group

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,7 @@ aliases:
     - Tof1973
     - devppratik
     - reedcort
+    - rbhilare
   srep-functional-leads:
     - abyrne55
     - clcollins


### PR DESCRIPTION
### What type of PR is this?
_(documentation)_

### What this PR does / why we need it?
Add rbhilare to srep-region-leads group

### Which Jira/Github issue(s) this PR fixes?
NA

### Special notes for your reviewer:
NA

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
