### PR TITLE
Scope Elasticsearch low-disk alert to only page SRE if disk capacity < 1200Gi

### DIFF
--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -152,7 +152,19 @@ spec:
           for: 1h
           labels:
             namespace: openshift-logging
-            severity: critical
+            severity: warning
+        - alert: ElasticsearchDiskNeedsResizingSRE
+          annotations:
+            message: Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h and should be resized to 1200Gi.
+            summary: Cluster low on disk space
+          expr: |
+            sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+              and
+            es_fs_path_total_bytes < 400 * 1024 * 1024 * 1024
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: critical  
         - alert: ElasticsearchHighFileDescriptorUsageSRE
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour.

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47995,6 +47995,17 @@ objects:
             for: 1h
             labels:
               namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchDiskNeedsResizingSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of disk
+                space within the next 6h and should be resized to 1200Gi.
+              summary: Cluster low on disk space
+            expr: "sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <\
+              \ 0\n  and\nes_fs_path_total_bytes < 400 * 1024 * 1024 * 1024\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
               severity: critical
           - alert: ElasticsearchHighFileDescriptorUsageSRE
             annotations:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47995,6 +47995,17 @@ objects:
             for: 1h
             labels:
               namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchDiskNeedsResizingSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of disk
+                space within the next 6h and should be resized to 1200Gi.
+              summary: Cluster low on disk space
+            expr: "sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <\
+              \ 0\n  and\nes_fs_path_total_bytes < 400 * 1024 * 1024 * 1024\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
               severity: critical
           - alert: ElasticsearchHighFileDescriptorUsageSRE
             annotations:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47995,6 +47995,17 @@ objects:
             for: 1h
             labels:
               namespace: openshift-logging
+              severity: warning
+          - alert: ElasticsearchDiskNeedsResizingSRE
+            annotations:
+              message: Cluster {{ $labels.cluster }} is predicted to be out of disk
+                space within the next 6h and should be resized to 1200Gi.
+              summary: Cluster low on disk space
+            expr: "sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <\
+              \ 0\n  and\nes_fs_path_total_bytes < 400 * 1024 * 1024 * 1024\n"
+            for: 1h
+            labels:
+              namespace: openshift-logging
               severity: critical
           - alert: ElasticsearchHighFileDescriptorUsageSRE
             annotations:


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR lowers the `ElasticsearchDiskSpaceRunningLowSRE` alert's severity to warning and creates a new critical alert, `ElasticsearchDiskNeedsResizingSRE` that fires only if both free space is low and the disk space is less than the threshold at which the alert becomes a no-op for SRE (400Gi per disk, or 1200Gi total, per the [SOP](https://github.com/openshift/ops-sop/blob/master/v4/howto/logging.md#can-i-grow-es-storage)) 

### Which Jira/Github issue(s) this PR fixes?
Finishes the job started by [OSD-18456](https://issues.redhat.com/browse/OSD-18456)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
