### PR TITLE
SREP-1000: Add supplemental node-exporter to collect ethtool AWS packet drop metrics

### DIFF
--- a/deploy/srep-1000-ethtool-exporter/00-Namespace.yaml
+++ b/deploy/srep-1000-ethtool-exporter/00-Namespace.yaml
@@ -3,13 +3,13 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/description: "Provide supplemental metrics not currently available in Openshift CMO"
-    openshift.io/display-name: "openshift-sre-observe"
+    openshift.io/display-name: "openshift-sre-ethtool-exporter"
     security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
   labels:
-    kubernetes.io/metadata.name: openshift-sre-observe
+    kubernetes.io/metadata.name: openshift-sre-ethtool-exporter
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/audit-version: latest
     pod-security.kubernetes.io/warn: privileged
     pod-security.kubernetes.io/warn-version: latest
-  name: openshift-sre-observe
+  name: openshift-sre-ethtool-exporter

--- a/deploy/srep-1000-ethtool-exporter/00-Namespace.yaml
+++ b/deploy/srep-1000-ethtool-exporter/00-Namespace.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/description: "Provide supplemental metrics not currently available in Openshift CMO"
+    openshift.io/display-name: "openshift-sre-observe"
+    security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
+  labels:
+    kubernetes.io/metadata.name: openshift-sre-observe
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+  name: openshift-sre-observe

--- a/deploy/srep-1000-ethtool-exporter/01-ServiceAccount.yaml
+++ b/deploy/srep-1000-ethtool-exporter/01-ServiceAccount.yaml
@@ -4,4 +4,4 @@ metadata:
   annotations:
   labels:
   name: ethtool-exporter-sa
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter

--- a/deploy/srep-1000-ethtool-exporter/01-ServiceAccount.yaml
+++ b/deploy/srep-1000-ethtool-exporter/01-ServiceAccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+  labels:
+  name: ethtool-exporter-sa
+  namespace: openshift-sre-observe

--- a/deploy/srep-1000-ethtool-exporter/02-Role.yaml
+++ b/deploy/srep-1000-ethtool-exporter/02-Role.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   labels:
   name: prometheus-k8s
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter
 rules:
   - apiGroups:
       - ""

--- a/deploy/srep-1000-ethtool-exporter/02-Role.yaml
+++ b/deploy/srep-1000-ethtool-exporter/02-Role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+  name: prometheus-k8s
+  namespace: openshift-sre-observe
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch

--- a/deploy/srep-1000-ethtool-exporter/03-RoleBinding.yaml
+++ b/deploy/srep-1000-ethtool-exporter/03-RoleBinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+  name: prometheus-k8s
+  namespace: openshift-sre-observe
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/deploy/srep-1000-ethtool-exporter/03-RoleBinding.yaml
+++ b/deploy/srep-1000-ethtool-exporter/03-RoleBinding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
   name: prometheus-k8s
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/srep-1000-ethtool-exporter/05-ClusterRoleBinding.yaml
+++ b/deploy/srep-1000-ethtool-exporter/05-ClusterRoleBinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: ethtool-exporter-sa
-    namespace: openshift-sre-observe
+    namespace: openshift-sre-ethtool-exporter

--- a/deploy/srep-1000-ethtool-exporter/05-ClusterRoleBinding.yaml
+++ b/deploy/srep-1000-ethtool-exporter/05-ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ethtool-exporter-token-reviewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: ethtool-exporter-sa
+    namespace: openshift-sre-observe

--- a/deploy/srep-1000-ethtool-exporter/06-SecurityContextConstraints.yaml
+++ b/deploy/srep-1000-ethtool-exporter/06-SecurityContextConstraints.yaml
@@ -1,0 +1,32 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: ethtool-exporter scc used by supplemental node-exporter to provide ethtool metrics
+  name: ethtool-exporter
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+users: ["system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa"]
+volumes:
+  - "*"

--- a/deploy/srep-1000-ethtool-exporter/06-SecurityContextConstraints.yaml
+++ b/deploy/srep-1000-ethtool-exporter/06-SecurityContextConstraints.yaml
@@ -27,6 +27,7 @@ seccompProfiles:
   - runtime/default
 supplementalGroups:
   type: RunAsAny
-users: ["system:serviceaccount:openshift-sre-ethtool-exporter:ethtool-exporter-sa"]
+users:
+  ["system:serviceaccount:openshift-sre-ethtool-exporter:ethtool-exporter-sa"]
 volumes:
   - "*"

--- a/deploy/srep-1000-ethtool-exporter/06-SecurityContextConstraints.yaml
+++ b/deploy/srep-1000-ethtool-exporter/06-SecurityContextConstraints.yaml
@@ -27,6 +27,6 @@ seccompProfiles:
   - runtime/default
 supplementalGroups:
   type: RunAsAny
-users: ["system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa"]
+users: ["system:serviceaccount:openshift-sre-ethtool-exporter:ethtool-exporter-sa"]
 volumes:
   - "*"

--- a/deploy/srep-1000-ethtool-exporter/07-ConfigMap.yaml
+++ b/deploy/srep-1000-ethtool-exporter/07-ConfigMap.yaml
@@ -5,4 +5,4 @@ metadata:
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
   name: ethtool-exporter-ca-bundle
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter

--- a/deploy/srep-1000-ethtool-exporter/07-ConfigMap.yaml
+++ b/deploy/srep-1000-ethtool-exporter/07-ConfigMap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: ethtool-exporter-ca-bundle
+  namespace: openshift-sre-observe

--- a/deploy/srep-1000-ethtool-exporter/08-Secret.yaml
+++ b/deploy/srep-1000-ethtool-exporter/08-Secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+data:
+  config.yaml: ImF1dGhvcml6YXRpb24iOgogICJzdGF0aWMiOgogIC0gInBhdGgiOiAiL21ldHJpY3MiCiAgICAicmVzb3VyY2VSZXF1ZXN0IjogZmFsc2UKICAgICJ1c2VyIjoKICAgICAgIm5hbWUiOiAic3lzdGVtOnNlcnZpY2VhY2NvdW50Om9wZW5zaGlmdC1tb25pdG9yaW5nOnByb21ldGhldXMtazhzIgogICAgInZlcmIiOiAiZ2V0Ig==
+metadata:
+  labels:
+  name: ethtool-exporter-kube-rbac-proxy-config
+  namespace: openshift-sre-observe
+type: Opaque

--- a/deploy/srep-1000-ethtool-exporter/08-Secret.yaml
+++ b/deploy/srep-1000-ethtool-exporter/08-Secret.yaml
@@ -5,5 +5,5 @@ data:
 metadata:
   labels:
   name: ethtool-exporter-kube-rbac-proxy-config
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter
 type: Opaque

--- a/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
+++ b/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
@@ -85,13 +85,13 @@ spec:
             - name: sysfs
               mountPath: /host/sys
               readOnly: true
-            - mountPath: /var/node_exporter/text/file
-              name: node-exporter-textfile
+            - mountPath: /var/ethtool_exporter/text/file
+              name: ethtool-exporter-textfile
               readOnly: true
             - name: procfs
               mountPath: /host/proc
               readOnly: true
-          workingDir: /var/node_exporter/textfile
+          workingDir: /var/ethtool_exporter/textfile
         - args:
             - --secure-listen-address=[$(IP)]:9500
             - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
@@ -163,12 +163,12 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-            - mountPath: /var/node_exporter/textfile
-              name: node-exporter-textfile
+            - mountPath: /var/ethtool_exporter/textfile
+              name: ethtool-exporter-textfile
             - mountPath: /var/log/wtmp
-              name: node-exporter-wtmp
+              name: ethtool-exporter-wtmp
               readOnly: true
-          workingDir: /var/node_exporter/textfile
+          workingDir: /var/ethtool_exporter/textfile
       volumes:
         - name: rootfs
           hostPath:
@@ -180,11 +180,11 @@ spec:
           hostPath:
             path: /proc
         - emptyDir: {}
-          name: node-exporter-textfile
+          name: ethtool-exporter-textfile
         - hostPath:
             path: /var/log/wtmp
             type: File
-          name: node-exporter-wtmp
+          name: ethtool-exporter-wtmp
         - name: ethtool-exporter-tls
           secret:
             defaultMode: 420

