### PR TITLE
SREP-3817: Allow day-2 CreateTags on existing EBS volumes and snapshots

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -112,6 +112,7 @@
       }
     },
     {
+      "Sid": "CreateTagsOnCreate",
       "Effect": "Allow",
       "Action": [
         "ec2:CreateTags"
@@ -126,6 +127,22 @@
             "CreateVolume",
             "CreateSnapshot"
           ]
+        }
+      }
+    },
+    {
+      "Sid": "CreateTagsExistingVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add a new IAM policy statement (`CreateTagsExistingVolumes`) to the HCP EBS CSI driver policy allowing `ec2:CreateTags` on existing volumes and snapshots that have the `red-hat-managed: true` tag
- Add a `Sid` to the existing creation-time statement (`CreateTagsOnCreate`) for clarity
- Follows the same pattern already used by the [CAPA Controller Manager policy](https://github.com/openshift/managed-cluster-config/blob/master/resources/sts/hypershift/openshift_hcp_capa_controller_manager_credentials_policy.json) for day-2 tag reconciliation

## Problem

The EBS CSI driver's `EBSVolumeTagsController` (introduced in OCP 4.19 via [CFE-1131 / PR #297](https://github.com/openshift/csi-operator/pull/297)) calls `ec2:CreateTags` on existing EBS volumes to reconcile infrastructure resource tags. The current policy restricts `CreateTags` with an `ec2:CreateAction` condition that only allows tagging during `CreateVolume`/`CreateSnapshot`, causing `AccessDenied` on all day-2 tag operations.

This affects all ROSA HCP clusters on OCP 4.19+. Classic STS clusters are not impacted (they have unrestricted `ec2:CreateTags`).

Support case: 04362496

## Fix

Add a second `CreateTags` statement that allows tagging existing resources scoped to `aws:ResourceTag/red-hat-managed: true`. This is the same approach used by the CAPA Controller Manager policy (`CreateTagsCAPAControllerReconcileVolume`).

## Test plan

- [ ] Validate JSON syntax
- [ ] Deploy to integration environment and verify EBS CSI driver day-2 tag reconciliation succeeds
- [ ] Verify volume creation still works with tags applied at creation time
- [ ] Check CloudTrail for absence of AccessDenied on CreateTags from the CSI driver role

Jira: https://issues.redhat.com/browse/SREP-3817
