### PR TITLE
NOJIRA: Cleanup SRE GLs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 reviewers:
 - srep-functional-leads
 - srep-team-leads
-- sre-group-leads
 # Following are individual approvers from the SRE-P team that have been added in
 # a one-off effort to find more maintainers for this repository.
 # If you feel like you should be part of this group, create a PR and ping TLs.
@@ -15,7 +14,6 @@ reviewers:
 approvers:
 - srep-functional-leads
 - srep-team-leads
-- sre-group-leads
 # Following are individual approvers from the SRE-P team that have been added in
 # a one-off effort to find more maintainers for this repository.
 # If you feel like you should be part of this group, create a PR and ping TLs.

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -31,7 +31,3 @@ aliases:
     - rogbas
   rosa-staff-engineers:
     - jmelis
-  sre-group-leads:
-    - apahim
-    - maorfr
-    - rogbas


### PR DESCRIPTION
The GL role doesn't exist anymore.

### What type of PR is this?

cleanup

### What this PR does / why we need it?

Removing GLs from approvers, as the GL role doesn't exist anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ownership configuration: removed a formerly listed reviewer and approver group and deleted its associated alias entries. As a result, the designated reviewer and approver lists have been simplified; other reviewer and approver entries remain unchanged. This adjusts who is assigned for reviews and approvals without changing functional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->