### PR TITLE
[SLSRE-534] Migrate ACM PlacementRule resources to Placement resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR ${REPO_PATH}
 
 # Upgrade pip and install necessasry packages
 RUN pip install --disable-pip-version-check oyaml
-ADD --chown=default https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.9.1/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator
+ADD --chown=default https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.17.1/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator
 RUN chmod +x /opt/app-root/bin/PolicyGenerator
 
 # Make

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -15,4 +15,4 @@ USER default
 
 RUN pip install --disable-pip-version-check oyaml
 
-ADD --chmod=755 https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.12.4/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator
+ADD --chmod=755 https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/v1.17.1/linux-amd64-PolicyGenerator /opt/app-root/bin/PolicyGenerator

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifndef GEN_CMO_CONFIG
 $(error GEN_CMO_CONFIG is not set; check project.mk file)
 endif
 
-POLICYGEN_VERSION=v1.12.4
+POLICYGEN_VERSION=v1.17.1
 
 VOLUME_MOUNT_FLAGS = :z
 CONTAINER_ENGINE?=$(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,15 @@ generate-rosa-brand-logo:
 .PHONY: generate-hive-templates
 generate-hive-templates: generate-oauth-templates
 	if [ -z ${IN_CONTAINER} ]; then \
-		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator; chmod +x /opt/app-root/bin/PolicyGenerator; ${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; ${GEN_POLICY}; ${GEN_CMO_CONFIG}";\
+		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; curl -sSL https://github.com/open-cluster-management-io/policy-generator-plugin/releases/download/${POLICYGEN_VERSION}/linux-amd64-PolicyGenerator --output /opt/app-root/bin/PolicyGenerator; chmod +x /opt/app-root/bin/PolicyGenerator; ${GEN_POLICY_CONFIG}; ${GEN_POLICY_CONFIG_SP}; ${GEN_POLICY}; ${GEN_CMO_CONFIG}; scripts/add-annotations-tolerations.py";\
 		$(CONTAINER_ENGINE) run $(CONTAINER_RUN_FLAGS) registry.access.redhat.com/ubi9/python-312 /bin/bash -xc "cd `pwd -P`; pip install --disable-pip-version-check oyaml; ${GEN_TEMPLATE}"; \
 	else \
 		${GEN_POLICY_CONFIG};\
 		${GEN_POLICY_CONFIG_SP};\
 		${GEN_POLICY};\
-		${GEN_TEMPLATE}; \
 		${GEN_CMO_CONFIG}; \
+		scripts/add-annotations-tolerations.py; \
+		${GEN_TEMPLATE}; \
 	fi
 
 .PHONY: enforce-backplane-rules

--- a/deploy/acm-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
+++ b/deploy/acm-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: openshift-acm-policies
+spec:
+  clusterSet: global

--- a/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-acs.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-acs
     namespace: openshift-acm-policies
@@ -874,18 +875,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-acs
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: api.openshift.com/addon-acs-fleetshard
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: api.openshift.com/addon-acs-fleetshard
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -893,8 +901,8 @@ metadata:
     name: binding-backplane-acs
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-acs
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-ai-agent-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-ai-agent-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-ai-agent-sp
     namespace: openshift-acm-policies
@@ -79,18 +80,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-ai-agent-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -98,8 +106,8 @@ metadata:
     name: binding-backplane-ai-agent-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-ai-agent-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-ai-agent.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-ai-agent.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-ai-agent
     namespace: openshift-acm-policies
@@ -33,18 +34,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-ai-agent
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -52,8 +60,8 @@ metadata:
     name: binding-backplane-ai-agent
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-ai-agent
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cee-sp
     namespace: openshift-acm-policies
@@ -109,18 +110,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cee-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -128,8 +136,8 @@ metadata:
     name: binding-backplane-cee-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cee-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cee.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cee
     namespace: openshift-acm-policies
@@ -190,18 +191,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cee
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -209,8 +217,8 @@ metadata:
     name: binding-backplane-cee
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cee
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cse-sp
     namespace: openshift-acm-policies
@@ -79,18 +80,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cse-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -98,8 +106,8 @@ metadata:
     name: binding-backplane-cse-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cse-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-cse.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-cse
     namespace: openshift-acm-policies
@@ -33,18 +34,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-cse
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -52,8 +60,8 @@ metadata:
     name: binding-backplane-cse
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-cse
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-csm-sp
     namespace: openshift-acm-policies
@@ -107,18 +108,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-csm-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -126,8 +134,8 @@ metadata:
     name: binding-backplane-csm-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-csm-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-csm.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-csm
     namespace: openshift-acm-policies
@@ -142,18 +143,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-csm
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -161,8 +169,8 @@ metadata:
     name: binding-backplane-csm
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-csm
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-elevated-sre.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-elevated-sre
     namespace: openshift-acm-policies
@@ -86,18 +87,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-elevated-sre
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -105,8 +113,8 @@ metadata:
     name: binding-backplane-elevated-sre
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-elevated-sre
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-lpsre-sp
     namespace: openshift-acm-policies
@@ -206,18 +207,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-lpsre-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -225,8 +233,8 @@ metadata:
     name: binding-backplane-lpsre-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-lpsre-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-lpsre.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-lpsre
     namespace: openshift-acm-policies
@@ -287,18 +288,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-lpsre
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -306,8 +314,8 @@ metadata:
     name: binding-backplane-lpsre
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-lpsre
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mcs-tier-two-sp
     namespace: openshift-acm-policies
@@ -109,18 +110,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mcs-tier-two-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -128,8 +136,8 @@ metadata:
     name: binding-backplane-mcs-tier-two-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mcs-tier-two-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mcs-tier-two.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mcs-tier-two
     namespace: openshift-acm-policies
@@ -181,18 +182,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mcs-tier-two
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -200,8 +208,8 @@ metadata:
     name: binding-backplane-mcs-tier-two
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mcs-tier-two
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mobb-sp
     namespace: openshift-acm-policies
@@ -107,18 +108,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mobb-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -126,8 +134,8 @@ metadata:
     name: binding-backplane-mobb-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mobb-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-mobb.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-mobb
     namespace: openshift-acm-policies
@@ -142,18 +143,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-mobb
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -161,8 +169,8 @@ metadata:
     name: binding-backplane-mobb
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-mobb
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-ro-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-ro-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep-ro-sp
     namespace: openshift-acm-policies
@@ -147,18 +148,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep-ro-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -166,8 +174,8 @@ metadata:
     name: binding-backplane-srep-ro-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep-ro-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-ro.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-ro.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep-ro
     namespace: openshift-acm-policies
@@ -403,18 +404,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep-ro
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -422,8 +430,8 @@ metadata:
     name: binding-backplane-srep-ro
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep-ro
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep-sp
     namespace: openshift-acm-policies
@@ -145,18 +146,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -164,8 +172,8 @@ metadata:
     name: binding-backplane-srep-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-srep.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-srep
     namespace: openshift-acm-policies
@@ -307,18 +308,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-srep
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -326,8 +334,8 @@ metadata:
     name: binding-backplane-srep
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-srep
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-tam-sp
     namespace: openshift-acm-policies
@@ -107,18 +108,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-tam-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -126,8 +134,8 @@ metadata:
     name: binding-backplane-tam-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-tam-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane-tam.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane-tam
     namespace: openshift-acm-policies
@@ -142,18 +143,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane-tam
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -161,8 +169,8 @@ metadata:
     name: binding-backplane-tam
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane-tam
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-backplane.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: backplane
     namespace: openshift-acm-policies
@@ -525,18 +526,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-backplane
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -544,8 +552,8 @@ metadata:
     name: binding-backplane
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-backplane
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: ccs-dedicated-admins-sp
     namespace: openshift-acm-policies
@@ -75,18 +76,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-ccs-dedicated-admins-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -94,8 +102,8 @@ metadata:
     name: binding-ccs-dedicated-admins-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-ccs-dedicated-admins-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-ccs-dedicated-admins.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: ccs-dedicated-admins
     namespace: openshift-acm-policies
@@ -42,18 +43,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-ccs-dedicated-admins
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -61,8 +69,8 @@ metadata:
     name: binding-ccs-dedicated-admins
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-ccs-dedicated-admins
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-customer-registry-cas.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: customer-registry-cas
     namespace: openshift-acm-policies
@@ -104,18 +105,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-customer-registry-cas
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -123,8 +131,8 @@ metadata:
     name: binding-customer-registry-cas
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-customer-registry-cas
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hcp-ze-ecr-creds.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: hcp-ze-ecr-creds
     namespace: openshift-acm-policies
@@ -526,29 +527,36 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-hcp-ze-ecr-creds
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: api.openshift.com/hosted-cluster-egress-policy
-              operator: In
-              values:
-                - NoEgress
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: api.openshift.com/hosted-cluster-egress-policy
+                      operator: In
+                      values:
+                        - NoEgress
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -556,8 +564,8 @@ metadata:
     name: binding-hcp-ze-ecr-creds
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-hcp-ze-ecr-creds
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hosted-uwm.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: hosted-uwm
     namespace: openshift-acm-policies
@@ -64,18 +65,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-hosted-uwm
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -83,8 +91,8 @@ metadata:
     name: binding-hosted-uwm
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-hosted-uwm
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-hypershift-ovn-logging.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: hypershift-ovn-logging
     namespace: openshift-acm-policies
@@ -37,18 +38,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-hypershift-ovn-logging
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/management-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/management-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -56,8 +64,8 @@ metadata:
     name: binding-hypershift-ovn-logging
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-hypershift-ovn-logging
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-backplane-managed-scripts.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-backplane-managed-scripts
     namespace: openshift-acm-policies
@@ -61,18 +62,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-backplane-managed-scripts
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -80,8 +88,8 @@ metadata:
     name: binding-osd-backplane-managed-scripts
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-backplane-managed-scripts
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-cluster-admin.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-cluster-admin
     namespace: openshift-acm-policies
@@ -41,18 +42,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-cluster-admin
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -60,8 +68,8 @@ metadata:
     name: binding-osd-cluster-admin
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-cluster-admin
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-customer-monitoring.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-customer-monitoring
     namespace: openshift-acm-policies
@@ -628,18 +629,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-customer-monitoring
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -647,8 +655,8 @@ metadata:
     name: binding-osd-customer-monitoring
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-customer-monitoring
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-script-resources.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-delete-backplane-script-resources
     namespace: openshift-acm-policies
@@ -238,18 +239,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-delete-backplane-script-resources
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -257,8 +265,8 @@ metadata:
     name: binding-osd-delete-backplane-script-resources
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-delete-backplane-script-resources
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-delete-backplane-serviceaccounts-sp
     namespace: openshift-acm-policies
@@ -72,18 +73,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-delete-backplane-serviceaccounts-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -91,8 +99,8 @@ metadata:
     name: binding-osd-delete-backplane-serviceaccounts-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-delete-backplane-serviceaccounts-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-delete-backplane-serviceaccounts.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-delete-backplane-serviceaccounts
     namespace: openshift-acm-policies
@@ -123,18 +124,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-delete-backplane-serviceaccounts
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -142,8 +150,8 @@ metadata:
     name: binding-osd-delete-backplane-serviceaccounts
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-delete-backplane-serviceaccounts
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-logging-unsupported.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-logging-unsupported
     namespace: openshift-acm-policies
@@ -172,18 +173,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-logging-unsupported
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -191,8 +199,8 @@ metadata:
     name: binding-osd-logging-unsupported
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-logging-unsupported
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-must-gather-operator.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-must-gather-operator
     namespace: openshift-acm-policies
@@ -38,18 +39,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-must-gather-operator
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -57,8 +65,8 @@ metadata:
     name: binding-osd-must-gather-operator
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-must-gather-operator
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-openshift-operators-redhat.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-openshift-operators-redhat
     namespace: openshift-acm-policies
@@ -97,18 +98,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-openshift-operators-redhat
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -116,8 +124,8 @@ metadata:
     name: binding-osd-openshift-operators-redhat
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-openshift-operators-redhat
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-pcap-collector.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-pcap-collector
     namespace: openshift-acm-policies
@@ -77,18 +78,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-pcap-collector
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -96,8 +104,8 @@ metadata:
     name: binding-osd-pcap-collector
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-pcap-collector
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-project-request-template.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-project-request-template
     namespace: openshift-acm-policies
@@ -59,18 +60,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-project-request-template
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -78,8 +86,8 @@ metadata:
     name: binding-osd-project-request-template
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-project-request-template
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-user-workload-monitoring-sp
     namespace: openshift-acm-policies
@@ -52,18 +53,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-user-workload-monitoring-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -71,8 +79,8 @@ metadata:
     name: binding-osd-user-workload-monitoring-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-user-workload-monitoring-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-osd-user-workload-monitoring.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: osd-user-workload-monitoring
     namespace: openshift-acm-policies
@@ -116,18 +117,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-osd-user-workload-monitoring
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -135,8 +143,8 @@ metadata:
     name: binding-osd-user-workload-monitoring
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-osd-user-workload-monitoring
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config-sp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rbac-permissions-operator-config-sp
     namespace: openshift-acm-policies
@@ -349,18 +350,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rbac-permissions-operator-config-sp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -368,8 +376,8 @@ metadata:
     name: binding-rbac-permissions-operator-config-sp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rbac-permissions-operator-config-sp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rbac-permissions-operator-config.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rbac-permissions-operator-config
     namespace: openshift-acm-policies
@@ -1051,18 +1052,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rbac-permissions-operator-config
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -1070,8 +1078,8 @@ metadata:
     name: binding-rbac-permissions-operator-config
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rbac-permissions-operator-config
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-console-branding-hcp.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-branding-hcp.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-console-branding-hcp
     namespace: openshift-acm-policies
@@ -39,18 +40,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-console-branding-hcp
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -58,8 +66,8 @@ metadata:
     name: binding-rosa-console-branding-hcp
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-console-branding-hcp
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-configmap.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-console-legacy-branding-configmap.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-console-legacy-branding-configmap
     namespace: openshift-acm-policies
@@ -135,18 +136,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-console-legacy-branding-configmap
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -154,8 +162,8 @@ metadata:
     name: binding-rosa-console-legacy-branding-configmap
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-console-legacy-branding-configmap
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-check.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-ingress-certificate-check
     namespace: openshift-acm-policies
@@ -34,18 +35,25 @@ spec:
                 severity: low
     remediationAction: inform
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-ingress-certificate-check
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -53,8 +61,8 @@ metadata:
     name: binding-rosa-ingress-certificate-check
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-ingress-certificate-check
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-rosa-ingress-certificate-policies.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: rosa-ingress-certificate-policies
     namespace: openshift-acm-policies
@@ -86,18 +87,25 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-rosa-ingress-certificate-policies
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -105,8 +113,8 @@ metadata:
     name: binding-rosa-ingress-certificate-policies
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-rosa-ingress-certificate-policies
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-srep-vap-autonode-karpenter.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-autonode-karpenter.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: srep-vap-autonode-karpenter
     namespace: openshift-acm-policies
@@ -182,28 +183,35 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-srep-vap-autonode-karpenter
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
-                - "4.18"
-                - "4.19"
-                - "4.20"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+                        - "4.18"
+                        - "4.19"
+                        - "4.20"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -211,8 +219,8 @@ metadata:
     name: binding-srep-vap-autonode-karpenter
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-srep-vap-autonode-karpenter
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-srep-vap-hcp-node-label.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-hcp-node-label.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: srep-vap-hcp-node-label
     namespace: openshift-acm-policies
@@ -70,26 +71,33 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-srep-vap-hcp-node-label
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
-                - "4.18"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+                        - "4.18"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -97,8 +105,8 @@ metadata:
     name: binding-srep-vap-hcp-node-label
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-srep-vap-hcp-node-label
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/acm-policies/50-GENERATED-srep-vap-vcpu-overcommit.Policy.yaml
+++ b/deploy/acm-policies/50-GENERATED-srep-vap-vcpu-overcommit.Policy.yaml
@@ -5,6 +5,7 @@ metadata:
     annotations:
         policy.open-cluster-management.io/categories: CM Configuration Management
         policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+        policy.open-cluster-management.io/description: ""
         policy.open-cluster-management.io/standards: NIST SP 800-53
     name: srep-vap-vcpu-overcommit
     namespace: openshift-acm-policies
@@ -63,30 +64,37 @@ spec:
                 severity: low
     remediationAction: enforce
 ---
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: Placement
 metadata:
     name: placement-srep-vap-vcpu-overcommit
     namespace: openshift-acm-policies
 spec:
-    clusterSelector:
-        matchExpressions:
-            - key: hypershift.open-cluster-management.io/hosted-cluster
-              operator: In
-              values:
-                - "true"
-            - key: api.openshift.com/win-li-enabled
-              operator: In
-              values:
-                - "true"
-            - key: openshiftVersion-major-minor
-              operator: NotIn
-              values:
-                - "4.14"
-                - "4.15"
-                - "4.16"
-                - "4.17"
-                - "4.18"
+    predicates:
+        - requiredClusterSelector:
+            labelSelector:
+                matchExpressions:
+                    - key: hypershift.open-cluster-management.io/hosted-cluster
+                      operator: In
+                      values:
+                        - "true"
+                    - key: api.openshift.com/win-li-enabled
+                      operator: In
+                      values:
+                        - "true"
+                    - key: openshiftVersion-major-minor
+                      operator: NotIn
+                      values:
+                        - "4.14"
+                        - "4.15"
+                        - "4.16"
+                        - "4.17"
+                        - "4.18"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -94,8 +102,8 @@ metadata:
     name: binding-srep-vap-vcpu-overcommit
     namespace: openshift-acm-policies
 placementRef:
-    apiGroup: apps.open-cluster-management.io
-    kind: PlacementRule
+    apiGroup: cluster.open-cluster-management.io
+    kind: Placement
     name: placement-srep-vap-vcpu-overcommit
 subjects:
     - apiGroup: policy.open-cluster-management.io

--- a/deploy/rosa-oauth-templates-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
+++ b/deploy/rosa-oauth-templates-policies/05-managedclustersetbinding-global.ManagedClusterSetBinding.yaml
@@ -1,0 +1,7 @@
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: global
+  namespace: openshift-rosa-oauth-tpl-policies
+spec:
+  clusterSet: global

--- a/scripts/add-annotations-tolerations.py
+++ b/scripts/add-annotations-tolerations.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+"""
+Post-processing script to add annotations to Policy resources and tolerations to Placement resources.
+This script is needed because:
+1. The PolicyGenerator tool doesn't support tolerations in the placement field of the template
+2. The description annotation needs to be explicitly set to an empty string on Policy resources
+"""
+
+import oyaml as yaml
+import os
+import sys
+from pathlib import Path
+
+PLACEMENT_TOLERATIONS = [
+    {
+        "key": "cluster.open-cluster-management.io/unavailable",
+        "operator": "Exists"
+    },
+    {
+        "key": "cluster.open-cluster-management.io/unreachable",
+        "operator": "Exists"
+    }
+]
+
+POLICY_DESCRIPTION_ANNOTATION = "policy.open-cluster-management.io/description"
+POLICY_DESCRIPTION_VALUE = ""
+
+def add_annotations_and_tolerations(policy_file):
+    """Add annotations to Policy resources and tolerations to Placement resources."""
+    try:
+        with open(policy_file, 'r') as f:
+            documents = list(yaml.safe_load_all(f))
+    except Exception as e:
+        print(f"Error reading {policy_file}: {e}", file=sys.stderr)
+        return False
+
+    modified = False
+    for doc in documents:
+        if not doc:
+            continue
+            
+        # Add description annotation to Policy resources
+        if doc.get('kind') == 'Policy':
+            if 'metadata' not in doc:
+                doc['metadata'] = {}
+            if 'annotations' not in doc['metadata']:
+                doc['metadata']['annotations'] = {}
+            # Only add if not already present
+            if POLICY_DESCRIPTION_ANNOTATION not in doc['metadata']['annotations']:
+                doc['metadata']['annotations'][POLICY_DESCRIPTION_ANNOTATION] = POLICY_DESCRIPTION_VALUE
+                modified = True
+        
+        # Add tolerations to Placement resources
+        elif doc.get('kind') == 'Placement':
+            if 'spec' not in doc:
+                doc['spec'] = {}
+            # Only add if not already present
+            if 'tolerations' not in doc['spec']:
+                doc['spec']['tolerations'] = PLACEMENT_TOLERATIONS
+                modified = True
+
+    if modified:
+        try:
+            with open(policy_file, 'w') as f:
+                yaml.dump_all(documents, f, default_flow_style=False)
+            return True
+        except Exception as e:
+            print(f"Error writing {policy_file}: {e}", file=sys.stderr)
+            return False
+
+    return True
+
+def main():
+    """Process all generated policy files."""
+    policy_dir = Path("deploy/acm-policies")
+    
+    if not policy_dir.exists():
+        print(f"Error: {policy_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    # Process all 50-GENERATED-*.Policy.yaml files
+    policy_files = list(policy_dir.glob("50-GENERATED-*.Policy.yaml"))
+    
+    if not policy_files:
+        print(f"No policy files found in {policy_dir}")
+        return
+
+    failed = []
+    for policy_file in sorted(policy_files):
+        if not add_annotations_and_tolerations(str(policy_file)):
+            failed.append(str(policy_file))
+            print(f"Failed to process {policy_file}")
+        else:
+            print(f"Processed {policy_file.name}")
+
+    if failed:
+        print(f"\nFailed files: {failed}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-policy-config.py
+++ b/scripts/generate-policy-config.py
@@ -98,7 +98,7 @@ for directory in sorted(directories, key=str.casefold):
         p['name'] = policy_name
         for m in p['manifests']:
             m['path'] = path
-    policy_template['policyDefaults']['placement']['clusterSelectors'] = cluster_selectors
+    policy_template['policyDefaults']['placement']['labelSelector'] = cluster_selectors
     if not len(namespace_selectors) == 0:
         policy_template['policyDefaults']['namespaceSelector'] = namespace_selectors
     with open(os.path.join(temp_directory, "policy-generator-config.yaml"),'w+') as output_file:

--- a/scripts/policy-generator-config.yaml
+++ b/scripts/policy-generator-config.yaml
@@ -5,8 +5,12 @@ metadata:
 policyDefaults:
     namespace: openshift-acm-policies
     placement:
-        clusterSelectors:
-          hypershift.open-cluster-management.io/hosted-cluster: "true" # Can be overridden by script
+        labelSelector:
+            matchExpressions:
+                - key: hypershift.open-cluster-management.io/hosted-cluster
+                  operator: In
+                  values:
+                    - "true"
     remediationAction: enforce
     evaluationInterval:
         compliant: 2h


### PR DESCRIPTION
### What type of PR is this?
_(bug/feature/cleanup/documentation)_
Cleanup

### What this PR does / why we need it?
Migrate ACM PlacementRule resources to Placement resources

### Which Jira/Github issue(s) this PR fixes?

_Fixes_ [SLSRE-534](https://redhat.atlassian.net/browse/SLSRE-534)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded PolicyGenerator binary to v1.17.1 in standard Docker builds and Prow CI images

* **Updates**
  * Migrated ACM placement wiring from legacy PlacementRule to the newer Placement API and updated corresponding bindings
  * Switched generated policy placement selectors to labelSelector/matchExpressions for hosted-cluster targeting
  * Added empty policy description annotations and updated placements with tolerations
  * Added ManagedClusterSetBinding manifests to bind the global cluster set
<!-- end of auto-generated comment: release notes by coderabbit.ai -->