### PR TITLE
Fix quoting issue in vector config

### DIFF
--- a/deploy/hypershift-control-plane-log-forwarding/30-vector-config.yaml
+++ b/deploy/hypershift-control-plane-log-forwarding/30-vector-config.yaml
@@ -201,7 +201,7 @@ data:
         # The weird brace syntax is how you escape these in the text/template
         # go library
         # Dynamic key prefix based on cluster/namespace/app/pod structure
-        key_prefix: "{{\"{{\"}} mc_cluster_id {{\"}}\"}}/{{\"{{\"}} namespace {{\"}}\"}}/{{\"{{\"}} application {{\"}}\"}}/{{\"{{\"}} pod_name {{\"}}\"}}/{{\"{{\"}} container_name {{\"}}\"}}/"
+        key_prefix: '{{ "{{" }} mc_cluster_id {{ "}}" }}/{{ "{{" }} namespace {{ "}}" }}/{{ "{{" }} application {{ "}}" }}/{{ "{{" }} pod_name {{ "}}" }}/{{ "{{" }} container_name {{ "}}" }}/'
         
         # Batch settings
         batch:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31599,20 +31599,20 @@ objects:
           \ attempt to interpolate\n    # the same syntax as vector does during the\
           \ selectorsyncset apply\n    # The weird brace syntax is how you escape\
           \ these in the text/template\n    # go library\n    # Dynamic key prefix\
-          \ based on cluster/namespace/app/pod structure\n    key_prefix: \"{{\\\"\
-          {{\\\"}} mc_cluster_id {{\\\"}}\\\"}}/{{\\\"{{\\\"}} namespace {{\\\"}}\\\
-          \"}}/{{\\\"{{\\\"}} application {{\\\"}}\\\"}}/{{\\\"{{\\\"}} pod_name {{\\\
-          \"}}\\\"}}/{{\\\"{{\\\"}} container_name {{\\\"}}\\\"}}/\"\n    \n    #\
-          \ Batch settings\n    batch:\n      max_bytes: 67108864  # 64MB\n      timeout_secs:\
-          \ 300    # 5 minutes\n    \n    # Request settings\n    request:\n     \
-          \ retry_attempts: 3\n      retry_initial_backoff_secs: 1\n      retry_max_duration_secs:\
-          \ 30\n      timeout_secs: 30\n    \n    # Compression\n    compression:\
-          \ \"gzip\"\n    \n    # File format\n    encoding:\n      codec: \"json\"\
-          \n      framing:\n        method: \"newline_delimited\"\n    \n    # Buffer\
-          \ configuration\n    buffer:\n      type: \"disk\"\n      max_size: 10737418240\
-          \  # 10GB\n      when_full: \"block\"\n    \n    # Authentication via IRSA\n\
-          \    auth:\n      assume_role: \"${S3_WRITER_ROLE_ARN}\"\n      \n    #\
-          \ Add timestamp to filename\n    filename_append_uuid: true\n    filename_time_format:\
+          \ based on cluster/namespace/app/pod structure\n    key_prefix: '{{ \"{{\"\
+          \ }} mc_cluster_id {{ \"}}\" }}/{{ \"{{\" }} namespace {{ \"}}\" }}/{{ \"\
+          {{\" }} application {{ \"}}\" }}/{{ \"{{\" }} pod_name {{ \"}}\" }}/{{ \"\
+          {{\" }} container_name {{ \"}}\" }}/'\n    \n    # Batch settings\n    batch:\n\
+          \      max_bytes: 67108864  # 64MB\n      timeout_secs: 300    # 5 minutes\n\
+          \    \n    # Request settings\n    request:\n      retry_attempts: 3\n \
+          \     retry_initial_backoff_secs: 1\n      retry_max_duration_secs: 30\n\
+          \      timeout_secs: 30\n    \n    # Compression\n    compression: \"gzip\"\
+          \n    \n    # File format\n    encoding:\n      codec: \"json\"\n      framing:\n\
+          \        method: \"newline_delimited\"\n    \n    # Buffer configuration\n\
+          \    buffer:\n      type: \"disk\"\n      max_size: 10737418240  # 10GB\n\
+          \      when_full: \"block\"\n    \n    # Authentication via IRSA\n    auth:\n\
+          \      assume_role: \"${S3_WRITER_ROLE_ARN}\"\n      \n    # Add timestamp\
+          \ to filename\n    filename_append_uuid: true\n    filename_time_format:\
           \ \"%Y%m%d-%H%M%S\"\n    filename_extension: \"json.gz\"\n"
     - apiVersion: apps/v1
       kind: DaemonSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31599,20 +31599,20 @@ objects:
           \ attempt to interpolate\n    # the same syntax as vector does during the\
           \ selectorsyncset apply\n    # The weird brace syntax is how you escape\
           \ these in the text/template\n    # go library\n    # Dynamic key prefix\
