### PR TITLE
chore(SLSRE-693): include cve-2026-43284 mitigation on SC/MC workers

### DIFF
--- a/deploy/cve-2026-43284-disable-dirtyfrag/hcp/01-disable-dirtyfrag-daemonset.yaml
+++ b/deploy/cve-2026-43284-disable-dirtyfrag/hcp/01-disable-dirtyfrag-daemonset.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat-cve-2026-43284-disable-dirtyfrag
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: disable-dirtyfrag
+  namespace: redhat-cve-2026-43284-disable-dirtyfrag
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: disable-dirtyfrag-privileged
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: disable-dirtyfrag
+    namespace: redhat-cve-2026-43284-disable-dirtyfrag
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: disable-dirtyfrag-ipsec-safe
+  namespace: redhat-cve-2026-43284-disable-dirtyfrag
+  labels:
+    app: disable-dirtyfrag-ipsec-safe
+spec:
+  selector:
+    matchLabels:
+      app: disable-dirtyfrag-ipsec-safe
+  template:
+    metadata:
+      labels:
+        app: disable-dirtyfrag-ipsec-safe
+    spec:
+      serviceAccountName: disable-dirtyfrag
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+      terminationGracePeriodSeconds: 1
+      containers:
+        - name: detect-modules
+          image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+          command:
+            - /bin/sh
+            - "-c"
+            - |
+              LOADED=false
+              for mod in esp4 esp6 rxrpc; do
+                if chroot /host grep -q "^${mod} " /proc/modules 2>/dev/null; then
+                  echo "DETECTED: ${mod} is loaded"
+                  LOADED=true
+                else
+                  echo "OK: ${mod} is not loaded"
+                fi
+              done
+              echo "=== result ==="
+              if [ "${LOADED}" = "true" ]; then
+                echo "WARNING: one or more modules are loaded, skipping mitigation"
+              else
+                if grep -qs "esp4" /host/etc/modprobe.d/dirtyfrag.conf 2>/dev/null; then
+                  echo "Modprobe blocklist already present, skipping"
+                else
+                  printf 'install esp4 /bin/false\ninstall esp6 /bin/false\ninstall rxrpc /bin/false\n' > /host/etc/modprobe.d/dirtyfrag.conf
+                  echo "Created /etc/modprobe.d/dirtyfrag.conf"
+                fi
+                for mod in esp4 esp6 rxrpc; do
+                  chroot /host modprobe -r "${mod}" 2>/dev/null || true
+                done
+                echo "Node is protected"
+              fi
+              sleep infinity
+          securityContext:
+            privileged: true
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -f /host/etc/modprobe.d/dirtyfrag.conf"]
+          volumeMounts:
+            - name: host-root
+              mountPath: /host
+      volumes:
+        - name: host-root
+          hostPath:
+            path: /

--- a/deploy/cve-2026-43284-disable-dirtyfrag/hcp/config.yaml
+++ b/deploy/cve-2026-43284-disable-dirtyfrag/hcp/config.yaml
@@ -6,5 +6,5 @@ selectorSyncSet:
       operator: NotIn
       values: ["true"]
     - key: ext-hypershift.openshift.io/cluster-type
-      operator: NotIn
+      operator: In
       values: ["management-cluster", "service-cluster"]

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -29666,6 +29666,11 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+        - service-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -29733,6 +29738,108 @@ objects:
                 sleep infinity\n"
               securityContext:
                 privileged: true
