### PR TITLE
SREP-1000: Change ENA metric label 'instance' to 'node' for otel filters

### DIFF
--- a/deploy/srep-1000-ethtool-exporter/12-ServiceMonitorRhobs.yaml
+++ b/deploy/srep-1000-ethtool-exporter/12-ServiceMonitorRhobs.yaml
@@ -33,7 +33,7 @@ spec:
           replacement: $1
           sourceLabels:
             - __meta_kubernetes_pod_node_name
-          targetLabel: instance
+          targetLabel: node
   jobLabel: app.kubernetes.io/name
   namespaceSelector:
     matchNames:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -50277,7 +50277,7 @@ objects:
             replacement: $1
             sourceLabels:
             - __meta_kubernetes_pod_node_name
-            targetLabel: instance
+            targetLabel: node
         jobLabel: app.kubernetes.io/name
         namespaceSelector:
           matchNames:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -50277,7 +50277,7 @@ objects:
             replacement: $1
             sourceLabels:
             - __meta_kubernetes_pod_node_name
-            targetLabel: instance
+            targetLabel: node
         jobLabel: app.kubernetes.io/name
         namespaceSelector:
           matchNames:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -50277,7 +50277,7 @@ objects:
             replacement: $1
             sourceLabels:
             - __meta_kubernetes_pod_node_name
-            targetLabel: instance
+            targetLabel: node
         jobLabel: app.kubernetes.io/name
         namespaceSelector:
           matchNames:


### PR DESCRIPTION
### What type of PR is this?

### What this PR does / why we need it?
This PR changes the 'instance' label, relabeling to 'node'. 
Currently the opentelemetrycollector used for Dynatrace is configured to drop the 'instance' labels. 
Renaming this label to 'node' allows us to retain the value, and evaluate the AWS ENA metrics within Dynatrace at the node level. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/SREP-1000

### Special notes for your reviewer:
Have manually tested this change against a staging MC. 

### Pre-checks (if applicable):
- [ X ] Tested latest changes against a cluster
- [ X] Included documentation changes with original PR
- [ X] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```