### PR TITLE
OCM-23909 | fix: Remove unused sts:AssumeRole and sts:AssumeRoleWithW…

### DIFF
--- a/resources/sts/4.10/sts_ocm_permission_policy.json
+++ b/resources/sts/4.10/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.11/sts_ocm_permission_policy.json
+++ b/resources/sts/4.11/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.12/sts_ocm_permission_policy.json
+++ b/resources/sts/4.12/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.13/sts_ocm_permission_policy.json
+++ b/resources/sts/4.13/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.14/sts_ocm_permission_policy.json
+++ b/resources/sts/4.14/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.15/sts_ocm_permission_policy.json
+++ b/resources/sts/4.15/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.16/sts_ocm_permission_policy.json
+++ b/resources/sts/4.16/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.17/sts_ocm_permission_policy.json
+++ b/resources/sts/4.17/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.18/sts_ocm_permission_policy.json
+++ b/resources/sts/4.18/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.19/sts_ocm_permission_policy.json
+++ b/resources/sts/4.19/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.20/sts_ocm_permission_policy.json
+++ b/resources/sts/4.20/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.21/sts_ocm_permission_policy.json
+++ b/resources/sts/4.21/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",

--- a/resources/sts/4.22/sts_ocm_permission_policy.json
+++ b/resources/sts/4.22/sts_ocm_permission_policy.json
@@ -10,8 +10,6 @@
         "ec2:DescribeRouteTables",
         "ec2:DescribeInstanceTypeOfferings",
         "iam:GetRole",
-        "sts:AssumeRole",
-        "sts:AssumeRoleWithWebIdentity",
         "iam:ListRoles",
         "iam:ListRoleTags",
         "iam:GetOpenIDConnectProvider",


### PR DESCRIPTION
…ebIdentity from OCM Role permission policy

### What type of PR is this?

Cleanup of unused permissions

### What this PR does / why we need it?

A review of the `OCM Role` permissions was conducted and it was determined that the `sts:AssumeRole` and `sts:AssumeRoleWithWebIdentity` are not required for the `OCM Role`. To ensure customers are working with least privilege requirements, this removes the `sts:AssumeRole` and `sts:AssumeRoleWithWebIdentity` permissions from the `OCM Role`.

I have tested that the permission policy definition remains valid with the removals:

```
# Policy analyzed as valid

rblake@rblake-mac /tmp % aws accessanalyzer validate-policy \
  --policy-document file://policy.json \
  --policy-type IDENTITY_POLICY
{
    "findings": []
}

# Policy creates without issue

rblake@rblake-mac /tmp % POLICY_ARN=$(aws iam create-policy \
  --policy-name "rblake-policy-validation-test-$(date +%s)" \
  --policy-document file://policy.json \
  --query 'Policy.Arn' \
  --output text)

echo "$POLICY_ARN"
arn:aws:iam::765374464689:policy/rblake-policy-validation-test-1780308760


# Display contents of the policy

rblake@rblake-mac /tmp % aws iam get-policy \
  --policy-arn $POLICY_ARN \ 
  --query 'Policy.DefaultVersionId' \
  --output text
v1

rblake@rblake-mac /tmp % aws iam get-policy-version \
  --policy-arn $POLICY_ARN \
  --version-id v1 \          
  --query 'PolicyVersion.Document'
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "ec2:DescribeSubnets",
                "ec2:DescribeVpcs",
                "ec2:DescribeRegions",
                "ec2:DescribeRouteTables",
                "ec2:DescribeInstanceTypeOfferings",
                "iam:GetRole",
                "iam:ListRoles",
                "iam:ListRoleTags",
                "iam:GetOpenIDConnectProvider",
                "iam:GetPolicy"
            ],
            "Resource": "*"
        }
    ]
}
```

The ROSA E2E have been updated to use an `OCM Role` with this reduced permission set, as have the E2E for console.redhat.com

### Which Jira/Github issue(s) this PR fixes?

https://redhat.atlassian.net/browse/OCM-23907

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Removed STS role assumption permissions from policies across versions 4.10–4.22, while retaining all other EC2 and IAM-related permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->