### PR TITLE
ACM-22748 | fix: update rosa ingress policy pruneObjectBehavior

### DIFF
--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -81,7 +81,7 @@ spec:
                           name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
                           namespace: openshift-ingress
                     {{hub- end hub}}
-                pruneObjectBehavior: DeleteIfCreated
+                pruneObjectBehavior: None
                 remediationAction: enforce
                 severity: low
     remediationAction: enforce

--- a/deploy/rosa-ingress-certificate-policies/01-rosa-ingress-certificate.Policy.yaml
+++ b/deploy/rosa-ingress-certificate-policies/01-rosa-ingress-certificate.Policy.yaml
@@ -20,6 +20,6 @@ spec:
           name: '{{hub (printf "%s-primary-cert-bundle-secret" .ManagedClusterName) hub}}'
           namespace: openshift-ingress
     {{hub- end hub}}
-  pruneObjectBehavior: DeleteIfCreated
+  pruneObjectBehavior: None
   remediationAction: enforce
   severity: low

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -10414,7 +10414,7 @@ objects:
                 \ .ManagedClusterName \"tls.key\" hub}}'\n    kind: Secret\n    metadata:\n\
                 \      name: '{{hub (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName)\
                 \ hub}}'\n      namespace: openshift-ingress\n{{hub- end hub}}\n"
-              pruneObjectBehavior: DeleteIfCreated
+              pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
         remediationAction: enforce

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -10414,7 +10414,7 @@ objects:
                 \ .ManagedClusterName \"tls.key\" hub}}'\n    kind: Secret\n    metadata:\n\
                 \      name: '{{hub (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName)\
                 \ hub}}'\n      namespace: openshift-ingress\n{{hub- end hub}}\n"
-              pruneObjectBehavior: DeleteIfCreated
+              pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
         remediationAction: enforce

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -10414,7 +10414,7 @@ objects:
                 \ .ManagedClusterName \"tls.key\" hub}}'\n    kind: Secret\n    metadata:\n\
                 \      name: '{{hub (printf \"%s-primary-cert-bundle-secret\" .ManagedClusterName)\
                 \ hub}}'\n      namespace: openshift-ingress\n{{hub- end hub}}\n"
-              pruneObjectBehavior: DeleteIfCreated
+              pruneObjectBehavior: None
               remediationAction: enforce
               severity: low
         remediationAction: enforce


### PR DESCRIPTION
set rosa-ingress-certificate-policies pruneObjectBehavior to None

### What type of PR is this?
bug

### What this PR does / why we need it?
When we upgrade to ACM 2.13; the immediate problem we see is ROSA HCP fail to successfully delete.
The managedcluster CR stalls deleting because the klusterlet addon pods associated to the HCP cluster cannot be deleted.
They cannot be deleted because there is a race condition where ACM is trying to delete resources under management while ACM agent itself is being uninstalled.
This was not a problem at 2.10, 2.11, but at 2.13, a new feature was added to ACM policy that expose this problem more.

Once ingress certificate secrets are created; the main other activity on them is to renew their content.
We do not need ACM to manage the deletion of the resource.

So changing the prune behavior from DeleteIfCreated to None is appropriate.

pruneObjectBehavior: None is the default behavior for policy.

Setting this should have no negative impact to existing HCP, but should make HCP cleanup more reliable, removing ACM policy from a dependency.

### Which Jira/Github issue(s) this PR fixes?

[ACM-22748](https://issues.redhat.com//browse/ACM-22748)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
