### PR TITLE
Generate resources required for log forwarder token refresher

### DIFF
--- a/deploy/sre-token-refresher/01-token-refresher.Deployment.yaml
+++ b/deploy/sre-token-refresher/01-token-refresher.Deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher
+  name: token-refresher
+  namespace: openshift-logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: authentication-proxy
+      app.kubernetes.io/name: token-refresher
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: authentication-proxy
+        app.kubernetes.io/name: token-refresher
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: Exists
+              weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+      volumes:
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: ca-bundle.crt
+                path: ca-certificates.crt
+            name: token-refresher-trusted-ca-bundle
+          name: token-refresher-trusted-ca-bundle
+      containers:
+        - args:
+            - --log.level=info
+            - --log.format=logfmt
+            - --web.listen=0.0.0.0:8080
+            - --web.internal.listen=0.0.0.0:8081
+            - --oidc.client-id=$(OIDC_CLIENT_ID)
+            - --oidc.client-secret=$(OIDC_CLIENT_SECRET)
+            - --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external
+            - --upstream.url=$(RECEIVER_URL)
+            - --scope=profile
+          env:
+            - name: CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: observatorium-credentials
+                  key: client-id
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: observatorium-credentials
+                  key: client-secret
+            - name: RECEIVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: observatorium-credentials
+                  key: receiver-url
+          image: quay.io/observatorium/token-refresher@sha256:0a3562d2a10bbb68f3edf60b3e471a1cb344735673dde2af16776b53c6674a43
+          name: token-refresher
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - mountPath: /etc/ssl/certs/
+              name: token-refresher-trusted-ca-bundle
+              readOnly: true

--- a/deploy/sre-token-refresher/02-token-refresher.Service.yaml
+++ b/deploy/sre-token-refresher/02-token-refresher.Service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher
+  name: token-refresher
+  namespace: openshift-logging
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher

--- a/deploy/sre-token-refresher/03-token-refresher.NetworkPolicy.yaml
+++ b/deploy/sre-token-refresher/03-token-refresher.NetworkPolicy.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: authentication-proxy
+    app.kubernetes.io/name: token-refresher
+  name: token-refresher
+  namespace: openshift-logging
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: authentication-proxy
+      app.kubernetes.io/name: token-refresher
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: openshift-monitoring
+          podSelector:
+            matchLabels:
+              prometheus: k8s
+

