### PR TITLE
SREP-1000: Deploy MC ethtool exporter to all non-fedramp sectors

### DIFF
--- a/deploy/srep-1000-ethtool-exporter/config.yaml
+++ b/deploy/srep-1000-ethtool-exporter/config.yaml
@@ -7,16 +7,3 @@ selectorSyncSet:
     - key: api.openshift.com/fedramp
       operator: NotIn
       values: ["true"]
-    - key: ext-hypershift.openshift.io/cluster-sector
-      operator: In
-      values: 
-      - "eu-west-2"
-      - "chaos"
-      - "dynatrace"
-      - "green"
-      - "main"
-      - "perf2"
-      - "perf3"
-      - "perf4"
-      - "podisolation"
-      - "regional-ap-southeast-1"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -49903,19 +49903,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - eu-west-2
-        - chaos
-        - dynatrace
-        - green
-        - main
-        - perf2
-        - perf3
-        - perf4
-        - podisolation
-        - regional-ap-southeast-1
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -49903,19 +49903,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - eu-west-2
-        - chaos
-        - dynatrace
-        - green
-        - main
-        - perf2
-        - perf3
-        - perf4
-        - podisolation
-        - regional-ap-southeast-1
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -49903,19 +49903,6 @@ objects:
         operator: NotIn
         values:
         - 'true'
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - eu-west-2
-        - chaos
-        - dynatrace
-        - green
-        - main
-        - perf2
-        - perf3
-        - perf4
-        - podisolation
-        - regional-ap-southeast-1
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Deploys supplemental ethtool node-exporter to Management Clusters in all non-fedramp sectors.  
This is currently deployed on 'most' int/staging management clusters, as well eu-west-2 in prod. 
Removes previously applied filters allowing this to be deployed in all int, stage and prod sectors. 

### Which Jira/Github issue(s) this PR fixes?
https://issues.redhat.com/browse/SREP-1000
(gather metrics for packet drops related to AWS ENA thresholds)

### Special notes for your reviewer:


### Pre-checks (if applicable):
- [ x] Tested latest changes against a cluster
- [ x] Included documentation changes with PR
- [ x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
