### PR TITLE
Remove SREP write permission in backplane rbac

### DIFF
--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -39,12 +39,6 @@ spec:
                             - apiGroups:
                                 - ""
                               resources:
-                                - nodes
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - ""
-                              resources:
                                 - nodes/proxy
                               verbs:
                                 - get
@@ -53,11 +47,8 @@ spec:
                               resources:
                                 - projects
                               verbs:
-                                - create
                                 - get
                                 - list
-                                - patch
-                                - update
                                 - watch
                             - apiGroups:
                                 - project.openshift.io
@@ -65,36 +56,22 @@ spec:
                                 - projects
                                 - projectrequests
                               verbs:
-                                - create
                                 - get
                                 - list
-                                - patch
-                                - update
                                 - watch
-                                - delete
                             - apiGroups:
                                 - ""
                               resources:
                                 - namespaces
                                 - namespaces/finalize
                               verbs:
-                                - create
                                 - get
                                 - list
-                                - patch
-                                - update
                                 - watch
-                                - delete
-                            - apiGroups:
-                                - certificates.k8s.io
-                              resources:
-                                - certificatesigningrequests/approval
-                              verbs:
-                                - update
                             - nonResourceURLs:
                                 - '*'
                               verbs:
-                                - '*'
+                                - get
                             - apiGroups:
                                 - authentication.k8s.io
                               resources:
@@ -146,12 +123,6 @@ spec:
                                 - list
                                 - watch
                             - apiGroups:
-                                - machine.openshift.io
-                              resources:
-                                - machines
-                              verbs:
-                                - delete
-                            - apiGroups:
                                 - apiserver.openshift.io
                               resources:
                                 - apirequestcounts
@@ -167,7 +138,6 @@ spec:
                                 - get
                                 - list
                                 - watch
-                                - delete
                             - apiGroups:
                                 - avo.openshift.io
                               resources:
@@ -176,7 +146,6 @@ spec:
                                 - get
                                 - list
                                 - watch
-                                - delete
                     - complianceType: mustonlyhave
                       metadataComplianceType: musthave
                       objectDefinition:
@@ -188,37 +157,9 @@ spec:
                             - apiGroups:
                                 - ""
                               resources:
-                                - pods/eviction
-                              verbs:
-                                - create
-                            - apiGroups:
-                                - ""
-                              resources:
                                 - pods/portforward
                               verbs:
                                 - create
-                            - apiGroups:
-                                - batch
-                              resources:
-                                - jobs
-                              verbs:
-                                - delete
-                                - deletecollection
-                                - create
-                            - apiGroups:
-                                - build.openshift.io
-                              resources:
-                                - builds
-                              verbs:
-                                - delete
-                                - deletecollection
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - pods
-                              verbs:
-                                - delete
-                                - deletecollection
                             - apiGroups:
                                 - security.openshift.io
                               resources:
@@ -232,21 +173,9 @@ spec:
                               resources:
                                 - '*'
                               verbs:
-                                - '*'
-                            - apiGroups:
-                                - velero.io
-                              resources:
-                                - backups
-                              verbs:
-                                - create
-                            - apiGroups:
-                                - velero.io
-                              resources:
-                                - deletebackuprequests
-                                - downloadrequests
-                                - serverstatusrequests
-                              verbs:
-                                - '*'
+                                - get
+                                - list
+                                - watch
                             - apiGroups:
                                 - velero.io
                               resources:
@@ -255,72 +184,6 @@ spec:
                                 - get
                                 - list
                                 - watch
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - persistentvolumeclaims
-                              verbs:
-                                - delete
-                                - patch
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - replicationcontrollers/scale
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - apps
-                              resources:
-                                - deployments/scale
-                                - replicasets/scale
-                                - statefulsets/scale
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - apps.openshift.io
-                              resources:
-                                - deploymentconfigs/scale
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - ""
-                              resources:
-                                - replicasets
-                              verbs:
-                                - delete
-                                - deletecollection
-                            - apiGroups:
-                                - machine.openshift.io
-                              resources:
-                                - machinehealthchecks
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - machine.openshift.io
-                              resources:
-                                - machinesets/scale
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - monitoring.coreos.com
-                              resources:
-                                - prometheuses
-                              verbs:
-                                - patch
-                            - apiGroups:
-                                - upgrade.managed.openshift.io
-                              resources:
-                                - upgradeconfigs
-                              verbs:
-                                - delete
-                            - apiGroups:
-                                - operators.coreos.com
-                              resources:
-                                - clusterserviceversions
-                                - installplans
-                                - subscriptions
-                              verbs:
-                                - delete
                             - apiGroups:
                                 - monitoring.coreos.com
                               resources:

--- a/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-cluster.ClusterRole.yml
@@ -3,13 +3,6 @@ kind: ClusterRole
 metadata:
   name: backplane-srep-admins-cluster
 rules:
-# SRE can manage nodes
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - patch
 # SRE can get node-logs
 - apiGroups:
   - ""
@@ -17,17 +10,14 @@ rules:
   - nodes/proxy
   verbs:
   - get
-# SRE can manage projects
+# SRE can view projects
 - apiGroups:
   - config.openshift.io
   resources:
   - projects
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - project.openshift.io
@@ -35,39 +25,24 @@ rules:
   - projects
   - projectrequests
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
-  - delete
-# SRE can manage namespaces
+# SRE can view namespaces
 - apiGroups:
   - ""
   resources:
   - namespaces
   - namespaces/finalize
   verbs:
-  - create
   - get
   - list
-  - patch
-  - update
   - watch
-  - delete
-# SRE can approve Certificate Signing Requests (CSR)
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests/approval
-  verbs:
-  - update
-# SRE can get and post to all endpoints
+# SRE can get all endpoints
 - nonResourceURLs:
   - '*'
   verbs:
-  - '*'
+  - get
 #### Start - more perms for srep
 # https://issues.redhat.com/browse/OSD-5537
 # SRE can create authz/n reviews
@@ -124,13 +99,6 @@ rules:
   - get
   - list
   - watch
-# SRE can delete machines
-- apiGroups:
-  - machine.openshift.io
-  resources:
-  - machines
-  verbs:
-  - delete
 # SRE can view api request counts
 - apiGroups:
   - apiserver.openshift.io
@@ -140,7 +108,7 @@ rules:
   - get
   - list
   - watch
-# SRE can view/delete CSR objects
+# SRE can view CSR objects
 - apiGroups:
   - certificates.k8s.io
   resources:
@@ -149,8 +117,7 @@ rules:
   - get
   - list
   - watch
-  - delete
-# SRE can view/delete vpcendpoints
+# SRE can view vpcendpoints
 - apiGroups:
   - avo.openshift.io
   resources:
@@ -159,4 +126,3 @@ rules:
   - get
   - list
   - watch
-  - delete

--- a/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
+++ b/deploy/backplane/srep/10-srep-admins-project.ClusterRole.yml
@@ -3,13 +3,6 @@ kind: ClusterRole
 metadata:
   name: backplane-srep-admins-project
 rules:
-# SRE can evict pods
-- apiGroups:
-  - ""
-  resources:
-  - pods/eviction
-  verbs:
-  - create
 # SRE can portforward pods
 - apiGroups:
   - ""
@@ -17,30 +10,6 @@ rules:
   - pods/portforward
   verbs:
   - create
-# SRE can manage jobs and builds
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - delete
-  - deletecollection
-  - create
-- apiGroups:
-  - build.openshift.io
-  resources:
-  - builds
-  verbs:
-  - delete
-  - deletecollection
-# SRE can delete pods
-- apiGroups:
-  - ""  
-  resources:
-  - pods
-  verbs:
-  - delete
-  - deletecollection
 # SRE can review pod security policies
 - apiGroups:
   - security.openshift.io
@@ -50,28 +19,16 @@ rules:
   - podsecuritypolicysubjectreviews
   verbs:
   - create
-# SRE can manage Logging (ClusterLogging and ElasticSearch CRs)
+# SRE can view Logging (ClusterLogging and ElasticSearch CRs)
 - apiGroups:
   - logging.openshift.io
   resources:
   - '*'
   verbs:
-  - '*'
-# SRE can download backups, review logs, and create backup
-- apiGroups:
-  - velero.io
-  resources:
-  - backups
-  verbs:
-  - create
-- apiGroups:
-  - velero.io
-  resources:
-  - deletebackuprequests
-  - downloadrequests
-  - serverstatusrequests
-  verbs:
-  - '*'
+  - get
+  - list
+  - watch
+# SRE can view backups
 - apiGroups:
   - velero.io
   resources:
@@ -80,80 +37,6 @@ rules:
   - get
   - list
   - watch
-# SRE can resize and delete pvcs
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumeclaims
-  verbs:
-  - delete
-  - patch
-# SRE can scale apps
-- apiGroups:
-  - ""
-  resources:
-  - replicationcontrollers/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/scale
-  - replicasets/scale
-  - statefulsets/scale
-  verbs:
-  - patch
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs/scale
-  verbs:
-  - patch
-# SRE can delete replicasets
-- apiGroups:
-  - ""
-  resources:
-  - replicasets
-  verbs:
-  - delete
-  - deletecollection
-# SRE can pause machinehealthchecks
-- apiGroups:
-  - machine.openshift.io
-  resources:
-  - machinehealthchecks
-  verbs:
-  - patch
-# SRE can scale machinesets
-- apiGroups:
-  - machine.openshift.io
-  resources:
-  - machinesets/scale
-  verbs:
-  - patch
-# SRE can scale prometheuses
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - prometheuses
-  verbs:
-  - patch
-# SRE can delete upgradeconfigs
-- apiGroups:
-  - upgrade.managed.openshift.io
-  resources:
-  - upgradeconfigs
-  verbs:
-  - delete
-# SRE can delete csv, installplans, and subscriptions
-- apiGroups:
-  - operators.coreos.com
-  resources:
-  - clusterserviceversions
-  - installplans
-  - subscriptions
-  verbs:
-  - delete
 # SRE can view monitoring.coreos.com CustomResources
 - apiGroups:
   - monitoring.coreos.com

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -5306,12 +5306,6 @@ objects:
                   - apiGroups:
                     - ''
                     resources:
-                    - nodes
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
                     - nodes/proxy
                     verbs:
                     - get
@@ -5320,11 +5314,8 @@ objects:
                     resources:
                     - projects
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
                   - apiGroups:
                     - project.openshift.io
@@ -5332,36 +5323,22 @@ objects:
                     - projects
                     - projectrequests
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
-                    - delete
                   - apiGroups:
                     - ''
                     resources:
                     - namespaces
                     - namespaces/finalize
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
-                    - delete
-                  - apiGroups:
-                    - certificates.k8s.io
-                    resources:
-                    - certificatesigningrequests/approval
-                    verbs:
-                    - update
                   - nonResourceURLs:
                     - '*'
                     verbs:
-                    - '*'
+                    - get
                   - apiGroups:
                     - authentication.k8s.io
                     resources:
@@ -5413,12 +5390,6 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machines
-                    verbs:
-                    - delete
-                  - apiGroups:
                     - apiserver.openshift.io
                     resources:
                     - apirequestcounts
@@ -5434,7 +5405,6 @@ objects:
                     - get
                     - list
                     - watch
-                    - delete
                   - apiGroups:
                     - avo.openshift.io
                     resources:
@@ -5443,7 +5413,6 @@ objects:
                     - get
                     - list
                     - watch
-                    - delete
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5455,37 +5424,9 @@ objects:
                   - apiGroups:
                     - ''
                     resources:
-                    - pods/eviction
-                    verbs:
-                    - create
-                  - apiGroups:
-                    - ''
-                    resources:
                     - pods/portforward
                     verbs:
                     - create
-                  - apiGroups:
-                    - batch
-                    resources:
-                    - jobs
-                    verbs:
-                    - delete
-                    - deletecollection
-                    - create
-                  - apiGroups:
-                    - build.openshift.io
-                    resources:
-                    - builds
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - pods
-                    verbs:
-                    - delete
-                    - deletecollection
                   - apiGroups:
                     - security.openshift.io
                     resources:
@@ -5499,21 +5440,9 @@ objects:
                     resources:
                     - '*'
                     verbs:
-                    - '*'
-                  - apiGroups:
-                    - velero.io
-                    resources:
-                    - backups
-                    verbs:
-                    - create
-                  - apiGroups:
-                    - velero.io
-                    resources:
-                    - deletebackuprequests
-                    - downloadrequests
-                    - serverstatusrequests
-                    verbs:
-                    - '*'
+                    - get
+                    - list
+                    - watch
                   - apiGroups:
                     - velero.io
                     resources:
@@ -5522,72 +5451,6 @@ objects:
                     - get
                     - list
                     - watch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - persistentvolumeclaims
-                    verbs:
-                    - delete
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - replicationcontrollers/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - apps
-                    resources:
-                    - deployments/scale
-                    - replicasets/scale
-                    - statefulsets/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - apps.openshift.io
-                    resources:
-                    - deploymentconfigs/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - replicasets
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machinehealthchecks
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machinesets/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - monitoring.coreos.com
-                    resources:
-                    - prometheuses
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - upgrade.managed.openshift.io
-                    resources:
-                    - upgradeconfigs
-                    verbs:
-                    - delete
-                  - apiGroups:
-                    - operators.coreos.com
-                    resources:
-                    - clusterserviceversions
-                    - installplans
-                    - subscriptions
-                    verbs:
-                    - delete
                   - apiGroups:
                     - monitoring.coreos.com
                     resources:
@@ -26854,12 +26717,6 @@ objects:
       - apiGroups:
         - ''
         resources:
-        - nodes
-        verbs:
-        - patch
-      - apiGroups:
-        - ''
-        resources:
         - nodes/proxy
         verbs:
         - get
@@ -26868,11 +26725,8 @@ objects:
         resources:
         - projects
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
       - apiGroups:
         - project.openshift.io
@@ -26880,36 +26734,22 @@ objects:
         - projects
         - projectrequests
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
-        - delete
       - apiGroups:
         - ''
         resources:
         - namespaces
         - namespaces/finalize
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
-        - delete
-      - apiGroups:
-        - certificates.k8s.io
-        resources:
-        - certificatesigningrequests/approval
-        verbs:
-        - update
       - nonResourceURLs:
         - '*'
         verbs:
-        - '*'
+        - get
       - apiGroups:
         - authentication.k8s.io
         resources:
@@ -26961,12 +26801,6 @@ objects:
         - list
         - watch
       - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machines
-        verbs:
-        - delete
-      - apiGroups:
         - apiserver.openshift.io
         resources:
         - apirequestcounts
@@ -26982,7 +26816,6 @@ objects:
         - get
         - list
         - watch
-        - delete
       - apiGroups:
         - avo.openshift.io
         resources:
@@ -26991,7 +26824,6 @@ objects:
         - get
         - list
         - watch
-        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -27000,37 +26832,9 @@ objects:
       - apiGroups:
         - ''
         resources:
-        - pods/eviction
-        verbs:
-        - create
-      - apiGroups:
-        - ''
-        resources:
         - pods/portforward
         verbs:
         - create
-      - apiGroups:
-        - batch
-        resources:
-        - jobs
-        verbs:
-        - delete
-        - deletecollection
-        - create
-      - apiGroups:
-        - build.openshift.io
-        resources:
-        - builds
-        verbs:
-        - delete
-        - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        verbs:
-        - delete
-        - deletecollection
       - apiGroups:
         - security.openshift.io
         resources:
@@ -27044,21 +26848,9 @@ objects:
         resources:
         - '*'
         verbs:
-        - '*'
-      - apiGroups:
-        - velero.io
-        resources:
-        - backups
-        verbs:
-        - create
-      - apiGroups:
-        - velero.io
-        resources:
-        - deletebackuprequests
-        - downloadrequests
-        - serverstatusrequests
-        verbs:
-        - '*'
+        - get
+        - list
+        - watch
       - apiGroups:
         - velero.io
         resources:
@@ -27067,72 +26859,6 @@ objects:
         - get
         - list
         - watch
