### PR TITLE
OLM dance for rbac-permissions-operator

### DIFF
--- a/deploy/rbac-permissions-operator-reinstall/10-job.yaml
+++ b/deploy/rbac-permissions-operator-reinstall/10-job.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-operator-reinstall-sa
+  namespace: openshift-rbac-permissions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sre-operator-reinstall-role
+  namespace: openshift-rbac-permissions
+rules:
+- apiGroups: ["operators.coreos.com"]
+  resources: [clusterserviceversions, subscriptions, installplans]
+  verbs: [list, get, delete, create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-operator-reinstall-rb
+  namespace: openshift-rbac-permissions
+roleRef:
+  kind: Role
+  name: sre-operator-reinstall-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: sre-operator-reinstall-sa
+  namespace: openshift-rbac-permissions
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sre-operator-reinstall
+  namespace: openshift-rbac-permissions
+spec:
+  backoffLimit: 6
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: sre-operator-reinstall-sa
+      containers:
+      - name: sre-operator-reinstall
+        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+        command:
+        - sh
+        - -c
+        - |
+          #!/bin/bash
+          set -uxo pipefail
+          NAMESPACE=openshift-rbac-permissions
+          OPERATOR=rbac-permissions-operator
+
+          # Export clean Subscription if exists
+          recreate_subscription=true
+          if oc get subscription.operators.coreos.com -n "$NAMESPACE" "$OPERATOR"; then
+            oc get subscription.operators.coreos.com -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp) | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)' > /tmp/sub.json
+            oc delete subscription.operators.coreos.com -n $NAMESPACE $OPERATOR
+          else
+            recreate_subscription=false
+          fi
+
+          # Delete CSVs
+          oc get clusterserviceversions.operators.coreos.com -n "$NAMESPACE" --no-headers | grep $OPERATOR | awk '{print $1}' | xargs oc delete clusterserviceversions.operators.coreos.com -n $NAMESPACE --wait=false
+
+          # Delete InstallPlans
+          oc get installplans.operators.coreos.com -n "$NAMESPACE" --no-headers | grep $OPERATOR | awk '{print $1}' | xargs oc delete installplan.operators.coreos.com -n "$NAMESPACE"
+
+          # Recreate Subscription
+          if [ $recreate_subscription == "true" ]; then
+            oc create -f /tmp/sub.json
+          fi
+
+          exit 0

--- a/deploy/rbac-permissions-operator-reinstall/README.md
+++ b/deploy/rbac-permissions-operator-reinstall/README.md
@@ -1,0 +1,1 @@
+This is a OLM dance to make RPO to run commit `951a9ca05be4eb153c6407ca2e5562a9e10ee11b` on production clusters.

--- a/deploy/rbac-permissions-operator-reinstall/config.yaml
+++ b/deploy/rbac-permissions-operator-reinstall/config.yaml
@@ -1,0 +1,8 @@
+deploymentMode: SelectorSyncSet
+selectorSyncSet:
+  resourceApplyMode: "Sync"
+  matchExpressions:
+  - key: api.openshift.com/fedramp
+    operator: NotIn
+    values:
+      - "true"

--- a/deploy/rbac-permissions-operator-reinstall/config.yaml
+++ b/deploy/rbac-permissions-operator-reinstall/config.yaml
@@ -6,3 +6,7 @@ selectorSyncSet:
     operator: NotIn
     values:
       - "true"
+  - key: api.openshift.com/environment
+    operator: NotIn
+    values:
+      - "integration"

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -45178,6 +45178,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - integration
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-integration.yaml.tmpl
@@ -45168,6 +45168,96 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rbac-permissions-operator-reinstall
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-rbac-permissions
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-rbac-permissions
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-rbac-permissions
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-rbac-permissions
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-rbac-permissions
+      spec:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        activeDeadlineSeconds: 300
+        template:
+          spec:
+            restartPolicy: OnFailure
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\nset -uxo pipefail\nNAMESPACE=openshift-rbac-permissions\n\
+                OPERATOR=rbac-permissions-operator\n\n# Export clean Subscription\
+                \ if exists\nrecreate_subscription=true\nif oc get subscription.operators.coreos.com\
+                \ -n \"$NAMESPACE\" \"$OPERATOR\"; then\n  oc get subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                \ | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n  oc delete subscription.operators.coreos.com -n\
+                \ $NAMESPACE $OPERATOR\nelse\n  recreate_subscription=false\nfi\n\n\
+                # Delete CSVs\noc get clusterserviceversions.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete clusterserviceversions.operators.coreos.com -n\
+                \ $NAMESPACE --wait=false\n\n# Delete InstallPlans\noc get installplans.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n\n# Recreate Subscription\nif [ $recreate_subscription == \"true\"\
+                \ ]; then\n  oc create -f /tmp/sub.json\nfi\n\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -45178,6 +45178,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - integration
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-production.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-production.yaml.tmpl
@@ -45168,6 +45168,96 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rbac-permissions-operator-reinstall
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-rbac-permissions
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-rbac-permissions
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-rbac-permissions
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-rbac-permissions
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-rbac-permissions
+      spec:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        activeDeadlineSeconds: 300
+        template:
+          spec:
+            restartPolicy: OnFailure
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\nset -uxo pipefail\nNAMESPACE=openshift-rbac-permissions\n\
+                OPERATOR=rbac-permissions-operator\n\n# Export clean Subscription\
+                \ if exists\nrecreate_subscription=true\nif oc get subscription.operators.coreos.com\
+                \ -n \"$NAMESPACE\" \"$OPERATOR\"; then\n  oc get subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                \ | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n  oc delete subscription.operators.coreos.com -n\
+                \ $NAMESPACE $OPERATOR\nelse\n  recreate_subscription=false\nfi\n\n\
+                # Delete CSVs\noc get clusterserviceversions.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete clusterserviceversions.operators.coreos.com -n\
+                \ $NAMESPACE --wait=false\n\n# Delete InstallPlans\noc get installplans.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n\n# Recreate Subscription\nif [ $recreate_subscription == \"true\"\
+                \ ]; then\n  oc create -f /tmp/sub.json\nfi\n\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -45178,6 +45178,10 @@ objects:
         operator: NotIn
         values:
         - 'true'