--- a/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
+++ b/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
@@ -1,0 +1,190 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    openshift.io/required-scc: ethtool-exporter
+    openshift.io/scc: ethtool-exporter
+    seccomp.security.alpha.kubernetes.io/pod: runtime/default
+    openshift.io/description: "Provde supplemental ethtool metrics not currently available in CMO"
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: ethtool-exporter
+  name: ethtool-exporter
+  namespace: openshift-sre-observe
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: ethtool-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: ethtool-exporter
+    spec:
+      automountServiceAccountToken: true
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      serviceAccount: ethtool-exporter-sa
+      serviceAccountName: ethtool-exporter-sa
+      containers:
+        - args:
+            - --web.listen-address=127.0.0.1:9500
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --path.procfs=/host/proc
+            - --path.udev.data="/host/root/run/udev/data"
+            - --collector.disable-defaults
+            - --collector.ethtool
+            - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
+            - --runtime.gomaxprocs=0
+          name: ethtool-exporter
+          image: prom/node-exporter
+          command:
+            - /bin/sh
+            - -c
+            - |
+              export GOMAXPROCS=4
+              # We don't take CPU affinity into account as the container doesn't have integer CPU requests.
+              # In case of error, fallback to the default value.
+              NUM_CPUS=$(grep -c '^processor' "/proc/cpuinfo" 2>/dev/null || echo "0")
+              if [ "$NUM_CPUS" -lt "$GOMAXPROCS" ]; then
+                export GOMAXPROCS="$NUM_CPUS"
+              fi
+              echo "num_cpus=$NUM_CPUS gomaxprocs=$GOMAXPROCS"
+              exec /bin/node_exporter "$0" "$@"
+          env:
+            - name: DBUS_SYSTEM_BUS_ADDRESS
+              value: unix:path=/host/root/var/run/dbus/system_bus_socket
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 250m
+              memory: 180Mi
+            requests:
+              cpu: 8m
+              memory: 32Mi
+          securityContext: {}
+          volumeMounts:
+            - name: rootfs
+              mountPath: /host/root
+              readOnly: true
+            - name: sysfs
+              mountPath: /host/sys
+              readOnly: true
+            - mountPath: /var/node_exporter/text/file
+              name: node-exporter-textfile
+              readOnly: true
+            - name: procfs
+              mountPath: /host/proc
+              readOnly: true
+          workingDir: /var/node_exporter/textfile
+        - args:
+            - --secure-listen-address=[$(IP)]:9500
+            - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+            - --upstream=http://127.0.0.1:9500/
+            - --tls-cert-file=/etc/tls/private/tls.crt
+            - --config-file=/etc/kube-rbac-policy/config.yaml
+            - --tls-min-version=VersionTLS12
+            - --tls-private-key-file=/etc/tls/private/tls.key
+            - --client-ca-file=/etc/tls/client/ca-bundle.crt
+          env:
+            - name: IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+          imagePullPolicy: IfNotPresent
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 9500
+              hostPort: 9500
+              name: exporter-port
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 1m
+              memory: 15Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 65532
+            runAsNonRoot: true
+            runAsUser: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /etc/tls/private
+              name: ethtool-exporter-tls
+            - mountPath: /etc/tls/client
+              name: ethtool-exporter-ca-bundle
+            - mountPath: /etc/kube-rbac-policy
+              name: ethtool-exporter-kube-rbac-proxy-config
+              readOnly: true
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - '[[ ! -d /node_exporter/collectors/init ]] || find /node_exporter/collectors/init -perm /111 -type f -exec {} \;'
+          env:
+            - name: TMPDIR
+              value: /tmp
+          #image: prom/node-exporter
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+          imagePullPolicy: IfNotPresent
+          name: init-textfile
+          resources:
+            requests:
+              cpu: 1m
+              memory: 1Mi
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: FallbackToLogsOnError
+          volumeMounts:
+            - mountPath: /var/node_exporter/textfile
+              name: node-exporter-textfile
+            - mountPath: /var/log/wtmp
+              name: node-exporter-wtmp
+              readOnly: true
+          workingDir: /var/node_exporter/textfile
+      volumes:
+        - name: rootfs
+          hostPath:
+            path: /
+        - name: sysfs
+          hostPath:
+            path: /sys
+        - name: procfs
+          hostPath:
+            path: /proc
+        - emptyDir: {}
+          name: node-exporter-textfile
+        - hostPath:
+            path: /var/log/wtmp
+            type: File
+          name: node-exporter-wtmp
+        - name: ethtool-exporter-tls
+          secret:
+            defaultMode: 420
+            secretName: ethtool-exporter-tls
+        - name: ethtool-exporter-kube-rbac-proxy-config
+          secret:
+            defaultMode: 420
+            secretName: ethtool-exporter-kube-rbac-proxy-config
+        - configMap:
+            defaultMode: 420
+            name: ethtool-exporter-ca-bundle
+          name: ethtool-exporter-ca-bundle

--- a/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
+++ b/deploy/srep-1000-ethtool-exporter/09-DaemonSet.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: ethtool-exporter
   name: ethtool-exporter
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter
 spec:
   selector:
     matchLabels:
@@ -34,6 +34,12 @@ spec:
       serviceAccountName: ethtool-exporter-sa
       containers:
         - args:
+            # Contrasts to CMO's node exporter config:
+            # - binds to host port 9500 to not compete with CMO's 9100
+            # - ethtool collector adds use of /proc on host
+            # - disables all collectors, and collector config != ethtool
+            # - defines only a specific set of (ethtool) metrics to include
+            #   (serviceMonitor is expected to filter out any other metrics)
             - --web.listen-address=127.0.0.1:9500
             - --path.sysfs=/host/sys
             - --path.rootfs=/host/root
@@ -44,7 +50,9 @@ spec:
             - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
             - --runtime.gomaxprocs=0
           name: ethtool-exporter
-          image: prom/node-exporter
+          # Taken from PROD 4.16.42 MCs currently using: @sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
+          # Can also use image: prom/node-exporter
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
           command:
             - /bin/sh
             - -c
@@ -99,7 +107,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+          # Taken from PROD 4.16.42 MCs currently using: sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy
           ports:
@@ -140,8 +149,8 @@ spec:
           env:
             - name: TMPDIR
               value: /tmp
-          #image: prom/node-exporter
-          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+          # Taken from PROD 4.16.42 MCs currently using: sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cdd
+          image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
           imagePullPolicy: IfNotPresent
           name: init-textfile
           resources:

--- a/deploy/srep-1000-ethtool-exporter/10-Service.yaml
+++ b/deploy/srep-1000-ethtool-exporter/10-Service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ethtool-exporter
+  namespace: openshift-sre-observe
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
+  labels:
+    app: ethtool-exporter
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: ethtool-exporter
+  ports:
+    - name: https
+      protocol: TCP
+      port: 9500
+      targetPort: 9500

--- a/deploy/srep-1000-ethtool-exporter/10-Service.yaml
+++ b/deploy/srep-1000-ethtool-exporter/10-Service.yaml
@@ -2,7 +2,7 @@ kind: Service
 apiVersion: v1
 metadata:
   name: ethtool-exporter
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
   labels:

--- a/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
+++ b/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     monitoring.openshift.io/collection-profile: full
   name: ethtool-exporter
-  namespace: openshift-sre-observe
+  namespace: openshift-sre-ethtool-exporter
 spec:
   endpoints:
     - interval: 15s
@@ -12,7 +12,7 @@ spec:
       port: https
       scheme: https
       tlsConfig:
-        serverName: ethtool-exporter.openshift-sre-observe.svc
+        serverName: ethtool-exporter.openshift-sre-ethtool-exporter.svc
         ca:
           configMap:
             key: service-ca.crt
@@ -40,7 +40,7 @@ spec:
   scrapeClass: tls-client-certificate-auth
   namespaceSelector:
     matchNames:
-      - openshift-sre-observe
+      - openshift-sre-ethtool-exporter
   selector:
     matchLabels:
       app: ethtool-exporter

--- a/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
+++ b/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring.openshift.io/collection-profile: full
+  name: ethtool-exporter
+  namespace: openshift-sre-observe
+spec:
+  endpoints:
+    - interval: 15s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      port: https
+      scheme: https
+      tlsConfig:
+        serverName: ethtool-exporter.openshift-sre-observe.svc
+        ca:
+          configMap:
+            key: service-ca.crt
+            name: openshift-service-ca.crt
+        cert:
+          secret:
+            key: tls.crt
+            name: ethtool-exporter-tls
+        keySecret:
+          key: tls.key
+          name: ethtool-exporter-tls
+      metricRelabelings:
+      - action: keep
+        regex: node_ethtool_.*_allowance_exceeded
+        sourceLabels:
+        - __name__
+      relabelings:
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: instance
+  jobLabel: app.kubernetes.io/name
+  scrapeClass: tls-client-certificate-auth
+  namespaceSelector:
+    matchNames:
+      - openshift-sre-observe
+  selector:
+    matchLabels:
+      app: ethtool-exporter

--- a/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
+++ b/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
@@ -25,10 +25,10 @@ spec:
           key: tls.key
           name: ethtool-exporter-tls
       metricRelabelings:
-      - action: keep
-        regex: node_ethtool_.*_allowance_exceeded
-        sourceLabels:
-        - __name__
+        - action: keep
+          regex: node_ethtool_.*_allowance_exceeded
+          sourceLabels:
+            - __name__
       relabelings:
         - action: replace
           regex: (.*)

--- a/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
+++ b/deploy/srep-1000-ethtool-exporter/11-ServiceMonitor.yaml
@@ -37,7 +37,6 @@ spec:
             - __meta_kubernetes_pod_node_name
           targetLabel: instance
   jobLabel: app.kubernetes.io/name
