### PR TITLE
Feat(SREP-1598): add EUS deploy patches and update to OCP 4.25

### DIFF
--- a/deploy/osd-channel-patch/candidate-4.20/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/candidate-4.20/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"candidate-4.20"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/candidate-4.20/config.yaml
+++ b/deploy/osd-channel-patch/candidate-4.20/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.20"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["candidate"]

--- a/deploy/osd-channel-patch/candidate-4.21/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/candidate-4.21/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"candidate-4.21"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/candidate-4.21/config.yaml
+++ b/deploy/osd-channel-patch/candidate-4.21/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.21"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["candidate"]

--- a/deploy/osd-channel-patch/candidate-4.22/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/candidate-4.22/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"candidate-4.22"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/candidate-4.22/config.yaml
+++ b/deploy/osd-channel-patch/candidate-4.22/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.22"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["candidate"]

--- a/deploy/osd-channel-patch/candidate-4.23/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/candidate-4.23/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"candidate-4.23"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/candidate-4.23/config.yaml
+++ b/deploy/osd-channel-patch/candidate-4.23/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.23"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["candidate"]

--- a/deploy/osd-channel-patch/candidate-4.24/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/candidate-4.24/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"candidate-4.24"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/candidate-4.24/config.yaml
+++ b/deploy/osd-channel-patch/candidate-4.24/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.24"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["candidate"]

--- a/deploy/osd-channel-patch/candidate-4.25/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/candidate-4.25/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"candidate-4.25"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/candidate-4.25/config.yaml
+++ b/deploy/osd-channel-patch/candidate-4.25/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.25"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["candidate"]

--- a/deploy/osd-channel-patch/eus-4.16/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.16/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.16"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.16/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.16/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.16"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.17/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.17/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.18"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.17/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.17/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.17"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.18/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.18/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.18"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.18/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.18/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.18"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.19/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.19/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.20"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.19/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.19/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.19"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.20/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.20/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.20"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.20/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.20/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.20"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.21/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.21/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.22"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.21/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.21/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.21"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.22/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.22/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.22"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.22/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.22/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.22"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.23/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.23/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.24"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.23/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.23/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.23"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.24/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.24/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.24"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.24/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.24/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.24"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/eus-4.25/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/eus-4.25/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"eus-4.26"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/eus-4.25/config.yaml
+++ b/deploy/osd-channel-patch/eus-4.25/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.25"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["eus"]

--- a/deploy/osd-channel-patch/fast-4.20/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/fast-4.20/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"fast-4.20"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/fast-4.20/config.yaml
+++ b/deploy/osd-channel-patch/fast-4.20/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.20"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["fast"]

--- a/deploy/osd-channel-patch/fast-4.21/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/fast-4.21/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"fast-4.21"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/fast-4.21/config.yaml
+++ b/deploy/osd-channel-patch/fast-4.21/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.21"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["fast"]

--- a/deploy/osd-channel-patch/fast-4.22/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/fast-4.22/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"fast-4.22"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/fast-4.22/config.yaml
+++ b/deploy/osd-channel-patch/fast-4.22/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.22"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["fast"]

--- a/deploy/osd-channel-patch/fast-4.23/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/fast-4.23/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"fast-4.23"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/fast-4.23/config.yaml
+++ b/deploy/osd-channel-patch/fast-4.23/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.23"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["fast"]

--- a/deploy/osd-channel-patch/fast-4.24/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/fast-4.24/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"fast-4.24"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/fast-4.24/config.yaml
+++ b/deploy/osd-channel-patch/fast-4.24/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.24"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["fast"]

--- a/deploy/osd-channel-patch/fast-4.25/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/fast-4.25/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"fast-4.25"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/fast-4.25/config.yaml
+++ b/deploy/osd-channel-patch/fast-4.25/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.25"]
+  - key: api.openshift.com/channel-group
+    operator: In
+    values: ["fast"]

--- a/deploy/osd-channel-patch/stable-4.10/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.10/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.10"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.11/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.11/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.11"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.12/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.12/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.12"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.13/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.13/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.13"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.14/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.14/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.14"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.15/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.15/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.15"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.16/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.16/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.16"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.17/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.17/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.17"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.18/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.18/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.18"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.19/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.19/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.19"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.20/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.20/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.20"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.20/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.20/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.20"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.21/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.21/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.21"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.21/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.21/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.21"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.22/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.22/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.22"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.22/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.22/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.22"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.23/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.23/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.23"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.23/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.23/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.23"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.24/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.24/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.24"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.24/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.24/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.24"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.25/01-patch.clusterversion.yaml
+++ b/deploy/osd-channel-patch/stable-4.25/01-patch.clusterversion.yaml
@@ -1,0 +1,6 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterVersion
+name: version
+applyMode: AlwaysApply
+patch: '{"spec":{"channel":"stable-4.25"}}'
+patchType: merge

