### PR TITLE
Adjust ElasticsearchDiskNeedsResizingSRE threshold to account for FS overhead

### DIFF
--- a/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/extended-logging/101-parsed_elasticsearch_openshift-logging_elasticsearch-prometheus-rules.PrometheusRule.yaml
@@ -160,7 +160,7 @@ spec:
           expr: |
             sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
               and
-            avg(last_over_time(es_fs_path_total_bytes[6h])) < 400 * 1024^3
+            avg(last_over_time(es_fs_path_total_bytes[6h])) < 390 * 1024^3
           for: 1h
           labels:
             namespace: openshift-logging

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -48003,7 +48003,7 @@ objects:
                 400Gi.
               summary: Cluster low on disk space and needs resizing
             expr: "sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <\
-              \ 0\n  and\navg(last_over_time(es_fs_path_total_bytes[6h])) < 400 *\
+              \ 0\n  and\navg(last_over_time(es_fs_path_total_bytes[6h])) < 390 *\
               \ 1024^3\n"
             for: 1h
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -48003,7 +48003,7 @@ objects:
                 400Gi.
               summary: Cluster low on disk space and needs resizing
             expr: "sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <\
-              \ 0\n  and\navg(last_over_time(es_fs_path_total_bytes[6h])) < 400 *\
+              \ 0\n  and\navg(last_over_time(es_fs_path_total_bytes[6h])) < 390 *\
               \ 1024^3\n"
             for: 1h
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -48003,7 +48003,7 @@ objects:
                 400Gi.
               summary: Cluster low on disk space and needs resizing
             expr: "sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) <\
-              \ 0\n  and\navg(last_over_time(es_fs_path_total_bytes[6h])) < 400 *\
+              \ 0\n  and\navg(last_over_time(es_fs_path_total_bytes[6h])) < 390 *\
               \ 1024^3\n"
             for: 1h
             labels:


### PR DESCRIPTION
This PR is a quick patch of #2547, which didn't account for ext4 filesystem overhead and might have allowed ElasticsearchDiskNeedsResizingSRE to fire if each disk was exactly 400 Gi (as reported by OpenShift). A 390 Gi threshold allows for up to 2.5% filesystem overhead.