-  scrapeClass: tls-client-certificate-auth
   namespaceSelector:
     matchNames:
       - openshift-sre-ethtool-exporter

--- a/deploy/srep-1000-ethtool-exporter/README.md
+++ b/deploy/srep-1000-ethtool-exporter/README.md
@@ -1,0 +1,17 @@
+# SREP-1000-ethtool-exporter
+
+Per SREP-1000, this contains a SelectorSyncSet config that targets `Management-Clusters` to deploy a supplemental node-exporter using the ethtool.collector. This is then used by openshift-monitoring prometheus-k8s to scrape AWS packet drop metrics related to ENA exceeding their allowed bandwidth as defined by the instance type.
+CMO does not currently support the ethtool collector. This SSS can be removed once support is added to CMO (See RFE-7342).
+
+## Metrics
+
+The serviceMonitor is currently filtering all but the following metrics:
+
+- bw_in_allowance_exceeded
+- bw_out_allowance_exceeded
+- conntrack_allowance_exceeded
+- linklocal_allowance_exceeded
+- pps_allowance_exceeded
+
+For more information on these metrics see AWS documentation:
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-network-performance-ena.html#network-performance-metrics

--- a/deploy/srep-1000-ethtool-exporter/config.yaml
+++ b/deploy/srep-1000-ethtool-exporter/config.yaml
@@ -8,7 +8,6 @@ selectorSyncSet:
       operator: NotIn
       values: ["true"]
     - key: api.openshift.com/environment
-      operator: In
+      operator: NotIn
       values:
-        - "integration"
-        - "staging"
+      - "production"

--- a/deploy/srep-1000-ethtool-exporter/config.yaml
+++ b/deploy/srep-1000-ethtool-exporter/config.yaml
@@ -7,3 +7,8 @@ selectorSyncSet:
     - key: api.openshift.com/fedramp
       operator: NotIn
       values: ["true"]
+    - key: api.openshift.com/environment
+      operator: In
+      values:
+        - "integration"
+        - "staging"

--- a/deploy/srep-1000-ethtool-exporter/config.yaml
+++ b/deploy/srep-1000-ethtool-exporter/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet" 
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type 
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/deploy/srep-1000-ethtool-exporter/config.yaml
+++ b/deploy/srep-1000-ethtool-exporter/config.yaml
@@ -1,9 +1,9 @@
-deploymentMode: "SelectorSyncSet" 
+deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   matchExpressions:
-  - key: ext-hypershift.openshift.io/cluster-type 
-    operator: In
-    values: ["management-cluster"]
-  - key: api.openshift.com/fedramp
-    operator: NotIn
-    values: ["true"]
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48151,10 +48151,9 @@ objects:
         values:
         - 'true'
       - key: api.openshift.com/environment
-        operator: In
+        operator: NotIn
         values:
-        - integration
-        - staging
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48136,6 +48136,399 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: srep-1000-ethtool-exporter
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        annotations:
+          openshift.io/description: Provide supplemental metrics not currently available
+            in Openshift CMO
+          openshift.io/display-name: openshift-sre-observe
+          security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
+        labels:
+          kubernetes.io/metadata.name: openshift-sre-observe
+          openshift.io/cluster-monitoring: 'true'
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
+        name: openshift-sre-observe
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        annotations: null
+        labels: null
+        name: ethtool-exporter-sa
+        namespace: openshift-sre-observe
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        labels: null
+        name: prometheus-k8s
+        namespace: openshift-sre-observe
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        labels: null
+        name: prometheus-k8s
+        namespace: openshift-sre-observe
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ethtool-exporter-token-reviewer
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:auth-delegator
+      subjects:
+      - kind: ServiceAccount
+        name: ethtool-exporter-sa
+        namespace: openshift-sre-observe
+    - apiVersion: security.openshift.io/v1
+      kind: SecurityContextConstraints
+      metadata:
+        annotations:
+          kubernetes.io/description: ethtool-exporter scc used by supplemental node-exporter
+            to provide ethtool metrics
+        name: ethtool-exporter
+      allowHostDirVolumePlugin: true
+      allowHostIPC: false
+      allowHostNetwork: true
+      allowHostPID: true
+      allowHostPorts: true
+      allowPrivilegeEscalation: true
+      allowPrivilegedContainer: true
+      allowedCapabilities: null
+      defaultAddCapabilities: null
+      fsGroup:
+        type: RunAsAny
+      groups: []
+      priority: null
+      readOnlyRootFilesystem: false
+      requiredDropCapabilities: null
+      runAsUser:
+        type: RunAsAny
+      seLinuxContext:
+        type: RunAsAny
+      seccompProfiles:
+      - runtime/default
+      supplementalGroups:
+        type: RunAsAny
+      users:
+      - system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa
+      volumes:
+      - '*'
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        annotations: null
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+        name: ethtool-exporter-ca-bundle
+        namespace: openshift-sre-observe
+    - apiVersion: v1
+      kind: Secret
+      data:
+        config.yaml: ImF1dGhvcml6YXRpb24iOgogICJzdGF0aWMiOgogIC0gInBhdGgiOiAiL21ldHJpY3MiCiAgICAicmVzb3VyY2VSZXF1ZXN0IjogZmFsc2UKICAgICJ1c2VyIjoKICAgICAgIm5hbWUiOiAic3lzdGVtOnNlcnZpY2VhY2NvdW50Om9wZW5zaGlmdC1tb25pdG9yaW5nOnByb21ldGhldXMtazhzIgogICAgInZlcmIiOiAiZ2V0Ig==
+      metadata:
+        labels: null
+        name: ethtool-exporter-kube-rbac-proxy-config
+        namespace: openshift-sre-observe
+      type: Opaque
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        annotations:
+          openshift.io/required-scc: ethtool-exporter
+          openshift.io/scc: ethtool-exporter
+          seccomp.security.alpha.kubernetes.io/pod: runtime/default
+          openshift.io/description: Provde supplemental ethtool metrics not currently
+            available in CMO
+        labels:
+          app.kubernetes.io/component: exporter
+          app.kubernetes.io/name: ethtool-exporter
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: exporter
+            app.kubernetes.io/name: ethtool-exporter
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: exporter
+              app.kubernetes.io/name: ethtool-exporter
+          spec:
+            automountServiceAccountToken: true
+            dnsPolicy: ClusterFirst
+            hostNetwork: true
+            hostPID: true
+            nodeSelector:
+              kubernetes.io/os: linux
+            tolerations:
+            - operator: Exists
+            serviceAccount: ethtool-exporter-sa
+            serviceAccountName: ethtool-exporter-sa
+            containers:
+            - args:
+              - --web.listen-address=127.0.0.1:9500
+              - --path.sysfs=/host/sys
+              - --path.rootfs=/host/root
+              - --path.procfs=/host/proc
+              - --path.udev.data="/host/root/run/udev/data"
+              - --collector.disable-defaults
+              - --collector.ethtool
+              - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
+              - --runtime.gomaxprocs=0
+              name: ethtool-exporter
+              image: prom/node-exporter
+              command:
+              - /bin/sh
+              - -c
+              - "export GOMAXPROCS=4\n# We don't take CPU affinity into account as\
+                \ the container doesn't have integer CPU requests.\n# In case of error,\
+                \ fallback to the default value.\nNUM_CPUS=$(grep -c '^processor'\
+                \ \"/proc/cpuinfo\" 2>/dev/null || echo \"0\")\nif [ \"$NUM_CPUS\"\
+                \ -lt \"$GOMAXPROCS\" ]; then\n  export GOMAXPROCS=\"$NUM_CPUS\"\n\
+                fi\necho \"num_cpus=$NUM_CPUS gomaxprocs=$GOMAXPROCS\"\nexec /bin/node_exporter\
+                \ \"$0\" \"$@\"\n"
+              env:
+              - name: DBUS_SYSTEM_BUS_ADDRESS
+                value: unix:path=/host/root/var/run/dbus/system_bus_socket
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 250m
+                  memory: 180Mi
+                requests:
+                  cpu: 8m
+                  memory: 32Mi
+              securityContext: {}
+              volumeMounts:
+              - name: rootfs
+                mountPath: /host/root
+                readOnly: true
+              - name: sysfs
+                mountPath: /host/sys
+                readOnly: true
+              - mountPath: /var/node_exporter/text/file
+                name: node-exporter-textfile
+                readOnly: true
+              - name: procfs
+                mountPath: /host/proc
+                readOnly: true
+              workingDir: /var/node_exporter/textfile
+            - args:
+              - --secure-listen-address=[$(IP)]:9500
+              - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+              - --upstream=http://127.0.0.1:9500/
+              - --tls-cert-file=/etc/tls/private/tls.crt
+              - --config-file=/etc/kube-rbac-policy/config.yaml
+              - --tls-min-version=VersionTLS12
+              - --tls-private-key-file=/etc/tls/private/tls.key
+              - --client-ca-file=/etc/tls/client/ca-bundle.crt
+              env:
+              - name: IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.podIP
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+              imagePullPolicy: IfNotPresent
+              name: kube-rbac-proxy
+              ports:
+              - containerPort: 9500
+                hostPort: 9500
+                name: exporter-port
+                protocol: TCP
+              resources:
+                requests:
+                  cpu: 1m
+                  memory: 15Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsGroup: 65532
+                runAsNonRoot: true
+                runAsUser: 65532
+                seccompProfile:
+                  type: RuntimeDefault
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+              - mountPath: /etc/tls/private
+                name: ethtool-exporter-tls
+              - mountPath: /etc/tls/client
+                name: ethtool-exporter-ca-bundle
+              - mountPath: /etc/kube-rbac-policy
+                name: ethtool-exporter-kube-rbac-proxy-config
+                readOnly: true
+            initContainers:
+            - command:
+              - /bin/sh
+              - -c
+              - '[[ ! -d /node_exporter/collectors/init ]] || find /node_exporter/collectors/init
+                -perm /111 -type f -exec {} \;'
+              env:
+              - name: TMPDIR
+                value: /tmp
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+              imagePullPolicy: IfNotPresent
+              name: init-textfile
+              resources:
+                requests:
+                  cpu: 1m
+                  memory: 1Mi
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+              - mountPath: /var/node_exporter/textfile
+                name: node-exporter-textfile
+              - mountPath: /var/log/wtmp
+                name: node-exporter-wtmp
+                readOnly: true
+              workingDir: /var/node_exporter/textfile
+            volumes:
+            - name: rootfs
+              hostPath:
+                path: /
+            - name: sysfs
+              hostPath:
+                path: /sys
+            - name: procfs
+              hostPath:
+                path: /proc
+            - emptyDir: {}
+              name: node-exporter-textfile
+            - hostPath:
+                path: /var/log/wtmp
+                type: File
+              name: node-exporter-wtmp
+            - name: ethtool-exporter-tls
+              secret:
+                defaultMode: 420
+                secretName: ethtool-exporter-tls
+            - name: ethtool-exporter-kube-rbac-proxy-config
+              secret:
+                defaultMode: 420
+                secretName: ethtool-exporter-kube-rbac-proxy-config
+            - configMap:
+                defaultMode: 420
+                name: ethtool-exporter-ca-bundle
+              name: ethtool-exporter-ca-bundle
+    - kind: Service
+      apiVersion: v1
+      metadata:
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+        annotations:
+          service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
+        labels:
+          app: ethtool-exporter
+      spec:
+        type: ClusterIP
+        selector:
+          app.kubernetes.io/component: exporter
+          app.kubernetes.io/name: ethtool-exporter
+        ports:
+        - name: https
+          protocol: TCP
+          port: 9500
+          targetPort: 9500
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        labels:
+          monitoring.openshift.io/collection-profile: full
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+      spec:
+        endpoints:
+        - interval: 15s
+          bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          port: https
+          scheme: https
+          tlsConfig:
+            serverName: ethtool-exporter.openshift-sre-observe.svc
+            ca:
+              configMap:
+                key: service-ca.crt
+                name: openshift-service-ca.crt
+            cert:
+              secret:
+                key: tls.crt
+                name: ethtool-exporter-tls
+            keySecret:
+              key: tls.key
+              name: ethtool-exporter-tls
+          metricRelabelings:
+          - action: keep
+            regex: node_ethtool_.*_allowance_exceeded
+            sourceLabels:
+            - __name__
+          relabelings:
+          - action: replace
+            regex: (.*)
+            replacement: $1
+            sourceLabels:
+            - __meta_kubernetes_pod_node_name
+            targetLabel: instance
+        jobLabel: app.kubernetes.io/name
+        scrapeClass: tls-client-certificate-auth
+        namespaceSelector:
+          matchNames:
+          - openshift-sre-observe
+        selector:
+          matchLabels:
+            app: ethtool-exporter
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: velero-configuration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48158,29 +48158,29 @@ objects:
         annotations:
           openshift.io/description: Provide supplemental metrics not currently available
             in Openshift CMO
