### PR TITLE
SREP-4581: (rere-)add must-gather trigger

### DIFF
--- a/deploy/sre-prometheus/100-create-must-gather.PrometheusRule.yaml
+++ b/deploy/sre-prometheus/100-create-must-gather.PrometheusRule.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: sre-create-must-gather
+    role: alert-rules
+  name: sre-create-must-gather
+  namespace: openshift-monitoring
+spec:
+  groups:
+    - name: sre-create-must-gather
+      rules:
+        - alert: CreateMustGather
+          expr: |
+            max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn"}) > 0
+            and on() absent(cluster_version{type="updating"})
+            and on() (time() - max(cluster_version{type="completed"}) > 14400)
+          for: 15m
+          labels:
+            severity: warning
+            namespace: openshift-monitoring
+            route_to_cad: "true"
+          annotations:
+            message: Create a must-gather for a non-silenced firing alert in a managed namespace
+            runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
+            summary: 'This alert is a trigger for CAD to create a must-gather.'
+            description: This alert fires when a non-silenced alert is firing in a managed namespace. This alert is meant to trigger configuration-anomaly-detection to create a must-gather

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -45966,6 +45966,40 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-create-must-gather
+          role: alert-rules
+        name: sre-create-must-gather
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-create-must-gather
+          rules:
+          - alert: CreateMustGather
+            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn"})
+              > 0
+
+              and on() absent(cluster_version{type="updating"})
+
+              and on() (time() - max(cluster_version{type="completed"}) > 14400)
+
+              '
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              route_to_cad: 'true'
+            annotations:
+              message: Create a must-gather for a non-silenced firing alert in a managed
+                namespace
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
+              summary: This alert is a trigger for CAD to create a must-gather.
+              description: This alert fires when a non-silenced alert is firing in
+                a managed namespace. This alert is meant to trigger configuration-anomaly-detection
+                to create a must-gather
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-elasticsearch-jobs
           role: alert-rules
         name: sre-elasticsearch-jobs

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -45966,6 +45966,40 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-create-must-gather
+          role: alert-rules
+        name: sre-create-must-gather
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-create-must-gather
+          rules:
+          - alert: CreateMustGather
+            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn"})
+              > 0
+
+              and on() absent(cluster_version{type="updating"})
+
+              and on() (time() - max(cluster_version{type="completed"}) > 14400)
+
+              '
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              route_to_cad: 'true'
+            annotations:
+              message: Create a must-gather for a non-silenced firing alert in a managed
+                namespace
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
+              summary: This alert is a trigger for CAD to create a must-gather.
+              description: This alert fires when a non-silenced alert is firing in
+                a managed namespace. This alert is meant to trigger configuration-anomaly-detection
+                to create a must-gather
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-elasticsearch-jobs
           role: alert-rules
         name: sre-elasticsearch-jobs

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -45966,6 +45966,40 @@ objects:
       kind: PrometheusRule
       metadata:
         labels:
+          prometheus: sre-create-must-gather
+          role: alert-rules
+        name: sre-create-must-gather
+        namespace: openshift-monitoring
+      spec:
+        groups:
+        - name: sre-create-must-gather
+          rules:
+          - alert: CreateMustGather
+            expr: 'max(ALERTS{alertstate="firing",alertname!="CreateMustGather",namespace=~"openshift-.*|kube-.*|default|redhat-.*",severity!~"info|alert|none",namespace!~"openshift-customer-monitoring|openshift-operators|openshift-storage|openshift-compliance|openshift-operators-redhat|openshift-user-workload-monitoring",alertname!~"Watchdog|CannotRetrieveUpdates|KubeQuotaExceeded|KubeQuotaFullyUsed|CPUThrottlingHigh|NodeFilesystemSpaceFillingUp|NodeFilesystemFilesFillingUp|NodeFilesystemAlmostOutOfSpace|NodeFilesystemAlmostOutOfFiles|NodeFileDescriptorLimit|CustomResourceDetected|ImagePruningDisabled|PodDisruptionBudgetLimit|KubeJobFailed|PrometheusRuleFailures|HAProxyDown|HAProxyReloadFail|CertificateIsAboutToExpire|KubeAPIErrorBudgetBurn"})
+              > 0
+
+              and on() absent(cluster_version{type="updating"})
+
+              and on() (time() - max(cluster_version{type="completed"}) > 14400)
+
+              '
+            for: 15m
+            labels:
+              severity: warning
+              namespace: openshift-monitoring
+              route_to_cad: 'true'
+            annotations:
+              message: Create a must-gather for a non-silenced firing alert in a managed
+                namespace
+              runbook_url: https://github.com/openshift/ops-sop/blob/master/v4/alerts/CreateMustGather.md
+              summary: This alert is a trigger for CAD to create a must-gather.
+              description: This alert fires when a non-silenced alert is firing in
+                a managed namespace. This alert is meant to trigger configuration-anomaly-detection
+                to create a must-gather
+    - apiVersion: monitoring.coreos.com/v1
+      kind: PrometheusRule
+      metadata:
+        labels:
           prometheus: sre-elasticsearch-jobs
           role: alert-rules
         name: sre-elasticsearch-jobs


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?

The CreateMustGather alert was firing on newly installed or recently upgraded clusters, which caused the OCP conformance test ([sig-instrumentation] Prometheus ... shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured) to fail in CI.                        
                                                                                                                                                                                                                                                                                                                  
  This PR adds two conditions to suppress the alert:                                                                                                                                                                                                                                                                
  - During active cluster upgrades (absent(cluster_version{type="updating"}))                                                                                                                                                                                                                                     
  - Within the first 4 hours after an install or upgrade completes (time() - min(cluster_version{type="completed"}) > 14400)       

### Which Jira/Github issue(s) this PR fixes?

  Fixes [SREP-4581](https://redhat.atlassian.net/browse/SREP-4581) 

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "CreateMustGather" alert that automatically triggers CAD must-gather when active alerts persist for 15 minutes on clusters that are not currently updating and whose last completed update was over 4 hours ago. Deployed to production, staging, and integration environments to speed diagnostics and reduce time-to-resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->