### PR TITLE
POC(SREP-1859): Create CAPI machine metrics for HCP

### DIFF
--- a/deploy/hypershift-kube-state-metrics/010-namespace.yaml
+++ b/deploy/hypershift-kube-state-metrics/010-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hypershift-observability
+  labels:
+    name: hypershift-observability
+    hypershift.openshift.io/monitoring: "true"

--- a/deploy/hypershift-kube-state-metrics/020-deployment.yaml
+++ b/deploy/hypershift-kube-state-metrics/020-deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: v2.17.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: v2.17.0
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        args:
+        - --host=0.0.0.0
+        - --port=8080
+        - --telemetry-host=0.0.0.0
+        - --telemetry-port=8081
+        - --custom-resource-state-only=true
+        - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: kube-state-metrics-config
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/deploy/hypershift-kube-state-metrics/025-configmap.yaml
+++ b/deploy/hypershift-kube-state-metrics/025-configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-state-metrics-config
+  namespace: hypershift-observability
+data:
+  custom-resource-state.yaml: |
+    spec:
+      resources:
+        - groupVersionKind:
+            group: cluster.x-k8s.io
+            version: v1beta1
+            kind: Machine
+          metricNamePrefix: capi_machine
+          labelsFromPath:
+            machine_name:
+              - metadata
+              - name
+            exported_namespace:
+              - metadata
+              - namespace
+            _id:
+              - metadata
+              - labels
+              - "cluster.x-k8s.io/cluster-name"
+          metrics:
+            - name: "info"
+              help: "The current state of a machine."
+              each:
+                type: Info
+                info:
+                    labelsFromPath:
+                      status_phase: [status, phase]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      healthcheck_succeeded: [status, conditions, "[type=HealthCheckSucceeded]", status]
+                      infrastructure_ready: [status, conditions, "[type=InfrastructureReady]", status]
+                      node_healthy: [status, conditions, "[type=NodeHealthy]", status]
+                      draining_succeeded: [status, conditions, "[type=DrainingSucceeded]", status]

--- a/deploy/hypershift-kube-state-metrics/030-serviceaccount.yaml
+++ b/deploy/hypershift-kube-state-metrics/030-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics

--- a/deploy/hypershift-kube-state-metrics/040-clusterrole.yaml
+++ b/deploy/hypershift-kube-state-metrics/040-clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hypershift-kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+rules:
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch

--- a/deploy/hypershift-kube-state-metrics/050-clusterrolebinding.yaml
+++ b/deploy/hypershift-kube-state-metrics/050-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hypershift-kube-state-metrics
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hypershift-kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: hypershift-observability

--- a/deploy/hypershift-kube-state-metrics/060-service.yaml
+++ b/deploy/hypershift-kube-state-metrics/060-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics

--- a/deploy/hypershift-kube-state-metrics/070-servicemonitor.yaml
+++ b/deploy/hypershift-kube-state-metrics/070-servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: kube-state-metrics
+  namespace: hypershift-observability
+  labels:
+    app.kubernetes.io/name: kube-state-metrics
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  endpoints:
+  - port: http-metrics
+    interval: 30s
+    path: /metrics

