### PR TITLE
Feat(SREP-1558): enable MHC for masters backed by CPMS

### DIFF
--- a/deploy/osd-machine-api/013-machine-api.srep-master-healthcheck.MachineHealthCheck.yaml
+++ b/deploy/osd-machine-api/013-machine-api.srep-master-healthcheck.MachineHealthCheck.yaml
@@ -1,0 +1,20 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: srep-master-healthcheck
+  namespace: openshift-machine-api
+spec:
+  selector:
+    matchExpressions:
+    - key: machine.openshift.io/cluster-api-machine-role
+      operator: In
+      values:
+      - "master"
+  unhealthyConditions:
+  - type:    "Ready"
+    timeout: "480s"
+    status: "False"
+  - type:    "Ready"
+    timeout: "600s"
+    status: "Unknown"
+  maxUnhealthy: 1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39736,6 +39736,26 @@ objects:
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 40m
+    - apiVersion: machine.openshift.io/v1beta1
+      kind: MachineHealthCheck
+      metadata:
+        name: srep-master-healthcheck
+        namespace: openshift-machine-api
+      spec:
+        selector:
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: In
+            values:
+            - master
+        unhealthyConditions:
+        - type: Ready
+          timeout: 480s
+          status: 'False'
+        - type: Ready
+          timeout: 600s
+          status: Unknown
+        maxUnhealthy: 1
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39736,6 +39736,26 @@ objects:
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 40m
+    - apiVersion: machine.openshift.io/v1beta1
+      kind: MachineHealthCheck
+      metadata:
+        name: srep-master-healthcheck
+        namespace: openshift-machine-api
+      spec:
+        selector:
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: In
+            values:
+            - master
+        unhealthyConditions:
+        - type: Ready
+          timeout: 480s
+          status: 'False'
+        - type: Ready
+          timeout: 600s
+          status: Unknown
+        maxUnhealthy: 1
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39736,6 +39736,26 @@ objects:
           status: Unknown
         maxUnhealthy: 3
         nodeStartupTimeout: 40m
+    - apiVersion: machine.openshift.io/v1beta1
+      kind: MachineHealthCheck
+      metadata:
+        name: srep-master-healthcheck
+        namespace: openshift-machine-api
+      spec:
+        selector:
+          matchExpressions:
+          - key: machine.openshift.io/cluster-api-machine-role
+            operator: In
+            values:
+            - master
+        unhealthyConditions:
+        - type: Ready
+          timeout: 480s
+          status: 'False'
+        - type: Ready
+          timeout: 600s
+          status: Unknown
+        maxUnhealthy: 1
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

We use CPMS, meaning we have a MachineSet for control planes, but don't use a MachineHealthCheck for automatic replacement of unhealthy nodes. This PR enables automated remediation of unhealthy master nodes.

I confirmed that the MHC will only remediate the machines in case they are backed by an active CPMS, so this won't break < 4.12 clusters or clusters with a disabled CPMS. 

Only when CPMS is enabled the machines will have a controller owner refernence, which is a prerequisite for health check remediations, see [here](https://github.com/openshift/machine-api-operator/blob/d9777350195fbc4ccd9ebaba0b8ad63a7b09ed4b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go#L637-L647).

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/SREP-1558 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
