### PR TITLE
[ROSAENG-22921]Scope down Karpenter controller IAM policy permissions

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_karpenter_controller_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_karpenter_controller_credentials_policy.json
@@ -33,15 +33,18 @@
       "Effect": "Allow",
       "Action": [
         "kms:DescribeKey",
-        "kms:Encrypt",
         "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*"
+        "kms:ReEncryptFrom",
+        "kms:ReEncryptTo",
+        "kms:GenerateDataKeyWithoutPlaintext"
       ],
       "Resource": "arn:aws:kms:*:*:key/*",
       "Condition": {
         "StringEquals": {
           "aws:ResourceTag/red-hat": "true"
+        },
+        "StringLike": {
+          "kms:ViaService": "ec2.*.amazonaws.com"
         }
       }
     },
@@ -49,9 +52,7 @@
       "Sid": "KMSGrantPermissions",
       "Effect": "Allow",
       "Action": [
-        "kms:CreateGrant",
-        "kms:ListGrants",
-        "kms:RevokeGrant"
+        "kms:CreateGrant"
       ],
       "Resource": "arn:aws:kms:*:*:key/*",
       "Condition": {
@@ -191,7 +192,7 @@
       "Action": [
         "iam:PassRole"
       ],
-      "Resource": "arn:aws:iam::*:role/*",
+      "Resource": "arn:aws:iam::*:role/*-ROSA-Worker-Role",
       "Condition": {
         "StringEquals": {
           "iam:PassedToService": [
@@ -209,8 +210,7 @@
         "iam:DeleteInstanceProfile"
       ],
       "Resource": [
-        "arn:aws:iam::*:instance-profile/rosa-service-managed-*",
-        "arn:aws:iam::*:instance-profile/*-worker"
+        "arn:aws:iam::*:instance-profile/rosa-service-managed-*"
       ]
     },
     {
@@ -221,8 +221,7 @@
         "iam:TagInstanceProfile"
       ],
       "Resource": [
-        "arn:aws:iam::*:instance-profile/rosa-service-managed-*",
-        "arn:aws:iam::*:instance-profile/*-worker"
+        "arn:aws:iam::*:instance-profile/rosa-service-managed-*"
       ],
       "Condition": {
         "StringEquals": {


### PR DESCRIPTION
### What type of PR is this?
cleanup

### What this PR does / why we need it?
Scopes down the Karpenter controller IAM policy per IAM Security review feedback:

- KMS: Remove kms:Encrypt, kms:ListGrants, kms:RevokeGrant (not required per AWS EBS encryption docs). Replace kms:ReEncrypt* and kms:GenerateDataKey* with enumerated actions. Add kms:ViaService condition to crypto operations.
  - PassRole: Scope from arn:aws:iam::*:role/* to *-ROSA-Worker-Role, matching the existing CAPA policy.
  - Instance profiles: Remove *-worker pattern, scope to only rosa-service-managed-*. HCP requires managed policies so *-worker is not needed.

Jira: https://redhat.atlassian.net/browse/ROSAENG-22921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated KMS access permissions with specific allowed actions and additional service-based authentication conditions.
  * Refined instance profile and role management permissions to use targeted resource patterns instead of broader access scopes, restricting permissions to only necessary resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->