### PR TITLE
SREP-941: New alerts added for CPU and Mem Error BudgetBurn

### DIFF
--- a/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-control-plane-resizing.PrometheusRule.yaml
@@ -87,6 +87,37 @@ spec:
               )
             )
         record: sre:node_control_plane:excessive_consumption_memory
+      ## Calculates CPU usage per master node as 100 – idle%.  
+      ## Converts each sample to 1 if usage >80%, 0 otherwise.  
+      ## avg_over_time(...[24h:5m]) computes the fraction of the last 24h each node was above 80% CPU.                 
+      - expr: |
+          avg_over_time(
+            (
+              (
+                (1 - avg by (instance) (
+                  rate(node_cpu_seconds_total{mode="idle"}[5m])
+                )) * 100
+                AND on(instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+              ) > bool 80
+            )[24h:5m]
+          )
+        record: sre:node_control_plane:cpu_usage_ebb
+      ## Calculates memory usage per master node as (1 – free/total) × 100.  
+      ## Converts each sample to 1 if usage >80%, 0 otherwise.  
+      ## avg_over_time(...[24h:5m]) computes the fraction of the last 24h each node was above 80% memory.
+      - expr: |
+          avg_over_time(
+            (
+              (
+                1 - (
+                  (node_memory_MemFree_bytes + node_memory_Buffers_bytes + node_memory_Cached_bytes)
+                  / node_memory_MemTotal_bytes
+                )
+              ) * 100 > bool 80
+              AND on(instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+            )[24h:5m]
+          )
+        record: sre:node_control_plane:memory_usage_ebb
   - name: sre-control-plane-resizing-alerts
     rules:
         # This used to be called MasterNodesNeedResizingSRE
@@ -107,3 +138,12 @@ spec:
           namespace: openshift-monitoring
         annotations:
           message: "The cluster's control plane nodes have been undersized for 24 hours and must be vertically scaled to support the existing workload. See linked SOP for details."
+
+      - alert: ControlPlaneNodeErrorBudgetBurn
+        expr: (sre:node_control_plane:cpu_usage_ebb > (2/24)) or (sre:node_control_plane:memory_usage_ebb > (2/24))
+        for: 5m
+        labels:
+          severity: critical
+          namespace: openshift-monitoring
+        annotations:
+          message: "Control plane CPU or memory usage exceeded 80% for >2h within the last 24h. Consider resizing nodes. See linked SOP for details."

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -44882,6 +44882,18 @@ objects:
               ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="master"} ) ) )
             record: sre:node_control_plane:excessive_consumption_memory
+          - expr: "avg_over_time(\n  (\n    (\n      (1 - avg by (instance) (\n  \
+              \      rate(node_cpu_seconds_total{mode=\"idle\"}[5m])\n      )) * 100\n\
+              \      AND on(instance) label_replace(kube_node_role{role=\"master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.+)\")\n    ) > bool 80\n  )[24h:5m]\n\
+              )\n"
+            record: sre:node_control_plane:cpu_usage_ebb
+          - expr: "avg_over_time(\n  (\n    (\n      1 - (\n        (node_memory_MemFree_bytes\
+              \ + node_memory_Buffers_bytes + node_memory_Cached_bytes)\n        /\
+              \ node_memory_MemTotal_bytes\n      )\n    ) * 100 > bool 80\n    AND\
+              \ on(instance) label_replace(kube_node_role{role=\"master\"}, \"instance\"\
+              , \"$1\", \"node\", \"(.+)\")\n  )[24h:5m]\n)\n"
+            record: sre:node_control_plane:memory_usage_ebb
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
@@ -44907,6 +44919,16 @@ objects:
               message: The cluster's control plane nodes have been undersized for
                 24 hours and must be vertically scaled to support the existing workload.
                 See linked SOP for details.
+          - alert: ControlPlaneNodeErrorBudgetBurn
+            expr: (sre:node_control_plane:cpu_usage_ebb > (2/24)) or (sre:node_control_plane:memory_usage_ebb
+              > (2/24))
+            for: 5m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Control plane CPU or memory usage exceeded 80% for >2h within
+                the last 24h. Consider resizing nodes. See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -44882,6 +44882,18 @@ objects:
               ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="master"} ) ) )
             record: sre:node_control_plane:excessive_consumption_memory
