### PR TITLE
OCM-18286 | update wif template policy bindings

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -145,18 +145,15 @@ service_accounts:
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
           - iam.roles.get
-          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.getIamPolicy
           - iam.serviceAccounts.list
-          - iam.serviceAccounts.signBlob
           - iam.workloadIdentityPoolProviders.get
           - iam.workloadIdentityPools.get
           - monitoring.timeSeries.list
           - orgpolicy.policy.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
-          - resourcemanager.projects.setIamPolicy
           - serviceusage.quotas.get
           - serviceusage.services.list
           - storage.buckets.create
@@ -168,6 +165,20 @@ service_accounts:
           - storage.objects.delete
           - storage.objects.get
           - storage.objects.list
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
+      - id: iam.serviceAccountTokenCreator
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-deployer
   - access_method: wif
     credential_request:
       secret_ref:
@@ -387,7 +398,6 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
-          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.list
           - resourcemanager.tagValues.get
@@ -395,6 +405,14 @@ service_accounts:
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
   - access_method: vm
     id: osd-worker
     kind: ServiceAccount

--- a/resources/wif/4.18/vanilla.yaml
+++ b/resources/wif/4.18/vanilla.yaml
@@ -145,18 +145,15 @@ service_accounts:
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
           - iam.roles.get
-          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.getIamPolicy
           - iam.serviceAccounts.list
-          - iam.serviceAccounts.signBlob
           - iam.workloadIdentityPoolProviders.get
           - iam.workloadIdentityPools.get
           - monitoring.timeSeries.list
           - orgpolicy.policy.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
-          - resourcemanager.projects.setIamPolicy
           - serviceusage.quotas.get
           - serviceusage.services.list
           - storage.buckets.create
@@ -168,6 +165,20 @@ service_accounts:
           - storage.objects.delete
           - storage.objects.get
           - storage.objects.list
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
+      - id: iam.serviceAccountTokenCreator
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-deployer
   - access_method: wif
     credential_request:
       secret_ref:
@@ -387,7 +398,6 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
-          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.list
           - resourcemanager.tagValues.get
@@ -395,6 +405,14 @@ service_accounts:
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
   - access_method: vm
     id: osd-worker
     kind: ServiceAccount

--- a/resources/wif/4.19/vanilla.yaml
+++ b/resources/wif/4.19/vanilla.yaml
@@ -145,18 +145,15 @@ service_accounts:
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
           - iam.roles.get
-          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.getIamPolicy
           - iam.serviceAccounts.list
-          - iam.serviceAccounts.signBlob
           - iam.workloadIdentityPoolProviders.get
           - iam.workloadIdentityPools.get
           - monitoring.timeSeries.list
           - orgpolicy.policy.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
-          - resourcemanager.projects.setIamPolicy
           - serviceusage.quotas.get
           - serviceusage.services.list
           - storage.buckets.create
@@ -168,6 +165,20 @@ service_accounts:
           - storage.objects.delete
           - storage.objects.get
           - storage.objects.list
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
+      - id: iam.serviceAccountTokenCreator
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-deployer
   - access_method: wif
     credential_request:
       secret_ref:
@@ -389,7 +400,6 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
-          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.list
           - resourcemanager.tagValues.get
@@ -397,6 +407,14 @@ service_accounts:
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list
+      - id: iam.serviceAccountUser
+        kind: Role
+        predefined: true
+        resource_bindings:
+          - type: iam.serviceAccounts
+            name: osd-worker
+          - type: iam.serviceAccounts
+            name: osd-control-plane
   - access_method: vm
     id: osd-worker
     kind: ServiceAccount


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

feature

### What this PR does / why we need it?

to utilize the new restricted access for service accounts in wif-config cluster operations, wif-templates need to be updated with the new policy bindings.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