-          openshift.io/display-name: openshift-sre-observe
+          openshift.io/display-name: openshift-sre-ethtool-exporter
           security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
         labels:
-          kubernetes.io/metadata.name: openshift-sre-observe
+          kubernetes.io/metadata.name: openshift-sre-ethtool-exporter
           openshift.io/cluster-monitoring: 'true'
           pod-security.kubernetes.io/audit: privileged
           pod-security.kubernetes.io/audit-version: latest
           pod-security.kubernetes.io/warn: privileged
           pod-security.kubernetes.io/warn-version: latest
-        name: openshift-sre-observe
+        name: openshift-sre-ethtool-exporter
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
         annotations: null
         labels: null
         name: ethtool-exporter-sa
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
         labels: null
         name: prometheus-k8s
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       rules:
       - apiGroups:
         - ''
@@ -48197,7 +48197,7 @@ objects:
       metadata:
         labels: null
         name: prometheus-k8s
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
@@ -48217,7 +48217,7 @@ objects:
       subjects:
       - kind: ServiceAccount
         name: ethtool-exporter-sa
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: security.openshift.io/v1
       kind: SecurityContextConstraints
       metadata:
@@ -48249,7 +48249,7 @@ objects:
       supplementalGroups:
         type: RunAsAny
       users:
-      - system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa
+      - system:serviceaccount:openshift-sre-ethtool-exporter:ethtool-exporter-sa
       volumes:
       - '*'
     - apiVersion: v1
@@ -48259,7 +48259,7 @@ objects:
         labels:
           config.openshift.io/inject-trusted-cabundle: 'true'
         name: ethtool-exporter-ca-bundle
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: v1
       kind: Secret
       data:
@@ -48267,7 +48267,7 @@ objects:
       metadata:
         labels: null
         name: ethtool-exporter-kube-rbac-proxy-config
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       type: Opaque
     - apiVersion: apps/v1
       kind: DaemonSet
@@ -48282,7 +48282,7 @@ objects:
           app.kubernetes.io/component: exporter
           app.kubernetes.io/name: ethtool-exporter
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       spec:
         selector:
           matchLabels:
@@ -48316,7 +48316,7 @@ objects:
               - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
               - --runtime.gomaxprocs=0
               name: ethtool-exporter
-              image: prom/node-exporter
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
               command:
               - /bin/sh
               - -c
@@ -48368,7 +48368,7 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: status.podIP
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
               imagePullPolicy: IfNotPresent
               name: kube-rbac-proxy
               ports:
@@ -48410,7 +48410,7 @@ objects:
               env:
               - name: TMPDIR
                 value: /tmp
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
               imagePullPolicy: IfNotPresent
               name: init-textfile
               resources:
@@ -48461,7 +48461,7 @@ objects:
       apiVersion: v1
       metadata:
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
         annotations:
           service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
         labels:
@@ -48482,7 +48482,7 @@ objects:
         labels:
           monitoring.openshift.io/collection-profile: full
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       spec:
         endpoints:
         - interval: 15s
@@ -48490,7 +48490,7 @@ objects:
           port: https
           scheme: https
           tlsConfig:
-            serverName: ethtool-exporter.openshift-sre-observe.svc
+            serverName: ethtool-exporter.openshift-sre-ethtool-exporter.svc
             ca:
               configMap:
                 key: service-ca.crt
@@ -48518,7 +48518,7 @@ objects:
         scrapeClass: tls-client-certificate-auth
         namespaceSelector:
           matchNames:
-          - openshift-sre-observe
+          - openshift-sre-ethtool-exporter
         selector:
           matchLabels:
             app: ethtool-exporter

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48346,13 +48346,13 @@ objects:
               - name: sysfs
                 mountPath: /host/sys
                 readOnly: true
-              - mountPath: /var/node_exporter/text/file
-                name: node-exporter-textfile
+              - mountPath: /var/ethtool_exporter/text/file
+                name: ethtool-exporter-textfile
                 readOnly: true
               - name: procfs
                 mountPath: /host/proc
                 readOnly: true
-              workingDir: /var/node_exporter/textfile
+              workingDir: /var/ethtool_exporter/textfile
             - args:
               - --secure-listen-address=[$(IP)]:9500
               - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
@@ -48423,12 +48423,12 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
               volumeMounts:
-              - mountPath: /var/node_exporter/textfile
-                name: node-exporter-textfile
+              - mountPath: /var/ethtool_exporter/textfile
+                name: ethtool-exporter-textfile
               - mountPath: /var/log/wtmp
-                name: node-exporter-wtmp
+                name: ethtool-exporter-wtmp
                 readOnly: true
-              workingDir: /var/node_exporter/textfile
+              workingDir: /var/ethtool_exporter/textfile
             volumes:
             - name: rootfs
               hostPath:
@@ -48440,11 +48440,11 @@ objects:
               hostPath:
                 path: /proc
             - emptyDir: {}
-              name: node-exporter-textfile
+              name: ethtool-exporter-textfile
             - hostPath:
                 path: /var/log/wtmp
                 type: File
-              name: node-exporter-wtmp
+              name: ethtool-exporter-wtmp
             - name: ethtool-exporter-tls
               secret:
                 defaultMode: 420
@@ -48515,7 +48515,6 @@ objects:
             - __meta_kubernetes_pod_node_name
             targetLabel: instance
         jobLabel: app.kubernetes.io/name
-        scrapeClass: tls-client-certificate-auth
         namespaceSelector:
           matchNames:
           - openshift-sre-ethtool-exporter

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48150,6 +48150,11 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+        - staging
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48151,10 +48151,9 @@ objects:
         values:
         - 'true'
       - key: api.openshift.com/environment
-        operator: In
+        operator: NotIn
         values:
-        - integration
-        - staging
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48136,6 +48136,399 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: srep-1000-ethtool-exporter
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        annotations:
+          openshift.io/description: Provide supplemental metrics not currently available
+            in Openshift CMO
+          openshift.io/display-name: openshift-sre-observe
+          security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
+        labels:
+          kubernetes.io/metadata.name: openshift-sre-observe
+          openshift.io/cluster-monitoring: 'true'
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
+        name: openshift-sre-observe
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        annotations: null
+        labels: null
+        name: ethtool-exporter-sa
+        namespace: openshift-sre-observe
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        labels: null
+        name: prometheus-k8s
+        namespace: openshift-sre-observe
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        labels: null
+        name: prometheus-k8s
+        namespace: openshift-sre-observe
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ethtool-exporter-token-reviewer
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:auth-delegator
+      subjects:
+      - kind: ServiceAccount
+        name: ethtool-exporter-sa
+        namespace: openshift-sre-observe
+    - apiVersion: security.openshift.io/v1
+      kind: SecurityContextConstraints
+      metadata:
+        annotations:
+          kubernetes.io/description: ethtool-exporter scc used by supplemental node-exporter
+            to provide ethtool metrics
+        name: ethtool-exporter
+      allowHostDirVolumePlugin: true
+      allowHostIPC: false
+      allowHostNetwork: true
+      allowHostPID: true
+      allowHostPorts: true
+      allowPrivilegeEscalation: true
+      allowPrivilegedContainer: true
+      allowedCapabilities: null
+      defaultAddCapabilities: null
+      fsGroup:
+        type: RunAsAny
+      groups: []
+      priority: null
+      readOnlyRootFilesystem: false
+      requiredDropCapabilities: null
+      runAsUser:
+        type: RunAsAny
+      seLinuxContext:
+        type: RunAsAny
+      seccompProfiles:
+      - runtime/default
+      supplementalGroups:
+        type: RunAsAny
+      users:
+      - system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa
+      volumes:
+      - '*'
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        annotations: null
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+        name: ethtool-exporter-ca-bundle
+        namespace: openshift-sre-observe
+    - apiVersion: v1
+      kind: Secret
+      data:
+        config.yaml: ImF1dGhvcml6YXRpb24iOgogICJzdGF0aWMiOgogIC0gInBhdGgiOiAiL21ldHJpY3MiCiAgICAicmVzb3VyY2VSZXF1ZXN0IjogZmFsc2UKICAgICJ1c2VyIjoKICAgICAgIm5hbWUiOiAic3lzdGVtOnNlcnZpY2VhY2NvdW50Om9wZW5zaGlmdC1tb25pdG9yaW5nOnByb21ldGhldXMtazhzIgogICAgInZlcmIiOiAiZ2V0Ig==
+      metadata:
+        labels: null
+        name: ethtool-exporter-kube-rbac-proxy-config
+        namespace: openshift-sre-observe
+      type: Opaque
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        annotations:
+          openshift.io/required-scc: ethtool-exporter
+          openshift.io/scc: ethtool-exporter
+          seccomp.security.alpha.kubernetes.io/pod: runtime/default
+          openshift.io/description: Provde supplemental ethtool metrics not currently
+            available in CMO
+        labels:
+          app.kubernetes.io/component: exporter
+          app.kubernetes.io/name: ethtool-exporter
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: exporter
+            app.kubernetes.io/name: ethtool-exporter
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: exporter
+              app.kubernetes.io/name: ethtool-exporter
+          spec:
+            automountServiceAccountToken: true
+            dnsPolicy: ClusterFirst
+            hostNetwork: true
+            hostPID: true
+            nodeSelector:
+              kubernetes.io/os: linux
+            tolerations:
+            - operator: Exists
+            serviceAccount: ethtool-exporter-sa
+            serviceAccountName: ethtool-exporter-sa
+            containers:
+            - args:
+              - --web.listen-address=127.0.0.1:9500
+              - --path.sysfs=/host/sys
+              - --path.rootfs=/host/root
+              - --path.procfs=/host/proc
+              - --path.udev.data="/host/root/run/udev/data"
+              - --collector.disable-defaults
+              - --collector.ethtool
+              - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
+              - --runtime.gomaxprocs=0
+              name: ethtool-exporter
+              image: prom/node-exporter
+              command:
+              - /bin/sh
+              - -c
+              - "export GOMAXPROCS=4\n# We don't take CPU affinity into account as\
+                \ the container doesn't have integer CPU requests.\n# In case of error,\
+                \ fallback to the default value.\nNUM_CPUS=$(grep -c '^processor'\
+                \ \"/proc/cpuinfo\" 2>/dev/null || echo \"0\")\nif [ \"$NUM_CPUS\"\
+                \ -lt \"$GOMAXPROCS\" ]; then\n  export GOMAXPROCS=\"$NUM_CPUS\"\n\
+                fi\necho \"num_cpus=$NUM_CPUS gomaxprocs=$GOMAXPROCS\"\nexec /bin/node_exporter\
+                \ \"$0\" \"$@\"\n"
+              env:
+              - name: DBUS_SYSTEM_BUS_ADDRESS
+                value: unix:path=/host/root/var/run/dbus/system_bus_socket
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 250m
+                  memory: 180Mi
+                requests:
+                  cpu: 8m
+                  memory: 32Mi
+              securityContext: {}
+              volumeMounts:
+              - name: rootfs
+                mountPath: /host/root
+                readOnly: true
+              - name: sysfs
+                mountPath: /host/sys
+                readOnly: true
+              - mountPath: /var/node_exporter/text/file
+                name: node-exporter-textfile
+                readOnly: true
+              - name: procfs
+                mountPath: /host/proc
+                readOnly: true
+              workingDir: /var/node_exporter/textfile
+            - args:
+              - --secure-listen-address=[$(IP)]:9500
+              - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+              - --upstream=http://127.0.0.1:9500/
+              - --tls-cert-file=/etc/tls/private/tls.crt
+              - --config-file=/etc/kube-rbac-policy/config.yaml
+              - --tls-min-version=VersionTLS12
+              - --tls-private-key-file=/etc/tls/private/tls.key
+              - --client-ca-file=/etc/tls/client/ca-bundle.crt
+              env:
+              - name: IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.podIP
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+              imagePullPolicy: IfNotPresent
+              name: kube-rbac-proxy
+              ports:
+              - containerPort: 9500
+                hostPort: 9500
+                name: exporter-port
+                protocol: TCP
+              resources:
+                requests:
+                  cpu: 1m
+                  memory: 15Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsGroup: 65532
+                runAsNonRoot: true
+                runAsUser: 65532
+                seccompProfile:
+                  type: RuntimeDefault
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+              - mountPath: /etc/tls/private
+                name: ethtool-exporter-tls
+              - mountPath: /etc/tls/client
+                name: ethtool-exporter-ca-bundle
+              - mountPath: /etc/kube-rbac-policy
+                name: ethtool-exporter-kube-rbac-proxy-config
+                readOnly: true
+            initContainers:
+            - command:
+              - /bin/sh
+              - -c
+              - '[[ ! -d /node_exporter/collectors/init ]] || find /node_exporter/collectors/init
+                -perm /111 -type f -exec {} \;'
+              env:
+              - name: TMPDIR
+                value: /tmp
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+              imagePullPolicy: IfNotPresent
+              name: init-textfile
+              resources:
+                requests:
+                  cpu: 1m
+                  memory: 1Mi
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+              - mountPath: /var/node_exporter/textfile
+                name: node-exporter-textfile
+              - mountPath: /var/log/wtmp
+                name: node-exporter-wtmp
+                readOnly: true
+              workingDir: /var/node_exporter/textfile
+            volumes:
+            - name: rootfs
+              hostPath:
+                path: /
+            - name: sysfs
+              hostPath:
+                path: /sys
+            - name: procfs
+              hostPath:
+                path: /proc
+            - emptyDir: {}
+              name: node-exporter-textfile
+            - hostPath:
+                path: /var/log/wtmp
+                type: File
+              name: node-exporter-wtmp
+            - name: ethtool-exporter-tls
+              secret:
+                defaultMode: 420
+                secretName: ethtool-exporter-tls
+            - name: ethtool-exporter-kube-rbac-proxy-config
+              secret:
+                defaultMode: 420
+                secretName: ethtool-exporter-kube-rbac-proxy-config
+            - configMap:
+                defaultMode: 420
+                name: ethtool-exporter-ca-bundle
+              name: ethtool-exporter-ca-bundle
+    - kind: Service
+      apiVersion: v1
+      metadata:
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+        annotations:
+          service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
+        labels:
+          app: ethtool-exporter
+      spec:
+        type: ClusterIP
+        selector:
+          app.kubernetes.io/component: exporter
+          app.kubernetes.io/name: ethtool-exporter
+        ports:
+        - name: https
+          protocol: TCP
+          port: 9500
+          targetPort: 9500
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        labels:
+          monitoring.openshift.io/collection-profile: full
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+      spec:
+        endpoints:
+        - interval: 15s
+          bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          port: https
+          scheme: https
+          tlsConfig:
+            serverName: ethtool-exporter.openshift-sre-observe.svc
+            ca:
+              configMap:
+                key: service-ca.crt
+                name: openshift-service-ca.crt
+            cert:
+              secret:
+                key: tls.crt
+                name: ethtool-exporter-tls
+            keySecret:
+              key: tls.key
+              name: ethtool-exporter-tls
+          metricRelabelings:
+          - action: keep
+            regex: node_ethtool_.*_allowance_exceeded
+            sourceLabels:
+            - __name__
+          relabelings:
+          - action: replace
+            regex: (.*)
+            replacement: $1
+            sourceLabels:
+            - __meta_kubernetes_pod_node_name
+            targetLabel: instance
+        jobLabel: app.kubernetes.io/name
+        scrapeClass: tls-client-certificate-auth
+        namespaceSelector:
+          matchNames:
+          - openshift-sre-observe
+        selector:
+          matchLabels:
+            app: ethtool-exporter
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: velero-configuration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48158,29 +48158,29 @@ objects:
         annotations:
           openshift.io/description: Provide supplemental metrics not currently available
             in Openshift CMO