-      - apiGroups:
-        - ''
-        resources:
-        - persistentvolumeclaims
-        verbs:
-        - delete
-        - patch
-      - apiGroups:
-        - ''
-        resources:
-        - replicationcontrollers/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - apps
-        resources:
-        - deployments/scale
-        - replicasets/scale
-        - statefulsets/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - apps.openshift.io
-        resources:
-        - deploymentconfigs/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - ''
-        resources:
-        - replicasets
-        verbs:
-        - delete
-        - deletecollection
-      - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machinehealthchecks
-        verbs:
-        - patch
-      - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machinesets/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - monitoring.coreos.com
-        resources:
-        - prometheuses
-        verbs:
-        - patch
-      - apiGroups:
-        - upgrade.managed.openshift.io
-        resources:
-        - upgradeconfigs
-        verbs:
-        - delete
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - clusterserviceversions
-        - installplans
-        - subscriptions
-        verbs:
-        - delete
       - apiGroups:
         - monitoring.coreos.com
         resources:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -5306,12 +5306,6 @@ objects:
                   - apiGroups:
                     - ''
                     resources:
-                    - nodes
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
                     - nodes/proxy
                     verbs:
                     - get
@@ -5320,11 +5314,8 @@ objects:
                     resources:
                     - projects
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
                   - apiGroups:
                     - project.openshift.io
@@ -5332,36 +5323,22 @@ objects:
                     - projects
                     - projectrequests
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
-                    - delete
                   - apiGroups:
                     - ''
                     resources:
                     - namespaces
                     - namespaces/finalize
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
-                    - delete
-                  - apiGroups:
-                    - certificates.k8s.io
-                    resources:
-                    - certificatesigningrequests/approval
-                    verbs:
-                    - update
                   - nonResourceURLs:
                     - '*'
                     verbs:
-                    - '*'
+                    - get
                   - apiGroups:
                     - authentication.k8s.io
                     resources:
@@ -5413,12 +5390,6 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machines
-                    verbs:
-                    - delete
-                  - apiGroups:
                     - apiserver.openshift.io
                     resources:
                     - apirequestcounts
@@ -5434,7 +5405,6 @@ objects:
                     - get
                     - list
                     - watch
-                    - delete
                   - apiGroups:
                     - avo.openshift.io
                     resources:
@@ -5443,7 +5413,6 @@ objects:
                     - get
                     - list
                     - watch
-                    - delete
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5455,37 +5424,9 @@ objects:
                   - apiGroups:
                     - ''
                     resources:
-                    - pods/eviction
-                    verbs:
-                    - create
-                  - apiGroups:
-                    - ''
-                    resources:
                     - pods/portforward
                     verbs:
                     - create
-                  - apiGroups:
-                    - batch
-                    resources:
-                    - jobs
-                    verbs:
-                    - delete
-                    - deletecollection
-                    - create
-                  - apiGroups:
-                    - build.openshift.io
-                    resources:
-                    - builds
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - pods
-                    verbs:
-                    - delete
-                    - deletecollection
                   - apiGroups:
                     - security.openshift.io
                     resources:
@@ -5499,21 +5440,9 @@ objects:
                     resources:
                     - '*'
                     verbs:
-                    - '*'
-                  - apiGroups:
-                    - velero.io
-                    resources:
-                    - backups
-                    verbs:
-                    - create
-                  - apiGroups:
-                    - velero.io
-                    resources:
-                    - deletebackuprequests
-                    - downloadrequests
-                    - serverstatusrequests
-                    verbs:
-                    - '*'
+                    - get
+                    - list
+                    - watch
                   - apiGroups:
                     - velero.io
                     resources:
@@ -5522,72 +5451,6 @@ objects:
                     - get
                     - list
                     - watch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - persistentvolumeclaims
-                    verbs:
-                    - delete
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - replicationcontrollers/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - apps
-                    resources:
-                    - deployments/scale
-                    - replicasets/scale
-                    - statefulsets/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - apps.openshift.io
-                    resources:
-                    - deploymentconfigs/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - replicasets
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machinehealthchecks
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machinesets/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - monitoring.coreos.com
-                    resources:
-                    - prometheuses
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - upgrade.managed.openshift.io
-                    resources:
-                    - upgradeconfigs
-                    verbs:
-                    - delete
-                  - apiGroups:
-                    - operators.coreos.com
-                    resources:
-                    - clusterserviceversions
-                    - installplans
-                    - subscriptions
-                    verbs:
-                    - delete
                   - apiGroups:
                     - monitoring.coreos.com
                     resources:
@@ -26854,12 +26717,6 @@ objects:
       - apiGroups:
         - ''
         resources:
-        - nodes
-        verbs:
-        - patch
-      - apiGroups:
-        - ''
-        resources:
         - nodes/proxy
         verbs:
         - get
@@ -26868,11 +26725,8 @@ objects:
         resources:
         - projects
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
       - apiGroups:
         - project.openshift.io
@@ -26880,36 +26734,22 @@ objects:
         - projects
         - projectrequests
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
-        - delete
       - apiGroups:
         - ''
         resources:
         - namespaces
         - namespaces/finalize
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
-        - delete
-      - apiGroups:
-        - certificates.k8s.io
-        resources:
-        - certificatesigningrequests/approval
-        verbs:
-        - update
       - nonResourceURLs:
         - '*'
         verbs:
-        - '*'
+        - get
       - apiGroups:
         - authentication.k8s.io
         resources:
@@ -26961,12 +26801,6 @@ objects:
         - list
         - watch
       - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machines
-        verbs:
-        - delete
-      - apiGroups:
         - apiserver.openshift.io
         resources:
         - apirequestcounts
@@ -26982,7 +26816,6 @@ objects:
         - get
         - list
         - watch
-        - delete
       - apiGroups:
         - avo.openshift.io
         resources:
@@ -26991,7 +26824,6 @@ objects:
         - get
         - list
         - watch
-        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -27000,37 +26832,9 @@ objects:
       - apiGroups:
         - ''
         resources:
-        - pods/eviction
-        verbs:
-        - create
-      - apiGroups:
-        - ''
-        resources:
         - pods/portforward
         verbs:
         - create
-      - apiGroups:
-        - batch
-        resources:
-        - jobs
-        verbs:
-        - delete
-        - deletecollection
-        - create
-      - apiGroups:
-        - build.openshift.io
-        resources:
-        - builds
-        verbs:
-        - delete
-        - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        verbs:
-        - delete
-        - deletecollection
       - apiGroups:
         - security.openshift.io
         resources:
@@ -27044,21 +26848,9 @@ objects:
         resources:
         - '*'
         verbs:
-        - '*'
-      - apiGroups:
-        - velero.io
-        resources:
-        - backups
-        verbs:
-        - create
-      - apiGroups:
-        - velero.io
-        resources:
-        - deletebackuprequests
-        - downloadrequests
-        - serverstatusrequests
-        verbs:
-        - '*'
+        - get
+        - list
+        - watch
       - apiGroups:
         - velero.io
         resources:
@@ -27067,72 +26859,6 @@ objects:
         - get
         - list
         - watch
-      - apiGroups:
-        - ''
-        resources:
-        - persistentvolumeclaims
-        verbs:
-        - delete
-        - patch
-      - apiGroups:
-        - ''
-        resources:
-        - replicationcontrollers/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - apps
-        resources:
-        - deployments/scale
-        - replicasets/scale
-        - statefulsets/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - apps.openshift.io
-        resources:
-        - deploymentconfigs/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - ''
-        resources:
-        - replicasets
-        verbs:
-        - delete
-        - deletecollection
-      - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machinehealthchecks
-        verbs:
-        - patch
-      - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machinesets/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - monitoring.coreos.com
-        resources:
-        - prometheuses
-        verbs:
-        - patch
-      - apiGroups:
-        - upgrade.managed.openshift.io
-        resources:
-        - upgradeconfigs
-        verbs:
-        - delete
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - clusterserviceversions
-        - installplans
-        - subscriptions
-        verbs:
-        - delete
       - apiGroups:
         - monitoring.coreos.com
         resources:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -5306,12 +5306,6 @@ objects:
                   - apiGroups:
                     - ''
                     resources:
-                    - nodes
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
                     - nodes/proxy
                     verbs:
                     - get
@@ -5320,11 +5314,8 @@ objects:
                     resources:
                     - projects
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
                   - apiGroups:
                     - project.openshift.io
