### PR TITLE
[SREPHOA-42] Add osd-master-node-labeller cronjob

### DIFF
--- a/deploy/osd-master-node-labeller/00-osd-master-node-labeller.ServiceAccount.yaml
+++ b/deploy/osd-master-node-labeller/00-osd-master-node-labeller.ServiceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: osd-master-node-labeller
+  namespace: openshift-config

--- a/deploy/osd-master-node-labeller/01-osd-master-node-labeller.ClusterRole.yaml
+++ b/deploy/osd-master-node-labeller/01-osd-master-node-labeller.ClusterRole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: osd-master-node-labeller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - "list"
+  - "get"
+  - "patch"

--- a/deploy/osd-master-node-labeller/02-osd-master-node-labeller.ClusterRoleBinding.yaml
+++ b/deploy/osd-master-node-labeller/02-osd-master-node-labeller.ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: osd-master-node-labeller
+subjects:
+- kind: ServiceAccount
+  name: osd-master-node-labeller
+  namespace: openshift-config
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: osd-master-node-labeller

--- a/deploy/osd-master-node-labeller/10-osd-master-node-labeller.CronJob.yaml
+++ b/deploy/osd-master-node-labeller/10-osd-master-node-labeller.CronJob.yaml
@@ -1,0 +1,78 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: osd-master-node-labeller
+  namespace: openshift-config
+spec:
+  failedJobsHistoryLimit: 3
+  successfulJobsHistoryLimit: 3
+  concurrencyPolicy: Replace
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/infra
+                        operator: Exists
+                  weight: 1
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+          serviceAccountName: osd-master-node-labeller
+          restartPolicy: Never
+          containers:
+            - name: osd-master-node-labeller
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+              imagePullPolicy: Always
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  #!/bin/bash
+                  set -euo pipefail
+
+                  echo "Starting master node labeller job..."
+
+                  # Get all nodes with node-role.kubernetes.io/master label
+                  master_nodes=$(oc get nodes -l node-role.kubernetes.io/master -o jsonpath='{.items[*].metadata.name}')
+
+                  if [ -z "$master_nodes" ]; then
+                    echo "No nodes found with label node-role.kubernetes.io/master"
+                    exit 0
+                  fi
+
+                  echo "Found master nodes: $master_nodes"
+
+                  # Check if all master nodes already have control-plane label
+                  master_count=$(echo $master_nodes | wc -w)
+                  control_plane_count=$(oc get nodes -l node-role.kubernetes.io/master,node-role.kubernetes.io/control-plane --no-headers 2>/dev/null | wc -l)
+
+                  if [ "$master_count" -eq "$control_plane_count" ]; then
+                    echo "All $master_count master nodes already have node-role.kubernetes.io/control-plane label. Exiting."
+                    exit 0
+                  fi
+
+                  nodes_needing_label=$((master_count - control_plane_count))
+                  echo "Found $nodes_needing_label master nodes that need the control-plane label"
+
+                  # Label each master node with control-plane label
+                  for node in $master_nodes; do
+                    echo "Processing node: $node"
+
+                    # Check if the node already has the control-plane label
+                    if oc get node "$node" --show-labels | grep -q "node-role.kubernetes.io/control-plane"; then
+                      echo "Node $node already has node-role.kubernetes.io/control-plane label, skipping"
+                    else
+                      echo "Adding node-role.kubernetes.io/control-plane label to node $node"
+                      oc label node "$node" node-role.kubernetes.io/control-plane="" --overwrite
+                      echo "Successfully labeled node $node"
+                    fi
+                  done
+
+                  echo "Master node labeller job completed successfully"

