### PR TITLE
Remove compute.firewall.create permission from WIF templates for 4.17

### DIFF
--- a/resources/wif/4.17/vanilla.yaml
+++ b/resources/wif/4.17/vanilla.yaml
@@ -473,7 +473,6 @@ support:
         - compute.disks.get
         - compute.disks.list
         - compute.disks.setLabels
-        - compute.firewalls.create
         - compute.firewalls.get
         - compute.firewalls.list
         - compute.forwardingRules.get


### PR DESCRIPTION
Title: https://issues.redhat.com/browse/SREP-1758