### PR TITLE
SREP-4038, STOR-2766: Update hcp aws-ebs-csi-driver credentials

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -4,11 +4,16 @@
     {
       "Effect": "Allow",
       "Action": [
+        "ec2:CopyVolumes",
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
         "ec2:DescribeSnapshots",
         "ec2:DescribeTags",
         "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications"
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus",
+        "ec2:EnableFastSnapshotRestores",
+        "ec2:LockSnapshot"
       ],
       "Resource": "*"
     },

--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -169,6 +169,39 @@
           ]
         }
       }
+    },
+    {
+      "Sid": "KMSEncryptedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKeyWithoutPlaintext"
+      ],
+      "Resource": "arn:aws:kms:*:*:key/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat": "true"
+        },
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "KMSCreateGrant",
+      "Effect": "Allow",
+      "Action": [
+        "kms:CreateGrant"
+      ],
+      "Resource": "arn:aws:kms:*:*:key/*",
+      "Condition": {
+        "Bool": {
+          "kms:GrantIsForAWSResource": true
+        },
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
+        }
+      }
     }
   ]
 }

--- a/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_cluster_csi_driver_ebs_operator_cloud_credentials_policy.json
@@ -2,26 +2,110 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "ReadOnlyDescribeOperations",
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInstances",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeSnapshots",
-        "ec2:DescribeTags",
         "ec2:DescribeVolumes",
-        "ec2:DescribeVolumesModifications"
+        "ec2:DescribeVolumesModifications",
+        "ec2:DescribeVolumeStatus"
       ],
       "Resource": "*"
     },
     {
+      "Sid": "CreateAndCopyVolumesWithManagedTag",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CopyManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CopyVolumes"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/vol-*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CreateSnapshotsWithManagedTag",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CreateSnapshotsFromManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "ManageManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyVolume",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "CreateVolumesFromAndEnableFSROnManagedSnapshots",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:EnableFastSnapshotRestores"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        }
+      }
+    },
+    {
+      "Sid": "AttachDetachVolumesToAnyInstance",
       "Effect": "Allow",
       "Action": [
         "ec2:AttachVolume",
         "ec2:DetachVolume"
       ],
-      "Resource": [
-        "arn:aws:ec2:*:*:instance/*",
-        "arn:aws:ec2:*:*:volume/*"
-      ],
+      "Resource": "arn:aws:ec2:*:*:instance/*",
       "Condition": {
         "StringEquals": {
           "aws:ResourceTag/red-hat-managed": "true"
@@ -29,14 +113,13 @@
       }
     },
     {
+      "Sid": "DeleteAndLockManagedSnapshots",
       "Effect": "Allow",
       "Action": [
-        "ec2:DeleteVolume",
-        "ec2:ModifyVolume"
-       ],
-      "Resource": [
-        "arn:aws:ec2:*:*:volume/*"
-       ],
+        "ec2:DeleteSnapshot",
+        "ec2:LockSnapshot"
+      ],
+      "Resource": "arn:aws:ec2:*:*:snapshot/*",
       "Condition": {
         "StringEquals": {
           "aws:ResourceTag/red-hat-managed": "true"
@@ -44,74 +127,7 @@
       }
     },
     {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateVolume"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:volume/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/red-hat-managed": "true"
-        }
-      }
-    },
-    {
-      "Sid": "CreateVolumeFromSnapshot",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateVolume"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:snapshot/*"
-      ]
-    },
-    {
-      "Sid": "CreateSnapshotResourceTag",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateSnapshot"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:volume/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:ResourceTag/red-hat-managed": "true"
-        }
-      }
-    },
-    {
-      "Sid": "CreateSnapshotRequestTag",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateSnapshot"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:snapshot/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:RequestTag/red-hat-managed": "true"
-        }
-      }
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:DeleteSnapshot"
-      ],
-      "Resource": [
-        "arn:aws:ec2:*:*:snapshot/*"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "aws:ResourceTag/red-hat-managed": "true"
-        }
-      }
-    },
-    {
+      "Sid": "TagResourcesOnCreation",
       "Effect": "Allow",
       "Action": [
         "ec2:CreateTags"
@@ -124,7 +140,32 @@
         "StringEquals": {
           "ec2:CreateAction": [
             "CreateVolume",
-            "CreateSnapshot"
+            "CreateSnapshot",
+            "CopyVolumes"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "ModifyTagsOnManagedVolumes",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/red-hat-managed": "true"
+        },
+        "Null": {
+          "aws:TagKeys": "false"
+        },
+        "ForAllValues:StringNotEquals": {
+          "aws:TagKeys": [
+            "red-hat-managed",
+            "ebs.csi.aws.com/cluster",
+            "kubernetes.io/created-for/pvc/name"
           ]
         }
       }


### PR DESCRIPTION
### What type of PR is this?
_feature_

### What this PR does / why we need it?
This PR updates the IAM permission policy for the aws-ebs-csi-driver to align with upstream changes required for the OpenShift rebase. These updates ensure full driver functionality and support for enhanced EBS features.

### Special notes for your reviewer:

It might seem like a lot of changes but a lot of them are just moved in the file so we are mroe aligned with upstream version https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/release-1.61/docs/AmazonEBSCSIDriverPolicyV2.json and following the AWS example of policies https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonEBSCSIDriverPolicyV2.html

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded the AWS IAM policy for the EBS CSI driver with additional EC2/EBS permissions, including availability zone and volume status reads, faster snapshot restores, and snapshot locking/deletion.
  * Added tag-scoped support for creating, copying, and snapshotting managed EBS volumes, with attachment/detachment allowed to any instance while other operations remain constrained by managed resource tags.
  * Updated KMS permissions for encrypted volume/snapshot workflows, constrained by the expected key tags.
* **Chores**
  * Tightened and refined tagging permissions for managed resources, restricting tag keys and ensuring tag operations apply correctly to copy/create actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->