--- a/deploy/osd-master-node-labeller/README.md
+++ b/deploy/osd-master-node-labeller/README.md
@@ -1,0 +1,38 @@
+# OSD Master Node Labeller
+
+This SelectorSyncSet deploys a CronJob that automatically adds the `node-role.kubernetes.io/control-plane` label to all nodes that have the `node-role.kubernetes.io/master` label.
+
+## Overview
+
+In Kubernetes/OpenShift, the `node-role.kubernetes.io/master` label has been deprecated in favor of `node-role.kubernetes.io/control-plane`. This cronjob ensures backward compatibility by automatically adding the new control-plane label to nodes that still only have the legacy master label.
+
+## Components
+
+- **ServiceAccount**: `osd-master-node-labeller` - Service account for the cronjob
+- **ClusterRole**: Grants permissions to list, get, and patch nodes
+- **ClusterRoleBinding**: Binds the ClusterRole to the ServiceAccount
+- **CronJob**: Runs every 5 minutes to label master nodes
+
+## Logic
+
+The CronJob runs a bash script that:
+
+1. Queries all nodes with the `node-role.kubernetes.io/master` label
+2. For each master node, checks if it already has the `node-role.kubernetes.io/control-plane` label
+3. If the control-plane label is missing, adds it to the node
+4. Logs all operations for visibility
+
+## Target Clusters
+
+This configuration is deployed to:
+- **Products**: OSD and ROSA clusters
+- **Versions**: OpenShift 4.14 through 4.18 only
+- **Resource Apply Mode**: Sync
+
+## Schedule
+
+The CronJob runs every 5 minutes (`*/5 * * * *`) to ensure newly provisioned or updated nodes are labeled promptly.
+
+## Node Affinity
+
+The job preferentially runs on infra nodes to minimize impact on customer workloads.