--- a/deploy/hypershift-kube-state-metrics/README.md
+++ b/deploy/hypershift-kube-state-metrics/README.md
@@ -1,0 +1,30 @@
+# Hypershift Kube-State-Metrics
+
+## What is Kube-State-Metrics (KSM)?
+
+Kube-State-Metrics is a service that listens to the Kubernetes API and generates Prometheus metrics from the state of Kubernetes objects. It converts resource statuses into queryable metrics, enabling observability for resources that don't naturally expose metrics.
+
+## Why Deploy to Management Clusters?
+
+In ROSA HCP environments, we're lacking comprehensive metrics for critical infrastructure components. Management clusters host Cluster API resources like machines, but their statuses aren't exposed as metrics by default.
+
+By deploying this specialized KSM instance to management clusters, we generate metrics ourselves for the statuses we want to monitor. This enables quick plug-in observability for ROSA HCP without requiring changes to core platform components.
+
+## What This Deployment Does
+
+This is an additional KSM deployment to the `hypershift-observability` namespace, separate from OpenShift's Cluster Monitoring Operator (CMO) KSM instance which does not support extensions for custom resource monitoring.
+
+Currently configured to monitor Cluster API Machine resources, this deployment converts their status fields into Prometheus metrics. The configuration is extensible to monitor any Kubernetes resources as needed.
+
+## Example Metrics Generated
+
+```prometheus
+# HELP capi_machine_info The current state of a machine.
+# TYPE capi_machine_info info
+capi_machine_info{_id="2lctq83qt6ijsojsi41n5836fkd7m87c",customresource_group="cluster.x-k8s.io",customresource_kind="Machine",customresource_version="v1beta1",healthcheck_succeeded="True",infrastructure_ready="True",machine_name="kirk-brand-hcp-workers-0-v54m7-pzxdf",exported_namespace="ocm-int-2lctq83qt6ijsojsi41n5836fkd7m87c-kirk-brand-hcp",node_healthy="True",ready="True",status_phase="Running"} 1
+capi_machine_info{_id="2lctq83qt6ijsojsi41n5836fkd7m87c",customresource_group="cluster.x-k8s.io",customresource_kind="Machine",customresource_version="v1beta1",healthcheck_succeeded="True",infrastructure_ready="True",machine_name="kirk-brand-hcp-workers-1-ks6v6-mc6vd",exported_namespace="ocm-int-2lctq83qt6ijsojsi41n5836fkd7m87c-kirk-brand-hcp",node_healthy="True",ready="True",status_phase="Running"} 1
+```
+
+## Observability Integration
+
+The deployment includes a ServiceMonitor using `monitoring.rhobs/v1` API which integrates with the Red Hat Observability Stack for automatic metrics collection.