--- a/deploy/osd-channel-patch/stable-4.25/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.25/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.25"]
+  - key: api.openshift.com/channel-group
+    operator: NotIn
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.5/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.5/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.5"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.6/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.6/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.6"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.7/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.7/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.7"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.8/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.8/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.8"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/deploy/osd-channel-patch/stable-4.9/config.yaml
+++ b/deploy/osd-channel-patch/stable-4.9/config.yaml
@@ -6,4 +6,4 @@ selectorSyncSet:
     values: ["4.9"]
   - key: api.openshift.com/channel-group
     operator: NotIn
-    values: ["nightly","candidate","fast"]
+    values: ["nightly","candidate","fast","eus"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -34790,6 +34790,180 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.25"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-channel-patch-candidate-4.5
   spec:
     clusterDeploymentSelector:
@@ -34927,6 +35101,296 @@ objects:
       name: version
       applyMode: AlwaysApply
       patch: '{"spec":{"channel":"candidate-4.9"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.16"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.17
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.17'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.18"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.18
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.18'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.18"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.19
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.19'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.26"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -35225,6 +35689,180 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.25"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-channel-patch-fast-4.5
   spec:
     clusterDeploymentSelector:
@@ -35411,6 +36049,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35442,6 +36081,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35473,6 +36113,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35504,6 +36145,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35535,6 +36177,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35566,6 +36209,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35597,6 +36241,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35628,6 +36273,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35659,6 +36305,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35690,6 +36337,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35697,6 +36345,198 @@ objects:
       name: version
       applyMode: AlwaysApply
       patch: '{"spec":{"channel":"stable-4.19"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.25"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -35721,6 +36561,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35752,6 +36593,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35783,6 +36625,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35814,6 +36657,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35845,6 +36689,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -34790,6 +34790,180 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.25"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-channel-patch-candidate-4.5
   spec:
     clusterDeploymentSelector:
@@ -34927,6 +35101,296 @@ objects:
       name: version
       applyMode: AlwaysApply
       patch: '{"spec":{"channel":"candidate-4.9"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.16"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.17
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.17'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.18"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.18
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.18'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.18"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.19
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.19'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.26"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -35225,6 +35689,180 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.25"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-channel-patch-fast-4.5
   spec:
     clusterDeploymentSelector:
@@ -35411,6 +36049,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35442,6 +36081,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35473,6 +36113,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35504,6 +36145,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35535,6 +36177,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35566,6 +36209,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35597,6 +36241,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35628,6 +36273,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35659,6 +36305,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35690,6 +36337,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35697,6 +36345,198 @@ objects:
       name: version
       applyMode: AlwaysApply
       patch: '{"spec":{"channel":"stable-4.19"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.25"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -35721,6 +36561,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35752,6 +36593,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35783,6 +36625,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35814,6 +36657,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35845,6 +36689,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -34790,6 +34790,180 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-candidate-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - candidate
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"candidate-4.25"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-channel-patch-candidate-4.5
   spec:
     clusterDeploymentSelector:
@@ -34927,6 +35101,296 @@ objects:
       name: version
       applyMode: AlwaysApply
       patch: '{"spec":{"channel":"candidate-4.9"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.16'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.16"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.17
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.17'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.18"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.18
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.18'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.18"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.19
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.19'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-eus-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"eus-4.26"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -35225,6 +35689,180 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-fast-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: In
+        values:
+        - fast
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"fast-4.25"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-channel-patch-fast-4.5
   spec:
     clusterDeploymentSelector:
@@ -35411,6 +36049,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35442,6 +36081,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35473,6 +36113,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35504,6 +36145,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35535,6 +36177,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35566,6 +36209,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35597,6 +36241,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35628,6 +36273,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35659,6 +36305,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35690,6 +36337,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35697,6 +36345,198 @@ objects:
       name: version
       applyMode: AlwaysApply
       patch: '{"spec":{"channel":"stable-4.19"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.20
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.20'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.20"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.21
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.21'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.21"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.22
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.22'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.22"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.23
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.23'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.23"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.24
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.24'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.24"}}'
+      patchType: merge
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: osd-channel-patch-stable-4.25
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.25'
+      - key: api.openshift.com/channel-group
+        operator: NotIn
+        values:
+        - nightly
+        - candidate
+        - fast
+        - eus
+    resourceApplyMode: Sync
+    patches:
+    - apiVersion: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+      applyMode: AlwaysApply
+      patch: '{"spec":{"channel":"stable-4.25"}}'
       patchType: merge
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
@@ -35721,6 +36561,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35752,6 +36593,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35783,6 +36625,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35814,6 +36657,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1
@@ -35845,6 +36689,7 @@ objects:
         - nightly
         - candidate
         - fast
+        - eus
     resourceApplyMode: Sync
     patches:
     - apiVersion: config.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
/feature

### What this PR does / why we need it?

This PR:
- updates existing channel patches all the way to 4.25
- adds eus to channel patches 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/SREP-1598

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
