### PR TITLE
SREP-1000: Allows deploying ethtool exporter to eu-west-2 region in prod

### DIFF
--- a/deploy/srep-1000-ethtool-exporter/config.yaml
+++ b/deploy/srep-1000-ethtool-exporter/config.yaml
@@ -7,7 +7,17 @@ selectorSyncSet:
     - key: api.openshift.com/fedramp
       operator: NotIn
       values: ["true"]
-    - key: api.openshift.com/environment
-      operator: NotIn
-      values:
-      - "production"
+    - key: ext-hypershift.openshift.io/cluster-sector
+      operator: In
+      values: 
+      - "eu-west-2"
+      - "chaos"
+      - "dynatrace"
+      - "green"
+      - "main"
+      - "perf2"
+      - "perf3"
+      - "perf4"
+      - "podisolation"
+      - "regional-ap-southeast-1"
+

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -49803,10 +49803,19 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: api.openshift.com/environment
-        operator: NotIn
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
         values:
-        - production
+        - eu-west-2
+        - chaos
+        - dynatrace
+        - green
+        - main
+        - perf2
+        - perf3
+        - perf4
+        - podisolation
+        - regional-ap-southeast-1
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -49803,10 +49803,19 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: api.openshift.com/environment
-        operator: NotIn
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
         values:
-        - production
+        - eu-west-2
+        - chaos
+        - dynatrace
+        - green
+        - main
+        - perf2
+        - perf3
+        - perf4
+        - podisolation
+        - regional-ap-southeast-1
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -49803,10 +49803,19 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: api.openshift.com/environment
-        operator: NotIn
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
         values:
-        - production
+        - eu-west-2
+        - chaos
+        - dynatrace
+        - green
+        - main
+        - perf2
+        - perf3
+        - perf4
+        - podisolation
+        - regional-ap-southeast-1
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION


### What type of PR is this?
feature

### What this PR does / why we need it?
Allows the following to be deployed to non fedramp management clusters in  production. 
Includes production sector 
      - 'eu-west-2'. 
Includes staging sectors. 
      - "chaos"
      - "dynatrace"
      - "green"
      - "main"
      - "perf2"
      - "perf3"
      - "perf4"
      - "podisolation"
      - "regional-ap-southeast-1" 

https://issues.redhat.com/browse/SREP-1000
Creates openshift-sre-ethtool-exporter namespace with daemon set running a trimmed down node-exporter,  limited to a select few AWS ENA metrics exposed by the ethtool.collector. Metrics are scraped by OBO and forwarded to dynatrace. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/SREP-1000


### Special notes for your reviewer:
The supplemental ethtool exporter has been deployed and running in stage for a few weeks now. This PR attempts to add a single production sector 'eu-west-2' to the existing stage sector deployments. 
Using the 'ext-hypershift.openshift.io/cluster-sector' matchExpression,  this PR attempts to limit the deployment to the single production sector 'eu-west-2',  as well as remain running on 'most' of the sectors within staging (excluding 'canary', and 'tech-preview' sectors). 
 Note: The 'canary' and 'tech-preview' sectors have not been included as they are not unique to stage, production, etc. envs. 