-          openshift.io/display-name: openshift-sre-observe
+          openshift.io/display-name: openshift-sre-ethtool-exporter
           security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
         labels:
-          kubernetes.io/metadata.name: openshift-sre-observe
+          kubernetes.io/metadata.name: openshift-sre-ethtool-exporter
           openshift.io/cluster-monitoring: 'true'
           pod-security.kubernetes.io/audit: privileged
           pod-security.kubernetes.io/audit-version: latest
           pod-security.kubernetes.io/warn: privileged
           pod-security.kubernetes.io/warn-version: latest
-        name: openshift-sre-observe
+        name: openshift-sre-ethtool-exporter
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
         annotations: null
         labels: null
         name: ethtool-exporter-sa
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
         labels: null
         name: prometheus-k8s
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       rules:
       - apiGroups:
         - ''
@@ -48197,7 +48197,7 @@ objects:
       metadata:
         labels: null
         name: prometheus-k8s
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
@@ -48217,7 +48217,7 @@ objects:
       subjects:
       - kind: ServiceAccount
         name: ethtool-exporter-sa
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: security.openshift.io/v1
       kind: SecurityContextConstraints
       metadata:
@@ -48249,7 +48249,7 @@ objects:
       supplementalGroups:
         type: RunAsAny
       users:
-      - system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa
+      - system:serviceaccount:openshift-sre-ethtool-exporter:ethtool-exporter-sa
       volumes:
       - '*'
     - apiVersion: v1
@@ -48259,7 +48259,7 @@ objects:
         labels:
           config.openshift.io/inject-trusted-cabundle: 'true'
         name: ethtool-exporter-ca-bundle
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: v1
       kind: Secret
       data:
@@ -48267,7 +48267,7 @@ objects:
       metadata:
         labels: null
         name: ethtool-exporter-kube-rbac-proxy-config
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       type: Opaque
     - apiVersion: apps/v1
       kind: DaemonSet
@@ -48282,7 +48282,7 @@ objects:
           app.kubernetes.io/component: exporter
           app.kubernetes.io/name: ethtool-exporter
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       spec:
         selector:
           matchLabels:
@@ -48316,7 +48316,7 @@ objects:
               - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
               - --runtime.gomaxprocs=0
               name: ethtool-exporter
-              image: prom/node-exporter
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
               command:
               - /bin/sh
               - -c
@@ -48368,7 +48368,7 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: status.podIP
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
               imagePullPolicy: IfNotPresent
               name: kube-rbac-proxy
               ports:
@@ -48410,7 +48410,7 @@ objects:
               env:
               - name: TMPDIR
                 value: /tmp
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
               imagePullPolicy: IfNotPresent
               name: init-textfile
               resources:
@@ -48461,7 +48461,7 @@ objects:
       apiVersion: v1
       metadata:
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
         annotations:
           service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
         labels:
@@ -48482,7 +48482,7 @@ objects:
         labels:
           monitoring.openshift.io/collection-profile: full
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       spec:
         endpoints:
         - interval: 15s
@@ -48490,7 +48490,7 @@ objects:
           port: https
           scheme: https
           tlsConfig:
-            serverName: ethtool-exporter.openshift-sre-observe.svc
+            serverName: ethtool-exporter.openshift-sre-ethtool-exporter.svc
             ca:
               configMap:
                 key: service-ca.crt
@@ -48518,7 +48518,7 @@ objects:
         scrapeClass: tls-client-certificate-auth
         namespaceSelector:
           matchNames:
-          - openshift-sre-observe
+          - openshift-sre-ethtool-exporter
         selector:
           matchLabels:
             app: ethtool-exporter

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48346,13 +48346,13 @@ objects:
               - name: sysfs
                 mountPath: /host/sys
                 readOnly: true
-              - mountPath: /var/node_exporter/text/file
-                name: node-exporter-textfile
+              - mountPath: /var/ethtool_exporter/text/file
+                name: ethtool-exporter-textfile
                 readOnly: true
               - name: procfs
                 mountPath: /host/proc
                 readOnly: true
-              workingDir: /var/node_exporter/textfile
+              workingDir: /var/ethtool_exporter/textfile
             - args:
               - --secure-listen-address=[$(IP)]:9500
               - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
@@ -48423,12 +48423,12 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
               volumeMounts:
-              - mountPath: /var/node_exporter/textfile
-                name: node-exporter-textfile
+              - mountPath: /var/ethtool_exporter/textfile
+                name: ethtool-exporter-textfile
               - mountPath: /var/log/wtmp
-                name: node-exporter-wtmp
+                name: ethtool-exporter-wtmp
                 readOnly: true
-              workingDir: /var/node_exporter/textfile
+              workingDir: /var/ethtool_exporter/textfile
             volumes:
             - name: rootfs
               hostPath:
@@ -48440,11 +48440,11 @@ objects:
               hostPath:
                 path: /proc
             - emptyDir: {}
-              name: node-exporter-textfile
+              name: ethtool-exporter-textfile
             - hostPath:
                 path: /var/log/wtmp
                 type: File
-              name: node-exporter-wtmp
+              name: ethtool-exporter-wtmp
             - name: ethtool-exporter-tls
               secret:
                 defaultMode: 420
@@ -48515,7 +48515,6 @@ objects:
             - __meta_kubernetes_pod_node_name
             targetLabel: instance
         jobLabel: app.kubernetes.io/name
-        scrapeClass: tls-client-certificate-auth
         namespaceSelector:
           matchNames:
           - openshift-sre-ethtool-exporter

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48150,6 +48150,11 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+        - staging
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48151,10 +48151,9 @@ objects:
         values:
         - 'true'
       - key: api.openshift.com/environment
-        operator: In
+        operator: NotIn
         values:
-        - integration
-        - staging
+        - production
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48136,6 +48136,399 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: srep-1000-ethtool-exporter
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        annotations:
+          openshift.io/description: Provide supplemental metrics not currently available
+            in Openshift CMO
+          openshift.io/display-name: openshift-sre-observe
+          security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
+        labels:
+          kubernetes.io/metadata.name: openshift-sre-observe
+          openshift.io/cluster-monitoring: 'true'
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/audit-version: latest
+          pod-security.kubernetes.io/warn: privileged
+          pod-security.kubernetes.io/warn-version: latest
+        name: openshift-sre-observe
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        annotations: null
+        labels: null
+        name: ethtool-exporter-sa
+        namespace: openshift-sre-observe
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        labels: null
+        name: prometheus-k8s
+        namespace: openshift-sre-observe
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - services
+        - endpoints
+        - pods
+        verbs:
+        - get
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        labels: null
+        name: prometheus-k8s
+        namespace: openshift-sre-observe
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: prometheus-k8s
+      subjects:
+      - kind: ServiceAccount
+        name: prometheus-k8s
+        namespace: openshift-monitoring
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: ethtool-exporter-token-reviewer
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:auth-delegator
+      subjects:
+      - kind: ServiceAccount
+        name: ethtool-exporter-sa
+        namespace: openshift-sre-observe
+    - apiVersion: security.openshift.io/v1
+      kind: SecurityContextConstraints
+      metadata:
+        annotations:
+          kubernetes.io/description: ethtool-exporter scc used by supplemental node-exporter
+            to provide ethtool metrics
+        name: ethtool-exporter
+      allowHostDirVolumePlugin: true
+      allowHostIPC: false
+      allowHostNetwork: true
+      allowHostPID: true
+      allowHostPorts: true
+      allowPrivilegeEscalation: true
+      allowPrivilegedContainer: true
+      allowedCapabilities: null
+      defaultAddCapabilities: null
+      fsGroup:
+        type: RunAsAny
+      groups: []
+      priority: null
+      readOnlyRootFilesystem: false
+      requiredDropCapabilities: null
+      runAsUser:
+        type: RunAsAny
+      seLinuxContext:
+        type: RunAsAny
+      seccompProfiles:
+      - runtime/default
+      supplementalGroups:
+        type: RunAsAny
+      users:
+      - system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa
+      volumes:
+      - '*'
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        annotations: null
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+        name: ethtool-exporter-ca-bundle
+        namespace: openshift-sre-observe
+    - apiVersion: v1
+      kind: Secret
+      data:
+        config.yaml: ImF1dGhvcml6YXRpb24iOgogICJzdGF0aWMiOgogIC0gInBhdGgiOiAiL21ldHJpY3MiCiAgICAicmVzb3VyY2VSZXF1ZXN0IjogZmFsc2UKICAgICJ1c2VyIjoKICAgICAgIm5hbWUiOiAic3lzdGVtOnNlcnZpY2VhY2NvdW50Om9wZW5zaGlmdC1tb25pdG9yaW5nOnByb21ldGhldXMtazhzIgogICAgInZlcmIiOiAiZ2V0Ig==
+      metadata:
+        labels: null
+        name: ethtool-exporter-kube-rbac-proxy-config
+        namespace: openshift-sre-observe
+      type: Opaque
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        annotations:
+          openshift.io/required-scc: ethtool-exporter
+          openshift.io/scc: ethtool-exporter
+          seccomp.security.alpha.kubernetes.io/pod: runtime/default
+          openshift.io/description: Provde supplemental ethtool metrics not currently
+            available in CMO
+        labels:
+          app.kubernetes.io/component: exporter
+          app.kubernetes.io/name: ethtool-exporter
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: exporter
+            app.kubernetes.io/name: ethtool-exporter
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: exporter
+              app.kubernetes.io/name: ethtool-exporter
+          spec:
+            automountServiceAccountToken: true
+            dnsPolicy: ClusterFirst
+            hostNetwork: true
+            hostPID: true
+            nodeSelector:
+              kubernetes.io/os: linux
+            tolerations:
+            - operator: Exists
+            serviceAccount: ethtool-exporter-sa
+            serviceAccountName: ethtool-exporter-sa
+            containers:
+            - args:
+              - --web.listen-address=127.0.0.1:9500
+              - --path.sysfs=/host/sys
+              - --path.rootfs=/host/root
+              - --path.procfs=/host/proc
+              - --path.udev.data="/host/root/run/udev/data"
+              - --collector.disable-defaults
+              - --collector.ethtool
+              - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
+              - --runtime.gomaxprocs=0
+              name: ethtool-exporter
+              image: prom/node-exporter
+              command:
+              - /bin/sh
+              - -c
+              - "export GOMAXPROCS=4\n# We don't take CPU affinity into account as\
+                \ the container doesn't have integer CPU requests.\n# In case of error,\
+                \ fallback to the default value.\nNUM_CPUS=$(grep -c '^processor'\
+                \ \"/proc/cpuinfo\" 2>/dev/null || echo \"0\")\nif [ \"$NUM_CPUS\"\
+                \ -lt \"$GOMAXPROCS\" ]; then\n  export GOMAXPROCS=\"$NUM_CPUS\"\n\
+                fi\necho \"num_cpus=$NUM_CPUS gomaxprocs=$GOMAXPROCS\"\nexec /bin/node_exporter\
+                \ \"$0\" \"$@\"\n"
+              env:
+              - name: DBUS_SYSTEM_BUS_ADDRESS
+                value: unix:path=/host/root/var/run/dbus/system_bus_socket
+              imagePullPolicy: IfNotPresent
+              resources:
+                limits:
+                  cpu: 250m
+                  memory: 180Mi
+                requests:
+                  cpu: 8m
+                  memory: 32Mi
+              securityContext: {}
+              volumeMounts:
+              - name: rootfs
+                mountPath: /host/root
+                readOnly: true
+              - name: sysfs
+                mountPath: /host/sys
+                readOnly: true
+              - mountPath: /var/node_exporter/text/file
+                name: node-exporter-textfile
+                readOnly: true
+              - name: procfs
+                mountPath: /host/proc
+                readOnly: true
+              workingDir: /var/node_exporter/textfile
+            - args:
+              - --secure-listen-address=[$(IP)]:9500
+              - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+              - --upstream=http://127.0.0.1:9500/
+              - --tls-cert-file=/etc/tls/private/tls.crt
+              - --config-file=/etc/kube-rbac-policy/config.yaml
+              - --tls-min-version=VersionTLS12
+              - --tls-private-key-file=/etc/tls/private/tls.key
+              - --client-ca-file=/etc/tls/client/ca-bundle.crt
+              env:
+              - name: IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.podIP
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+              imagePullPolicy: IfNotPresent
+              name: kube-rbac-proxy
+              ports:
+              - containerPort: 9500
+                hostPort: 9500
+                name: exporter-port
+                protocol: TCP
+              resources:
+                requests:
+                  cpu: 1m
+                  memory: 15Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsGroup: 65532
+                runAsNonRoot: true
+                runAsUser: 65532
+                seccompProfile:
+                  type: RuntimeDefault
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+              - mountPath: /etc/tls/private
+                name: ethtool-exporter-tls
+              - mountPath: /etc/tls/client
+                name: ethtool-exporter-ca-bundle
+              - mountPath: /etc/kube-rbac-policy
+                name: ethtool-exporter-kube-rbac-proxy-config
+                readOnly: true
+            initContainers:
+            - command:
+              - /bin/sh
+              - -c
+              - '[[ ! -d /node_exporter/collectors/init ]] || find /node_exporter/collectors/init
+                -perm /111 -type f -exec {} \;'
+              env:
+              - name: TMPDIR
+                value: /tmp
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+              imagePullPolicy: IfNotPresent
+              name: init-textfile
+              resources:
+                requests:
+                  cpu: 1m
+                  memory: 1Mi
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+              - mountPath: /var/node_exporter/textfile
+                name: node-exporter-textfile
+              - mountPath: /var/log/wtmp
+                name: node-exporter-wtmp
+                readOnly: true
+              workingDir: /var/node_exporter/textfile
+            volumes:
+            - name: rootfs
+              hostPath:
+                path: /
+            - name: sysfs
+              hostPath:
+                path: /sys
+            - name: procfs
+              hostPath:
+                path: /proc
+            - emptyDir: {}
+              name: node-exporter-textfile
+            - hostPath:
+                path: /var/log/wtmp
+                type: File
+              name: node-exporter-wtmp
+            - name: ethtool-exporter-tls
+              secret:
+                defaultMode: 420
+                secretName: ethtool-exporter-tls
+            - name: ethtool-exporter-kube-rbac-proxy-config
+              secret:
+                defaultMode: 420
+                secretName: ethtool-exporter-kube-rbac-proxy-config
+            - configMap:
+                defaultMode: 420
+                name: ethtool-exporter-ca-bundle
+              name: ethtool-exporter-ca-bundle
+    - kind: Service
+      apiVersion: v1
+      metadata:
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+        annotations:
+          service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
+        labels:
+          app: ethtool-exporter
+      spec:
+        type: ClusterIP
+        selector:
+          app.kubernetes.io/component: exporter
+          app.kubernetes.io/name: ethtool-exporter
+        ports:
+        - name: https
+          protocol: TCP
+          port: 9500
+          targetPort: 9500
+    - apiVersion: monitoring.coreos.com/v1
+      kind: ServiceMonitor
+      metadata:
+        labels:
+          monitoring.openshift.io/collection-profile: full
+        name: ethtool-exporter
+        namespace: openshift-sre-observe
+      spec:
+        endpoints:
+        - interval: 15s
+          bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+          port: https
+          scheme: https
+          tlsConfig:
+            serverName: ethtool-exporter.openshift-sre-observe.svc
+            ca:
+              configMap:
+                key: service-ca.crt
+                name: openshift-service-ca.crt
+            cert:
+              secret:
+                key: tls.crt
+                name: ethtool-exporter-tls
+            keySecret:
+              key: tls.key
+              name: ethtool-exporter-tls
+          metricRelabelings:
+          - action: keep
+            regex: node_ethtool_.*_allowance_exceeded
+            sourceLabels:
+            - __name__
+          relabelings:
+          - action: replace
+            regex: (.*)
+            replacement: $1
+            sourceLabels:
+            - __meta_kubernetes_pod_node_name
+            targetLabel: instance
+        jobLabel: app.kubernetes.io/name
+        scrapeClass: tls-client-certificate-auth
+        namespaceSelector:
+          matchNames:
+          - openshift-sre-observe
+        selector:
+          matchLabels:
+            app: ethtool-exporter
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: velero-configuration
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48158,29 +48158,29 @@ objects:
         annotations:
           openshift.io/description: Provide supplemental metrics not currently available
             in Openshift CMO
