### PR TITLE
chore(SLSRE-681): applies CVE-2026-31431 mitigation to SC/MC workers in int/stage canary sectors

### DIFF
--- a/deploy/cve-2026-31431-disable-algif-aead/integration/01-machineconfig.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/integration/01-machineconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-disable-algif-aead
+spec:
+  kernelArguments:
+    - initcall_blacklist=algif_aead_init

--- a/deploy/cve-2026-31431-disable-algif-aead/integration/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/integration/config.yaml
@@ -1,0 +1,17 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: api.openshift.com/environment
+      operator: In
+      values: ["integration"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster", "service-cluster"]
+    - key: ext-hypershift.openshift.io/cluster-sector
+      operator: In
+      values:
+        - canary

--- a/deploy/cve-2026-31431-disable-algif-aead/staging/01-machineconfig.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/staging/01-machineconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-disable-algif-aead
+spec:
+  kernelArguments:
+    - initcall_blacklist=algif_aead_init

--- a/deploy/cve-2026-31431-disable-algif-aead/staging/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/staging/config.yaml
@@ -1,0 +1,17 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: api.openshift.com/environment
+      operator: In
+      values: ["staging"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster", "service-cluster"]
+    - key: ext-hypershift.openshift.io/cluster-sector
+      operator: In
+      values:
+        - canary

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29368,6 +29368,88 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-integration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
+        values:
+        - canary
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-staging
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
+        values:
+        - canary
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29368,6 +29368,88 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-integration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
+        values:
+        - canary
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-staging
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
+        values:
+        - canary
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29368,6 +29368,88 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-integration
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - integration
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
+        values:
+        - canary
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-staging
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - staging
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+      - key: ext-hypershift.openshift.io/cluster-sector
+        operator: In
+        values:
+        - canary
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_chore_

### What this PR does / why we need it?

[SLSRE-681](https://redhat.atlassian.net/browse/SLSRE-681)

### Which Jira/Github issue(s) this PR fixes?

[SLSRE-681](https://redhat.atlassian.net/browse/SLSRE-681)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations for integration, staging, and production environments to apply new system-level settings to worker nodes across managed OpenShift clusters with specific cluster type and sector criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->