-          \ based on cluster/namespace/app/pod structure\n    key_prefix: \"{{\\\"\
-          {{\\\"}} mc_cluster_id {{\\\"}}\\\"}}/{{\\\"{{\\\"}} namespace {{\\\"}}\\\
-          \"}}/{{\\\"{{\\\"}} application {{\\\"}}\\\"}}/{{\\\"{{\\\"}} pod_name {{\\\
-          \"}}\\\"}}/{{\\\"{{\\\"}} container_name {{\\\"}}\\\"}}/\"\n    \n    #\
-          \ Batch settings\n    batch:\n      max_bytes: 67108864  # 64MB\n      timeout_secs:\
-          \ 300    # 5 minutes\n    \n    # Request settings\n    request:\n     \
-          \ retry_attempts: 3\n      retry_initial_backoff_secs: 1\n      retry_max_duration_secs:\
-          \ 30\n      timeout_secs: 30\n    \n    # Compression\n    compression:\
-          \ \"gzip\"\n    \n    # File format\n    encoding:\n      codec: \"json\"\
-          \n      framing:\n        method: \"newline_delimited\"\n    \n    # Buffer\
-          \ configuration\n    buffer:\n      type: \"disk\"\n      max_size: 10737418240\
-          \  # 10GB\n      when_full: \"block\"\n    \n    # Authentication via IRSA\n\
-          \    auth:\n      assume_role: \"${S3_WRITER_ROLE_ARN}\"\n      \n    #\
-          \ Add timestamp to filename\n    filename_append_uuid: true\n    filename_time_format:\
+          \ based on cluster/namespace/app/pod structure\n    key_prefix: '{{ \"{{\"\
+          \ }} mc_cluster_id {{ \"}}\" }}/{{ \"{{\" }} namespace {{ \"}}\" }}/{{ \"\
+          {{\" }} application {{ \"}}\" }}/{{ \"{{\" }} pod_name {{ \"}}\" }}/{{ \"\
+          {{\" }} container_name {{ \"}}\" }}/'\n    \n    # Batch settings\n    batch:\n\
+          \      max_bytes: 67108864  # 64MB\n      timeout_secs: 300    # 5 minutes\n\
+          \    \n    # Request settings\n    request:\n      retry_attempts: 3\n \
+          \     retry_initial_backoff_secs: 1\n      retry_max_duration_secs: 30\n\
+          \      timeout_secs: 30\n    \n    # Compression\n    compression: \"gzip\"\
+          \n    \n    # File format\n    encoding:\n      codec: \"json\"\n      framing:\n\
+          \        method: \"newline_delimited\"\n    \n    # Buffer configuration\n\
+          \    buffer:\n      type: \"disk\"\n      max_size: 10737418240  # 10GB\n\
+          \      when_full: \"block\"\n    \n    # Authentication via IRSA\n    auth:\n\
+          \      assume_role: \"${S3_WRITER_ROLE_ARN}\"\n      \n    # Add timestamp\
+          \ to filename\n    filename_append_uuid: true\n    filename_time_format:\
           \ \"%Y%m%d-%H%M%S\"\n    filename_extension: \"json.gz\"\n"
     - apiVersion: apps/v1
       kind: DaemonSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31599,20 +31599,20 @@ objects:
           \ attempt to interpolate\n    # the same syntax as vector does during the\
           \ selectorsyncset apply\n    # The weird brace syntax is how you escape\
           \ these in the text/template\n    # go library\n    # Dynamic key prefix\