--- a/deploy/sre-token-refresher/04-token-refresher.ConfigMap.yaml
+++ b/deploy/sre-token-refresher/04-token-refresher.ConfigMap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-logging
+  name: token-refresher-trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/deploy/sre-token-refresher/config.yaml
+++ b/deploy/sre-token-refresher/config.yaml
@@ -1,0 +1,12 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: [ "true" ]
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster", "service-cluster"]
+    - key: environment
+      operator: In
+      values: ["integration"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -49202,6 +49202,156 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-token-refresher
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: environment
+        operator: In
+        values:
+        - integration
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: authentication-proxy
+              app.kubernetes.io/name: token-refresher
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            volumes:
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: ca-certificates.crt
+                name: token-refresher-trusted-ca-bundle
+              name: token-refresher-trusted-ca-bundle
+            containers:
+            - args:
+              - --log.level=info
+              - --log.format=logfmt
+              - --web.listen=0.0.0.0:8080
+              - --web.internal.listen=0.0.0.0:8081
+              - --oidc.client-id=$(OIDC_CLIENT_ID)
+              - --oidc.client-secret=$(OIDC_CLIENT_SECRET)
+              - --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external
+              - --upstream.url=$(RECEIVER_URL)
+              - --scope=profile
+              env:
+              - name: CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-id
+              - name: CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-secret
+              - name: RECEIVER_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: receiver-url
+              image: quay.io/observatorium/token-refresher@sha256:0a3562d2a10bbb68f3edf60b3e471a1cb344735673dde2af16776b53c6674a43
+              name: token-refresher
+              ports:
+              - containerPort: 8080
+                name: http
+              volumeMounts:
+              - mountPath: /etc/ssl/certs/
+                name: token-refresher-trusted-ca-bundle
+                readOnly: true
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+        selector:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        policyTypes:
+        - Ingress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                name: openshift-monitoring
+            podSelector:
+              matchLabels:
+                prometheus: k8s
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: openshift-logging
+        name: token-refresher-trusted-ca-bundle
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: srep-1000-ethtool-exporter
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -49202,6 +49202,156 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-token-refresher
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: environment
+        operator: In
+        values:
+        - integration
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: authentication-proxy
+              app.kubernetes.io/name: token-refresher
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            volumes:
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: ca-certificates.crt
+                name: token-refresher-trusted-ca-bundle
+              name: token-refresher-trusted-ca-bundle
+            containers:
+            - args:
+              - --log.level=info
+              - --log.format=logfmt
+              - --web.listen=0.0.0.0:8080
+              - --web.internal.listen=0.0.0.0:8081
+              - --oidc.client-id=$(OIDC_CLIENT_ID)
+              - --oidc.client-secret=$(OIDC_CLIENT_SECRET)
+              - --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external
+              - --upstream.url=$(RECEIVER_URL)
+              - --scope=profile
+              env:
+              - name: CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-id
+              - name: CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-secret
+              - name: RECEIVER_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: receiver-url
+              image: quay.io/observatorium/token-refresher@sha256:0a3562d2a10bbb68f3edf60b3e471a1cb344735673dde2af16776b53c6674a43
+              name: token-refresher
+              ports:
+              - containerPort: 8080
+                name: http
+              volumeMounts:
+              - mountPath: /etc/ssl/certs/
+                name: token-refresher-trusted-ca-bundle
+                readOnly: true
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+        selector:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        policyTypes:
+        - Ingress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                name: openshift-monitoring
+            podSelector:
+              matchLabels:
+                prometheus: k8s
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: openshift-logging
+        name: token-refresher-trusted-ca-bundle
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: srep-1000-ethtool-exporter
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -49202,6 +49202,156 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: sre-token-refresher
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: environment
+        operator: In
+        values:
+        - integration
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/component: authentication-proxy
+              app.kubernetes.io/name: token-refresher
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            volumes:
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: ca-certificates.crt
+                name: token-refresher-trusted-ca-bundle
+              name: token-refresher-trusted-ca-bundle
+            containers:
+            - args:
+              - --log.level=info
+              - --log.format=logfmt
+              - --web.listen=0.0.0.0:8080
+              - --web.internal.listen=0.0.0.0:8081
+              - --oidc.client-id=$(OIDC_CLIENT_ID)
+              - --oidc.client-secret=$(OIDC_CLIENT_SECRET)
+              - --oidc.issuer-url=https://sso.redhat.com/auth/realms/redhat-external
+              - --upstream.url=$(RECEIVER_URL)
+              - --scope=profile
+              env:
+              - name: CLIENT_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-id
+              - name: CLIENT_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: client-secret
+              - name: RECEIVER_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: observatorium-credentials
+                    key: receiver-url
+              image: quay.io/observatorium/token-refresher@sha256:0a3562d2a10bbb68f3edf60b3e471a1cb344735673dde2af16776b53c6674a43
+              name: token-refresher
+              ports:
+              - containerPort: 8080
+                name: http
+              volumeMounts:
+              - mountPath: /etc/ssl/certs/
+                name: token-refresher-trusted-ca-bundle
+                readOnly: true
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+        selector:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+    - apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        labels:
+          app.kubernetes.io/component: authentication-proxy
+          app.kubernetes.io/name: token-refresher
+        name: token-refresher
+        namespace: openshift-logging
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: authentication-proxy
+            app.kubernetes.io/name: token-refresher
+        policyTypes:
+        - Ingress
+        ingress:
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                name: openshift-monitoring
+            podSelector:
+              matchLabels:
+                prometheus: k8s
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        namespace: openshift-logging
+        name: token-refresher-trusted-ca-bundle
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: srep-1000-ethtool-exporter
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?

This PR deploys a token refresher to the SC and MC for HCP in order to enable forwarding logs securely to a remote Loki

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/RHOBS-1287

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
