### PR TITLE
SPLAT-2721: Add SetSecurityGroups IAM permission

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_kube_controller_manager_credentials_policy.json
@@ -79,6 +79,7 @@
         "elasticloadbalancing:ModifyTargetGroup",
         "elasticloadbalancing:DeleteTargetGroup",
         "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+        "elasticloadbalancing:SetSecurityGroups",
         "elasticloadbalancing:CreateLoadBalancerListeners",
         "elasticloadbalancing:DeleteLoadBalancerListeners",
         "elasticloadbalancing:AttachLoadBalancerToSubnets",


### PR DESCRIPTION
### What type of PR is this?
_(feature)_

### What this PR does / why we need it?
This PR adds the `elasticloadbalancing:SetSecurityGroups` IAM permission required for the BYO Security Group feature for AWS NLBs by AWS CCM. 

As part of the new Bring Your Own Security Groups (BYO SG) for AWS Network Load Balancers (NLBs) feature currently [under review in upstream](https://github.com/kubernetes/cloud-provider-aws/pull/1379), it is required to add a new `elasticloadbalancing:SetSecurityGroups` permission to the role used by AWS CCM to interact with AWS APIs. For more info on the workstream see [OCPSTRAT-1553](https://redhat.atlassian.net/browse/OCPSTRAT-1553).

The `elasticloadbalancing:SetSecurityGroups` permission is required to enable AWS CCM to change the security groups associated with Network Load Balancers without deleting and recreating the NLB, which is not viable.

Without this permission, the following operations are not possible:

- Changing BYO security groups
- Transition from managed to BYO Security Group
- Transition from BYO Security Group to managed

### Which Jira/Github issue(s) this PR fixes?

_Fixes #https://redhat.atlassian.net/browse/SPLAT-2721_
_Fixes #https://redhat.atlassian.net/browse/SPLAT-2452_

### Special notes for your reviewer:
- The new permission is similar to `elasticloadbalancing:ApplySecurityGroupsToLoadBalancer` which is already present and required to edit BYO Security Groups associated with Classic Load Balancers (CLBs).
- The upstream `kOps` Kubernetes infrastructure provisioning tool has been already updated to add the required permission: https://github.com/kubernetes/kops/pull/18211 
- An equivalent change has been requested for the Openshift Installer, see https://github.com/openshift/installer/pull/10512

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated IAM permissions for load balancer management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->