### PR TITLE
Remove FedRAMP exclusion filtering for cve-2026-31431

### DIFF
--- a/deploy/cve-2026-31431-disable-algif-aead/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/config.yaml
@@ -1,7 +1,3 @@
 deploymentMode: "SelectorSyncSet"
 selectorSyncSet:
   resourceApplyMode: Sync
-  matchExpressions:
-    - key: api.openshift.com/fedramp
-      operator: NotIn
-      values: ["true"]

--- a/deploy/cve-2026-31431-disable-algif-aead/integration/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/integration/config.yaml
@@ -5,9 +5,6 @@ selectorSyncSet:
     - key: api.openshift.com/environment
       operator: In
       values: ["integration"]
-    - key: api.openshift.com/fedramp
-      operator: NotIn
-      values: ["true"]
     - key: ext-hypershift.openshift.io/cluster-type
       operator: In
       values: ["management-cluster", "service-cluster"]

--- a/deploy/cve-2026-31431-disable-algif-aead/production/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/production/config.yaml
@@ -5,9 +5,6 @@ selectorSyncSet:
     - key: api.openshift.com/environment
       operator: In
       values: ["production"]
-    - key: api.openshift.com/fedramp
-      operator: NotIn
-      values: ["true"]
     - key: ext-hypershift.openshift.io/cluster-type
       operator: In
       values: ["management-cluster", "service-cluster"]

--- a/deploy/cve-2026-31431-disable-algif-aead/staging/config.yaml
+++ b/deploy/cve-2026-31431-disable-algif-aead/staging/config.yaml
@@ -5,9 +5,6 @@ selectorSyncSet:
     - key: api.openshift.com/environment
       operator: In
       values: ["staging"]
-    - key: api.openshift.com/fedramp
-      operator: NotIn
-      values: ["true"]
     - key: ext-hypershift.openshift.io/cluster-type
       operator: In
       values: ["management-cluster", "service-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29539,11 +29539,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -29572,10 +29567,6 @@ objects:
         operator: In
         values:
         - integration
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:
@@ -29609,10 +29600,6 @@ objects:
         operator: In
         values:
         - production
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:
@@ -29646,10 +29633,6 @@ objects:
         operator: In
         values:
         - staging
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29539,11 +29539,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -29572,10 +29567,6 @@ objects:
         operator: In
         values:
         - integration
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:
@@ -29609,10 +29600,6 @@ objects:
         operator: In
         values:
         - production
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:
@@ -29646,10 +29633,6 @@ objects:
         operator: In
         values:
         - staging
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29539,11 +29539,6 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-      matchExpressions:
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
     resourceApplyMode: Sync
     resources:
     - apiVersion: machineconfiguration.openshift.io/v1
@@ -29572,10 +29567,6 @@ objects:
         operator: In
         values:
         - integration
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:
@@ -29609,10 +29600,6 @@ objects:
         operator: In
         values:
         - production
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:
@@ -29646,10 +29633,6 @@ objects:
         operator: In
         values:
         - staging
-      - key: api.openshift.com/fedramp
-        operator: NotIn
-        values:
-        - 'true'
       - key: ext-hypershift.openshift.io/cluster-type
         operator: In
         values:


### PR DESCRIPTION
### What type of PR is this?
_chore_

### What this PR does / why we need it?
- Removes FedRAMP exclusion filtering for CVE-2026-31431

### Which Jira/Github issue(s) this PR fixes?

[ROSAENG-809](https://redhat.atlassian.net/browse/ROSAENG-809)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster deployment configuration selectors across integration, staging, and production environments with refined label-based selection criteria to improve environment routing precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->