### PR TITLE
updates legacy branding configmap to deploy to all rosa clusters up to 4.21

### DIFF
--- a/deploy/rosa-console-legacy-branding-configmap/config.yaml
+++ b/deploy/rosa-console-legacy-branding-configmap/config.yaml
@@ -6,7 +6,27 @@ selectorSyncSet:
     values: ["rosa"]
   - key: hive.openshift.io/version-major-minor
     operator: In
-    values: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13", "4.14"]
-    # Due to a race condition found during testing for SREP-901 for upgrades, we do not remove the legacy brand image
-    # until 4.15
+    values:
+      # SREP-1662 - We need to keep this configmap present in ROSA clusters for versions up to 4.22 to support ACM
+      - "4.1"
+      - "4.2"
+      - "4.3"
+      - "4.4"
+      - "4.5"
+      - "4.6"
+      - "4.7"
+      - "4.8"
+      - "4.9"
+      - "4.10"
+      - "4.11"
+      - "4.12"
+      - "4.13"
+      - "4.14"
+      - "4.15"
+      - "4.16"
+      - "4.17"
+      - "4.18"
+      - "4.19"
+      - "4.20"
+      - "4.21"
   applyBehavior: "CreateOrUpdate"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -44838,6 +44838,13 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+        - '4.18'
+        - '4.19'
+        - '4.20'
+        - '4.21'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -44838,6 +44838,13 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+        - '4.18'
+        - '4.19'
+        - '4.20'
+        - '4.21'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -44838,6 +44838,13 @@ objects:
         - '4.12'
         - '4.13'
         - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+        - '4.18'
+        - '4.19'
+        - '4.20'
+        - '4.21'
     resourceApplyMode: Sync
     applyBehavior: CreateOrUpdate
     resources:


### PR DESCRIPTION
### What type of PR is this?
Bug

### What this PR does / why we need it?

ACM depends on this configmap to determine if a cluster is ROSA. We will support this up to 4.21. In the next major ACM release they will branch and look for another thing to determine if a cluster is ROSA or not.

### Which Jira/Github issue(s) this PR fixes?

Fixes [SREP-1662](https://issues.redhat.com//browse/SREP-1662)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