-          \ based on cluster/namespace/app/pod structure\n    key_prefix: \"{{\\\"\
-          {{\\\"}} mc_cluster_id {{\\\"}}\\\"}}/{{\\\"{{\\\"}} namespace {{\\\"}}\\\
-          \"}}/{{\\\"{{\\\"}} application {{\\\"}}\\\"}}/{{\\\"{{\\\"}} pod_name {{\\\
-          \"}}\\\"}}/{{\\\"{{\\\"}} container_name {{\\\"}}\\\"}}/\"\n    \n    #\
-          \ Batch settings\n    batch:\n      max_bytes: 67108864  # 64MB\n      timeout_secs:\
-          \ 300    # 5 minutes\n    \n    # Request settings\n    request:\n     \
-          \ retry_attempts: 3\n      retry_initial_backoff_secs: 1\n      retry_max_duration_secs:\
-          \ 30\n      timeout_secs: 30\n    \n    # Compression\n    compression:\
-          \ \"gzip\"\n    \n    # File format\n    encoding:\n      codec: \"json\"\
-          \n      framing:\n        method: \"newline_delimited\"\n    \n    # Buffer\
-          \ configuration\n    buffer:\n      type: \"disk\"\n      max_size: 10737418240\
-          \  # 10GB\n      when_full: \"block\"\n    \n    # Authentication via IRSA\n\
-          \    auth:\n      assume_role: \"${S3_WRITER_ROLE_ARN}\"\n      \n    #\
-          \ Add timestamp to filename\n    filename_append_uuid: true\n    filename_time_format:\
+          \ based on cluster/namespace/app/pod structure\n    key_prefix: '{{ \"{{\"\
+          \ }} mc_cluster_id {{ \"}}\" }}/{{ \"{{\" }} namespace {{ \"}}\" }}/{{ \"\
+          {{\" }} application {{ \"}}\" }}/{{ \"{{\" }} pod_name {{ \"}}\" }}/{{ \"\
+          {{\" }} container_name {{ \"}}\" }}/'\n    \n    # Batch settings\n    batch:\n\
+          \      max_bytes: 67108864  # 64MB\n      timeout_secs: 300    # 5 minutes\n\
+          \    \n    # Request settings\n    request:\n      retry_attempts: 3\n \
+          \     retry_initial_backoff_secs: 1\n      retry_max_duration_secs: 30\n\
+          \      timeout_secs: 30\n    \n    # Compression\n    compression: \"gzip\"\
+          \n    \n    # File format\n    encoding:\n      codec: \"json\"\n      framing:\n\
+          \        method: \"newline_delimited\"\n    \n    # Buffer configuration\n\
+          \    buffer:\n      type: \"disk\"\n      max_size: 10737418240  # 10GB\n\
+          \      when_full: \"block\"\n    \n    # Authentication via IRSA\n    auth:\n\
+          \      assume_role: \"${S3_WRITER_ROLE_ARN}\"\n      \n    # Add timestamp\
+          \ to filename\n    filename_append_uuid: true\n    filename_time_format:\
           \ \"%Y%m%d-%H%M%S\"\n    filename_extension: \"json.gz\"\n"
     - apiVersion: apps/v1
       kind: DaemonSet


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?
Fixes template quoting issue by switching to single quotes and using double-quotes within the hive-level template 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