@@ -5332,36 +5323,22 @@ objects:
                     - projects
                     - projectrequests
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
-                    - delete
                   - apiGroups:
                     - ''
                     resources:
                     - namespaces
                     - namespaces/finalize
                     verbs:
-                    - create
                     - get
                     - list
-                    - patch
-                    - update
                     - watch
-                    - delete
-                  - apiGroups:
-                    - certificates.k8s.io
-                    resources:
-                    - certificatesigningrequests/approval
-                    verbs:
-                    - update
                   - nonResourceURLs:
                     - '*'
                     verbs:
-                    - '*'
+                    - get
                   - apiGroups:
                     - authentication.k8s.io
                     resources:
@@ -5413,12 +5390,6 @@ objects:
                     - list
                     - watch
                   - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machines
-                    verbs:
-                    - delete
-                  - apiGroups:
                     - apiserver.openshift.io
                     resources:
                     - apirequestcounts
@@ -5434,7 +5405,6 @@ objects:
                     - get
                     - list
                     - watch
-                    - delete
                   - apiGroups:
                     - avo.openshift.io
                     resources:
@@ -5443,7 +5413,6 @@ objects:
                     - get
                     - list
                     - watch
-                    - delete
               - complianceType: mustonlyhave
                 metadataComplianceType: musthave
                 objectDefinition:
@@ -5455,37 +5424,9 @@ objects:
                   - apiGroups:
                     - ''
                     resources:
-                    - pods/eviction
-                    verbs:
-                    - create
-                  - apiGroups:
-                    - ''
-                    resources:
                     - pods/portforward
                     verbs:
                     - create
-                  - apiGroups:
-                    - batch
-                    resources:
-                    - jobs
-                    verbs:
-                    - delete
-                    - deletecollection
-                    - create
-                  - apiGroups:
-                    - build.openshift.io
-                    resources:
-                    - builds
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - pods
-                    verbs:
-                    - delete
-                    - deletecollection
                   - apiGroups:
                     - security.openshift.io
                     resources:
@@ -5499,21 +5440,9 @@ objects:
                     resources:
                     - '*'
                     verbs:
-                    - '*'
-                  - apiGroups:
-                    - velero.io
-                    resources:
-                    - backups
-                    verbs:
-                    - create
-                  - apiGroups:
-                    - velero.io
-                    resources:
-                    - deletebackuprequests
-                    - downloadrequests
-                    - serverstatusrequests
-                    verbs:
-                    - '*'
+                    - get
+                    - list
+                    - watch
                   - apiGroups:
                     - velero.io
                     resources:
@@ -5522,72 +5451,6 @@ objects:
                     - get
                     - list
                     - watch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - persistentvolumeclaims
-                    verbs:
-                    - delete
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - replicationcontrollers/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - apps
-                    resources:
-                    - deployments/scale
-                    - replicasets/scale
-                    - statefulsets/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - apps.openshift.io
-                    resources:
-                    - deploymentconfigs/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - ''
-                    resources:
-                    - replicasets
-                    verbs:
-                    - delete
-                    - deletecollection
-                  - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machinehealthchecks
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - machine.openshift.io
-                    resources:
-                    - machinesets/scale
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - monitoring.coreos.com
-                    resources:
-                    - prometheuses
-                    verbs:
-                    - patch
-                  - apiGroups:
-                    - upgrade.managed.openshift.io
-                    resources:
-                    - upgradeconfigs
-                    verbs:
-                    - delete
-                  - apiGroups:
-                    - operators.coreos.com
-                    resources:
-                    - clusterserviceversions
-                    - installplans
-                    - subscriptions
-                    verbs:
-                    - delete
                   - apiGroups:
                     - monitoring.coreos.com
                     resources:
@@ -26854,12 +26717,6 @@ objects:
       - apiGroups:
         - ''
         resources:
-        - nodes
-        verbs:
-        - patch
-      - apiGroups:
-        - ''
-        resources:
         - nodes/proxy
         verbs:
         - get
@@ -26868,11 +26725,8 @@ objects:
         resources:
         - projects
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
       - apiGroups:
         - project.openshift.io
