### PR TITLE
SREP-1300: Enable the kubeControllerManager SRE metric set for HCP

### DIFF
--- a/deploy/hypershift-sre-metric-set/sre-metric-set.yaml
+++ b/deploy/hypershift-sre-metric-set/sre-metric-set.yaml
@@ -13,3 +13,13 @@ data:
       - action:       "keep"
         regex:        "apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\+Inf)"
         sourceLabels: ["__name__", "le"]
+    kubeControllerManager:
+      - action:       "drop"
+        regex:        "etcd_(debugging|disk|request|server).*"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "rest_client_request_latency_seconds_(bucket|count|sum)"
+        sourceLabels: ["__name__"]
+      - action:       "drop"
+        regex:        "root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)"
+        sourceLabels: ["__name__"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31852,7 +31852,13 @@ objects:
           apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
           \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nopenshiftAPIServer:\n\
           \  - action:       \"keep\"\n    regex:        \"apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
-          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\n"
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nkubeControllerManager:\n\
+          \  - action:       \"drop\"\n    regex:        \"etcd_(debugging|disk|request|server).*\"\
+          \n    sourceLabels: [\"__name__\"]\n  - action:       \"drop\"\n    regex:\
+          \        \"rest_client_request_latency_seconds_(bucket|count|sum)\"\n  \
+          \  sourceLabels: [\"__name__\"]\n  - action:       \"drop\"\n    regex:\
+          \        \"root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)\"\
+          \n    sourceLabels: [\"__name__\"]\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31852,7 +31852,13 @@ objects:
           apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
           \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nopenshiftAPIServer:\n\
           \  - action:       \"keep\"\n    regex:        \"apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
-          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\n"
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nkubeControllerManager:\n\
+          \  - action:       \"drop\"\n    regex:        \"etcd_(debugging|disk|request|server).*\"\
+          \n    sourceLabels: [\"__name__\"]\n  - action:       \"drop\"\n    regex:\
+          \        \"rest_client_request_latency_seconds_(bucket|count|sum)\"\n  \
+          \  sourceLabels: [\"__name__\"]\n  - action:       \"drop\"\n    regex:\
+          \        \"root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)\"\
+          \n    sourceLabels: [\"__name__\"]\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31852,7 +31852,13 @@ objects:
           apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
           \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nopenshiftAPIServer:\n\
           \  - action:       \"keep\"\n    regex:        \"apiserver_request_total.*|apiserver_request_duration_seconds_count.*|apiserver_request_duration_seconds_bucket;(1|5|\\\
-          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\n"
+          \\+Inf)\"\n    sourceLabels: [\"__name__\", \"le\"]\nkubeControllerManager:\n\
+          \  - action:       \"drop\"\n    regex:        \"etcd_(debugging|disk|request|server).*\"\
+          \n    sourceLabels: [\"__name__\"]\n  - action:       \"drop\"\n    regex:\
+          \        \"rest_client_request_latency_seconds_(bucket|count|sum)\"\n  \
+          \  sourceLabels: [\"__name__\"]\n  - action:       \"drop\"\n    regex:\
+          \        \"root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)\"\
+          \n    sourceLabels: [\"__name__\"]\n"
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet
   metadata:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Per the steps documented by Hypershift [here](https://github.com/openshift/hypershift/blob/main/docs/content/how-to/metrics-sets.md), turn on the kube-controller-manager metrics. This includes their example configuration for which metrics to drop, found [here](https://github.com/openshift/hypershift/blob/21088b5edf54e98fe024dcd6e9856d4d36c709cd/support/metrics/testdata/sreconfig.yaml#L35-L44).

### Which Jira/Github issue(s) this PR fixes?

https://issues.redhat.com/browse/SREP-1300

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