+          - expr: "avg_over_time(\n  (\n    (\n      (1 - avg by (instance) (\n  \
+              \      rate(node_cpu_seconds_total{mode=\"idle\"}[5m])\n      )) * 100\n\
+              \      AND on(instance) label_replace(kube_node_role{role=\"master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.+)\")\n    ) > bool 80\n  )[24h:5m]\n\
+              )\n"
+            record: sre:node_control_plane:cpu_usage_ebb
+          - expr: "avg_over_time(\n  (\n    (\n      1 - (\n        (node_memory_MemFree_bytes\
+              \ + node_memory_Buffers_bytes + node_memory_Cached_bytes)\n        /\
+              \ node_memory_MemTotal_bytes\n      )\n    ) * 100 > bool 80\n    AND\
+              \ on(instance) label_replace(kube_node_role{role=\"master\"}, \"instance\"\
+              , \"$1\", \"node\", \"(.+)\")\n  )[24h:5m]\n)\n"
+            record: sre:node_control_plane:memory_usage_ebb
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
@@ -44907,6 +44919,16 @@ objects:
               message: The cluster's control plane nodes have been undersized for
                 24 hours and must be vertically scaled to support the existing workload.
                 See linked SOP for details.
+          - alert: ControlPlaneNodeErrorBudgetBurn
+            expr: (sre:node_control_plane:cpu_usage_ebb > (2/24)) or (sre:node_control_plane:memory_usage_ebb
+              > (2/24))
+            for: 5m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Control plane CPU or memory usage exceeded 80% for >2h within
+                the last 24h. Consider resizing nodes. See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -44882,6 +44882,18 @@ objects:
               ="master"} ) - 1 ) / count ( cluster:nodes_roles{label_node_role_kubernetes_io
               ="master"} ) ) )
             record: sre:node_control_plane:excessive_consumption_memory
+          - expr: "avg_over_time(\n  (\n    (\n      (1 - avg by (instance) (\n  \
+              \      rate(node_cpu_seconds_total{mode=\"idle\"}[5m])\n      )) * 100\n\
+              \      AND on(instance) label_replace(kube_node_role{role=\"master\"\
+              }, \"instance\", \"$1\", \"node\", \"(.+)\")\n    ) > bool 80\n  )[24h:5m]\n\
+              )\n"
+            record: sre:node_control_plane:cpu_usage_ebb
+          - expr: "avg_over_time(\n  (\n    (\n      1 - (\n        (node_memory_MemFree_bytes\
+              \ + node_memory_Buffers_bytes + node_memory_Cached_bytes)\n        /\
+              \ node_memory_MemTotal_bytes\n      )\n    ) * 100 > bool 80\n    AND\
+              \ on(instance) label_replace(kube_node_role{role=\"master\"}, \"instance\"\
+              , \"$1\", \"node\", \"(.+)\")\n  )[24h:5m]\n)\n"
+            record: sre:node_control_plane:memory_usage_ebb
         - name: sre-control-plane-resizing-alerts
           rules:
           - alert: ControlPlaneNodesNeedResizingSRE
@@ -44907,6 +44919,16 @@ objects:
               message: The cluster's control plane nodes have been undersized for
                 24 hours and must be vertically scaled to support the existing workload.
                 See linked SOP for details.
+          - alert: ControlPlaneNodeErrorBudgetBurn
+            expr: (sre:node_control_plane:cpu_usage_ebb > (2/24)) or (sre:node_control_plane:memory_usage_ebb
+              > (2/24))
+            for: 5m
+            labels:
+              severity: critical
+              namespace: openshift-monitoring
+            annotations:
+              message: Control plane CPU or memory usage exceeded 80% for >2h within
+                the last 24h. Consider resizing nodes. See linked SOP for details.
     - apiVersion: monitoring.coreos.com/v1
       kind: PrometheusRule
       metadata:


### PR DESCRIPTION
### What type of PR is this?
Add warning and critical alerts for control plane CPU/memory error budget burn to detect sustained high usage and guide node resizing.

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
