### PR TITLE
ROSAENG-856: Fix exclusion selector for dirtyfrag cve

### DIFF
--- a/deploy/cve-2026-43284-disable-dirtyfrag/config.yaml
+++ b/deploy/cve-2026-43284-disable-dirtyfrag/config.yaml
@@ -3,7 +3,7 @@ selectorSyncSet:
   resourceApplyMode: Sync
   matchExpressions:
     - key: disable-dirtyfrag-mitigation-daemonset
-      operator: In
+      operator: NotIn
       values: ["true"]
     - key: api.openshift.com/fedramp
       operator: NotIn

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29663,7 +29663,7 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: disable-dirtyfrag-mitigation-daemonset
-        operator: In
+        operator: NotIn
         values:
         - 'true'
       - key: api.openshift.com/fedramp

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29663,7 +29663,7 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: disable-dirtyfrag-mitigation-daemonset
-        operator: In
+        operator: NotIn
         values:
         - 'true'
       - key: api.openshift.com/fedramp

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29663,7 +29663,7 @@ objects:
         api.openshift.com/managed: 'true'
       matchExpressions:
       - key: disable-dirtyfrag-mitigation-daemonset
-        operator: In
+        operator: NotIn
         values:
         - 'true'
       - key: api.openshift.com/fedramp


### PR DESCRIPTION
### What type of PR is this?
bug

### What this PR does / why we need it?
Fix the exclusion selector for when we want to _not_ schedule the DaemonSet in cases of single-cluster issues. It should have been `NotIn`

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration selector matching expressions across integration, production, and staging environments, reversing label-based selection criteria to adjust workload scheduling and distribution behavior across infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->