### PR TITLE
SREP-1070: Remove delete permissions from users & identities resources

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -122,14 +122,6 @@ spec:
                               verbs:
                                 - create
                             - apiGroups:
-                                - user.openshift.io
-                              resources:
-                                - users
-                                - identities
-                              verbs:
-                                - delete
-                                - deletecollection
-                            - apiGroups:
                                 - machineconfiguration.openshift.io
                               resources:
                                 - '*'

--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -97,15 +97,6 @@ rules:
   - subjectrulesreviews
   verbs:
   - create
-# SRE can delete users and identities
-- apiGroups:
-  - user.openshift.io
-  resources:
-  - users
-  - identities
-  verbs:
-  - delete
-  - deletecollection
 # SREP can view machineconfigs, machineconfigpools, kubeletconfigs, controllerconfigs
 - apiGroups:
   - machineconfiguration.openshift.io

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4889,14 +4889,6 @@ objects:
                     verbs:
                     - create
                   - apiGroups:
-                    - user.openshift.io
-                    resources:
-                    - users
-                    - identities
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
                     - machineconfiguration.openshift.io
                     resources:
                     - '*'
@@ -29085,14 +29077,6 @@ objects:
         - subjectrulesreviews
         verbs:
         - create
-      - apiGroups:
-        - user.openshift.io
-        resources:
-        - users
-        - identities
-        verbs:
-        - delete
-        - deletecollection
       - apiGroups:
         - machineconfiguration.openshift.io
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4889,14 +4889,6 @@ objects:
                     verbs:
                     - create
                   - apiGroups:
-                    - user.openshift.io
-                    resources:
-                    - users
-                    - identities
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
                     - machineconfiguration.openshift.io
                     resources:
                     - '*'
@@ -29085,14 +29077,6 @@ objects:
         - subjectrulesreviews
         verbs:
         - create
-      - apiGroups:
-        - user.openshift.io
-        resources:
-        - users
-        - identities
-        verbs:
-        - delete
-        - deletecollection
       - apiGroups:
         - machineconfiguration.openshift.io
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4889,14 +4889,6 @@ objects:
                     verbs:
                     - create
                   - apiGroups:
-                    - user.openshift.io
-                    resources:
-                    - users
-                    - identities
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
                     - machineconfiguration.openshift.io
                     resources:
                     - '*'
@@ -29085,14 +29077,6 @@ objects:
         - subjectrulesreviews
         verbs:
         - create
-      - apiGroups:
-        - user.openshift.io
-        resources:
-        - users
-        - identities
-        verbs:
-        - delete
-        - deletecollection
       - apiGroups:
         - machineconfiguration.openshift.io
         resources:


### PR DESCRIPTION
### What type of PR is this?
_cleanup_

### What this PR does / why we need it?
This PR aims to remove the delete and deletecollection permissions from the users and identities resources which SRE don't need to have access to.

### Which Jira/Github issue(s) this PR fixes?

_Fixes_ #[SREP-1070](https://issues.redhat.com/browse/SREP-1070)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
