### PR TITLE
[WIP] [SREP-1604] Removing deletecollection verb for SREs

### DIFF
--- a/deploy/backplane/lpsre/10-lpsre-admins-project.ClusterRole.yml
+++ b/deploy/backplane/lpsre/10-lpsre-admins-project.ClusterRole.yml
@@ -24,7 +24,6 @@ rules:
   - jobs
   verbs:
   - delete
-  - deletecollection
   - create
 - apiGroups:
   - build.openshift.io
@@ -32,7 +31,6 @@ rules:
   - builds
   verbs:
   - delete
-  - deletecollection
 # SRE can delete pods
 - apiGroups:
   - ""
@@ -40,7 +38,6 @@ rules:
   - pods
   verbs:
   - delete
-  - deletecollection
 # SRE can review pod security policies
 - apiGroups:
   - security.openshift.io
@@ -116,7 +113,6 @@ rules:
   - replicasets
   verbs:
   - delete
-  - deletecollection
 # SRE can pause machinehealthchecks
 - apiGroups:
   - machine.openshift.io

--- a/deploy/backplane/lpsre/rhmi/01-rhmi-lpsre-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/lpsre/rhmi/01-rhmi-lpsre-admins-project.ClusterRole.yaml
@@ -25,14 +25,12 @@ rules:
   - cronjobs
   verbs:
   - delete
-  - deletecollection
 - apiGroups:
   - build.openshift.io
   resources:
   - builds
   verbs:
   - delete
-  - deletecollection
 # LP SRE can get pod logs
 - apiGroups:
   - ""

--- a/deploy/backplane/lpsre/rhoam/01-rhoam-lpsre-admins-project.ClusterRole.yaml
+++ b/deploy/backplane/lpsre/rhoam/01-rhoam-lpsre-admins-project.ClusterRole.yaml
@@ -25,14 +25,12 @@ rules:
   - cronjobs
   verbs:
   - delete
-  - deletecollection
 - apiGroups:
   - build.openshift.io
   resources:
   - builds
   verbs:
   - delete
-  - deletecollection
 # LP SRE can get pod logs
 - apiGroups:
   - ""

--- a/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
@@ -24,7 +24,6 @@ rules:
   - jobs
   verbs:
   - delete
-  - deletecollection
   - create
 - apiGroups:
   - build.openshift.io
@@ -32,7 +31,6 @@ rules:
   - builds
   verbs:
   - delete
-  - deletecollection
 # SRE can delete pods
 - apiGroups:
   - ""  
@@ -40,7 +38,6 @@ rules:
   - pods
   verbs:
   - delete
-  - deletecollection
 # SRE can review pod security policies
 - apiGroups:
   - security.openshift.io
@@ -116,7 +113,6 @@ rules:
   - replicasets
   verbs:
   - delete
-  - deletecollection
 # SRE can pause machinehealthchecks
 - apiGroups:
   - machine.openshift.io


### PR DESCRIPTION
### What type of PR is this?

Improvement 

### What this PR does / why we need it?

This PR addresses the recent incident where multiple resources were accidentally deleted in the `openshift-ingress` namespace.

By removing the `deletecollection` verb, we will limit SREP and LPSRE to be able to remove multiple objects at once. This change will significantly improve the security and reliability of the platform. By removing a high-risk permission that is not required for routine tasks, we are increasing confidence in our operational procedures. 

The reference is https://issues.redhat.com/browse/SREP-1604

