### PR TITLE
SREP-4235: Fix Dockerfile.prow permissions for Prow clonerefs

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -10,6 +10,7 @@ COPY --from=promtool /bin/promtool /bin/
 
 USER root
 RUN dnf install -y jq git make diffutils && dnf clean all
+RUN mkdir -p /go && chmod 1777 /go
 USER default
 
 RUN pip install --disable-pip-version-check oyaml


### PR DESCRIPTION
## What

Add `/go` directory with world-writable permissions to `Dockerfile.prow` so ci-operator's clonerefs can clone the source tree as a non-root user.

## Why

Prow rehearsal for the ci-operator config PR (openshift/release#77425) failed with:
```
mkdir: cannot create directory '/go': Permission denied
```
ci-operator's clonerefs clones into `/go/src/github.com/openshift/managed-cluster-config/` as a non-root user, but the `ubi9/python-312` base image doesn't have a `/go` directory.

## Tickets

- [SREP-4235](https://redhat.atlassian.net/browse/SREP-4235)

## Validation

- Prow rehearsal on openshift/release#77425 should pass after this merges

## Dependency

- openshift/release#77425 depends on this fix