### PR TITLE
ROSAENG-57993: add ec2:DescribeSubnets to CPO and SharedVPC endpoint IAM policies

### DIFF
--- a/resources/sts/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_control_plane_operator_credentials_policy.json
@@ -8,6 +8,7 @@
                 "ec2:DescribeVpcEndpoints",
                 "ec2:DescribeVpcs",
                 "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
                 "route53:ListHostedZones"
             ],
             "Resource": "*"

--- a/resources/sts/hypershift/openshift_hcp_shared_vpc_vpc_endpoint_credentials_policy.json
+++ b/resources/sts/hypershift/openshift_hcp_shared_vpc_vpc_endpoint_credentials_policy.json
@@ -7,7 +7,8 @@
       "Action" : [
         "ec2:DescribeVpcEndpoints",
         "ec2:DescribeVpcs",
-        "ec2:DescribeSecurityGroups"
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets"
       ],
       "Resource" : "*"
     },


### PR DESCRIPTION
### What type of PR is this?
feature

### What this PR does / why we need it?

Adds `ec2:DescribeSubnets` to the CPO and SharedVPC endpoint IAM credential policies.

The CPO's VPC endpoint reconciler now calls `DescribeSubnets` to resolve subnet AZ membership
for deduplication (OCPBUGS-82443). Without this permission, the dedup fix gracefully degrades
but ROSA clusters won't benefit from the fix until the policies are updated.

Two policies updated:
- `openshift_hcp_control_plane_operator_credentials_policy.json` — used by CPO in non-SharedVPC clusters
- `openshift_hcp_shared_vpc_vpc_endpoint_credentials_policy.json` — assumed by CPO in SharedVPC clusters

### Which Jira/Github issue(s) this PR fixes?

Fixes [ROSAENG-57993](https://issues.redhat.com/browse/ROSAENG-57993)

Related: [OCPBUGS-82443](https://issues.redhat.com/browse/OCPBUGS-82443) (HyperShift fix PR: https://github.com/openshift/hypershift/pull/8651)

### Special notes for your reviewer:

- `ec2:DescribeSubnets` is a read-only action consistent with the existing `ec2:DescribeVpcEndpoints`, `ec2:DescribeVpcs`, and `ec2:DescribeSecurityGroups` already in these policies
- These policy changes must also be reflected in the AWS-managed `ROSAControlPlaneOperatorPolicy` — a separate request to AWS is needed

### Pre-checks (if applicable):
- [ ] Tested latest changes against a cluster
- [ ] Included documentation changes with PR
- [x] If this is a new object that is not intended for the FedRAMP environment (if unsure, please reach out to team FedRAMP), please exclude it with:
    - N/A — this modifies existing policies, not a new object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated IAM policies to include subnet discovery permissions, enabling enhanced network visibility for HyperShift control plane operator and VPC endpoint management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->