### PR TITLE
Add block-copyfail ACM policy for ROSA HCP clusters

### DIFF
--- a/deploy/acm-policies/50-GENERATED-block-copyfail.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-block-copyfail.Policy.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+    annotations:
+        policy.open-cluster-management.io/categories: CM Configuration Management
+        policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/standards: NIST SP 800-53
+    name: block-copyfail
+    namespace: openshift-acm-policies
+spec:
+    disabled: false
+    policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+                name: block-copyfail
+            spec:
+                evaluationInterval:
+                    compliant: 2h
+                    noncompliant: 45s
+                object-templates:
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: v1
+                        kind: Namespace
+                        metadata:
+                            labels:
+                                pod-security.kubernetes.io/audit: privileged
+                                pod-security.kubernetes.io/enforce: privileged
+                                pod-security.kubernetes.io/warn: privileged
+                            name: block-copyfail
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: rbac.authorization.k8s.io/v1
+                        kind: RoleBinding
+                        metadata:
+                            name: system:openshift:scc:privileged
+                            namespace: block-copyfail
+                        roleRef:
+                            apiGroup: rbac.authorization.k8s.io
+                            kind: ClusterRole
+                            name: system:openshift:scc:privileged
+                        subjects:
+                            - kind: ServiceAccount
+                              name: default
+                              namespace: block-copyfail
+                    - complianceType: musthave
+                      metadataComplianceType: musthave
+                      objectDefinition:
+                        apiVersion: apps/v1
+                        kind: DaemonSet
+                        metadata:
+                            labels:
+                                app: block-copyfail
+                            name: block-copyfail
+                            namespace: block-copyfail
+                        spec:
+                            selector:
+                                matchLabels:
+                                    app: block-copyfail
+                            template:
+                                metadata:
+                                    labels:
+                                        app: block-copyfail
+                                spec:
+                                    containers:
+                                        - image: quay.io/openshift/block-copyfail@sha256:bbf0b19bfb63d79bab6adc47cae70f15c62f83a4a6bcc6f41509656cf0dae52f
+                                          name: blocker
+                                          resources:
+                                            limits:
+                                                cpu: 100m
+                                                memory: 64Mi
+                                            requests:
+                                                cpu: 10m
+                                                memory: 32Mi
+                                          securityContext:
+                                            privileged: true
+                                          volumeMounts:
+                                            - mountPath: /sys/fs/bpf
+                                              name: bpf
+                                            - mountPath: /sys/kernel/btf/vmlinux
+                                              name: btf
+                                              readOnly: true
+                                    priorityClassName: system-node-critical
+                                    terminationGracePeriodSeconds: 5
+                                    tolerations:
+                                        - operator: Exists
+                                    volumes:
+                                        - hostPath:
+                                            path: /sys/fs/bpf
+                                            type: DirectoryOrCreate
+                                          name: bpf
+                                        - hostPath:
+                                            path: /sys/kernel/btf/vmlinux
+                                            type: File
+                                          name: btf
+                pruneObjectBehavior: DeleteIfCreated
+                remediationAction: enforce
+                severity: low
+    remediationAction: enforce
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+    name: placement-block-copyfail
+    namespace: openshift-acm-policies
+spec:
+    clusterSelector:
+        matchExpressions:
+            - key: hypershift.open-cluster-management.io/hosted-cluster
+              operator: In
+              values:
+                - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+    name: binding-block-copyfail
+    namespace: openshift-acm-policies
+placementRef:
+    apiGroup: apps.open-cluster-management.io
+    kind: PlacementRule
+    name: placement-block-copyfail
+subjects:
+    - apiGroup: policy.open-cluster-management.io
+      kind: Policy
+      name: block-copyfail

--- a/deploy/block-copyfail/00-Namespace.yaml
+++ b/deploy/block-copyfail/00-Namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: block-copyfail
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/deploy/block-copyfail/01-RoleBinding.yaml
+++ b/deploy/block-copyfail/01-RoleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:openshift:scc:privileged
+  namespace: block-copyfail
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: block-copyfail

--- a/deploy/block-copyfail/02-DaemonSet.yaml
+++ b/deploy/block-copyfail/02-DaemonSet.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: block-copyfail
+  namespace: block-copyfail
+  labels:
+    app: block-copyfail
+spec:
+  selector:
+    matchLabels:
+      app: block-copyfail
+  template:
+    metadata:
+      labels:
+        app: block-copyfail
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: blocker
+        image: quay.io/openshift/block-copyfail@sha256:bbf0b19bfb63d79bab6adc47cae70f15c62f83a4a6bcc6f41509656cf0dae52f
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: bpf
+          mountPath: /sys/fs/bpf
+        - name: btf
+          mountPath: /sys/kernel/btf/vmlinux
+          readOnly: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+      volumes:
+      - name: bpf
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+      - name: btf
+        hostPath:
+          path: /sys/kernel/btf/vmlinux
+          type: File
+      terminationGracePeriodSeconds: 5

