### PR TITLE
Add elasticloadbalancing:RemoveTags to 4.22 STS installer policy

### DIFF
--- a/resources/sts/4.22/sts_installer_permission_policy.json
+++ b/resources/sts/4.22/sts_installer_permission_policy.json
@@ -87,6 +87,7 @@
                 "ec2:StopInstances",
                 "ec2:TerminateInstances",
                 "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags",
                 "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
                 "elasticloadbalancing:AttachLoadBalancerToSubnets",
                 "elasticloadbalancing:ConfigureHealthCheck",


### PR DESCRIPTION
## Summary

- Add `elasticloadbalancing:RemoveTags` to the 4.22 Classic STS installer permission policy
- OCP 4.22 promotes CAPI to GA via `ClusterAPIMachineManagement` feature gate, and the new CAPI version calls `elasticloadbalancing:RemoveTags` during NLB tag reconciliation
- Without this permission, Classic STS 4.22 cluster provisioning gets stuck in an AccessDenied loop in the CAPI AWSCluster controller

## Test plan

- [ ] Verify Classic STS 4.22 nightly cluster can provision on staging after policy update
- [ ] Confirm no regressions for 4.19/4.20/4.21 Classic STS provisioning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Elastic Load Balancing permissions to support tag removal operations in the STS installer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->