-          openshift.io/display-name: openshift-sre-observe
+          openshift.io/display-name: openshift-sre-ethtool-exporter
           security.openshift.io/MinimallySufficientPodSecurityStandard: privileged
         labels:
-          kubernetes.io/metadata.name: openshift-sre-observe
+          kubernetes.io/metadata.name: openshift-sre-ethtool-exporter
           openshift.io/cluster-monitoring: 'true'
           pod-security.kubernetes.io/audit: privileged
           pod-security.kubernetes.io/audit-version: latest
           pod-security.kubernetes.io/warn: privileged
           pod-security.kubernetes.io/warn-version: latest
-        name: openshift-sre-observe
+        name: openshift-sre-ethtool-exporter
     - apiVersion: v1
       kind: ServiceAccount
       metadata:
         annotations: null
         labels: null
         name: ethtool-exporter-sa
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
         labels: null
         name: prometheus-k8s
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       rules:
       - apiGroups:
         - ''
@@ -48197,7 +48197,7 @@ objects:
       metadata:
         labels: null
         name: prometheus-k8s
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       roleRef:
         apiGroup: rbac.authorization.k8s.io
         kind: Role
@@ -48217,7 +48217,7 @@ objects:
       subjects:
       - kind: ServiceAccount
         name: ethtool-exporter-sa
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: security.openshift.io/v1
       kind: SecurityContextConstraints
       metadata:
@@ -48249,7 +48249,7 @@ objects:
       supplementalGroups:
         type: RunAsAny
       users:
-      - system:serviceaccount:openshift-sre-observe:ethtool-exporter-sa
+      - system:serviceaccount:openshift-sre-ethtool-exporter:ethtool-exporter-sa
       volumes:
       - '*'
     - apiVersion: v1
@@ -48259,7 +48259,7 @@ objects:
         labels:
           config.openshift.io/inject-trusted-cabundle: 'true'
         name: ethtool-exporter-ca-bundle
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
     - apiVersion: v1
       kind: Secret
       data:
@@ -48267,7 +48267,7 @@ objects:
       metadata:
         labels: null
         name: ethtool-exporter-kube-rbac-proxy-config
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       type: Opaque
     - apiVersion: apps/v1
       kind: DaemonSet
@@ -48282,7 +48282,7 @@ objects:
           app.kubernetes.io/component: exporter
           app.kubernetes.io/name: ethtool-exporter
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       spec:
         selector:
           matchLabels:
@@ -48316,7 +48316,7 @@ objects:
               - --collector.ethtool.metrics-include=^(bw_in_allowance_exceeded|bw_out_allowance_exceeded|conntrack_allowance_exceeded|linklocal_allowance_exceeded|pps_allowance_exceeded)$
               - --runtime.gomaxprocs=0
               name: ethtool-exporter
-              image: prom/node-exporter
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
               command:
               - /bin/sh
               - -c
@@ -48368,7 +48368,7 @@ objects:
                   fieldRef:
                     apiVersion: v1
                     fieldPath: status.podIP
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:971174692a1aae68ac07ffa132254eb3c018a52507eb32621b6dc286fd25ca0d
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:82f5ad5a8c1827db890f6bbb9f85e3f571eceba5bc6903b721be6fdeaea651fa
               imagePullPolicy: IfNotPresent
               name: kube-rbac-proxy
               ports:
@@ -48410,7 +48410,7 @@ objects:
               env:
               - name: TMPDIR
                 value: /tmp
-              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:310bb92390dfc716f46a4fefed4add1b5e4f09c008985cb24f4ea53a152b1de7
+              image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:85765701a29f4a47596da38ecd9ec26a3a4173a952673c1bf8faf00ab2eb07cd
               imagePullPolicy: IfNotPresent
               name: init-textfile
               resources:
@@ -48461,7 +48461,7 @@ objects:
       apiVersion: v1
       metadata:
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
         annotations:
           service.beta.openshift.io/serving-cert-secret-name: ethtool-exporter-tls
         labels:
@@ -48482,7 +48482,7 @@ objects:
         labels:
           monitoring.openshift.io/collection-profile: full
         name: ethtool-exporter
-        namespace: openshift-sre-observe
+        namespace: openshift-sre-ethtool-exporter
       spec:
         endpoints:
         - interval: 15s
@@ -48490,7 +48490,7 @@ objects:
           port: https
           scheme: https
           tlsConfig:
-            serverName: ethtool-exporter.openshift-sre-observe.svc
+            serverName: ethtool-exporter.openshift-sre-ethtool-exporter.svc
             ca:
               configMap:
                 key: service-ca.crt
@@ -48518,7 +48518,7 @@ objects:
         scrapeClass: tls-client-certificate-auth
         namespaceSelector:
           matchNames:
-          - openshift-sre-observe
+          - openshift-sre-ethtool-exporter
         selector:
           matchLabels:
             app: ethtool-exporter

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48346,13 +48346,13 @@ objects:
               - name: sysfs
                 mountPath: /host/sys
                 readOnly: true
-              - mountPath: /var/node_exporter/text/file
-                name: node-exporter-textfile
+              - mountPath: /var/ethtool_exporter/text/file
+                name: ethtool-exporter-textfile
                 readOnly: true
               - name: procfs
                 mountPath: /host/proc
                 readOnly: true
-              workingDir: /var/node_exporter/textfile
+              workingDir: /var/ethtool_exporter/textfile
             - args:
               - --secure-listen-address=[$(IP)]:9500
               - --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
@@ -48423,12 +48423,12 @@ objects:
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: FallbackToLogsOnError
               volumeMounts:
-              - mountPath: /var/node_exporter/textfile
-                name: node-exporter-textfile
+              - mountPath: /var/ethtool_exporter/textfile
+                name: ethtool-exporter-textfile
               - mountPath: /var/log/wtmp
-                name: node-exporter-wtmp
+                name: ethtool-exporter-wtmp
                 readOnly: true
-              workingDir: /var/node_exporter/textfile
+              workingDir: /var/ethtool_exporter/textfile
             volumes:
             - name: rootfs
               hostPath:
@@ -48440,11 +48440,11 @@ objects:
               hostPath:
                 path: /proc
             - emptyDir: {}
-              name: node-exporter-textfile
+              name: ethtool-exporter-textfile
             - hostPath:
                 path: /var/log/wtmp
                 type: File
-              name: node-exporter-wtmp
+              name: ethtool-exporter-wtmp
             - name: ethtool-exporter-tls
               secret:
                 defaultMode: 420
@@ -48515,7 +48515,6 @@ objects:
             - __meta_kubernetes_pod_node_name
             targetLabel: instance
         jobLabel: app.kubernetes.io/name
-        scrapeClass: tls-client-certificate-auth
         namespaceSelector:
           matchNames:
           - openshift-sre-ethtool-exporter

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48150,6 +48150,11 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+        - staging
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
Feature. Deploy a supplemental node-exporter daemonset to management-clusters in order to monitor dropped packets per [AWS ENA allowance exceeded metrics](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-network-performance-ena.html#network-performance-metrics). 
This is intended to be a temporary measure to help address [SREP-1000](https://issues.redhat.com/browse/SREP-1000) until CMO supports the node-exporter ethtool collector per [RFE-7342](https://issues.redhat.com/browse/RFE-7342).

### What this PR does / why we need it?
(See [SREP-1000](https://issues.redhat.com/browse/SREP-1000) for additional info). This helps SRE identify the root cause of specific packet drops events due to AWS bandwidth limits.  

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/SREP-1000


### Special notes for your reviewer:
This has been validated with manual deployments. Per normal release cycle, this will need to be validated in int, stage before promoted to prod.  
When current MR is acceptable, this should be tested on an MC in staging prior to merging. 
This should including verifying :
- this installs/applies to cluster w/o error 
- works as expected. Targets are healthy, metrics are query-able in prom and only the exact metrics expected are exported and scraped
- does not interfere with CMO or any other processes
- pod/node resource consumption is reasonable
- important to check on uninstall/delete does not have a negative impact CMO.

I've been testing on a 4.16.42 cluster, and will definitely test on a staging cluster once we are ok with the current draft, and before merging.

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ X] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