--- a/deploy/block-copyfail/config.yaml
+++ b/deploy/block-copyfail/config.yaml
@@ -1,0 +1,9 @@
+deploymentMode: Policy
+clusterSelectors:
+  matchExpressions:
+    - key: hypershift.open-cluster-management.io/hosted-cluster
+      operator: In
+      values:
+        - "true"
+policy:
+  complianceType: "musthave"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -6454,6 +6454,134 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: block-copyfail
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: block-copyfail
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    labels:
+                      pod-security.kubernetes.io/audit: privileged
+                      pod-security.kubernetes.io/enforce: privileged
+                      pod-security.kubernetes.io/warn: privileged
+                    name: block-copyfail
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: system:openshift:scc:privileged
+                    namespace: block-copyfail
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: system:openshift:scc:privileged
+                  subjects:
+                  - kind: ServiceAccount
+                    name: default
+                    namespace: block-copyfail
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: apps/v1
+                  kind: DaemonSet
+                  metadata:
+                    labels:
+                      app: block-copyfail
+                    name: block-copyfail
+                    namespace: block-copyfail
+                  spec:
+                    selector:
+                      matchLabels:
+                        app: block-copyfail
+                    template:
+                      metadata:
+                        labels:
+                          app: block-copyfail
+                      spec:
+                        containers:
+                        - image: quay.io/openshift/block-copyfail@sha256:bbf0b19bfb63d79bab6adc47cae70f15c62f83a4a6bcc6f41509656cf0dae52f
+                          name: blocker
+                          resources:
+                            limits:
+                              cpu: 100m
+                              memory: 64Mi
+                            requests:
+                              cpu: 10m
+                              memory: 32Mi
+                          securityContext:
+                            privileged: true
+                          volumeMounts:
+                          - mountPath: /sys/fs/bpf
+                            name: bpf
+                          - mountPath: /sys/kernel/btf/vmlinux
+                            name: btf
+                            readOnly: true
+                        priorityClassName: system-node-critical
+                        terminationGracePeriodSeconds: 5
+                        tolerations:
+                        - operator: Exists
+                        volumes:
+                        - hostPath:
+                            path: /sys/fs/bpf
+                            type: DirectoryOrCreate
+                          name: bpf
+                        - hostPath:
+                            path: /sys/kernel/btf/vmlinux
+                            type: File
+                          name: btf
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-block-copyfail
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-block-copyfail
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-block-copyfail
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: block-copyfail
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -6454,6 +6454,134 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: block-copyfail
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: block-copyfail
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    labels:
+                      pod-security.kubernetes.io/audit: privileged
+                      pod-security.kubernetes.io/enforce: privileged
+                      pod-security.kubernetes.io/warn: privileged
+                    name: block-copyfail
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: system:openshift:scc:privileged
+                    namespace: block-copyfail
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: system:openshift:scc:privileged
+                  subjects:
+                  - kind: ServiceAccount
+                    name: default
+                    namespace: block-copyfail
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: apps/v1
+                  kind: DaemonSet
+                  metadata:
+                    labels:
+                      app: block-copyfail
+                    name: block-copyfail
+                    namespace: block-copyfail
+                  spec:
+                    selector:
+                      matchLabels:
+                        app: block-copyfail
+                    template:
+                      metadata:
+                        labels:
+                          app: block-copyfail
+                      spec:
+                        containers:
+                        - image: quay.io/openshift/block-copyfail@sha256:bbf0b19bfb63d79bab6adc47cae70f15c62f83a4a6bcc6f41509656cf0dae52f
+                          name: blocker
+                          resources:
+                            limits:
+                              cpu: 100m
+                              memory: 64Mi
+                            requests:
+                              cpu: 10m
+                              memory: 32Mi
+                          securityContext:
+                            privileged: true
+                          volumeMounts:
+                          - mountPath: /sys/fs/bpf
+                            name: bpf
+                          - mountPath: /sys/kernel/btf/vmlinux
+                            name: btf
+                            readOnly: true
+                        priorityClassName: system-node-critical
+                        terminationGracePeriodSeconds: 5
+                        tolerations:
+                        - operator: Exists
+                        volumes:
+                        - hostPath:
+                            path: /sys/fs/bpf
+                            type: DirectoryOrCreate
+                          name: bpf
+                        - hostPath:
+                            path: /sys/kernel/btf/vmlinux
+                            type: File
+                          name: btf
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-block-copyfail
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-block-copyfail
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-block-copyfail
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: block-copyfail
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       spec:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -6454,6 +6454,134 @@ objects:
           policy.open-cluster-management.io/categories: CM Configuration Management
           policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
           policy.open-cluster-management.io/standards: NIST SP 800-53
