### PR TITLE
Add hypershift autoscaler podmonitor for srep-1665

### DIFF
--- a/deploy/hypershift-autoscaler-podmonitor/01-autoscaler-podmonitor.yaml
+++ b/deploy/hypershift-autoscaler-podmonitor/01-autoscaler-podmonitor.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+  name: "autoscaler-podmonitor-policy"
+  namespace: openshift-acm-policies
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    # Deployment
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: autoscaler-podmonitor-policy
+        spec:
+          namespaceSelector:
+            matchLabels:
+              hypershift.openshift.io/hosted-control-plane: "true"
+          pruneObjectBehavior: None
+          object-templates-raw: |
+            {{- range (lookup "hypershift.openshift.io/v1beta1" "HostedCluster" "" "").items }}
+            - complianceType: MustHave
+              objectDefinition:
+                apiVersion: monitoring.rhobs/v1
+                kind: PodMonitor
+                metadata:
+                  name: autoscaler
+                  namespace: {{ (printf "%s-%s" .metadata.namespace .metadata.name) }}
+                spec:
+                  podMetricsEndpoints:
+                  - path: /metrics
+                    port: metrics
+                    metricRelabelings:
+                      - action: replace
+                        replacement: {{ (printf "%s" .spec.clusterID) }}
+                        targetLabel: _id
+                    relabelings:
+                      - action: replace
+                        replacement: {{ (printf "%s" .spec.clusterID) }}
+                        targetLabel: _id
+                    scheme: http
+                    targetPort: 8085
+                  selector:
+                    matchLabels:
+                      app: cluster-autoscaler
+            {{- end}}
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: "autoscaler-podmonitor-placement-rule"
+  namespace: openshift-acm-policies
+spec:
+  clusterSelector:
+    matchExpressions:
+      - key: hypershift.open-cluster-management.io/management-cluster
+        operator: In
+        values:
+          - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: "autoscaler-podmonitor-placement-binding"
+  namespace: openshift-acm-policies
+placementRef:
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+  name: autoscaler-podmonitor-placement-rule
+subjects:
+  - apiGroup: policy.open-cluster-management.io
+    kind: Policy
+    name: "autoscaler-podmonitor-policy"

--- a/deploy/hypershift-autoscaler-podmonitor/config.yaml
+++ b/deploy/hypershift-autoscaler-podmonitor/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["service-cluster"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31288,6 +31288,90 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-autoscaler-podmonitor
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        name: autoscaler-podmonitor-policy
+        namespace: openshift-acm-policies
+      spec:
+        remediationAction: enforce
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: autoscaler-podmonitor-policy
+            spec:
+              namespaceSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
+              pruneObjectBehavior: None
+              object-templates-raw: "{{- range (lookup \"hypershift.openshift.io/v1beta1\"\
+                \ \"HostedCluster\" \"\" \"\").items }}\n- complianceType: MustHave\n\
+                \  objectDefinition:\n    apiVersion: monitoring.rhobs/v1\n    kind:\
+                \ PodMonitor\n    metadata:\n      name: autoscaler\n      namespace:\
+                \ {{ (printf \"%s-%s\" .metadata.namespace .metadata.name) }}\n  \
+                \  spec:\n      podMetricsEndpoints:\n      - path: /metrics\n   \
+                \     port: metrics\n        metricRelabelings:\n          - action:\
+                \ replace\n            replacement: {{ (printf \"%s\" .spec.clusterID)\
+                \ }}\n            targetLabel: _id\n        relabelings:\n       \
+                \   - action: replace\n            replacement: {{ (printf \"%s\"\
+                \ .spec.clusterID) }}\n            targetLabel: _id\n        scheme:\
+                \ http\n        targetPort: 8085\n      selector:\n        matchLabels:\n\
+                \          app: cluster-autoscaler\n{{- end}}\n"
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: autoscaler-podmonitor-placement-rule
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: autoscaler-podmonitor-placement-binding
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: autoscaler-podmonitor-placement-rule
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: autoscaler-podmonitor-policy
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31288,6 +31288,90 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-autoscaler-podmonitor
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        name: autoscaler-podmonitor-policy
+        namespace: openshift-acm-policies
+      spec:
+        remediationAction: enforce
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: autoscaler-podmonitor-policy
+            spec:
+              namespaceSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
+              pruneObjectBehavior: None
+              object-templates-raw: "{{- range (lookup \"hypershift.openshift.io/v1beta1\"\
+                \ \"HostedCluster\" \"\" \"\").items }}\n- complianceType: MustHave\n\
+                \  objectDefinition:\n    apiVersion: monitoring.rhobs/v1\n    kind:\
+                \ PodMonitor\n    metadata:\n      name: autoscaler\n      namespace:\
+                \ {{ (printf \"%s-%s\" .metadata.namespace .metadata.name) }}\n  \
+                \  spec:\n      podMetricsEndpoints:\n      - path: /metrics\n   \
+                \     port: metrics\n        metricRelabelings:\n          - action:\
+                \ replace\n            replacement: {{ (printf \"%s\" .spec.clusterID)\
+                \ }}\n            targetLabel: _id\n        relabelings:\n       \
+                \   - action: replace\n            replacement: {{ (printf \"%s\"\
+                \ .spec.clusterID) }}\n            targetLabel: _id\n        scheme:\
+                \ http\n        targetPort: 8085\n      selector:\n        matchLabels:\n\
+                \          app: cluster-autoscaler\n{{- end}}\n"
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: autoscaler-podmonitor-placement-rule
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: autoscaler-podmonitor-placement-binding
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: autoscaler-podmonitor-placement-rule
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: autoscaler-podmonitor-policy
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31288,6 +31288,90 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-autoscaler-podmonitor
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - service-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/standards: NIST SP 800-53
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        name: autoscaler-podmonitor-policy
+        namespace: openshift-acm-policies
+      spec:
+        remediationAction: enforce
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: autoscaler-podmonitor-policy
+            spec:
+              namespaceSelector:
+                matchLabels:
+                  hypershift.openshift.io/hosted-control-plane: 'true'
+              pruneObjectBehavior: None
+              object-templates-raw: "{{- range (lookup \"hypershift.openshift.io/v1beta1\"\
+                \ \"HostedCluster\" \"\" \"\").items }}\n- complianceType: MustHave\n\
+                \  objectDefinition:\n    apiVersion: monitoring.rhobs/v1\n    kind:\
+                \ PodMonitor\n    metadata:\n      name: autoscaler\n      namespace:\
+                \ {{ (printf \"%s-%s\" .metadata.namespace .metadata.name) }}\n  \
+                \  spec:\n      podMetricsEndpoints:\n      - path: /metrics\n   \
+                \     port: metrics\n        metricRelabelings:\n          - action:\
+                \ replace\n            replacement: {{ (printf \"%s\" .spec.clusterID)\
+                \ }}\n            targetLabel: _id\n        relabelings:\n       \
+                \   - action: replace\n            replacement: {{ (printf \"%s\"\
+                \ .spec.clusterID) }}\n            targetLabel: _id\n        scheme:\
+                \ http\n        targetPort: 8085\n      selector:\n        matchLabels:\n\
+                \          app: cluster-autoscaler\n{{- end}}\n"
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: autoscaler-podmonitor-placement-rule
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/management-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: autoscaler-podmonitor-placement-binding
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: autoscaler-podmonitor-placement-rule
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: autoscaler-podmonitor-policy
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?

feature

### What this PR does / why we need it?
Adds a podmonitor to the autoscaler for hypershift clusters to allow to monitor it

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/SREP-1665

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
