### PR TITLE
chore(SLSRE-681): apply cve-2026-31431 mitigation to prod

### DIFF
--- a/deploy/cve-2026-31431-disable-algif-aead/production/01-machineconfig.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/production/01-machineconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-disable-algif-aead
+spec:
+  kernelArguments:
+    - initcall_blacklist=algif_aead_init

--- a/deploy/cve-2026-31431-disable-algif-aead/production/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/production/config.yaml
@@ -1,0 +1,13 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: api.openshift.com/environment
+      operator: In
+      values: ["production"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]
+    - key: ext-hypershift.openshift.io/cluster-type
+      operator: In
+      values: ["management-cluster", "service-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29409,6 +29409,43 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-production
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: cve-2026-31431-disable-algif-aead-staging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29409,6 +29409,43 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-production
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: cve-2026-31431-disable-algif-aead-staging
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29409,6 +29409,43 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-31431-disable-algif-aead-production
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/environment
+        operator: In
+        values:
+        - production
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: machineconfiguration.openshift.io/v1
+      kind: MachineConfig
+      metadata:
+        labels:
+          machineconfiguration.openshift.io/role: worker
+        name: 99-worker-disable-algif-aead
+      spec:
+        kernelArguments:
+        - initcall_blacklist=algif_aead_init
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: cve-2026-31431-disable-algif-aead-staging
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
_chore_

### What this PR does / why we need it?

Broadly applies cve-2026-31431 mitigation to prod

### Which Jira/Github issue(s) this PR fixes?

[SLSRE-681](https://redhat.atlassian.net/browse/SLSRE-681)

### Special notes for your reviewer:

Additional restrictions to target sectors can be applied if desired.
```
# Rollout will be progressive across Hives naturally, but excluding larger sectors would add a second layer of progressive rollout.
matchExpressions:
  - key: ext-hypershift.openshift.io/cluster-sector
    operator: NotIn
    values:
    - us-east-1
```

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployed security configurations to production and staging managed cluster environments
  * Applied kernel-level modifications to worker nodes across targeted cluster types
  * Configured automatic synchronization of security settings to designated production clusters based on environment and cluster type criteria
  * Updates exclude FedRAMP-certified clusters and limit deployment to specific managed cluster configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->