### PR TITLE
adding missing permission for 422 control plane role

### DIFF
--- a/resources/sts/4.22/sts_instance_controlplane_permission_policy.json
+++ b/resources/sts/4.22/sts_instance_controlplane_permission_policy.json
@@ -13,10 +13,11 @@
                 "ec2:DescribeVpcs",
                 "elasticloadbalancing:DescribeLoadBalancers",
                 "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeLoadBalancerPolicies",
                 "elasticloadbalancing:DescribeListeners",
                 "elasticloadbalancing:DescribeTargetGroups",
                 "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeLoadBalancerPolicies"
+                "elasticloadbalancing:DescribeTargetGroupAttributes"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated AWS STS instance control plane permission policy to enhance Elastic Load Balancer v2 management capabilities. Added new permissions to query target group attributes, providing additional visibility into load balancer configurations. Removed duplicate load balancer policy actions to optimize the permission configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->