### PR TITLE
SREP-3883: Resolve typo in hypershift_cluster_waiting_initial_availability_duration_seconds

### DIFF
--- a/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/ocm-agent/obo-monitoring/100-oidc-missing.PrometheusRule.yaml
@@ -17,10 +17,10 @@ spec:
             description: "Customer cloud environment is unreachable from the management cluster due to invalid aws credentials"
             summary: "Cluster has invalid AWS credentials"
           # Clusters tend to have their `hypershift_cluster_invalid_aws_creds` set to > 0 while the HCP didn't finish the installation, thus we check
-          # that the HCP is not rolling out in our expression (= hypershift_cluster_waiting_initial_avaibility_duration_seconds does not exist)
+          # that the HCP is not rolling out in our expression (= hypershift_cluster_waiting_initial_availability_duration_seconds does not exist)
           # hypershift_cluster_waiting_initial_avaibility_duration_seconds stops being emitted once the HCP is rolled out
           # This will be fixed with https://issues.redhat.com/browse/OCPBUGS-63353 
-          expr: (max by (exported_namespace, _id) (hypershift_cluster_invalid_aws_creds) == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_avaibility_duration_seconds or hypershift_cluster_deleting_duration_seconds)
+          expr: (max by (exported_namespace, _id) (hypershift_cluster_invalid_aws_creds) == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_availability_duration_seconds or hypershift_cluster_deleting_duration_seconds)
           for: 4m # api-ErrorBudgetBurn is our highest SLA and triggers after 5 minutes of CrashLooping kube-apiserver pods. KAS pods can CrashLoop due to missing OIDC/invalid AWS permissions. To reduce self-resolving alerts, we need the limited support to be in place before the alert triggers.
           labels:
             severity: warning

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -51086,7 +51086,7 @@ objects:
                 cluster due to invalid aws credentials
               summary: Cluster has invalid AWS credentials
             expr: (max by (exported_namespace, _id) (hypershift_cluster_invalid_aws_creds)
-              == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_avaibility_duration_seconds
+              == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_availability_duration_seconds
               or hypershift_cluster_deleting_duration_seconds)
             for: 4m
             labels:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -51086,7 +51086,7 @@ objects:
                 cluster due to invalid aws credentials
               summary: Cluster has invalid AWS credentials
             expr: (max by (exported_namespace, _id) (hypershift_cluster_invalid_aws_creds)
-              == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_avaibility_duration_seconds
+              == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_availability_duration_seconds
               or hypershift_cluster_deleting_duration_seconds)
             for: 4m
             labels:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -51086,7 +51086,7 @@ objects:
                 cluster due to invalid aws credentials
               summary: Cluster has invalid AWS credentials
             expr: (max by (exported_namespace, _id) (hypershift_cluster_invalid_aws_creds)
-              == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_avaibility_duration_seconds
+              == 1) unless on (exported_namespace) (hypershift_cluster_waiting_initial_availability_duration_seconds
               or hypershift_cluster_deleting_duration_seconds)
             for: 4m
             labels:


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Fix typo in metric that is being resolved in https://github.com/openshift/hypershift/pull/7730

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