--- a/deploy/osd-master-node-labeller/config.yaml
+++ b/deploy/osd-master-node-labeller/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  matchExpressions:
+  - key: api.openshift.com/product
+    operator: In
+    values: ["osd", "rosa"]
+  - key: hive.openshift.io/version-major-minor-patch
+    operator: In
+    values: ["4.12", "4.13", "4.14", "4.15", "4.16", "4.17", "4.18"]
+  resourceApplyMode: "Sync"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -41483,6 +41483,126 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-master-node-labeller
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/product
+        operator: In
+        values:
+        - osd
+        - rosa
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+        - '4.18'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-master-node-labeller
+        namespace: openshift-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-master-node-labeller
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - list
+        - get
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-master-node-labeller
+      subjects:
+      - kind: ServiceAccount
+        name: osd-master-node-labeller
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-master-node-labeller
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-master-node-labeller
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-master-node-labeller
+                restartPolicy: Never
+                containers:
+                - name: osd-master-node-labeller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "#!/bin/bash\nset -euo pipefail\n\necho \"Starting master node\
+                    \ labeller job...\"\n\n# Get all nodes with node-role.kubernetes.io/master\
+                    \ label\nmaster_nodes=$(oc get nodes -l node-role.kubernetes.io/master\
+                    \ -o jsonpath='{.items[*].metadata.name}')\n\nif [ -z \"$master_nodes\"\
+                    \ ]; then\n  echo \"No nodes found with label node-role.kubernetes.io/master\"\
+                    \n  exit 0\nfi\n\necho \"Found master nodes: $master_nodes\"\n\
+                    \n# Check if all master nodes already have control-plane label\n\
+                    master_count=$(echo $master_nodes | wc -w)\ncontrol_plane_count=$(oc\
+                    \ get nodes -l node-role.kubernetes.io/master,node-role.kubernetes.io/control-plane\
+                    \ --no-headers 2>/dev/null | wc -l)\n\nif [ \"$master_count\"\
+                    \ -eq \"$control_plane_count\" ]; then\n  echo \"All $master_count\
+                    \ master nodes already have node-role.kubernetes.io/control-plane\
+                    \ label. Exiting.\"\n  exit 0\nfi\n\nnodes_needing_label=$((master_count\
+                    \ - control_plane_count))\necho \"Found $nodes_needing_label master\
+                    \ nodes that need the control-plane label\"\n\n# Label each master\
+                    \ node with control-plane label\nfor node in $master_nodes; do\n\
+                    \  echo \"Processing node: $node\"\n\n  # Check if the node already\
+                    \ has the control-plane label\n  if oc get node \"$node\" --show-labels\
+                    \ | grep -q \"node-role.kubernetes.io/control-plane\"; then\n\
+                    \    echo \"Node $node already has node-role.kubernetes.io/control-plane\
+                    \ label, skipping\"\n  else\n    echo \"Adding node-role.kubernetes.io/control-plane\
+                    \ label to node $node\"\n    oc label node \"$node\" node-role.kubernetes.io/control-plane=\"\
+                    \" --overwrite\n    echo \"Successfully labeled node $node\"\n\
+                    \  fi\ndone\n\necho \"Master node labeller job completed successfully\"\
+                    \n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-must-gather-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -41483,6 +41483,126 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-master-node-labeller
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/product
+        operator: In
+        values:
+        - osd
+        - rosa
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+        - '4.18'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-master-node-labeller
+        namespace: openshift-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-master-node-labeller
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - list
+        - get
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-master-node-labeller
+      subjects:
+      - kind: ServiceAccount
+        name: osd-master-node-labeller
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-master-node-labeller
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-master-node-labeller
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-master-node-labeller
+                restartPolicy: Never
+                containers:
+                - name: osd-master-node-labeller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "#!/bin/bash\nset -euo pipefail\n\necho \"Starting master node\
+                    \ labeller job...\"\n\n# Get all nodes with node-role.kubernetes.io/master\
+                    \ label\nmaster_nodes=$(oc get nodes -l node-role.kubernetes.io/master\
+                    \ -o jsonpath='{.items[*].metadata.name}')\n\nif [ -z \"$master_nodes\"\
+                    \ ]; then\n  echo \"No nodes found with label node-role.kubernetes.io/master\"\
+                    \n  exit 0\nfi\n\necho \"Found master nodes: $master_nodes\"\n\
+                    \n# Check if all master nodes already have control-plane label\n\
+                    master_count=$(echo $master_nodes | wc -w)\ncontrol_plane_count=$(oc\
+                    \ get nodes -l node-role.kubernetes.io/master,node-role.kubernetes.io/control-plane\
+                    \ --no-headers 2>/dev/null | wc -l)\n\nif [ \"$master_count\"\
+                    \ -eq \"$control_plane_count\" ]; then\n  echo \"All $master_count\
+                    \ master nodes already have node-role.kubernetes.io/control-plane\
+                    \ label. Exiting.\"\n  exit 0\nfi\n\nnodes_needing_label=$((master_count\
+                    \ - control_plane_count))\necho \"Found $nodes_needing_label master\
+                    \ nodes that need the control-plane label\"\n\n# Label each master\
+                    \ node with control-plane label\nfor node in $master_nodes; do\n\
+                    \  echo \"Processing node: $node\"\n\n  # Check if the node already\
+                    \ has the control-plane label\n  if oc get node \"$node\" --show-labels\
+                    \ | grep -q \"node-role.kubernetes.io/control-plane\"; then\n\
+                    \    echo \"Node $node already has node-role.kubernetes.io/control-plane\
+                    \ label, skipping\"\n  else\n    echo \"Adding node-role.kubernetes.io/control-plane\
+                    \ label to node $node\"\n    oc label node \"$node\" node-role.kubernetes.io/control-plane=\"\
+                    \" --overwrite\n    echo \"Successfully labeled node $node\"\n\
+                    \  fi\ndone\n\necho \"Master node labeller job completed successfully\"\
+                    \n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-must-gather-operator
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -41483,6 +41483,126 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: osd-master-node-labeller
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/product
+        operator: In
+        values:
+        - osd
+        - rosa
+      - key: hive.openshift.io/version-major-minor-patch
+        operator: In
+        values:
+        - '4.12'
+        - '4.13'
+        - '4.14'
+        - '4.15'
+        - '4.16'
+        - '4.17'
+        - '4.18'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: osd-master-node-labeller
+        namespace: openshift-config
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: osd-master-node-labeller
+      rules:
+      - apiGroups:
+        - ''
+        resources:
+        - nodes
+        verbs:
+        - list
+        - get
+        - patch
+    - kind: ClusterRoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: osd-master-node-labeller
+      subjects:
+      - kind: ServiceAccount
+        name: osd-master-node-labeller
+        namespace: openshift-config
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: osd-master-node-labeller
+    - apiVersion: batch/v1
+      kind: CronJob
+      metadata:
+        name: osd-master-node-labeller
+        namespace: openshift-config
+      spec:
+        failedJobsHistoryLimit: 3
+        successfulJobsHistoryLimit: 3
+        concurrencyPolicy: Replace
+        schedule: 0 0 * * *
+        jobTemplate:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+                      weight: 1
+                tolerations:
+                - effect: NoSchedule
+                  key: node-role.kubernetes.io/infra
+                  operator: Exists
+                serviceAccountName: osd-master-node-labeller
+                restartPolicy: Never
+                containers:
+                - name: osd-master-node-labeller
+                  image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+                  imagePullPolicy: Always
+                  command:
+                  - /bin/bash
+                  - -c
+                  - "#!/bin/bash\nset -euo pipefail\n\necho \"Starting master node\
+                    \ labeller job...\"\n\n# Get all nodes with node-role.kubernetes.io/master\
+                    \ label\nmaster_nodes=$(oc get nodes -l node-role.kubernetes.io/master\
+                    \ -o jsonpath='{.items[*].metadata.name}')\n\nif [ -z \"$master_nodes\"\
+                    \ ]; then\n  echo \"No nodes found with label node-role.kubernetes.io/master\"\
+                    \n  exit 0\nfi\n\necho \"Found master nodes: $master_nodes\"\n\
+                    \n# Check if all master nodes already have control-plane label\n\
+                    master_count=$(echo $master_nodes | wc -w)\ncontrol_plane_count=$(oc\
+                    \ get nodes -l node-role.kubernetes.io/master,node-role.kubernetes.io/control-plane\
+                    \ --no-headers 2>/dev/null | wc -l)\n\nif [ \"$master_count\"\
+                    \ -eq \"$control_plane_count\" ]; then\n  echo \"All $master_count\
+                    \ master nodes already have node-role.kubernetes.io/control-plane\
+                    \ label. Exiting.\"\n  exit 0\nfi\n\nnodes_needing_label=$((master_count\
+                    \ - control_plane_count))\necho \"Found $nodes_needing_label master\
+                    \ nodes that need the control-plane label\"\n\n# Label each master\
+                    \ node with control-plane label\nfor node in $master_nodes; do\n\
+                    \  echo \"Processing node: $node\"\n\n  # Check if the node already\
+                    \ has the control-plane label\n  if oc get node \"$node\" --show-labels\
+                    \ | grep -q \"node-role.kubernetes.io/control-plane\"; then\n\
+                    \    echo \"Node $node already has node-role.kubernetes.io/control-plane\
+                    \ label, skipping\"\n  else\n    echo \"Adding node-role.kubernetes.io/control-plane\
+                    \ label to node $node\"\n    oc label node \"$node\" node-role.kubernetes.io/control-plane=\"\
+                    \" --overwrite\n    echo \"Successfully labeled node $node\"\n\
+                    \  fi\ndone\n\necho \"Master node labeller job completed successfully\"\
+                    \n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: osd-must-gather-operator
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
This adds a CronJob that automatically labels master nodes with the node-role.kubernetes.io/control-plane label for backward compatibility.

The job runs daily at midnight and targets OSD/ROSA clusters running OpenShift 4.14-4.18. It exits early if all master nodes already have the control-plane label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
