### PR TITLE
ROSAENG-856: Add a DaemonSet mitigation for CVE-2026-43284

### DIFF
--- a/deploy/cve-2026-43284-disable-dirtyfrag/01-disable-dirtyfrag-daemonset.yaml
+++ b/deploy/cve-2026-43284-disable-dirtyfrag/01-disable-dirtyfrag-daemonset.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat-cve-2026-43284-disable-dirtyfrag
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: disable-dirtyfrag
+  namespace: redhat-cve-2026-43284-disable-dirtyfrag
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: disable-dirtyfrag-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: disable-dirtyfrag
+    namespace: redhat-cve-2026-43284-disable-dirtyfrag
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: disable-dirtyfrag-ipsec-safe
+  namespace: redhat-cve-2026-43284-disable-dirtyfrag
+  labels:
+    app: disable-dirtyfrag-ipsec-safe
+spec:
+  selector:
+    matchLabels:
+      app: disable-dirtyfrag-ipsec-safe
+  template:
+    metadata:
+      labels:
+        app: disable-dirtyfrag-ipsec-safe
+    spec:
+      serviceAccountName: disable-dirtyfrag
+      nodeSelector:
+        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - operator: Exists
+      terminationGracePeriodSeconds: 1
+      containers:
+        - name: detect-modules
+          image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+          command:
+            - /bin/sh
+            - "-c"
+            - |
+              LOADED=false
+              for mod in esp4 esp6 rxrpc; do
+                if chroot /host grep -q "^${mod} " /proc/modules 2>/dev/null; then
+                  echo "DETECTED: ${mod} is loaded"
+                  LOADED=true
+                else
+                  echo "OK: ${mod} is not loaded"
+                fi
+              done
+              echo "=== result ==="
+              if [ "${LOADED}" = "true" ]; then
+                echo "WARNING: one or more modules are loaded, skipping mitigation"
+              else
+                if grep -qs "esp4" /host/etc/modprobe.d/dirtyfrag.conf 2>/dev/null; then
+                  echo "Modprobe blocklist already present, skipping"
+                else
+                  printf 'install esp4 /bin/false\ninstall esp6 /bin/false\ninstall rxrpc /bin/false\n' > /host/etc/modprobe.d/dirtyfrag.conf
+                  echo "Created /etc/modprobe.d/dirtyfrag.conf"
+                fi
+                for mod in esp4 esp6 rxrpc; do
+                  chroot /host modprobe -r "${mod}" 2>/dev/null || true
+                done
+                echo "Node is protected"
+              fi
+              sleep infinity
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /

--- a/deploy/cve-2026-43284-disable-dirtyfrag/README.md
+++ b/deploy/cve-2026-43284-disable-dirtyfrag/README.md
@@ -1,0 +1,36 @@
+# CVE-2026-43284: Disable dirtyfrag modules
+
+## Overview
+
+This deploys a DaemonSet (`disable-dirtyfrag-ipsec-safe`) to master nodes that mitigates CVE-2026-43284 by preventing the `esp4`, `esp6`, and `rxrpc` kernel modules from loading.
+
+The DaemonSet runs on every master node and:
+
+1. Checks whether any of the affected modules (`esp4`, `esp6`, `rxrpc`) are currently loaded.
+2. If any are loaded, it logs a warning and **skips** the mitigation to avoid disrupting active IPsec or RxRPC connections.
+3. If none are loaded, it creates `/etc/modprobe.d/dirtyfrag.conf` on the host to block future loading of the modules, then attempts to unload them.
+4. Sleeps indefinitely to keep the pod running and the mitigation visible.
+
+## Targeting
+
+The SelectorSyncSet targets clusters with the label `disable-dirtyfrag-mitigation-daemonset=true`.
+
+## Undoing the mitigation
+
+To reverse the DaemonSet changes on a node:
+
+1. Remove the SelectorSyncSet label from the cluster so the DaemonSet is cleaned up:
+   ```
+   ocm post /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/external_configuration/labels --body {"key": "disable-dirtyfrag-mitigation-daemonset","value": "true"}
+   ```
+2. On each master node, remove the modprobe blocklist file:
+   ```
+   oc debug node/<node-name> -- chroot /host rm -f /etc/modprobe.d/dirtyfrag.conf
+   ```
+3. Verify the file is gone:
+   ```
+   oc debug node/<node-name> -- chroot /host ls /etc/modprobe.d/dirtyfrag.conf
+   ```
+   This should return "No such file or directory".
+
+After removing the blocklist file, the `esp4`, `esp6`, and `rxrpc` modules will be loadable again on the next request or reboot.