+              volumeMounts:
+              - name: host-root
+                mountPath: /host
+            volumes:
+            - name: host-root
+              hostPath:
+                path: /
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cve-2026-43284-disable-dirtyfrag-hcp
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: disable-dirtyfrag-mitigation-daemonset
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: disable-dirtyfrag-privileged
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:openshift:scc:privileged
+      subjects:
+      - kind: ServiceAccount
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: disable-dirtyfrag-ipsec-safe
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+        labels:
+          app: disable-dirtyfrag-ipsec-safe
+      spec:
+        selector:
+          matchLabels:
+            app: disable-dirtyfrag-ipsec-safe
+        template:
+          metadata:
+            labels:
+              app: disable-dirtyfrag-ipsec-safe
+          spec:
+            serviceAccountName: disable-dirtyfrag
+            nodeSelector:
+              kubernetes.io/os: linux
+            tolerations:
+            - operator: Exists
+            terminationGracePeriodSeconds: 1
+            containers:
+            - name: detect-modules
+              image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+              command:
+              - /bin/sh
+              - -c
+              - "LOADED=false\nfor mod in esp4 esp6 rxrpc; do\n  if chroot /host grep\
+                \ -q \"^${mod} \" /proc/modules 2>/dev/null; then\n    echo \"DETECTED:\
+                \ ${mod} is loaded\"\n    LOADED=true\n  else\n    echo \"OK: ${mod}\
+                \ is not loaded\"\n  fi\ndone\necho \"=== result ===\"\nif [ \"${LOADED}\"\
+                \ = \"true\" ]; then\n  echo \"WARNING: one or more modules are loaded,\
+                \ skipping mitigation\"\nelse\n  if grep -qs \"esp4\" /host/etc/modprobe.d/dirtyfrag.conf\
+                \ 2>/dev/null; then\n    echo \"Modprobe blocklist already present,\
+                \ skipping\"\n  else\n    printf 'install esp4 /bin/false\\ninstall\
+                \ esp6 /bin/false\\ninstall rxrpc /bin/false\\n' > /host/etc/modprobe.d/dirtyfrag.conf\n\
+                \    echo \"Created /etc/modprobe.d/dirtyfrag.conf\"\n  fi\n  for\
+                \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
+                \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
+                sleep infinity\n"
+              securityContext:
+                privileged: true
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                    - /bin/sh
+                    - -c
+                    - rm -f /host/etc/modprobe.d/dirtyfrag.conf
               volumeMounts:
               - name: host-root
                 mountPath: /host

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -29666,6 +29666,11 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+        - service-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -29733,6 +29738,108 @@ objects:
                 sleep infinity\n"
               securityContext:
                 privileged: true
+              volumeMounts:
+              - name: host-root
+                mountPath: /host
+            volumes:
+            - name: host-root
+              hostPath:
+                path: /
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cve-2026-43284-disable-dirtyfrag-hcp
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: disable-dirtyfrag-mitigation-daemonset
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: disable-dirtyfrag-privileged
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:openshift:scc:privileged
+      subjects:
+      - kind: ServiceAccount
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: disable-dirtyfrag-ipsec-safe
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+        labels:
+          app: disable-dirtyfrag-ipsec-safe
+      spec:
+        selector:
+          matchLabels:
+            app: disable-dirtyfrag-ipsec-safe
+        template:
+          metadata:
+            labels:
+              app: disable-dirtyfrag-ipsec-safe
+          spec:
+            serviceAccountName: disable-dirtyfrag
+            nodeSelector:
+              kubernetes.io/os: linux
+            tolerations:
+            - operator: Exists
+            terminationGracePeriodSeconds: 1
+            containers:
+            - name: detect-modules
+              image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+              command:
+              - /bin/sh
+              - -c
+              - "LOADED=false\nfor mod in esp4 esp6 rxrpc; do\n  if chroot /host grep\
+                \ -q \"^${mod} \" /proc/modules 2>/dev/null; then\n    echo \"DETECTED:\
+                \ ${mod} is loaded\"\n    LOADED=true\n  else\n    echo \"OK: ${mod}\
+                \ is not loaded\"\n  fi\ndone\necho \"=== result ===\"\nif [ \"${LOADED}\"\
+                \ = \"true\" ]; then\n  echo \"WARNING: one or more modules are loaded,\
+                \ skipping mitigation\"\nelse\n  if grep -qs \"esp4\" /host/etc/modprobe.d/dirtyfrag.conf\
+                \ 2>/dev/null; then\n    echo \"Modprobe blocklist already present,\
+                \ skipping\"\n  else\n    printf 'install esp4 /bin/false\\ninstall\
+                \ esp6 /bin/false\\ninstall rxrpc /bin/false\\n' > /host/etc/modprobe.d/dirtyfrag.conf\n\
+                \    echo \"Created /etc/modprobe.d/dirtyfrag.conf\"\n  fi\n  for\
+                \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
+                \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
+                sleep infinity\n"
+              securityContext:
+                privileged: true
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                    - /bin/sh
+                    - -c
+                    - rm -f /host/etc/modprobe.d/dirtyfrag.conf
               volumeMounts:
               - name: host-root
                 mountPath: /host

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -29666,6 +29666,11 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: NotIn
+        values:
+        - management-cluster
+        - service-cluster
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1
@@ -29733,6 +29738,108 @@ objects:
                 sleep infinity\n"
               securityContext:
                 privileged: true
