### PR TITLE
SREP-4556: Fix SRE recording rule evaluation failures caused by series cardinality

### DIFF
--- a/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-operators-recording-rules.yaml
@@ -20,7 +20,7 @@ spec:
               sum by (exported_namespace, name, version, channel, package) (
                   label_replace(csv_succeeded, "name", "$1", "name", "([^.]+).*")
                 ^ on (name) group_left (channel, package)
-                  subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
+                  max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
               )
           record:
             sre:operators:succeeded:olm

--- a/deploy/sre-prometheus/centralized-observability/100-sre-telemetry-managed-labels-recording-rules.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/centralized-observability/100-sre-telemetry-managed-labels-recording-rules.PrometheusRule.yaml
@@ -17,13 +17,13 @@ spec:
             # ensure value of 1 to use as bool against other metrics
             sum by (_id, provider, region, version, sre)
             (
-            label_replace(cluster_id, "sre", "true", "", "")
+            max by (sre, _id) (label_replace(cluster_id, "sre", "true", "", ""))
             * on (sre) group_left(provider, region, version)
-            (
+            max by (sre, version) (
             label_replace(cluster_version{type="current"}, "sre", "true", "", "")
             )
             * on (sre) group_left(provider, region)
-            label_replace(sum without (type) (label_replace(cluster_infrastructure_provider, "provider", "$1", "type", "(.*)")), "sre", "true", "", "")
+            max by (sre, provider, region) (label_replace(sum without (type) (label_replace(cluster_infrastructure_provider, "provider", "$1", "type", "(.*)")), "sre", "true", "", ""))
             ) > bool 0
             # sre:telemetry:managed_labels{_id="not-a-real-cluster-id", provider="AWS", region="ap-southeast-2", sre="true", version="4.10.18"} => 1654679854 @[1655873133.121]
           record:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47112,7 +47112,7 @@ objects:
               "version", ".*") * on () group_right (_id, cluster_version, provider)
               sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
               "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
-              package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
+              package) max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
               )
             record: sre:operators:succeeded:olm
           - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
@@ -47214,12 +47214,13 @@ objects:
         groups:
         - name: sre-telemetry-managed-labels.rules
           rules:
-          - expr: sum by (_id, provider, region, version, sre) ( label_replace(cluster_id,
-              "sre", "true", "", "") * on (sre) group_left(provider, region, version)
-              ( label_replace(cluster_version{type="current"}, "sre", "true", "",
-              "") ) * on (sre) group_left(provider, region) label_replace(sum without
-              (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
-              "type", "(.*)")), "sre", "true", "", "") ) > bool 0
+          - expr: sum by (_id, provider, region, version, sre) ( max by (sre, _id)
+              (label_replace(cluster_id, "sre", "true", "", "")) * on (sre) group_left(provider,
+              region, version) max by (sre, version) ( label_replace(cluster_version{type="current"},
+              "sre", "true", "", "") ) * on (sre) group_left(provider, region) max
+              by (sre, provider, region) (label_replace(sum without (type) (label_replace(cluster_infrastructure_provider,
+              "provider", "$1", "type", "(.*)")), "sre", "true", "", "")) ) > bool
+              0
             record: sre:telemetry:managed_labels
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47112,7 +47112,7 @@ objects:
               "version", ".*") * on () group_right (_id, cluster_version, provider)
               sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
               "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
-              package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
+              package) max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
               )
             record: sre:operators:succeeded:olm
           - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
@@ -47214,12 +47214,13 @@ objects:
         groups:
         - name: sre-telemetry-managed-labels.rules
           rules:
-          - expr: sum by (_id, provider, region, version, sre) ( label_replace(cluster_id,
-              "sre", "true", "", "") * on (sre) group_left(provider, region, version)
-              ( label_replace(cluster_version{type="current"}, "sre", "true", "",
-              "") ) * on (sre) group_left(provider, region) label_replace(sum without
-              (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
-              "type", "(.*)")), "sre", "true", "", "") ) > bool 0
+          - expr: sum by (_id, provider, region, version, sre) ( max by (sre, _id)
+              (label_replace(cluster_id, "sre", "true", "", "")) * on (sre) group_left(provider,
+              region, version) max by (sre, version) ( label_replace(cluster_version{type="current"},
+              "sre", "true", "", "") ) * on (sre) group_left(provider, region) max
+              by (sre, provider, region) (label_replace(sum without (type) (label_replace(cluster_infrastructure_provider,
+              "provider", "$1", "type", "(.*)")), "sre", "true", "", "")) ) > bool
+              0
             record: sre:telemetry:managed_labels
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47112,7 +47112,7 @@ objects:
               "version", ".*") * on () group_right (_id, cluster_version, provider)
               sum by (exported_namespace, name, version, channel, package) ( label_replace(csv_succeeded,
               "name", "$1", "name", "([^.]+).*") ^ on (name) group_left (channel,
-              package) subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"}
+              package) max by (name, channel, package) (subscription_sync_total{name=~"addon-operator|aws-vpce-operator|custom-domains-operator|managed-node-metadata-operator|managed-upgrade-operator|must-gather-operator|ocm-agent-operator|osd-metrics-exporter|rbac-permissions-operator|openshift-splunk-forwarder-operator|aws-account-operator|certman-operator|cloud-ingress-operator|configure-alertmanager-operator|deadmanssnitch-operator|deployment-validation-operator|dynatrace-operator|gcp-project-operator|managed-velero-operator|observability-operator|opentelemetry-operator|pagerduty-operator|route-monitor-operator"})
               )
             record: sre:operators:succeeded:olm
           - expr: label_replace(sre:telemetry:managed_labels, "cluster_version", "$0",
@@ -47214,12 +47214,13 @@ objects:
         groups:
         - name: sre-telemetry-managed-labels.rules
           rules:
-          - expr: sum by (_id, provider, region, version, sre) ( label_replace(cluster_id,
-              "sre", "true", "", "") * on (sre) group_left(provider, region, version)
-              ( label_replace(cluster_version{type="current"}, "sre", "true", "",
-              "") ) * on (sre) group_left(provider, region) label_replace(sum without
-              (type) (label_replace(cluster_infrastructure_provider, "provider", "$1",
-              "type", "(.*)")), "sre", "true", "", "") ) > bool 0
+          - expr: sum by (_id, provider, region, version, sre) ( max by (sre, _id)
+              (label_replace(cluster_id, "sre", "true", "", "")) * on (sre) group_left(provider,
+              region, version) max by (sre, version) ( label_replace(cluster_version{type="current"},
+              "sre", "true", "", "") ) * on (sre) group_left(provider, region) max
+              by (sre, provider, region) (label_replace(sum without (type) (label_replace(cluster_infrastructure_provider,
+              "provider", "$1", "type", "(.*)")), "sre", "true", "", "")) ) > bool
+              0
             record: sre:telemetry:managed_labels
 - apiVersion: hive.openshift.io/v1
   kind: SelectorSyncSet


### PR DESCRIPTION
## Problem

SRE recording rules (`sre-telemetry-managed-labels.rules` and `sre-operators.rules`) produce `group_left` cardinality errors during OLM operator initialization on fresh clusters, causing the `shouldn't have failing rules evaluation` conformance test to fail.

Root cause: `subscription_sync_total` can have multiple series per subscription name (different `installedCSV`, `source` label combinations), and the telemetry join on synthetic `sre="true"` label is vulnerable to stale/duplicate series.

## Fix

- **`sre:operators:succeeded:olm`**: Wrap `subscription_sync_total` with `max by (name, channel, package)` before the `^ on(name) group_left(channel, package)` join
- **`sre:telemetry:managed_labels`**: Wrap each metric with `max by(...)` on join-relevant labels before the `* on(sre) group_left()` joins

The PKO rule already had `max by(...)` wrapping. The other 3 rules in `sre-operators.rules` use `or` unions or `absent()` and are not affected.

## Testing

Validated on two stage clusters:

1. **Stable cluster** (hs-sc-a8p1rblbg, 4.21.11): Applied fix, waited 2 min. Zero new evaluation failures (rate 0.0). Recording rule output unchanged.

2. **Fresh cluster during OLM initialization** (osde2e-bf2ze, 4.21.11): Applied fix immediately after Prometheus came up with only 4/23 operators installed. Zero evaluation failures across all 57 SRE rule groups during the initialization window. `sre:operators:succeeded:olm` correctly tracked 4 operators, `sre:telemetry:managed_labels` produced 1 series.

The `max by(...)` guards prevent `group_left` many-to-many errors when `subscription_sync_total` has multiple series per operator during OLM installation, without changing the recording rule semantics.

Jira: https://redhat.atlassian.net/browse/SREP-4556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined Prometheus recording rules to de-duplicate and normalize metric inputs, ensuring a single representative value per logical group. Improves accuracy and consistency of operator lifecycle and managed-label telemetry across environments, reducing spurious counts and making related alerts and dashboards more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->