+      - key: api.openshift.com/environment
+        operator: NotIn
+        values:
+        - integration
     resourceApplyMode: Sync
     resources:
     - apiVersion: v1

--- a/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+++ b/hack/00-osd-managed-cluster-config-stage.yaml.tmpl
@@ -45168,6 +45168,96 @@ objects:
       managed.openshift.io/gitHash: ${IMAGE_TAG}
       managed.openshift.io/gitRepoName: ${REPO_NAME}
       managed.openshift.io/osd: 'true'
+    name: rbac-permissions-operator-reinstall
+  spec:
+    clusterDeploymentSelector:
+      matchLabels:
+        api.openshift.com/managed: 'true'
+      matchExpressions:
+      - key: api.openshift.com/fedramp
+        operator: NotIn
+        values:
+        - 'true'
+    resourceApplyMode: Sync
+    resources:
+    - apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: sre-operator-reinstall-sa
+        namespace: openshift-rbac-permissions
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: sre-operator-reinstall-role
+        namespace: openshift-rbac-permissions
+      rules:
+      - apiGroups:
+        - operators.coreos.com
+        resources:
+        - clusterserviceversions
+        - subscriptions
+        - installplans
+        verbs:
+        - list
+        - get
+        - delete
+        - create
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: sre-operator-reinstall-rb
+        namespace: openshift-rbac-permissions
+      roleRef:
+        kind: Role
+        name: sre-operator-reinstall-role
+        apiGroup: rbac.authorization.k8s.io
+      subjects:
+      - kind: ServiceAccount
+        name: sre-operator-reinstall-sa
+        namespace: openshift-rbac-permissions
+    - apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: sre-operator-reinstall
+        namespace: openshift-rbac-permissions
+      spec:
+        backoffLimit: 6
+        completions: 1
+        parallelism: 1
+        activeDeadlineSeconds: 300
+        template:
+          spec:
+            restartPolicy: OnFailure
+            serviceAccountName: sre-operator-reinstall-sa
+            containers:
+            - name: sre-operator-reinstall
+              image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+              command:
+              - sh
+              - -c
+              - "#!/bin/bash\nset -uxo pipefail\nNAMESPACE=openshift-rbac-permissions\n\
+                OPERATOR=rbac-permissions-operator\n\n# Export clean Subscription\
+                \ if exists\nrecreate_subscription=true\nif oc get subscription.operators.coreos.com\
+                \ -n \"$NAMESPACE\" \"$OPERATOR\"; then\n  oc get subscription.operators.coreos.com\
+                \ -n $NAMESPACE $OPERATOR -o json | jq 'del(.status) | del(.metadata.creationTimestamp)\
+                \ | del(.metadata.generation) | del(.metadata.resourceVersion) | del(.metadata.uid)'\
+                \ > /tmp/sub.json\n  oc delete subscription.operators.coreos.com -n\
+                \ $NAMESPACE $OPERATOR\nelse\n  recreate_subscription=false\nfi\n\n\
+                # Delete CSVs\noc get clusterserviceversions.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete clusterserviceversions.operators.coreos.com -n\
+                \ $NAMESPACE --wait=false\n\n# Delete InstallPlans\noc get installplans.operators.coreos.com\
+                \ -n \"$NAMESPACE\" --no-headers | grep $OPERATOR | awk '{print $1}'\
+                \ | xargs oc delete installplan.operators.coreos.com -n \"$NAMESPACE\"\
+                \n\n# Recreate Subscription\nif [ $recreate_subscription == \"true\"\
+                \ ]; then\n  oc create -f /tmp/sub.json\nfi\n\nexit 0\n"
+- apiVersion: hive.openshift.io/v1
+  kind: SelectorSyncSet
+  metadata:
+    labels:
+      managed.openshift.io/gitHash: ${IMAGE_TAG}
+      managed.openshift.io/gitRepoName: ${REPO_NAME}
+      managed.openshift.io/osd: 'true'
     name: resource-quotas
   spec:
     clusterDeploymentSelector:


### PR DESCRIPTION
### What type of PR is this?
clean up

### What this PR does / why we need it?
We need to perform an OLM dance to make RPO on production clusters to use the commit `951a9ca05be4eb153c6407ca2e5562a9e10ee11b`.

This OLM dance job only deploy to STG & PROD as INT is running PKO.

### Which Jira/Github issue(s) this PR fixes?

Part of [ROSAENG-958](https://redhat.atlassian.net/browse/ROSAENG-958) rollout.

Tested the job on a cluster and it ran as expected.

### Special notes for your reviewer:

### Pre-checks (if applicable):
- [x] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [ ] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:

    ```yaml
    matchExpressions:
    - key: api.openshift.com/fedramp
      operator: NotIn
      values: ["true"]
    ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated reinstall job for the operator to improve recovery and deployment reliability.
  * Updated deployment configuration to use selector-based synchronization with exclusion criteria for certain environments.
* **Documentation**
  * Added a brief README entry describing the operator reinstall procedure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->