+              volumeMounts:
+              - name: host-root
+                mountPath: /host
+            volumes:
+            - name: host-root
+              hostPath:
+                path: /
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
+    name: cve-2026-43284-disable-dirtyfrag-hcp
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: disable-dirtyfrag-mitigation-daemonset
+        operator: NotIn
+        values:
+        - 'true'
+      - key: ext-hypershift.openshift.io/cluster-type
+        operator: In
+        values:
+        - management-cluster
+        - service-cluster
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: disable-dirtyfrag-privileged
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: system:openshift:scc:privileged
+      subjects:
+      - kind: ServiceAccount
+        name: disable-dirtyfrag
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+    - apiVersion: apps/v1
+      kind: DaemonSet
+      metadata:
+        name: disable-dirtyfrag-ipsec-safe
+        namespace: redhat-cve-2026-43284-disable-dirtyfrag
+        labels:
+          app: disable-dirtyfrag-ipsec-safe
+      spec:
+        selector:
+          matchLabels:
+            app: disable-dirtyfrag-ipsec-safe
+        template:
+          metadata:
+            labels:
+              app: disable-dirtyfrag-ipsec-safe
+          spec:
+            serviceAccountName: disable-dirtyfrag
+            nodeSelector:
+              kubernetes.io/os: linux
+            tolerations:
+            - operator: Exists
+            terminationGracePeriodSeconds: 1
+            containers:
+            - name: detect-modules
+              image: registry.redhat.io/openshift4/ose-cli-rhel9@sha256:20e1fd3f0dd3fd28d5bb9c3067ceb8752a63ebd1a07c24873ba13e3e96c98413
+              command:
+              - /bin/sh
+              - -c
+              - "LOADED=false\nfor mod in esp4 esp6 rxrpc; do\n  if chroot /host grep\
+                \ -q \"^${mod} \" /proc/modules 2>/dev/null; then\n    echo \"DETECTED:\
+                \ ${mod} is loaded\"\n    LOADED=true\n  else\n    echo \"OK: ${mod}\
+                \ is not loaded\"\n  fi\ndone\necho \"=== result ===\"\nif [ \"${LOADED}\"\
+                \ = \"true\" ]; then\n  echo \"WARNING: one or more modules are loaded,\
+                \ skipping mitigation\"\nelse\n  if grep -qs \"esp4\" /host/etc/modprobe.d/dirtyfrag.conf\
+                \ 2>/dev/null; then\n    echo \"Modprobe blocklist already present,\
+                \ skipping\"\n  else\n    printf 'install esp4 /bin/false\\ninstall\
+                \ esp6 /bin/false\\ninstall rxrpc /bin/false\\n' > /host/etc/modprobe.d/dirtyfrag.conf\n\
+                \    echo \"Created /etc/modprobe.d/dirtyfrag.conf\"\n  fi\n  for\
+                \ mod in esp4 esp6 rxrpc; do\n    chroot /host modprobe -r \"${mod}\"\
+                \ 2>/dev/null || true\n  done\n  echo \"Node is protected\"\nfi\n\
+                sleep infinity\n"
+              securityContext:
+                privileged: true
+              lifecycle:
+                preStop:
+                  exec:
+                    command:
+                    - /bin/sh
+                    - -c
+                    - rm -f /host/etc/modprobe.d/dirtyfrag.conf
               volumeMounts:
               - name: host-root
                 mountPath: /host


### PR DESCRIPTION
### What type of PR is this?
_chore_

### What this PR does / why we need it?

Expands the scope of the daemonset used to mitigate cve-2026-43284 on MCs and SCs to all workers.

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_ [SLSRE-693](https://redhat.atlassian.net/browse/SLSRE-693)

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed CVE-2026-43284 security mitigation to management and service clusters.
  * Added detection and blocking of vulnerable kernel modules (esp4, esp6, rxrpc) via DaemonSet.
  * Configuration rolled out across integration, production, and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->