### PR TITLE
MON-4343: CMO: Prometheus Adapter was deprecated in 4.17

### DIFF
--- a/deploy/cluster-monitoring-config-non-uwm/4.11-4.16/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/4.11-4.16/50-GENERATED-cluster-monitoring-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    enableUserWorkload: true
+    enableUserWorkload: false
     prometheusK8s:
       remoteWrite:
       - url: ${OBSERVATORIUM_URL}
@@ -38,7 +38,7 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-      retention: 11d
+      retention: 7d
       retentionSize: 85GB
       volumeClaimTemplate:
         metadata:
@@ -76,6 +76,13 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    k8sPrometheusAdapter:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
@@ -105,6 +112,13 @@ data:
         key: node-role.kubernetes.io/infra
         operator: Exists
     metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    grafana:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config-non-uwm/4.11-4.16/config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/4.11-4.16/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16"]
+  - key: ext-managed.openshift.io/uwm-disabled
+    operator: In
+    values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: NotIn
+    values: ["management-cluster"]

--- a/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/50-GENERATED-cluster-monitoring-config.yaml
@@ -76,13 +76,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    k8sPrometheusAdapter:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config-non-uwm/config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/config.yaml
@@ -3,7 +3,7 @@ selectorSyncSet:
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
-      values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10"]
+      values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13", "4.14", "4.15", "4.16"]
     - key: ext-managed.openshift.io/uwm-disabled
       operator: In
       values: ["true"]

--- a/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config-non-uwm/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -76,13 +76,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    k8sPrometheusAdapter:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/cluster-monitoring-config/4.11-4.16/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/4.11-4.16/50-GENERATED-cluster-monitoring-config.yaml
@@ -38,7 +38,7 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-      retention: 11d
+      retention: 7d
       retentionSize: 85GB
       volumeClaimTemplate:
         metadata:
@@ -76,6 +76,13 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
+    k8sPrometheusAdapter:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
@@ -105,6 +112,13 @@ data:
         key: node-role.kubernetes.io/infra
         operator: Exists
     metricsServer:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    grafana:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
       tolerations:

--- a/deploy/cluster-monitoring-config/4.11-4.16/config.yaml
+++ b/deploy/cluster-monitoring-config/4.11-4.16/config.yaml
@@ -1,0 +1,15 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: hive.openshift.io/version-major-minor
+    operator: In
+    values: ["4.11", "4.12", "4.13", "4.14", "4.15", "4.16"]
+  - key: ext-managed.openshift.io/uwm-disabled
+    operator: NotIn
+    values: ["true"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: NotIn
+    values: ["management-cluster"]

--- a/deploy/cluster-monitoring-config/config.yaml
+++ b/deploy/cluster-monitoring-config/config.yaml
@@ -3,7 +3,7 @@ selectorSyncSet:
   matchExpressions:
     - key: hive.openshift.io/version-major-minor
       operator: NotIn
-      values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10"]
+      values: ["4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12", "4.13", "4.14", "4.15", "4.16"]
     - key: ext-managed.openshift.io/uwm-disabled
       operator: NotIn
       values: ["true"]

--- a/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/cluster-monitoring-config/management-clusters/50-GENERATED-cluster-monitoring-config.yaml
@@ -76,13 +76,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    k8sPrometheusAdapter:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
+++ b/deploy/osd-fedramp-cluster-monitoring-config/50-GENERATED-cluster-monitoring-config.yaml
@@ -51,13 +51,6 @@ data:
       - effect: NoSchedule
         key: node-role.kubernetes.io/infra
         operator: Exists
-    k8sPrometheusAdapter:
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/infra
-        operator: Exists
     kubeStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ''

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -30154,6 +30154,12 @@ objects:
         - '4.8'
         - '4.9'
         - '4.10'
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -30196,8 +30202,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30231,6 +30235,12 @@ objects:
         - '4.8'
         - '4.9'
         - '4.10'
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: In
         values:
@@ -30269,6 +30279,77 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-non-uwm-4.11-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (lpsre:slo:pko_deployment_availability|sre:telemetry:package_operator_object_set_succeeded_timestamp_seconds|sre:telemetry:package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30280,6 +30361,8 @@ objects:
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -30399,8 +30482,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30451,6 +30532,85 @@ objects:
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
           \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (lpsre:slo:pko_deployment_availability|sre:telemetry:package_operator_object_set_succeeded_timestamp_seconds|sre:telemetry:package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-4.11-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
           \          key: client-id\n          name: observatorium-credentials\n \
           \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
           \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
@@ -30544,8 +30704,6 @@ objects:
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -38909,9 +39067,7 @@ objects:
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
-          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -30154,6 +30154,12 @@ objects:
         - '4.8'
         - '4.9'
         - '4.10'
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -30196,8 +30202,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30231,6 +30235,12 @@ objects:
         - '4.8'
         - '4.9'
         - '4.10'
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: In
         values:
@@ -30269,6 +30279,77 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-non-uwm-4.11-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (lpsre:slo:pko_deployment_availability|sre:telemetry:package_operator_object_set_succeeded_timestamp_seconds|sre:telemetry:package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30280,6 +30361,8 @@ objects:
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -30399,8 +30482,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30451,6 +30532,85 @@ objects:
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
           \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (lpsre:slo:pko_deployment_availability|sre:telemetry:package_operator_object_set_succeeded_timestamp_seconds|sre:telemetry:package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-4.11-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
           \          key: client-id\n          name: observatorium-credentials\n \
           \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
           \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
@@ -30544,8 +30704,6 @@ objects:
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -38909,9 +39067,7 @@ objects:
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
-          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -30154,6 +30154,12 @@ objects:
         - '4.8'
         - '4.9'
         - '4.10'
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: NotIn
         values:
@@ -30196,8 +30202,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30231,6 +30235,12 @@ objects:
         - '4.8'
         - '4.9'
         - '4.10'
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
       - key: ext-managed.openshift.io/uwm-disabled
         operator: In
         values:
@@ -30269,6 +30279,77 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-non-uwm-4.11-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: In
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
+          \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (lpsre:slo:pko_deployment_availability|sre:telemetry:package_operator_object_set_succeeded_timestamp_seconds|sre:telemetry:package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30280,6 +30361,8 @@ objects:
           \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\n"
 - apiVersion: hive.openshift.io/v1
@@ -30399,8 +30482,6 @@ objects:
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
@@ -30451,6 +30532,85 @@ objects:
       data:
         config.yaml: "enableUserWorkload: false\nprometheusK8s:\n  remoteWrite:\n\
           \  - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
+          \          key: client-id\n          name: observatorium-credentials\n \
+          \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
+          \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
+          \    remoteTimeout: 30s\n    writeRelabelConfigs:\n    - sourceLabels:\n\
+          \      - __name__\n      action: keep\n      regex: (lpsre:slo:pko_deployment_availability|sre:telemetry:package_operator_object_set_succeeded_timestamp_seconds|sre:telemetry:package_operator_package_availability|addon_operator_addons_count|addon_operator_reconcile_error|addon_operator_addon_health_info|addon_operator_ocm_api_requests_durations|addon_operator_ocm_api_requests_durations_sum|addon_operator_ocm_api_requests_durations_count|addon_operator_paused|cluster_admin_enabled|limited_support_enabled|identity_provider|cpms_enabled|ingress_canary_route_reachable|ocm_agent_service_log_sent_total|sre:slo:probe_success_api|sre:slo:probe_success_console|sre:slo:upgradeoperator_upgrade_result|sre:slo:imageregistry_http_requests_total|sre:slo:oauth_server_requests_total|sre:sla:outage_5_minutes|sre:slo:apiserver_28d_slo|sre:slo:console_28d_slo|sre:error_budget_burn:apiserver_28d_slo|sre:error_budget_burn:console_28d_slo|sre:operators:succeeded|sre:record:upgradeoperator_upgrade_healthcheck_result|sre:slo:upgradeoperator_upgrade_started_timestamp|sre:slo:upgradeoperator_upgrade_completed_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_started_timestamp|sre:slo:upgradeoperator_controlplane_upgrade_completed_timestamp|sre:slo:upgradeoperator_workernode_upgrade_started_timestamp|sre:slo:upgradeoperator_workernode_upgrade_completed_timestamp)\n\
+          \    queueConfig:\n      capacity: 2500\n      maxShards: 1000\n      minShards:\
+          \ 1\n      maxSamplesPerSend: 2000\n      batchSendDeadline: 60s\n     \
+          \ minBackoff: 30ms\n      maxBackoff: 1m\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n  retention: 7d\n  retentionSize: 85GB\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: prometheus-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 100Gi\nalertmanagerMain:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  volumeClaimTemplate:\n\
+          \    metadata:\n      name: alertmanager-data\n    spec:\n      resources:\n\
+          \        requests:\n          storage: 10Gi\ntelemeterClient:\n  nodeSelector:\n\
+          \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
+          \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
+          \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nthanosQuerier:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmonitoringPlugin:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\nmetricsServer:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\ngrafana:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
+          \    operator: Exists\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cluster-monitoring-config-4.11-4.16
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: hive.openshift.io/version-major-minor
+        operator: In
+        values:
+        - '4.11'
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+      - key: ext-managed.openshift.io/uwm-disabled
+        operator: NotIn
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      data:
+        config.yaml: "enableUserWorkload: true\nprometheusK8s:\n  remoteWrite:\n \
+          \ - url: ${OBSERVATORIUM_URL}\n    oauth2:\n      clientId:\n        secret:\n\
           \          key: client-id\n          name: observatorium-credentials\n \
           \     clientSecret:\n        key: client-secret\n        name: observatorium-credentials\n\
           \      tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token\n\
@@ -30544,8 +30704,6 @@ objects:
           \    node-role.kubernetes.io/infra: ''\n  tolerations:\n  - effect: NoSchedule\n\
           \    key: node-role.kubernetes.io/infra\n    operator: Exists\n  telemeterServerURL:\
           \ ${TELEMETER_SERVER_URL}\nprometheusOperator:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
@@ -38909,9 +39067,7 @@ objects:
           \    operator: Exists\n  telemeterServerURL: ${TELEMETER_SERVER_URL}\nprometheusOperator:\n\
           \  nodeSelector:\n    node-role.kubernetes.io/infra: ''\n  tolerations:\n\
           \  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n    operator:\
-          \ Exists\nk8sPrometheusAdapter:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
-          \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
-          \    operator: Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
+          \ Exists\nkubeStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\
           \    operator: Exists\nopenshiftStateMetrics:\n  nodeSelector:\n    node-role.kubernetes.io/infra:\
           \ ''\n  tolerations:\n  - effect: NoSchedule\n    key: node-role.kubernetes.io/infra\n\

--- a/scripts/generate-cmo-config.py
+++ b/scripts/generate-cmo-config.py
@@ -8,8 +8,10 @@ input_file_path = os.path.join("resources", "cluster-monitoring-config", "config
 output_file_path_non_uwm = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_non_uwm_4_5 = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "clusters-v4.5", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_non_uwm_pre_411 = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "pre-4.11", "50-GENERATED-cluster-monitoring-config.yaml")
+output_file_path_non_uwm_411_416 = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "4.11-4.16", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_uwm = os.path.join("deploy", "cluster-monitoring-config", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_uwm_pre_411 = os.path.join("deploy", "cluster-monitoring-config", "pre-4.11", "50-GENERATED-cluster-monitoring-config.yaml")
+output_file_path_uwm_411_416 = os.path.join("deploy", "cluster-monitoring-config", "4.11-4.16", "50-GENERATED-cluster-monitoring-config.yaml")
 output_file_path_fr = os.path.join("deploy", "osd-fedramp-cluster-monitoring-config", "50-GENERATED-cluster-monitoring-config.yaml")
 output_mc_file_path_non_uwm = os.path.join("deploy", "cluster-monitoring-config-non-uwm", "management-clusters", "50-GENERATED-cluster-monitoring-config.yaml")
 output_mc_file_path_uwm = os.path.join("deploy", "cluster-monitoring-config", "management-clusters", "50-GENERATED-cluster-monitoring-config.yaml")
@@ -23,17 +25,21 @@ yaml.add_representer(str, str_presenter)
 
 def dump_configmap(input_path, configmap_path, enableUserWorkload,
                    disableremoteWrite, retentionTime = "11d",
-                   enableGrafana = False):
+                   enableGrafana = False,
+                   keepPrometheusAdapter = False):
     with open(input_path,'r') as input_file:
         config = yaml.safe_load(input_file)
         config["enableUserWorkload"] = enableUserWorkload
         config["prometheusK8s"]["retention"] = retentionTime
         if disableremoteWrite:
-           del config['prometheusK8s']['remoteWrite']
+            del config['prometheusK8s']['remoteWrite']
 
         if enableGrafana:
             # Grafana config was removed in 4.11, pre-4.11, put it back
             config["grafana"] = copy.deepcopy(config["prometheusOperator"])
+
+        if not keepPrometheusAdapter:
+            del config['k8sPrometheusAdapter']
 
         cmo_config = {
             "apiVersion": "v1",
@@ -52,10 +58,12 @@ def dump_configmap(input_path, configmap_path, enableUserWorkload,
             yaml.dump(cmo_config, outfile)
 
 dump_configmap(input_file_path, output_file_path_uwm, True, False)
-dump_configmap(input_file_path, output_file_path_uwm_pre_411, True, False, "7d", True)
+dump_configmap(input_file_path, output_file_path_uwm_pre_411, True, False, "7d", True, True)
+dump_configmap(input_file_path, output_file_path_uwm_411_416, True, False, "7d", True, True)
 dump_configmap(input_file_path, output_file_path_non_uwm, False, False)
-dump_configmap(input_file_path, output_file_path_non_uwm_4_5, False, False, "11d", True)
-dump_configmap(input_file_path, output_file_path_non_uwm_pre_411, False, False, "7d", True)
+dump_configmap(input_file_path, output_file_path_non_uwm_4_5, False, False, "11d", True, True)
+dump_configmap(input_file_path, output_file_path_non_uwm_pre_411, False, False, "7d", True, True)
+dump_configmap(input_file_path, output_file_path_non_uwm_411_416, False, False, "7d", True, True)
 dump_configmap(input_file_path, output_file_path_fr, True, True)
 dump_configmap(input_file_path, output_mc_file_path_uwm, True, False, "7d")
 dump_configmap(input_file_path, output_mc_file_path_non_uwm, False, False, "7d")


### PR DESCRIPTION
The Monitoring team wants to remove the `k8sPrometheusAdapter` config so adjust the OSD configs for 4.17 and later.

### What type of PR is this?
cleanup

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

Fixes: [MON-4343](https://issues.redhat.com//browse/MON-4343)

### Special notes for your reviewer:

Issue reported in https://issues.redhat.com/browse/OCPBUGS-61135

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
