### PR TITLE
ROSAENG-856: DaemonSet for CVE-2026-43284 cleans up on pod termination

### DIFF
--- a/deploy/cve-2026-43284-disable-dirtyfrag/01-disable-dirtyfrag-daemonset.yaml
+++ b/deploy/cve-2026-43284-disable-dirtyfrag/01-disable-dirtyfrag-daemonset.yaml
@@ -78,6 +78,13 @@ spec:
                 echo "Node is protected"
               fi
               sleep infinity
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - "-c"
+                  - "rm -f /host/etc/modprobe.d/dirtyfrag.conf"
           securityContext:
             privileged: true
           volumeMounts:

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29731,6 +29731,13 @@ objects:
                 \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
                 \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
                 sleep infinity\n"
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                    - /bin/sh
+                    - -c
+                    - rm -f /host/etc/modprobe.d/dirtyfrag.conf
               securityContext:
                 privileged: true
               volumeMounts:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29731,6 +29731,13 @@ objects:
                 \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
                 \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
                 sleep infinity\n"
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                    - /bin/sh
+                    - -c
+                    - rm -f /host/etc/modprobe.d/dirtyfrag.conf
               securityContext:
                 privileged: true
               volumeMounts:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29731,6 +29731,13 @@ objects:
                 \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
                 \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
                 sleep infinity\n"
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                    - /bin/sh
+                    - -c
+                    - rm -f /host/etc/modprobe.d/dirtyfrag.conf
               securityContext:
                 privileged: true
               volumeMounts:


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?
This further hardens the DaemonSet to mitigate CVE-2026-43284 by having it use a `preStop` hook to remove the `modprobe.d` file, allowing the modules to be loaded normally after we remove the DaemonSet.

This allows for a cleaner rollback in the future once we have a list of patched Z streams.

### Which Jira/Github issue(s) this PR fixes?

Fixes [ROSAENG-856](https://redhat.atlassian.net/browse/ROSAENG-856?atlOrigin=eyJpIjoiYjM0MTA4MzUyYTYxNDVkY2IwMzVjOGQ3ZWQ3NzMwM2QiLCJwIjoianN3LWdpdGxhYlNNLWludCJ9)

### Special notes for your reviewer:
I tested this by applying it to my cluster, seeing the file exist, then deleting the DaemonSet and observing it get removed:

```
sh-5.1# cat /etc/modprobe.d/dirtyfrag.conf
install esp4 /bin/false
install esp6 /bin/false
install rxrpc /bin/false
sh-5.1# cat /etc/modprobe.d/dirtyfrag.conf
install esp4 /bin/false
install esp6 /bin/false
install rxrpc /bin/false
sh-5.1# cat /etc/modprobe.d/dirtyfrag.conf
cat: /etc/modprobe.d/dirtyfrag.conf: No such file or directory
```

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure pod termination now removes a host modprobe blocklist file to prevent leftover configuration after shutdown.
  * Added pre-stop cleanup to the affected daemon/pod so the host file is removed reliably on pod exit.
  * Applied the same cleanup behavior consistently across integration, staging, and production configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->