### PR TITLE
Updated image for osd-cluster-ready 

### DIFF
--- a/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
+++ b/deploy/osd-cluster-ready/job/10-osd-ready.Job.yaml
@@ -18,6 +18,6 @@ spec:
             - name: osd-cluster-ready
               # Keep the `managed.openshift.io/version` label in sync
               # with this
-              image: "quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:b31101e1483fdedab934c8a214fce74d94d3005510b3d7df247d618fa573de7e"
+              image: "quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:430f2d28c7b0b0f486997a96c04ee2482bf4a2b209b9e9aacb35c1aea70c4e96"
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -39507,7 +39507,7 @@ objects:
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:b31101e1483fdedab934c8a214fce74d94d3005510b3d7df247d618fa573de7e
+              image: quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:430f2d28c7b0b0f486997a96c04ee2482bf4a2b209b9e9aacb35c1aea70c4e96
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -39507,7 +39507,7 @@ objects:
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:b31101e1483fdedab934c8a214fce74d94d3005510b3d7df247d618fa573de7e
+              image: quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:430f2d28c7b0b0f486997a96c04ee2482bf4a2b209b9e9aacb35c1aea70c4e96
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -39507,7 +39507,7 @@ objects:
           spec:
             containers:
             - name: osd-cluster-ready
-              image: quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:b31101e1483fdedab934c8a214fce74d94d3005510b3d7df247d618fa573de7e
+              image: quay.io/redhat-services-prod/openshift/osd-cluster-ready@sha256:430f2d28c7b0b0f486997a96c04ee2482bf4a2b209b9e9aacb35c1aea70c4e96
             restartPolicy: OnFailure
             serviceAccountName: osd-cluster-ready
 - apiVersion: hive.openshift.io/v1


### PR DESCRIPTION
Updated image for osd-cluster-ready  to sha256:430f2d28c7b0b0f486997a96c04ee2482bf4a2b209b9e9aacb35c1aea70c4e96

