### PR TITLE
SREP-4437: Downgrade all Dynatrace MC alerts from critical to warning

### DIFF
--- a/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/management-cluster/100-dynatrace-workloads-monitoring.PrometheusRule.yaml
@@ -20,7 +20,7 @@ spec:
           for: 15m
           labels:
             namespace: dynatrace
-            severity: critical
+            severity: warning
           annotations:
             summary: "Dynatrace Workload(s) are absent or have failed to deploy on the Management Cluster"
             description: |
@@ -59,7 +59,7 @@ spec:
           for: 5m
           labels:
             namespace: dynatrace
-            severity: critical
+            severity: warning
           annotations:
             summary: "Dynatrace OTEL Collector is Degraded"
             description: "{{$value}} replicas are not running out of total required replicas for the OpenTelemetry Dynatrace Collector"
@@ -87,7 +87,7 @@ spec:
           labels:
             daemonset: hcp-workload-oneagent
             namespace: dynatrace
-            severity: critical
+            severity: warning
             state: missing
 
         - alert: DynatraceDynakubeComponentsDegradedSRE
@@ -95,7 +95,7 @@ spec:
           for: 60m
           labels:
             namespace: dynatrace
-            severity: critical
+            severity: warning
             daemonset: hcp-workload-oneagent
             state: degraded
           annotations:
@@ -113,7 +113,7 @@ spec:
           for: 60m
           labels:
             namespace: dynatrace
-            severity: critical
+            severity: warning
             statefulset: activegate
             state: missing
 
@@ -122,7 +122,7 @@ spec:
           for: 60m
           labels:
             namespace: dynatrace
-            severity: critical
+            severity: warning
             statefulset: activegate
             state: degraded
           annotations:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -47835,7 +47835,7 @@ objects:
             for: 15m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
             annotations:
               summary: Dynatrace Workload(s) are absent or have failed to deploy on
                 the Management Cluster
@@ -47884,7 +47884,7 @@ objects:
             for: 5m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
             annotations:
               summary: Dynatrace OTEL Collector is Degraded
               description: '{{$value}} replicas are not running out of total required
@@ -47917,7 +47917,7 @@ objects:
             labels:
               daemonset: hcp-workload-oneagent
               namespace: dynatrace
-              severity: critical
+              severity: warning
               state: missing
           - alert: DynatraceDynakubeComponentsDegradedSRE
             expr: (kube_daemonset_status_desired_number_scheduled{namespace="dynatrace",
@@ -47926,7 +47926,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               daemonset: hcp-workload-oneagent
               state: degraded
             annotations:
@@ -47947,7 +47947,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               statefulset: activegate
               state: missing
           - alert: DynatraceDynakubeComponentsDegradedSRE
@@ -47957,7 +47957,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               statefulset: activegate
               state: degraded
             annotations:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -47835,7 +47835,7 @@ objects:
             for: 15m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
             annotations:
               summary: Dynatrace Workload(s) are absent or have failed to deploy on
                 the Management Cluster
@@ -47884,7 +47884,7 @@ objects:
             for: 5m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
             annotations:
               summary: Dynatrace OTEL Collector is Degraded
               description: '{{$value}} replicas are not running out of total required
@@ -47917,7 +47917,7 @@ objects:
             labels:
               daemonset: hcp-workload-oneagent
               namespace: dynatrace
-              severity: critical
+              severity: warning
               state: missing
           - alert: DynatraceDynakubeComponentsDegradedSRE
             expr: (kube_daemonset_status_desired_number_scheduled{namespace="dynatrace",
@@ -47926,7 +47926,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               daemonset: hcp-workload-oneagent
               state: degraded
             annotations:
@@ -47947,7 +47947,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               statefulset: activegate
               state: missing
           - alert: DynatraceDynakubeComponentsDegradedSRE
@@ -47957,7 +47957,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               statefulset: activegate
               state: degraded
             annotations:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -47835,7 +47835,7 @@ objects:
             for: 15m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
             annotations:
               summary: Dynatrace Workload(s) are absent or have failed to deploy on
                 the Management Cluster
@@ -47884,7 +47884,7 @@ objects:
             for: 5m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
             annotations:
               summary: Dynatrace OTEL Collector is Degraded
               description: '{{$value}} replicas are not running out of total required
@@ -47917,7 +47917,7 @@ objects:
             labels:
               daemonset: hcp-workload-oneagent
               namespace: dynatrace
-              severity: critical
+              severity: warning
               state: missing
           - alert: DynatraceDynakubeComponentsDegradedSRE
             expr: (kube_daemonset_status_desired_number_scheduled{namespace="dynatrace",
@@ -47926,7 +47926,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               daemonset: hcp-workload-oneagent
               state: degraded
             annotations:
@@ -47947,7 +47947,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               statefulset: activegate
               state: missing
           - alert: DynatraceDynakubeComponentsDegradedSRE
@@ -47957,7 +47957,7 @@ objects:
             for: 60m
             labels:
               namespace: dynatrace
-              severity: critical
+              severity: warning
               statefulset: activegate
               state: degraded
             annotations:


### PR DESCRIPTION
## Summary

- Downgrade all critical Dynatrace alerts to warning in the MC PrometheusRule
- RHOBS has replaced Dynatrace as the primary alerting source for ROSA HCP, so Dynatrace component health alerts no longer need to page on-call

**Alerts changed (critical -> warning):**
- DynatraceMonitoringStackDownSRE
- DynatraceOpenTelemetryCollectorDownSRE
- DynatraceDynakubeComponentsDegradedSRE (4 variants: oneagent missing/degraded, activegate missing/degraded)

Jira: https://redhat.atlassian.net/browse/SREP-4437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dynatrace monitoring alert severities from critical to warning across production, staging, and integration environments. Affected alerts include: Dynatrace monitoring stack down, OTEL Collector degradation, and Dynakube component health alerts. Alert expressions and thresholds remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->