### PR TITLE
Remove cblecker from OWNERS files, consolidate architect aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -30,12 +30,7 @@ aliases:
     - jeremyeder
     - boranx
     - rogbas
-  sre-mst-observatorium:
-    - jeremyeder
-  srep-architects:
-    - cblecker
-  sd-architects:
-    - cblecker
+  rosa-staff-engineers:
     - jmelis
   sre-group-leads:
     - apahim

--- a/deploy/backplane/OWNERS
+++ b/deploy/backplane/OWNERS
@@ -3,4 +3,4 @@ reviewers:
 - srep-team-leads
 approvers:
 - srep-team-leads
-- srep-architects
+- rosa-staff-engineers

--- a/deploy/cloud-ingress-operator-configuration/OWNERS
+++ b/deploy/cloud-ingress-operator-configuration/OWNERS
@@ -1,4 +1,0 @@
-reviewers:
-- cblecker
-- lisa
-- sam-nguyen7

--- a/deploy/cluster-monitoring-config-non-uwm/OWNERS
+++ b/deploy/cluster-monitoring-config-non-uwm/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- boranx
-- cblecker

--- a/deploy/cluster-monitoring-config/OWNERS
+++ b/deploy/cluster-monitoring-config/OWNERS
@@ -1,4 +1,0 @@
-reviewers:
-- boranx
-- cblecker
-- sre-mst-observatorium

--- a/deploy/osd-codeready-workspaces/OWNERS
+++ b/deploy/osd-codeready-workspaces/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- rogbas
-- cblecker

--- a/deploy/osd-ingress/OWNERS
+++ b/deploy/osd-ingress/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- cblecker
-- boranx

--- a/deploy/osd-machine-api/OWNERS
+++ b/deploy/osd-machine-api/OWNERS
@@ -1,4 +1,0 @@
-reviewers:
-- cblecker
-- luis-falcon
-- yithian

--- a/deploy/resource-quotas/OWNERS
+++ b/deploy/resource-quotas/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- lisa
-- cblecker

--- a/deploy/rosa-console-legacy-branding-configmap/OWNERS
+++ b/deploy/rosa-console-legacy-branding-configmap/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- boranx
-- cblecker

--- a/deploy/rosa-console-legacy-branding/OWNERS
+++ b/deploy/rosa-console-legacy-branding/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- boranx
-- cblecker

--- a/deploy/rosa-oauth-templates-errors/OWNERS
+++ b/deploy/rosa-oauth-templates-errors/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- boranx
-- cblecker

--- a/deploy/rosa-oauth-templates-login/OWNERS
+++ b/deploy/rosa-oauth-templates-login/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- boranx
-- cblecker

--- a/deploy/rosa-oauth-templates-providers/OWNERS
+++ b/deploy/rosa-oauth-templates-providers/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- boranx
-- cblecker

--- a/deploy/rosa-oauth-templates/OWNERS
+++ b/deploy/rosa-oauth-templates/OWNERS
@@ -1,3 +1,0 @@
-reviewers:
-- boranx
-- cblecker

--- a/deploy/sre-prometheus/OWNERS
+++ b/deploy/sre-prometheus/OWNERS
@@ -1,5 +1,4 @@
 reviewers:
-- cblecker
 - sre-alert-sme
 - srep-region-leads
 approvers:

--- a/deploy/sre-pruning/OWNERS
+++ b/deploy/sre-pruning/OWNERS
@@ -1,2 +1,0 @@
-reviewers:
-- cblecker

--- a/deploy/velero-configuration/OWNERS
+++ b/deploy/velero-configuration/OWNERS
@@ -1,2 +1,0 @@
-reviewers:
-- cblecker

--- a/docs/backplane/OWNERS
+++ b/docs/backplane/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- sd-architects
+- rosa-staff-engineers
 options:
   no_parent_owners: true

--- a/docs/backplane/requirements/hybridsre-hcp/OWNERS
+++ b/docs/backplane/requirements/hybridsre-hcp/OWNERS
@@ -1,6 +1,6 @@
 reviewers:
 - celebdor
 approvers:
-- srep-architects
+- rosa-staff-engineers
 options:
   no_parent_owners: true

--- a/docs/backplane/requirements/srep/OWNERS
+++ b/docs/backplane/requirements/srep/OWNERS
@@ -3,4 +3,4 @@ reviewers:
 - srep-team-leads
 approvers:
 - srep-team-leads
-- srep-architects
+- rosa-staff-engineers

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -5,4 +5,4 @@ reviewers:
 approvers:
 - srep-region-leads
 - srep-team-leads
-- srep-architects
+- rosa-staff-engineers

--- a/resources/sts/OWNERS
+++ b/resources/sts/OWNERS
@@ -3,6 +3,6 @@ reviewers:
 - srep-team-leads
 approvers:
 - srep-team-leads
-- srep-architects
+- rosa-staff-engineers
 options:
   no_parent_owners: true


### PR DESCRIPTION
## Summary

- Remove `cblecker` as approver/reviewer from all OWNERS files, deleting files that became empty or redundant as a result
- Consolidate `srep-architects` and `sd-architects` into a single `rosa-staff-engineers` alias (retaining `jmelis`)
- Remove the now-unused `sre-mst-observatorium` alias

## Test plan

- [x] Verify no references to `cblecker`, `srep-architects`, `sd-architects`, or `sre-mst-observatorium` remain in any OWNERS or OWNERS_ALIASES file
- [x] Verify `rosa-staff-engineers` is defined in OWNERS_ALIASES and referenced in all files that previously used the two old architect aliases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code ownership and review configuration across multiple deployment and documentation directories to reorganize team responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->