--- a/deploy/hypershift-kube-state-metrics/config.yaml
+++ b/deploy/hypershift-kube-state-metrics/config.yaml
@@ -1,0 +1,10 @@
+---
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: ext-hypershift.openshift.io/cluster-type
+    operator: In
+    values: ["management-cluster"]
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -31727,6 +31727,209 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-kube-state-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: hypershift-observability
+        labels:
+          name: hypershift-observability
+          hypershift.openshift.io/monitoring: 'true'
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+          app.kubernetes.io/version: v2.17.0
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: kube-state-metrics
+              app.kubernetes.io/version: v2.17.0
+          spec:
+            serviceAccountName: kube-state-metrics
+            containers:
+            - name: kube-state-metrics
+              image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+              ports:
+              - containerPort: 8080
+                name: http-metrics
+              - containerPort: 8081
+                name: telemetry
+              args:
+              - --host=0.0.0.0
+              - --port=8080
+              - --telemetry-host=0.0.0.0
+              - --telemetry-port=8081
+              - --custom-resource-state-only=true
+              - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+              volumeMounts:
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8081
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                  - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            volumes:
+            - name: config
+              configMap:
+                name: kube-state-metrics-config
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-state-metrics-config
+        namespace: hypershift-observability
+      data:
+        custom-resource-state.yaml: "spec:\n  resources:\n    - groupVersionKind:\n\
+          \        group: cluster.x-k8s.io\n        version: v1beta1\n        kind:\
+          \ Machine\n      metricNamePrefix: capi_machine\n      labelsFromPath:\n\
+          \        machine_name:\n          - metadata\n          - name\n       \
+          \ exported_namespace:\n          - metadata\n          - namespace\n   \
+          \     _id:\n          - metadata\n          - labels\n          - \"cluster.x-k8s.io/cluster-name\"\
+          \n      metrics:\n        - name: \"info\"\n          help: \"The current\
+          \ state of a machine.\"\n          each:\n            type: Info\n     \
+          \       info:\n                labelsFromPath:\n                  status_phase:\
+          \ [status, phase]\n                  ready: [status, conditions, \"[type=Ready]\"\
+          , status]\n                  healthcheck_succeeded: [status, conditions,\
+          \ \"[type=HealthCheckSucceeded]\", status]\n                  infrastructure_ready:\
+          \ [status, conditions, \"[type=InfrastructureReady]\", status]\n       \
+          \           node_healthy: [status, conditions, \"[type=NodeHealthy]\", status]\n\
+          \                  draining_succeeded: [status, conditions, \"[type=DrainingSucceeded]\"\
+          , status]"
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hypershift-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      rules:
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - machines
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: hypershift-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hypershift-kube-state-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: kube-state-metrics
+        namespace: hypershift-observability
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        clusterIP: None
+        ports:
+        - name: http-metrics
+          port: 8080
+          targetPort: http-metrics
+        - name: telemetry
+          port: 8081
+          targetPort: telemetry
+        selector:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        endpoints:
+        - port: http-metrics
+          interval: 30s
+          path: /metrics
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -31727,6 +31727,209 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-kube-state-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: hypershift-observability
+        labels:
+          name: hypershift-observability
+          hypershift.openshift.io/monitoring: 'true'
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+          app.kubernetes.io/version: v2.17.0
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: kube-state-metrics
+              app.kubernetes.io/version: v2.17.0
+          spec:
+            serviceAccountName: kube-state-metrics
+            containers:
+            - name: kube-state-metrics
+              image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+              ports:
+              - containerPort: 8080
+                name: http-metrics
+              - containerPort: 8081
+                name: telemetry
+              args:
+              - --host=0.0.0.0
+              - --port=8080
+              - --telemetry-host=0.0.0.0
+              - --telemetry-port=8081
+              - --custom-resource-state-only=true
+              - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+              volumeMounts:
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8081
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                  - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            volumes:
+            - name: config
+              configMap:
+                name: kube-state-metrics-config
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-state-metrics-config
+        namespace: hypershift-observability
+      data:
+        custom-resource-state.yaml: "spec:\n  resources:\n    - groupVersionKind:\n\
+          \        group: cluster.x-k8s.io\n        version: v1beta1\n        kind:\
+          \ Machine\n      metricNamePrefix: capi_machine\n      labelsFromPath:\n\
+          \        machine_name:\n          - metadata\n          - name\n       \
+          \ exported_namespace:\n          - metadata\n          - namespace\n   \
+          \     _id:\n          - metadata\n          - labels\n          - \"cluster.x-k8s.io/cluster-name\"\
+          \n      metrics:\n        - name: \"info\"\n          help: \"The current\
+          \ state of a machine.\"\n          each:\n            type: Info\n     \
+          \       info:\n                labelsFromPath:\n                  status_phase:\
+          \ [status, phase]\n                  ready: [status, conditions, \"[type=Ready]\"\
+          , status]\n                  healthcheck_succeeded: [status, conditions,\
+          \ \"[type=HealthCheckSucceeded]\", status]\n                  infrastructure_ready:\
+          \ [status, conditions, \"[type=InfrastructureReady]\", status]\n       \
+          \           node_healthy: [status, conditions, \"[type=NodeHealthy]\", status]\n\
+          \                  draining_succeeded: [status, conditions, \"[type=DrainingSucceeded]\"\
+          , status]"
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hypershift-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      rules:
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - machines
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: hypershift-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hypershift-kube-state-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: kube-state-metrics
+        namespace: hypershift-observability
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        clusterIP: None
+        ports:
+        - name: http-metrics
+          port: 8080
+          targetPort: http-metrics
+        - name: telemetry
+          port: 8081
+          targetPort: telemetry
+        selector:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        endpoints:
+        - port: http-metrics
+          interval: 30s
+          path: /metrics
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -31727,6 +31727,209 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: hypershift-kube-state-metrics
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: hypershift-observability
+        labels:
+          name: hypershift-observability
+          hypershift.openshift.io/monitoring: 'true'
+    - apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+          app.kubernetes.io/version: v2.17.0
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        template:
+          metadata:
+            labels:
+              app.kubernetes.io/name: kube-state-metrics
+              app.kubernetes.io/version: v2.17.0
+          spec:
+            serviceAccountName: kube-state-metrics
+            containers:
+            - name: kube-state-metrics
+              image: quay.io/openshift/origin-kube-state-metrics:4.19.0
+              ports:
+              - containerPort: 8080
+                name: http-metrics
+              - containerPort: 8081
+                name: telemetry
+              args:
+              - --host=0.0.0.0
+              - --port=8080
+              - --telemetry-host=0.0.0.0
+              - --telemetry-port=8081
+              - --custom-resource-state-only=true
+              - --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml
+              volumeMounts:
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: 8080
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8081
+                initialDelaySeconds: 5
+                timeoutSeconds: 5
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop:
+                  - ALL
+                seccompProfile:
+                  type: RuntimeDefault
+            volumes:
+            - name: config
+              configMap:
+                name: kube-state-metrics-config
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kube-state-metrics-config
+        namespace: hypershift-observability
+      data:
+        custom-resource-state.yaml: "spec:\n  resources:\n    - groupVersionKind:\n\
+          \        group: cluster.x-k8s.io\n        version: v1beta1\n        kind:\
+          \ Machine\n      metricNamePrefix: capi_machine\n      labelsFromPath:\n\
+          \        machine_name:\n          - metadata\n          - name\n       \
+          \ exported_namespace:\n          - metadata\n          - namespace\n   \
+          \     _id:\n          - metadata\n          - labels\n          - \"cluster.x-k8s.io/cluster-name\"\
+          \n      metrics:\n        - name: \"info\"\n          help: \"The current\
+          \ state of a machine.\"\n          each:\n            type: Info\n     \
+          \       info:\n                labelsFromPath:\n                  status_phase:\
+          \ [status, phase]\n                  ready: [status, conditions, \"[type=Ready]\"\
+          , status]\n                  healthcheck_succeeded: [status, conditions,\
+          \ \"[type=HealthCheckSucceeded]\", status]\n                  infrastructure_ready:\
+          \ [status, conditions, \"[type=InfrastructureReady]\", status]\n       \
+          \           node_healthy: [status, conditions, \"[type=NodeHealthy]\", status]\n\
+          \                  draining_succeeded: [status, conditions, \"[type=DrainingSucceeded]\"\
+          , status]"
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: hypershift-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      rules:
+      - apiGroups:
+        - cluster.x-k8s.io
+        resources:
+        - machines
+        verbs:
+        - get
+        - list
+        - watch
+      - apiGroups:
+        - apiextensions.k8s.io
+        resources:
+        - customresourcedefinitions
+        verbs:
+        - list
+        - watch
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: hypershift-kube-state-metrics
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: hypershift-kube-state-metrics
+      subjects:
+      - kind: ServiceAccount
+        name: kube-state-metrics
+        namespace: hypershift-observability
+    - apiVersion: v1
+      kind: Service
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        clusterIP: None
+        ports:
+        - name: http-metrics
+          port: 8080
+          targetPort: http-metrics
+        - name: telemetry
+          port: 8081
+          targetPort: telemetry
+        selector:
+          app.kubernetes.io/name: kube-state-metrics
+    - apiVersion: monitoring.rhobs/v1
+      kind: ServiceMonitor
+      metadata:
+        name: kube-state-metrics
+        namespace: hypershift-observability
+        labels:
+          app.kubernetes.io/name: kube-state-metrics
+      spec:
+        selector:
+          matchLabels:
+            app.kubernetes.io/name: kube-state-metrics
+        endpoints:
+        - port: http-metrics
+          interval: 30s
+          path: /metrics
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hypershift-namespace-labels
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

This PR deploys `kube-state-metrics` to the `hypershift-observability` namespace of management clusters (non-prod for now). This enables us to create metrics for CAPI machine states, which we lack pending https://issues.redhat.com/browse/OCPSTRAT-1615. 

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ https://issues.redhat.com/browse/SREP-1859 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
