### PR TITLE
Add sts_ocm_no_console_permission_policy for all supported versions

### DIFF
--- a/resources/sts/4.10/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.10/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.11/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.11/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.12/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.12/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.13/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.13/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.14/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.14/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.15/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.15/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.16/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.16/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.17/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.17/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.18/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.18/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.19/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.19/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.20/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.20/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.21/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.21/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/4.22/sts_ocm_no_console_permission_policy.json
+++ b/resources/sts/4.22/sts_ocm_no_console_permission_policy.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "iam:GetRole",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:ResourceTag/red-hat-managed": "true",
+          "iam:ResourceTag/rosa_role_type": "OCM"
+        }
+      }
+    }
+  ]
+}

--- a/resources/sts/README.md
+++ b/resources/sts/README.md
@@ -10,5 +10,11 @@ When policies and/or permissions need to be updated, execute the following.
 2. Once merged, Create an MR to [Cluster Services](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/ocm/shared-resources/common.yml#L19) to update the referenced commit hash to consume new changes. 
 3. Cluster service will restart pods automatically making policy changes available almost immediately.
 
+## `sts_ocm_no_console_permission_policy` (clusters-service contract)
+
+The policy document `sts_ocm_no_console_permission_policy.json` must stay **byte-for-byte aligned** with the same file under clusters service, [`configs/policies/sts_ocm_no_console_permission_policy.json`](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/configs/policies/sts_ocm_no_console_permission_policy.json) in `uhc-clusters-service`. That service uses policy ID `sts_ocm_no_console_permission_policy` (see `StsOcmNoConsolePermissionPolicyID` in `pkg/aws/stshelper.go`), classifies it as an OCM role policy in `pkg/config/aws/sts_policy_loader.go`, and exposes it on the STS policies inquiry API when the `sts-ocm-no-console-permission-policy` feature toggle is enabled.
+
+Add an identical copy under every OpenShift Y-stream directory still supported by clusters service (for example `resources/sts/4.10/` through `resources/sts/4.22/`). This policy is **not tied to a specific OpenShift version**: customers are not required to change their OCM role when it is added, and existing OCM roles remain valid.
+
 ## Managed Policies for HCP
 Unlike classic deployments, managed policies for HCP are not versioned. They are stored under the `resources/sts/hypershift` directory. When updating managed policies, you must submit a PR with your changes to this folder before submitting any request to AWS. The managed policy names correspond to roles in AWS and can be found in any AWS account by searching for ROSA-prefixed policies in IAM.


### PR DESCRIPTION
Align JSON with uhc-clusters-service configs/policies and document the contract in resources/sts/README.md for clusters-service STS API.

### What type of PR is this?
_(bug/feature/cleanup/documentation)_

### What this PR does / why we need it?

### Which Jira/Github issue(s) this PR fixes?

_Fixes #_

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New OCM-specific STS policy available via the STS policies inquiry API (exposed when the related feature toggle is enabled). The policy enforces tag-based restrictions for role access (limits retrieval of role details to roles with specific resource tags).

* **Documentation**
  * Added guidance on the policy, API exposure conditions, alignment across supported release branches, and confirmation that existing OCM roles need not be changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->