### PR TITLE
ROSAENG-60017: Add ec2:DescribeInstanceTypes to CAPA policy

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json
@@ -7,6 +7,7 @@
         "ec2:DescribeDhcpOptions",
         "ec2:DescribeImages",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeInternetGateways",
         "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeNetworkInterfaceAttribute",


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

ROSA HCP supports scale-to-zero functionality. For this to work, `AWSMachineTemplate.Status.Capacity` fields need to be populated by the CAPA provider.

This PR adds `ec2:DescribeInstanceTypes` permission to the CAPA controller manager credentials policy (`ROSANodePoolManagementPolicy`), enabling the controller to query instance type specifications (vCPU, memory, etc.) needed for capacity calculations.

**Permission Details:**
| Field | Value |
|-------|-------|
| Permission | `ec2:DescribeInstanceTypes` |
| Purpose | Populate `AWSMachineTemplate.Status.Capacity` for scale-to-zero |
| Conditions | None - AWS Describe APIs don't support resource-level conditions |
| Resource | `*` (required for Describe actions) |

### Which Jira/Github issue(s) this PR fixes?

Fixes [SREP-3410](https://issues.redhat.com/browse/SREP-3410)

### Special notes for your reviewer:

This permission already exists in other policies in this repo:
- `sts_hcp_installer_permission_policy.json`
- `sts_extended_hcp_support_permission_policy.json` (NetworkVerifier)
- `openshift_hcp_cloud_network_config_cloud_credentials_permission_policy.json`

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment - N/A (modification to existing policy)