### PR TITLE
Revert resource_bindings from 4.17, 4.18, and 4.19 WIF templates

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -145,15 +145,18 @@ service_accounts:
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
           - iam.roles.get
+          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.getIamPolicy
           - iam.serviceAccounts.list
+          - iam.serviceAccounts.signBlob
           - iam.workloadIdentityPoolProviders.get
           - iam.workloadIdentityPools.get
           - monitoring.timeSeries.list
           - orgpolicy.policy.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
+          - resourcemanager.projects.setIamPolicy
           - serviceusage.quotas.get
           - serviceusage.services.list
           - storage.buckets.create
@@ -165,20 +168,6 @@ service_accounts:
           - storage.objects.delete
           - storage.objects.get
           - storage.objects.list
-      - id: iam.serviceAccountUser
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-worker
-          - type: iam.serviceAccounts
-            name: osd-control-plane
-      - id: iam.serviceAccountTokenCreator
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-deployer
   - access_method: wif
     credential_request:
       secret_ref:
@@ -398,6 +387,7 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
+          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.list
           - resourcemanager.tagValues.get
@@ -405,14 +395,6 @@ service_accounts:
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list
-      - id: iam.serviceAccountUser
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-worker
-          - type: iam.serviceAccounts
-            name: osd-control-plane
   - access_method: vm
     id: osd-worker
     kind: ServiceAccount

--- a/resources/wif/4.18/vanilla.yaml
+++ b/resources/wif/4.18/vanilla.yaml
@@ -145,15 +145,18 @@ service_accounts:
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
           - iam.roles.get
+          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.getIamPolicy
           - iam.serviceAccounts.list
+          - iam.serviceAccounts.signBlob
           - iam.workloadIdentityPoolProviders.get
           - iam.workloadIdentityPools.get
           - monitoring.timeSeries.list
           - orgpolicy.policy.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
+          - resourcemanager.projects.setIamPolicy
           - serviceusage.quotas.get
           - serviceusage.services.list
           - storage.buckets.create
@@ -165,20 +168,6 @@ service_accounts:
           - storage.objects.delete
           - storage.objects.get
           - storage.objects.list
-      - id: iam.serviceAccountUser
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-worker
-          - type: iam.serviceAccounts
-            name: osd-control-plane
-      - id: iam.serviceAccountTokenCreator
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-deployer
   - access_method: wif
     credential_request:
       secret_ref:
@@ -398,6 +387,7 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
+          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.list
           - resourcemanager.tagValues.get
@@ -405,14 +395,6 @@ service_accounts:
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list
-      - id: iam.serviceAccountUser
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-worker
-          - type: iam.serviceAccounts
-            name: osd-control-plane
   - access_method: vm
     id: osd-worker
     kind: ServiceAccount

--- a/resources/wif/4.19/vanilla.yaml
+++ b/resources/wif/4.19/vanilla.yaml
@@ -145,15 +145,18 @@ service_accounts:
           - dns.resourceRecordSets.delete
           - dns.resourceRecordSets.list
           - iam.roles.get
+          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.getIamPolicy
           - iam.serviceAccounts.list
+          - iam.serviceAccounts.signBlob
           - iam.workloadIdentityPoolProviders.get
           - iam.workloadIdentityPools.get
           - monitoring.timeSeries.list
           - orgpolicy.policy.get
           - resourcemanager.projects.get
           - resourcemanager.projects.getIamPolicy
+          - resourcemanager.projects.setIamPolicy
           - serviceusage.quotas.get
           - serviceusage.services.list
           - storage.buckets.create
@@ -165,20 +168,6 @@ service_accounts:
           - storage.objects.delete
           - storage.objects.get
           - storage.objects.list
-      - id: iam.serviceAccountUser
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-worker
-          - type: iam.serviceAccounts
-            name: osd-control-plane
-      - id: iam.serviceAccountTokenCreator
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-deployer
   - access_method: wif
     credential_request:
       secret_ref:
@@ -400,6 +389,7 @@ service_accounts:
           - compute.zoneOperations.list
           - compute.zones.get
           - compute.zones.list
+          - iam.serviceAccounts.actAs
           - iam.serviceAccounts.get
           - iam.serviceAccounts.list
           - resourcemanager.tagValues.get
@@ -407,14 +397,6 @@ service_accounts:
           - serviceusage.quotas.get
           - serviceusage.services.get
           - serviceusage.services.list
-      - id: iam.serviceAccountUser
-        kind: Role
-        predefined: true
-        resource_bindings:
-          - type: iam.serviceAccounts
-            name: osd-worker
-          - type: iam.serviceAccounts
-            name: osd-control-plane
   - access_method: vm
     id: osd-worker
     kind: ServiceAccount


### PR DESCRIPTION
This PR reverts the `resource_bindings` enhancements introduced in PR #2508 for OpenShift versions 4.17, 4.18, and 4.19.

4.20 is left unchanged (continues to use resource_bindings)
Reverts are based on commit SHAs prior to #2508
Done as per Renan’s instructions to decouple production rollout from QE approval

_Fixes #_  [OSD-31035](https://issues.redhat.com/browse/OSD-31035)