### PR TITLE
Allow backplane users to read from RHOBS namespaces

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -86,6 +86,7 @@ spec:
                         - openshift-*
                         - default
                         - redhat-*
+                        - rhobs*
                 object-templates:
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
@@ -124,6 +125,7 @@ spec:
                         - openshift-*
                         - default
                         - redhat-*
+                        - rhobs*
                 object-templates:
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave

--- a/deploy/backplane/srep/20-srep.SubjectPermission.yml
+++ b/deploy/backplane/srep/20-srep.SubjectPermission.yml
@@ -9,10 +9,10 @@ spec:
   - backplane-readers-cluster
   permissions:
   - clusterRoleName: backplane-srep-admins-project
-    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)"
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   - clusterRoleName: dedicated-readers
-    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)"
+    namespacesAllowedRegex: "(^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)"
     namespacesDeniedRegex: openshift-backplane-cluster-admin
   subjectKind: Group
   subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -4691,6 +4691,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhobs*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -4729,6 +4730,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhobs*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -29314,10 +29316,10 @@ objects:
         - backplane-readers-cluster
         permissions:
         - clusterRoleName: backplane-srep-admins-project
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         - clusterRoleName: dedicated-readers
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -4691,6 +4691,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhobs*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -4729,6 +4730,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhobs*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -29314,10 +29316,10 @@ objects:
         - backplane-readers-cluster
         permissions:
         - clusterRoleName: backplane-srep-admins-project
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         - clusterRoleName: dedicated-readers
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -4691,6 +4691,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhobs*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -4729,6 +4730,7 @@ objects:
                 - openshift-*
                 - default
                 - redhat-*
+                - rhobs*
               object-templates:
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
@@ -29314,10 +29316,10 @@ objects:
         - backplane-readers-cluster
         permissions:
         - clusterRoleName: backplane-srep-admins-project
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         - clusterRoleName: dedicated-readers
-          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*)
+          namespacesAllowedRegex: (^kube$|^kube-.*|^openshift$|^openshift-.*|^default$|^redhat-.*|^rhobs.*)
           namespacesDeniedRegex: openshift-backplane-cluster-admin
         subjectKind: Group
         subjectName: system:serviceaccounts:openshift-backplane-srep


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?

Allows regular backplane users to access RHOBS namespaces without having to elevate. This is necessary for SRE to effectively support RHOBS.next

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