--- a/deploy/cve-2026-43284-disable-dirtyfrag/config.yaml
+++ b/deploy/cve-2026-43284-disable-dirtyfrag/config.yaml
@@ -1,0 +1,10 @@
+deploymentMode: "SelectorSyncSet"
+selectorSyncSet:
+  resourceApplyMode: Sync
+  matchExpressions:
+    - key: disable-dirtyfrag-mitigation-daemonset
+      operator: In
+      values: ["true"]
+    - key: api.openshift.com/fedramp
+      operator: NotIn
+      values: ["true"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29656,6 +29656,101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-43284-disable-dirtyfrag
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: disable-dirtyfrag-mitigation-daemonset
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: disable-dirtyfrag-privileged
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:openshift:scc:privileged
+      subjects:
+      - kind: ServiceAccount
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: disable-dirtyfrag-ipsec-safe
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+        labels:
+          app: disable-dirtyfrag-ipsec-safe
+      spec:
+        selector:
+          matchLabels:
+            app: disable-dirtyfrag-ipsec-safe
+        template:
+          metadata:
+            labels:
+              app: disable-dirtyfrag-ipsec-safe
+          spec:
+            serviceAccountName: disable-dirtyfrag
+            nodeSelector:
+              kubernetes.io/os: linux
+              node-role.kubernetes.io/master: ''
+            tolerations:
+            - operator: Exists
+            terminationGracePeriodSeconds: 1
+            containers:
+            - name: detect-modules
+              image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+              command:
+              - /bin/sh
+              - -c
+              - "LOADED=false\nfor mod in esp4 esp6 rxrpc; do\n  if chroot /host grep\
+                \ -q \"^${mod} \" /proc/modules 2>/dev/null; then\n    echo \"DETECTED:\
+                \ ${mod} is loaded\"\n    LOADED=true\n  else\n    echo \"OK: ${mod}\
+                \ is not loaded\"\n  fi\ndone\necho \"=== result ===\"\nif [ \"${LOADED}\"\
+                \ = \"true\" ]; then\n  echo \"WARNING: one or more modules are loaded,\
+                \ skipping mitigation\"\nelse\n  if grep -qs \"esp4\" /host/etc/modprobe.d/dirtyfrag.conf\
+                \ 2>/dev/null; then\n    echo \"Modprobe blocklist already present,\
+                \ skipping\"\n  else\n    printf 'install esp4 /bin/false\\ninstall\
+                \ esp6 /bin/false\\ninstall rxrpc /bin/false\\n' > /host/etc/modprobe.d/dirtyfrag.conf\n\
+                \    echo \"Created /etc/modprobe.d/dirtyfrag.conf\"\n  fi\n  for\
+                \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
+                \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
+                sleep infinity\n"
+              securityContext:
+                privileged: true
+              volumeMounts:
+              - name: host-root
+                mountPath: /host
+            volumes:
+            - name: host-root
+              hostPath:
+                path: /
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29656,6 +29656,101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-43284-disable-dirtyfrag
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: disable-dirtyfrag-mitigation-daemonset
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: disable-dirtyfrag-privileged
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:openshift:scc:privileged
+      subjects:
+      - kind: ServiceAccount
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: disable-dirtyfrag-ipsec-safe
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+        labels:
+          app: disable-dirtyfrag-ipsec-safe
+      spec:
+        selector:
+          matchLabels:
+            app: disable-dirtyfrag-ipsec-safe
+        template:
+          metadata:
+            labels:
+              app: disable-dirtyfrag-ipsec-safe
+          spec:
+            serviceAccountName: disable-dirtyfrag
+            nodeSelector:
+              kubernetes.io/os: linux
+              node-role.kubernetes.io/master: ''
+            tolerations:
+            - operator: Exists
+            terminationGracePeriodSeconds: 1
+            containers:
+            - name: detect-modules
+              image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+              command:
+              - /bin/sh
+              - -c
+              - "LOADED=false\nfor mod in esp4 esp6 rxrpc; do\n  if chroot /host grep\
+                \ -q \"^${mod} \" /proc/modules 2>/dev/null; then\n    echo \"DETECTED:\
+                \ ${mod} is loaded\"\n    LOADED=true\n  else\n    echo \"OK: ${mod}\
+                \ is not loaded\"\n  fi\ndone\necho \"=== result ===\"\nif [ \"${LOADED}\"\
+                \ = \"true\" ]; then\n  echo \"WARNING: one or more modules are loaded,\
+                \ skipping mitigation\"\nelse\n  if grep -qs \"esp4\" /host/etc/modprobe.d/dirtyfrag.conf\
+                \ 2>/dev/null; then\n    echo \"Modprobe blocklist already present,\
+                \ skipping\"\n  else\n    printf 'install esp4 /bin/false\\ninstall\
+                \ esp6 /bin/false\\ninstall rxrpc /bin/false\\n' > /host/etc/modprobe.d/dirtyfrag.conf\n\
+                \    echo \"Created /etc/modprobe.d/dirtyfrag.conf\"\n  fi\n  for\
+                \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
+                \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
+                sleep infinity\n"
+              securityContext:
+                privileged: true
+              volumeMounts:
+              - name: host-root
+                mountPath: /host
+            volumes:
+            - name: host-root
+              hostPath:
+                path: /
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29656,6 +29656,101 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: cve-2026-43284-disable-dirtyfrag
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: disable-dirtyfrag-mitigation-daemonset
+        operator: In
+        values:
+        - 'true'
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: disable-dirtyfrag-privileged
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:openshift:scc:privileged
+      subjects:
+      - kind: ServiceAccount
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: disable-dirtyfrag-ipsec-safe
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+        labels:
+          app: disable-dirtyfrag-ipsec-safe
+      spec:
+        selector:
+          matchLabels:
+            app: disable-dirtyfrag-ipsec-safe
+        template:
+          metadata:
+            labels:
+              app: disable-dirtyfrag-ipsec-safe
+          spec:
+            serviceAccountName: disable-dirtyfrag
+            nodeSelector:
+              kubernetes.io/os: linux
+              node-role.kubernetes.io/master: ''
+            tolerations:
+            - operator: Exists
+            terminationGracePeriodSeconds: 1
+            containers:
+            - name: detect-modules
+              image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+              command:
+              - /bin/sh
+              - -c
+              - "LOADED=false\nfor mod in esp4 esp6 rxrpc; do\n  if chroot /host grep\
+                \ -q \"^${mod} \" /proc/modules 2>/dev/null; then\n    echo \"DETECTED:\
+                \ ${mod} is loaded\"\n    LOADED=true\n  else\n    echo \"OK: ${mod}\
+                \ is not loaded\"\n  fi\ndone\necho \"=== result ===\"\nif [ \"${LOADED}\"\
+                \ = \"true\" ]; then\n  echo \"WARNING: one or more modules are loaded,\
+                \ skipping mitigation\"\nelse\n  if grep -qs \"esp4\" /host/etc/modprobe.d/dirtyfrag.conf\
+                \ 2>/dev/null; then\n    echo \"Modprobe blocklist already present,\
+                \ skipping\"\n  else\n    printf 'install esp4 /bin/false\\ninstall\
+                \ esp6 /bin/false\\ninstall rxrpc /bin/false\\n' > /host/etc/modprobe.d/dirtyfrag.conf\n\
+                \    echo \"Created /etc/modprobe.d/dirtyfrag.conf\"\n  fi\n  for\
+                \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
+                \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
+                sleep infinity\n"
+              securityContext:
+                privileged: true
+              volumeMounts:
+              - name: host-root
+                mountPath: /host
+            volumes:
+            - name: host-root
+              hostPath:
+                path: /
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: hs-delete-custom-cmo-config
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
Roll out a DaemonSet that mitigates https://access.redhat.com/security/cve/cve-2026-43284 by using modprobe to block the affected modules from loading.

In cases where a cluster has already loaded them (they are dynamic) return early and log. This is primarily to protect clusters that are running IPSEC in OpenShift.

### Which Jira/Github issue(s) this PR fixes?

Fixes #[ROSAENG-856](https://redhat.atlassian.net/browse/ROSAENG-856)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [x] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in cluster/node deployment that runs a privileged DaemonSet on selected Linux control-plane nodes to inspect specific host kernel modules, skip mitigation if in use, optionally add a host blocklist to prevent future loads, attempt to unload modules when safe, and remain running per node.

* **Documentation**
  * Added deployment and rollback guide with label-based targeting and step‑by‑step undo instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->