### PR TITLE
chore(SLSRE-681): broadly apply cve-2026-31431 mitigations to int/stage

### DIFF
--- a/deploy/cve-2026-31431-disable-algif-aead/integration/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/integration/config.yaml
@@ -11,7 +11,3 @@ selectorSyncSet:
     - key: ext-hypershift.openshift.io/cluster-type
       operator: In
       values: ["management-cluster", "service-cluster"]
-    - key: ext-hypershift.openshift.io/cluster-sector
-      operator: In
-      values:
-        - canary

--- a/deploy/cve-2026-31431-disable-algif-aead/staging/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/staging/config.yaml
@@ -11,7 +11,3 @@ selectorSyncSet:
     - key: ext-hypershift.openshift.io/cluster-type
       operator: In
       values: ["management-cluster", "service-cluster"]
-    - key: ext-hypershift.openshift.io/cluster-sector
-      operator: In
-      values:
-        - canary

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29387,10 +29387,6 @@ objects:
         values:
         - management-cluster
         - service-cluster
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - canary
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -29428,10 +29424,6 @@ objects:
         values:
         - management-cluster
         - service-cluster
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - canary
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29387,10 +29387,6 @@ objects:
         values:
         - management-cluster
         - service-cluster
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - canary
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -29428,10 +29424,6 @@ objects:
         values:
         - management-cluster
         - service-cluster
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - canary
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29387,10 +29387,6 @@ objects:
         values:
         - management-cluster
         - service-cluster
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - canary
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -29428,10 +29424,6 @@ objects:
         values:
         - management-cluster
         - service-cluster
-      - key: ext-hypershift.openshift.io/cluster-sector
-        operator: In
-        values:
-        - canary
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1


### PR DESCRIPTION
### What type of PR is this?
_chore_

### What this PR does / why we need it?

Removes sector selection for cve-2026-31431 mitigations in int/stage to broadly apply the fix.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [SLSRE-681](https://redhat.atlassian.net/browse/SLSRE-681)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```
