### PR TITLE
Adding RBAC for MVO to OADP Migration help

### DIFF
--- a/deploy/velero-configuration/120-velero.Secret-Role.yaml
+++ b/deploy/velero-configuration/120-velero.Secret-Role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mvo-migration-reader
+  namespace: openshift-velero
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - velero-iam-credentials
+  verbs:
+  - get

--- a/deploy/velero-configuration/130-velero.Secret-RoleBinding.yaml
+++ b/deploy/velero-configuration/130-velero.Secret-RoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mvo-migration-reader
+  namespace: openshift-velero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mvo-migration-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: dedicated-admins

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -49140,6 +49140,33 @@ objects:
           - events
           snapshotVolumes: false
           ttl: 720h0m0s
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: mvo-migration-reader
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - velero-iam-credentials
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: mvo-migration-reader
+        namespace: openshift-velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: mvo-migration-reader
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -49140,6 +49140,33 @@ objects:
           - events
           snapshotVolumes: false
           ttl: 720h0m0s
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: mvo-migration-reader
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - velero-iam-credentials
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: mvo-migration-reader
+        namespace: openshift-velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: mvo-migration-reader
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -49140,6 +49140,33 @@ objects:
           - events
           snapshotVolumes: false
           ttl: 720h0m0s
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: mvo-migration-reader
+        namespace: openshift-velero
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - secrets
+        resourceNames:
+        - velero-iam-credentials
+        verbs:
+        - get
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: mvo-migration-reader
+        namespace: openshift-velero
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: mvo-migration-reader
+      subjects:
+      - apiGroup: rbac.authorization.k8s.io
+        kind: Group
+        name: dedicated-admins
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
_(maintenance)_

### What this PR does / why we need it?
This PR is specifically for OSD clusters without cluster-admin users to help only dedicated-admin users to be able to restore from default bucket of managed-velero-operator(MVO) via OpenShift API for Data Protection(OADP) operator.

This requirement is due to upcoming deprecation and removal of MVO from OSD and ROSA Classic Non-STS clusters in favor of OADP.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [SREP-1606](https://issues.redhat.com/browse/SREP-1606)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