@@ -26880,36 +26734,22 @@ objects:
         - projects
         - projectrequests
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
-        - delete
       - apiGroups:
         - ''
         resources:
         - namespaces
         - namespaces/finalize
         verbs:
-        - create
         - get
         - list
-        - patch
-        - update
         - watch
-        - delete
-      - apiGroups:
-        - certificates.k8s.io
-        resources:
-        - certificatesigningrequests/approval
-        verbs:
-        - update
       - nonResourceURLs:
         - '*'
         verbs:
-        - '*'
+        - get
       - apiGroups:
         - authentication.k8s.io
         resources:
@@ -26961,12 +26801,6 @@ objects:
         - list
         - watch
       - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machines
-        verbs:
-        - delete
-      - apiGroups:
         - apiserver.openshift.io
         resources:
         - apirequestcounts
@@ -26982,7 +26816,6 @@ objects:
         - get
         - list
         - watch
-        - delete
       - apiGroups:
         - avo.openshift.io
         resources:
@@ -26991,7 +26824,6 @@ objects:
         - get
         - list
         - watch
-        - delete
     - apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRole
       metadata:
@@ -27000,37 +26832,9 @@ objects:
       - apiGroups:
         - ''
         resources:
-        - pods/eviction
-        verbs:
-        - create
-      - apiGroups:
-        - ''
-        resources:
         - pods/portforward
         verbs:
         - create
-      - apiGroups:
-        - batch
-        resources:
-        - jobs
-        verbs:
-        - delete
-        - deletecollection
-        - create
-      - apiGroups:
-        - build.openshift.io
-        resources:
-        - builds
-        verbs:
-        - delete
-        - deletecollection
-      - apiGroups:
-        - ''
-        resources:
-        - pods
-        verbs:
-        - delete
-        - deletecollection
       - apiGroups:
         - security.openshift.io
         resources:
@@ -27044,21 +26848,9 @@ objects:
         resources:
         - '*'
         verbs:
-        - '*'
-      - apiGroups:
-        - velero.io
-        resources:
-        - backups
-        verbs:
-        - create
-      - apiGroups:
-        - velero.io
-        resources:
-        - deletebackuprequests
-        - downloadrequests
-        - serverstatusrequests
-        verbs:
-        - '*'
+        - get
+        - list
+        - watch
       - apiGroups:
         - velero.io
         resources:
@@ -27067,72 +26859,6 @@ objects:
         - get
         - list
         - watch
-      - apiGroups:
-        - ''
-        resources:
-        - persistentvolumeclaims
-        verbs:
-        - delete
-        - patch
-      - apiGroups:
-        - ''
-        resources:
-        - replicationcontrollers/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - apps
-        resources:
-        - deployments/scale
-        - replicasets/scale
-        - statefulsets/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - apps.openshift.io
-        resources:
-        - deploymentconfigs/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - ''
-        resources:
-        - replicasets
-        verbs:
-        - delete
-        - deletecollection
-      - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machinehealthchecks
-        verbs:
-        - patch
-      - apiGroups:
-        - machine.openshift.io
-        resources:
-        - machinesets/scale
-        verbs:
-        - patch
-      - apiGroups:
-        - monitoring.coreos.com
-        resources:
-        - prometheuses
-        verbs:
-        - patch
-      - apiGroups:
-        - upgrade.managed.openshift.io
-        resources:
-        - upgradeconfigs
-        verbs:
-        - delete
-      - apiGroups:
-        - operators.coreos.com
-        resources:
-        - clusterserviceversions
-        - installplans
-        - subscriptions
-        verbs:
-        - delete
       - apiGroups:
         - monitoring.coreos.com
         resources:


### PR DESCRIPTION
This PR redos https://github.com/openshift/managed-cluster-config/pull/2702 .

https://github.com/openshift/managed-cluster-config/pull/2702 was merged earlier and validated on staging.  We reverted the PR in https://github.com/openshift/managed-cluster-config/pull/2719 as we want to promote other changes first.

This PR revert the revert. It is ready to merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted administrator role permissions by removing write, delete, create, and patch capabilities on core resources.
  * Narrowed broad wildcard access permissions to read-only operations across cluster and project-scoped administrative roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->