### PR TITLE
Maint: update managedfleetnotification SSS and docs

### DIFF
--- a/deploy/ocm-agent-operator-managedfleetnotifications/OWNERS
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/OWNERS
@@ -1,4 +1,0 @@
-reviewers:
-- mrbarge
-- bmeng
-- ravitri

--- a/deploy/ocm-agent-operator-managedfleetnotifications/README.md
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/README.md
@@ -1,10 +1,10 @@
 # ocm-agent-operator ManagedFleetNotifications-CR
 
-This location manages the distribution of the OCM Agent Operator `ManagedFleetNotification` CR to hypershift-only OCM agent running on `rhobsp02ue1`.
+This location manages the distribution of the OCM Agent Operator `ManagedFleetNotification` CR to hypershift-only OCM agent running on management clusters.
 
 The purpose of the `ManagedFleetNotification` CR is to define notification templates that map to AlertManager alerts, allowing the OCM Agent to build and send notifications when it is notified about those alerts.
 
-`ManagedNotifications` are specifically for HyperShift and are currently sent from a centralized place (`rhobsp02ue1`) to the whole fleet of HCP clusters. Furthermore, `ManagedNotifications` support notifications of type limited support by setting the `limitedSupport` field to `true`. 
+`ManagedNotifications` are specifically for HyperShift and are currently sent from the fleet mode `ocm-agent` instance running on management clusters to the OCM backend for hosted clusters. Furthermore, `ManagedNotifications` support notifications of type limited support by setting the `limitedSupport` field to `true`. 
 
 ## How to make changes
 

--- a/deploy/ocm-agent-operator-managedfleetnotifications/config.yaml
+++ b/deploy/ocm-agent-operator-managedfleetnotifications/config.yaml
@@ -6,3 +6,6 @@ selectorSyncSet:
     operator: NotIn
     values:
       - "true"
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -32469,6 +32469,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -32469,6 +32469,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -32469,6 +32469,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: ocmagent.managed.openshift.io/v1alpha1


### PR DESCRIPTION
cleanup

### What this PR does / why we need it?
This PR updates managedfleetnotification documentation and changes the SSS to only target management clusters, as we moved fleet mode ocm-agent there after deprovisioning RHOBS. 

### Which Jira/Github issue(s) this PR fixes?

Fixes https://issues.redhat.com/browse/SREP-1830 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
