### PR TITLE
itn-2026-00129 - Disable algif_aead kernel module on control-plane nodes

### DIFF
--- a/deploy/cve-2026-31431-disable-algif-aead/01-machineconfig.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/01-machineconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-disable-algif-aead
+spec:
+  kernelArguments:
+    - initcall_blacklist=algif_aead_init

--- a/deploy/cve-2026-31431-disable-algif-aead/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/config.yaml
@@ -1,0 +1,7 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29340,6 +29340,34 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: master
+        name: 99-master-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29340,6 +29340,34 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: master
+        name: 99-master-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29340,6 +29340,34 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: master
+        name: 99-master-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_bug_

### What this PR does / why we need it?

Disables the `algif_aead` crypto module to mitigate [CVE-2026-31431](https://access.redhat.com/security/cve/cve-2026-31431) on control-plane nodes

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ itn-2026-00129

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added system-level configuration to disable the algif_aead algorithm on master nodes via kernel argument
  * Added selector-based deployment configuration to sync that MachineConfig to managed clusters (excludes clusters labeled api.openshift.com/fedramp=true); applied in sync mode across stage and production templates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->