+        name: block-copyfail
+        namespace: openshift-acm-policies
+      spec:
+        disabled: false
+        policy-templates:
+        - objectDefinition:
+            apiVersion: policy.open-cluster-management.io/v1
+            kind: ConfigurationPolicy
+            metadata:
+              name: block-copyfail
+            spec:
+              evaluationInterval:
+                compliant: 2h
+                noncompliant: 45s
+              object-templates:
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: v1
+                  kind: Namespace
+                  metadata:
+                    labels:
+                      pod-security.kubernetes.io/audit: privileged
+                      pod-security.kubernetes.io/enforce: privileged
+                      pod-security.kubernetes.io/warn: privileged
+                    name: block-copyfail
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: rbac.authorization.k8s.io/v1
+                  kind: RoleBinding
+                  metadata:
+                    name: system:openshift:scc:privileged
+                    namespace: block-copyfail
+                  roleRef:
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: ClusterRole
+                    name: system:openshift:scc:privileged
+                  subjects:
+                  - kind: ServiceAccount
+                    name: default
+                    namespace: block-copyfail
+              - complianceType: musthave
+                metadataComplianceType: musthave
+                objectDefinition:
+                  apiVersion: apps/v1
+                  kind: DaemonSet
+                  metadata:
+                    labels:
+                      app: block-copyfail
+                    name: block-copyfail
+                    namespace: block-copyfail
+                  spec:
+                    selector:
+                      matchLabels:
+                        app: block-copyfail
+                    template:
+                      metadata:
+                        labels:
+                          app: block-copyfail
+                      spec:
+                        containers:
+                        - image: quay.io/openshift/block-copyfail@sha256:bbf0b19bfb63d79bab6adc47cae70f15c62f83a4a6bcc6f41509656cf0dae52f
+                          name: blocker
+                          resources:
+                            limits:
+                              cpu: 100m
+                              memory: 64Mi
+                            requests:
+                              cpu: 10m
+                              memory: 32Mi
+                          securityContext:
+                            privileged: true
+                          volumeMounts:
+                          - mountPath: /sys/fs/bpf
+                            name: bpf
+                          - mountPath: /sys/kernel/btf/vmlinux
+                            name: btf
+                            readOnly: true
+                        priorityClassName: system-node-critical
+                        terminationGracePeriodSeconds: 5
+                        tolerations:
+                        - operator: Exists
+                        volumes:
+                        - hostPath:
+                            path: /sys/fs/bpf
+                            type: DirectoryOrCreate
+                          name: bpf
+                        - hostPath:
+                            path: /sys/kernel/btf/vmlinux
+                            type: File
+                          name: btf
+              pruneObjectBehavior: DeleteIfCreated
+              remediationAction: enforce
+              severity: low
+        remediationAction: enforce
+    - apiVersion: apps.open-cluster-management.io/v1
+      kind: PlacementRule
+      metadata:
+        name: placement-block-copyfail
+        namespace: openshift-acm-policies
+      spec:
+        clusterSelector:
+          matchExpressions:
+          - key: hypershift.open-cluster-management.io/hosted-cluster
+            operator: In
+            values:
+            - 'true'
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: PlacementBinding
+      metadata:
+        name: binding-block-copyfail
+        namespace: openshift-acm-policies
+      placementRef:
+        apiGroup: apps.open-cluster-management.io
+        kind: PlacementRule
+        name: placement-block-copyfail
+      subjects:
+      - apiGroup: policy.open-cluster-management.io
+        kind: Policy
+        name: block-copyfail
+    - apiVersion: policy.open-cluster-management.io/v1
+      kind: Policy
+      metadata:
+        annotations:
+          policy.open-cluster-management.io/categories: CM Configuration Management
+          policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+          policy.open-cluster-management.io/standards: NIST SP 800-53
         name: ccs-dedicated-admins-sp
         namespace: openshift-acm-policies
       spec:

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -17,6 +17,7 @@ directories = [
         'backplane/cee',
         'backplane/cse',
         'backplane/csm',
+        'block-copyfail',
         'hosted-uwm',
         'backplane/elevated-sre',
         'backplane/lpsre',


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Deploy the block-copyfail eBPF DaemonSet to all ROSA HCP dataplane clusters via ACM policy. This creates a privileged DaemonSet that runs on every node to block copy-on-write failures.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new cluster management policy for hosted cluster environments
  * Policy deploys node-level components with system-level security privileges
  * Includes automatic enforcement and periodic compliance evaluation (2-hour compliant monitoring, 45-second non-compliant response)
  * Automatically targets and applies policy to designated hosted clusters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->